### PR TITLE
feat: conversational Admin Content shell (#295)

### DIFF
--- a/public/admin-content-advanced.html
+++ b/public/admin-content-advanced.html
@@ -1,0 +1,949 @@
+<!doctype html>
+<html lang="en-GB">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A2 Content Setup Workspace</title>
+    <link rel="stylesheet" href="/static/shared.css" />
+    <link rel="stylesheet" href="/static/loading.css" />
+    <link rel="stylesheet" href="/static/toast.css" />
+    <style>
+      .selected-module-summary { border: 1px solid var(--color-module-summary-border); background: var(--color-module-summary-bg); border-radius: var(--space-1); padding: var(--space-1); min-height: calc(var(--space-1) * 4.625); }
+      .stack { display: grid; gap: var(--space-2); }
+      .action-cluster { display: grid; gap: var(--space-1); margin-top: var(--space-2); }
+      .button-row { display: flex; flex-wrap: wrap; gap: var(--space-1); }
+      .button-row .btn-primary,
+      .button-row .btn-secondary,
+      .button-row .btn-danger { width: auto; }
+      .module-status-card { display: grid; gap: var(--space-2); border: 1px solid var(--color-module-summary-border); background: linear-gradient(180deg, #f8fbff 0%, #fcfdff 100%); border-radius: var(--radius-card); padding: var(--space-2); }
+      .module-status-header { display: flex; justify-content: space-between; align-items: flex-start; gap: var(--space-2); }
+      .module-status-title { font-size: 20px; font-weight: 700; color: var(--color-text); }
+      .module-status-summary { color: var(--color-text); line-height: 1.5; }
+      .module-status-description { color: var(--color-meta); line-height: 1.5; }
+      .module-status-badge { display: inline-flex; align-items: center; justify-content: center; border-radius: 999px; padding: 6px 12px; font-size: 12px; font-weight: 700; white-space: nowrap; }
+      .module-status-badge.live { background: #e6f4ea; color: #12613a; }
+      .module-status-badge.draft { background: #fff3db; color: #7a4b00; }
+      .module-status-badge.shell { background: #edf1f7; color: #42526b; }
+      .module-status-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-2); }
+      .module-status-line { display: grid; gap: calc(var(--space-1) * 0.5); padding: var(--space-1); border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); background: var(--color-surface); }
+      .module-status-label { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.02em; color: var(--color-link-active); }
+      .module-status-value { line-height: 1.5; color: var(--color-text); }
+      .version-badge { display: inline-flex; align-items: center; justify-content: center; min-width: 34px; border-radius: 999px; padding: 4px 10px; background: var(--color-blue-light); color: var(--color-link-active); font-size: 12px; font-weight: 700; }
+      .status-chain { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+      .status-separator { color: var(--color-meta); }
+      .import-panel textarea { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; }
+      .import-controls { display: grid; gap: var(--space-1); }
+      .import-file { display: grid; gap: calc(var(--space-1) * 0.5); }
+      textarea { overflow-y: hidden; resize: vertical; }
+      .manual-shell-row textarea { min-height: 88px; }
+      .start-mode-nav { display: flex; flex-wrap: wrap; gap: var(--space-1); margin-bottom: var(--space-2); }
+      .start-mode-tab { display: inline-flex; align-items: center; width: auto; padding: 10px 16px; border: 1px solid var(--color-border-soft); border-radius: 999px; background: var(--color-surface); color: var(--color-navy); cursor: pointer; font-size: 14px; font-weight: 600; }
+      .start-mode-tab.active { border-color: var(--color-blue); background: var(--color-blue-light); color: var(--color-link-active); }
+      .start-mode-tab:hover:not(.active) { border-color: var(--color-link-hover-border); background: var(--color-blue-light); }
+      .start-mode-tab:focus-visible { outline: 3px solid var(--color-focus); outline-offset: 2px; }
+      @media (max-width: 900px) {
+        .module-status-header { flex-direction: column; }
+        .module-status-grid { grid-template-columns: 1fr; }
+      }
+      /* Content cards */
+      .content-cards-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-2); }
+      .content-card { display: grid; gap: calc(var(--space-1) * 0.5); border: 1px solid var(--color-module-summary-border); border-radius: var(--radius-card); padding: var(--space-2); background: var(--color-surface); }
+      .content-card-header { display: flex; justify-content: space-between; align-items: center; gap: var(--space-1); }
+      .content-card-meta { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+      .content-card-label { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.02em; color: var(--color-link-active); }
+      .content-card-badges { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
+      .content-card-unsaved { display: inline-flex; align-items: center; border-radius: 999px; padding: 2px 8px; background: #fff3db; color: #7a4b00; font-size: 11px; font-weight: 700; }
+      .content-card-edit-btn { flex-shrink: 0; width: auto !important; padding: 4px 12px !important; font-size: 13px !important; }
+      .content-card-summary { font-size: 13px; color: var(--color-meta); line-height: 1.5; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; min-height: 2.5em; }
+      .content-card-summary.empty { font-style: italic; }
+      @media (max-width: 700px) { .content-cards-grid { grid-template-columns: 1fr; } }
+      /* Field dialogs */
+      .field-dialog { border: 1px solid var(--color-module-summary-border); border-radius: var(--radius-card); padding: var(--space-2); max-width: 600px; width: calc(100vw - 2rem); box-shadow: 0 8px 32px rgba(0,0,0,0.18); max-height: 90vh; overflow-y: auto; }
+      .field-dialog::backdrop { background: rgba(0,0,0,0.35); }
+      .field-dialog-header { margin-bottom: var(--space-2); }
+      .field-dialog-title { font-size: 16px; font-weight: 700; color: var(--color-text); margin: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+      .dialog-locale-tabs { display: flex; gap: 2px; margin-bottom: var(--space-2); border-bottom: 1px solid var(--color-border-soft); }
+      .dialog-locale-tab { background: none; border: none; border-bottom: 2px solid transparent; padding: 6px 14px; font-size: 13px; font-weight: 600; color: var(--color-meta); cursor: pointer; margin-bottom: -1px; }
+      .dialog-locale-tab.active { color: var(--color-link-active); border-bottom-color: var(--color-blue); }
+      .dialog-locale-tab:hover:not(.active) { color: var(--color-text); }
+      .dialog-locale-pane { display: none; gap: var(--space-1); }
+      .dialog-locale-pane.active { display: grid; }
+      .dialog-footer { display: flex; justify-content: flex-end; gap: var(--space-1); margin-top: var(--space-2); padding-top: var(--space-1); border-top: 1px solid var(--color-border-soft); }
+      .dialog-footer .btn-primary, .dialog-footer .btn-secondary { width: auto; }
+      .dialog-section-label { font-size: 12px; font-weight: 700; color: var(--color-meta); text-transform: uppercase; letter-spacing: 0.05em; margin: var(--space-2) 0 6px; border-bottom: 1px solid var(--color-border-soft); padding-bottom: 4px; }
+      .rubric-criterion-row { display: grid; grid-template-columns: 90px 1fr 64px 28px; gap: 6px; align-items: end; margin-bottom: 8px; }
+      .rubric-criterion-row label { font-size: 11px; margin-bottom: 2px; }
+      .json-fallback-panel > summary { font-size: 13px; font-weight: 600; color: var(--color-meta); cursor: pointer; padding: 4px 0; user-select: none; list-style: revert; }
+      .json-fallback-panel > summary:hover { color: var(--color-text); }
+      .json-fallback-panel[open] > summary { margin-bottom: var(--space-1); border-bottom: 1px solid var(--color-border-soft); padding-bottom: var(--space-1); }
+      .mcq-question-item { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-1); margin-bottom: var(--space-1); }
+      .mcq-q-header { display: flex; justify-content: space-between; align-items: center; font-weight: 700; font-size: 13px; margin-bottom: 8px; }
+      .mcq-q-remove, .mcq-opt-remove, .prompt-ex-remove, .ss-field-remove { background: none; border: none; color: var(--color-error); cursor: pointer; padding: 2px 6px; font-size: 14px; line-height: 1; border-radius: 4px; opacity: 0.7; }
+      .mcq-q-remove:hover, .mcq-opt-remove:hover, .prompt-ex-remove:hover, .ss-field-remove:hover { opacity: 1; }
+      .mcq-option-row { display: grid; grid-template-columns: 20px 1fr 24px; gap: 6px; align-items: center; margin-bottom: 6px; }
+      .mcq-option-row input[type="radio"] { margin: 0; }
+      .prompt-example-row { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-1); margin-bottom: var(--space-1); }
+      .prompt-example-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; font-size: 12px; font-weight: 700; color: var(--color-meta); text-transform: uppercase; letter-spacing: 0.05em; }
+      .ss-field-row { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-1); margin-bottom: var(--space-1); }
+      .ss-field-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+      /* Content tabs (Moduler / Kurs) */
+      .content-tab-nav { display: flex; gap: 0; border-bottom: 2px solid var(--color-border-soft); margin-top: var(--space-2); margin-bottom: var(--space-2); }
+      .content-tab { background: none; border: none; border-bottom: 3px solid transparent; padding: 10px 24px; font-size: 15px; font-weight: 600; color: var(--color-meta); cursor: pointer; margin-bottom: -2px; }
+      .content-tab.active { color: var(--color-link-active); border-bottom-color: var(--color-blue); }
+      .content-tab:hover:not(.active) { color: var(--color-text); }
+      /* Course list */
+      .course-list { display: grid; gap: var(--space-2); }
+      .course-card { border: 1px solid var(--color-module-summary-border); border-radius: var(--radius-card); padding: var(--space-2); background: var(--color-surface); display: grid; gap: var(--space-1); }
+      .course-card-header { display: flex; justify-content: space-between; align-items: flex-start; gap: var(--space-2); }
+      .course-card-title { font-size: 16px; font-weight: 700; color: var(--color-text); }
+      .course-card-meta { font-size: 12px; color: var(--color-meta); }
+      .course-module-chips { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
+      .course-module-chip { background: var(--color-blue-light); color: var(--color-link-active); border-radius: 999px; padding: 2px 10px; font-size: 12px; font-weight: 600; }
+      /* Course dialog module ordering */
+      .course-module-order-row { display: flex; align-items: center; gap: 8px; padding: 6px 10px; border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); background: var(--color-surface); margin-bottom: 4px; }
+      .course-module-order-label { flex: 1; font-size: 14px; color: var(--color-text); }
+      .course-module-order-btn { background: none; border: 1px solid var(--color-border-soft); border-radius: 4px; padding: 1px 7px; cursor: pointer; color: var(--color-meta); font-size: 13px; line-height: 1.6; }
+      .course-module-order-btn:hover:not(:disabled) { color: var(--color-text); border-color: var(--color-text); }
+      .course-module-order-btn:disabled { opacity: 0.4; cursor: default; }
+      .course-module-order-remove { background: none; border: none; color: var(--color-error); cursor: pointer; padding: 2px 8px; font-size: 16px; opacity: 0.7; line-height: 1; }
+      .course-module-order-remove:hover { opacity: 1; }
+      .table-wrap { overflow-x: auto; border: 1px solid var(--color-table-wrap-border); border-radius: var(--space-1); margin-top: calc(var(--space-1) * 1.25); max-height: 360px; overflow-y: auto; }
+      table { width: 100%; border-collapse: collapse; min-width: 920px; }
+      th, td { border-bottom: 1px solid var(--color-table-border); padding: var(--space-1); font-size: 12px; text-align: left; vertical-align: top; }
+      tr:hover { background: var(--color-row-hover); }
+    </style>
+  </head>
+  <body>
+    <a href="#main-content" class="skip-nav" data-i18n="nav.skipToContent">Skip to main content</a>
+    <main id="main-content" class="layout-container">
+    <div class="page-top-bar">
+      <nav id="workspaceNav" class="workspace-nav"></nav>
+      <div class="locale-picker">
+        <span id="appVersion" class="version-badge">…</span>
+        <label for="localeSelect" class="sr-only" data-i18n="locale.label">Language</label>
+        <select id="localeSelect" class="locale-select-compact"></select>
+      </div>
+    </div>
+    <h1 data-i18n="adminContentPage.title">Content Setup Workspace</h1>
+    <p class="small" data-i18n="adminContentPage.subtitle">Define module content and scoring rules in a guided sequence.</p>
+
+    <section class="card mock-identity-card">
+      <details class="mock-identity-panel">
+        <summary><span data-i18n="identity.title">Test User</span><span class="mock-identity-dev-badge" data-i18n="identity.devOnlyBadge">Dev only</span></summary>
+        <div class="mock-identity-panel-body">
+          <div class="row">
+            <div><label for="userId" data-i18n="identity.userId">User Id</label><input id="userId" value="content-owner-1" autocomplete="off" /></div>
+            <div><label for="email" data-i18n="identity.email">Email</label><input id="email" value="content.owner@company.com" autocomplete="email" /></div>
+          </div>
+          <div class="row">
+            <div><label for="name" data-i18n="identity.name">Name</label><input id="name" value="Platform Content Owner" autocomplete="name" /></div>
+            <div><label for="department" data-i18n="identity.department">Department</label><input id="department" value="Learning" autocomplete="organization" /></div>
+          </div>
+          <div>
+            <label for="roles" data-i18n="identity.roles">Roles (comma-separated)</label>
+            <input id="roles" value="SUBJECT_MATTER_OWNER" autocomplete="off" />
+          </div>
+          <div id="mockRolePresetContainer">
+            <label for="mockRolePreset" data-i18n="identity.rolePreset">Role preset</label>
+            <select id="mockRolePreset"></select>
+            <div class="small" id="mockRolePresetHint"></div>
+          </div>
+          <button id="loadMe" class="btn-secondary" data-i18n="identity.loadMe">Show my user details</button>
+        </div>
+      </details>
+    </section>
+
+    <div role="note" style="border:1px solid #f5c37f;background:#fffbf0;border-radius:var(--radius-card);padding:var(--space-1) var(--space-2);margin-top:var(--space-2);margin-bottom:var(--space-2)">
+      <strong data-i18n="adminContent.privacy.warning.title">Special category data risk</strong>
+      <p class="small" style="margin-top:4px;color:var(--color-meta)" data-i18n="adminContent.privacy.warning.body">
+        Participants may include health information, political views, or other special category data in free-text submissions.
+      </p>
+    </div>
+
+    <div class="content-tab-nav" role="tablist">
+      <button type="button" id="tabModuler" role="tab" class="content-tab active" aria-selected="true" data-i18n="adminContent.tab.modules">Moduler</button>
+      <button type="button" id="tabKurs" role="tab" class="content-tab" aria-selected="false" data-i18n="adminContent.tab.courses">Kurs</button>
+      <button type="button" id="tabKalibrering" role="tab" class="content-tab" aria-selected="false" data-i18n="nav.calibration">Kalibrering</button>
+    </div>
+    <div id="modulesTab">
+    <div id="moduleStartModeTabs" class="start-mode-nav" role="tablist" aria-label="Module start paths">
+      <button type="button" id="startModeImportTab" class="start-mode-tab" role="tab" aria-selected="false" aria-controls="startModeImportPanel" data-i18n="adminContent.startMode.import">LLM draft</button>
+      <button type="button" id="startModeManualTab" class="start-mode-tab" role="tab" aria-selected="false" aria-controls="startModeManualPanel" data-i18n="adminContent.startMode.manual">Manual</button>
+      <button type="button" id="startModeExistingTab" class="start-mode-tab active" role="tab" aria-selected="true" aria-controls="startModeExistingPanel" data-i18n="adminContent.startMode.existing">Existing module</button>
+    </div>
+
+    <section class="card import-panel" id="startModeImportPanel" role="tabpanel" aria-labelledby="startModeImportTab" hidden>
+      <h2 data-i18n="adminContent.import.title">1) Start from draft JSON (optional)</h2>
+      <div class="small" data-i18n="adminContent.help.importOverview">Use this when your draft already includes both module shell fields and version content. Import only fills the editor. Review, save, and publish separately.</div>
+      <div class="row">
+        <div class="import-file">
+          <label for="importDraftFile" data-i18n="adminContent.import.file">Draft JSON file</label>
+          <input id="importDraftFile" type="file" accept=".json,application/json" />
+        </div>
+      </div>
+      <div><label for="importDraftJson" data-i18n="adminContent.import.json">Draft JSON</label><textarea id="importDraftJson" rows="6"></textarea></div>
+      <div class="small" data-i18n="adminContent.help.importShape">Supports either exported module JSON or a simpler authoring draft with module, rubric, promptTemplate, mcqSet, and moduleVersion.</div>
+      <div class="button-row">
+        <button id="copyAuthoringPrompt" class="btn-secondary" data-i18n="adminContent.import.copyPrompt">Copy authoring prompt</button>
+        <button id="applyImportDraft" class="btn-primary" data-i18n="adminContent.import.applyDraft">Apply draft JSON</button>
+      </div>
+      <div class="small" data-i18n="adminContent.help.copyPrompt">The copied prompt ends with a placeholder/source section. Replace the source material references before sending it to an LLM.</div>
+    </section>
+
+    <section class="card" id="startModeManualPanel" role="tabpanel" aria-labelledby="startModeManualTab" hidden>
+      <h2 data-i18n="adminContent.module.title">2) Create module shell manually</h2>
+      <div class="small" data-i18n="adminContent.help.moduleOverview">Use this path when you want to create the module shell manually before adding scoring, evaluation instruction, and test.</div>
+      <div class="row manual-shell-row">
+        <div><label for="moduleTitle" data-i18n="adminContent.module.name">Module name shown to participants</label><textarea id="moduleTitle" rows="2"></textarea></div>
+        <div><label for="moduleCertificationLevel" data-i18n="adminContent.module.certificationLevel">Level (for example foundation)</label><textarea id="moduleCertificationLevel" rows="2"></textarea></div>
+      </div>
+      <div class="small" data-i18n="adminContent.help.moduleName">Use plain text or locale JSON: {&quot;en-GB&quot;:&quot;...&quot;,&quot;nb&quot;:&quot;...&quot;,&quot;nn&quot;:&quot;...&quot;}.</div>
+      <div><label for="moduleDescription" data-i18n="adminContent.module.description">Short module description</label><textarea id="moduleDescription" rows="2"></textarea></div>
+      <div class="small" data-i18n="adminContent.help.moduleDescription">Shown in module lists. Supports the same locale JSON format.</div>
+      <div class="row">
+        <div><label for="moduleValidFrom" data-i18n="adminContent.module.validFrom">Available from date</label><input id="moduleValidFrom" type="date" /></div>
+        <div><label for="moduleValidTo" data-i18n="adminContent.module.validTo">Available until date</label><input id="moduleValidTo" type="date" /></div>
+      </div>
+      <div class="small" data-i18n="adminContent.help.moduleValidity">Optional module-level availability window. A published version must still be active; these dates only control when the module is offered. Dates are interpreted as UTC midnight.</div>
+      <button id="createModule" class="btn-primary" data-i18n="adminContent.module.create">Create module</button>
+    </section>
+
+    <section class="card" id="startModeExistingPanel" role="tabpanel" aria-labelledby="startModeExistingTab">
+      <h2 data-i18n="adminContent.select.title">3) Open existing module</h2>
+      <div class="small" data-i18n="adminContent.help.selectOverview">Load an existing module, inspect what is live, and decide whether you are preparing a new draft.</div>
+      <div class="row">
+        <div>
+          <label for="selectedModuleId" data-i18n="adminContent.select.moduleId">Module ID</label>
+          <input id="selectedModuleId" />
+        </div>
+        <div>
+          <label for="moduleDropdown" data-i18n="adminContent.select.moduleDropdown">Available modules</label>
+          <select id="moduleDropdown"></select>
+        </div>
+      </div>
+      <div class="action-cluster">
+        <div class="button-row">
+          <button id="loadModules" class="btn-secondary" data-i18n="adminContent.select.loadModules">Refresh module list</button>
+          <button id="loadModuleContent" class="btn-primary" data-i18n="adminContent.select.loadContent">Load draft</button>
+        </div>
+        <div class="button-row">
+          <button id="exportModule" class="btn-secondary" data-i18n="adminContent.select.exportModule">Export selected module</button>
+          <button id="duplicateModule" class="btn-secondary" data-i18n="adminContent.select.duplicateModule">Duplicate module</button>
+          <button id="deleteModule" class="btn-danger" data-i18n="adminContent.select.deleteModule">Delete selected module</button>
+        </div>
+      </div>
+      <div class="small" data-i18n="adminContent.help.loadContent">Loads the saved rubric, prompt, MCQ, and module version into steps 3-7.</div>
+      <div class="small" data-i18n="adminContent.help.deleteModule">Deletes only empty modules without submissions, versions, or published content.</div>
+      <div class="small" id="selectedModuleMeta"></div>
+    </section>
+
+    <section class="card" id="archiveLibrarySection">
+      <h2 data-i18n="adminContent.archive.title">Module archive library</h2>
+      <div class="small" data-i18n="adminContent.archive.hint">Archived modules are hidden from the main list. Search here to restore or inspect them.</div>
+      <div class="row" style="margin-top:var(--space-1)">
+        <div>
+          <label for="archiveSearchInput" data-i18n="adminContent.archive.searchLabel">Search by title</label>
+          <input id="archiveSearchInput" data-i18n-placeholder="adminContent.archive.searchPlaceholder" placeholder="Filter archived modules..." />
+        </div>
+        <div style="display:flex;align-items:flex-end">
+          <button id="archiveSearchBtn" class="btn-secondary" data-i18n="adminContent.archive.searchBtn">Search</button>
+        </div>
+      </div>
+      <div id="archiveLibraryList" style="margin-top:var(--space-1)"></div>
+    </section>
+
+    <section class="card">
+      <h2 data-i18n="adminContent.status.title">4) Module status</h2>
+      <div id="moduleStatusCard" class="module-status-card">
+        <div class="module-status-header">
+          <div class="stack">
+            <div id="moduleStatusTitle" class="module-status-title" data-i18n="adminContent.status.noneTitle">No module selected</div>
+            <div id="moduleStatusSummary" class="module-status-summary" data-i18n="adminContent.status.noneSummary">Choose a module to inspect live and draft versions.</div>
+          </div>
+          <div id="moduleStatusBadge" class="module-status-badge shell" data-i18n="adminContent.status.badge.none">No module selected</div>
+        </div>
+        <div id="moduleStatusDescription" class="module-status-description"></div>
+        <div class="module-status-grid">
+          <div class="module-status-line">
+            <div class="module-status-label" data-i18n="adminContent.status.liveChain">Live now</div>
+            <div id="moduleStatusLive" class="module-status-value" data-i18n="adminContent.status.noPublishedVersion">No published version.</div>
+          </div>
+          <div class="module-status-line">
+            <div class="module-status-label" data-i18n="adminContent.status.latestDraft">Latest saved draft</div>
+            <div id="moduleStatusDraft" class="module-status-value" data-i18n="adminContent.status.noDraftVersion">No unpublished draft.</div>
+          </div>
+          <div class="module-status-line">
+            <div class="module-status-label" data-i18n="adminContent.status.publishInfo">Published</div>
+            <div id="moduleStatusPublishedAt" class="module-status-value">-</div>
+          </div>
+          <div class="module-status-line">
+            <div class="module-status-label" data-i18n="adminContent.status.versionCounts">Saved versions</div>
+            <div id="moduleStatusCounts" class="module-status-value">-</div>
+          </div>
+        </div>
+        <button id="unpublishModuleBtn" class="btn-danger" hidden data-i18n="adminContent.status.unpublishBtn">Unpublish module</button>
+        <button id="archiveModuleBtn" class="btn-danger" hidden data-i18n="adminContent.status.archiveBtn">Archive module</button>
+        <details>
+          <summary data-i18n="adminContent.status.technicalDetails">Technical details</summary>
+          <pre id="moduleStatusDetails">-</pre>
+        </details>
+      </div>
+    </section>
+
+    <section class="card" id="contentCardsSection">
+      <h2 data-i18n="adminContent.cards.title">Content overview</h2>
+      <div class="small" id="contentCardsHint" data-i18n="adminContent.cards.noModule">Load a module to edit its content.</div>
+      <div id="contentCardsGrid" class="content-cards-grid" style="margin-top:var(--space-2)">
+
+        <div class="content-card" id="contentCard_moduleDetails">
+          <div class="content-card-header">
+            <div class="content-card-meta">
+              <span class="content-card-label" data-i18n="adminContent.cards.card.moduleDetails">Module details</span>
+              <div class="content-card-badges">
+                <span id="contentCard_moduleDetails_unsaved" class="content-card-unsaved" hidden data-i18n="adminContent.cards.unsaved">Unsaved</span>
+              </div>
+            </div>
+            <button id="editBtn_moduleDetails" class="btn-secondary content-card-edit-btn" data-i18n="adminContent.cards.editBtn">Edit</button>
+          </div>
+          <div id="contentCard_moduleDetails_summary" class="content-card-summary empty"></div>
+        </div>
+
+        <div class="content-card" id="contentCard_versionDetails">
+          <div class="content-card-header">
+            <div class="content-card-meta">
+              <span class="content-card-label" data-i18n="adminContent.cards.card.versionDetails">Version details</span>
+              <div class="content-card-badges">
+                <span id="contentCard_versionDetails_unsaved" class="content-card-unsaved" hidden data-i18n="adminContent.cards.unsaved">Unsaved</span>
+              </div>
+            </div>
+            <button id="editBtn_versionDetails" class="btn-secondary content-card-edit-btn" data-i18n="adminContent.cards.editBtn">Edit</button>
+          </div>
+          <div id="contentCard_versionDetails_summary" class="content-card-summary empty"></div>
+        </div>
+
+        <div class="content-card" id="contentCard_rubric">
+          <div class="content-card-header">
+            <div class="content-card-meta">
+              <span class="content-card-label" data-i18n="adminContent.cards.card.rubric">Submission scoring</span>
+              <div class="content-card-badges">
+                <span id="contentCard_rubric_unsaved" class="content-card-unsaved" hidden data-i18n="adminContent.cards.unsaved">Unsaved</span>
+              </div>
+            </div>
+            <button id="editBtn_rubric" class="btn-secondary content-card-edit-btn" data-i18n="adminContent.cards.editBtn">Edit</button>
+          </div>
+          <div id="contentCard_rubric_summary" class="content-card-summary empty"></div>
+        </div>
+
+        <div class="content-card" id="contentCard_assessmentPolicy">
+          <div class="content-card-header">
+            <div class="content-card-meta">
+              <span class="content-card-label" data-i18n="adminContent.cards.card.assessmentPolicy">Assessment policy</span>
+              <div class="content-card-badges">
+                <span id="contentCard_assessmentPolicy_unsaved" class="content-card-unsaved" hidden data-i18n="adminContent.cards.unsaved">Unsaved</span>
+              </div>
+            </div>
+            <button id="editBtn_assessmentPolicy" class="btn-secondary content-card-edit-btn" data-i18n="adminContent.cards.editBtn">Edit</button>
+          </div>
+          <div id="contentCard_assessmentPolicy_summary" class="content-card-summary empty"></div>
+        </div>
+
+        <div class="content-card" id="contentCard_prompt">
+          <div class="content-card-header">
+            <div class="content-card-meta">
+              <span class="content-card-label" data-i18n="adminContent.cards.card.prompt">LLM prompt</span>
+              <div class="content-card-badges">
+                <span id="contentCard_prompt_unsaved" class="content-card-unsaved" hidden data-i18n="adminContent.cards.unsaved">Unsaved</span>
+              </div>
+            </div>
+            <button class="btn-secondary content-card-edit-btn" id="editBtn_prompt" data-i18n="adminContent.cards.editBtn">Edit</button>
+          </div>
+          <div id="contentCard_prompt_summary" class="content-card-summary empty"></div>
+        </div>
+
+        <div class="content-card" id="contentCard_mcq">
+          <div class="content-card-header">
+            <div class="content-card-meta">
+              <span class="content-card-label" data-i18n="adminContent.cards.card.mcq">Multiple-choice test</span>
+              <div class="content-card-badges">
+                <span id="contentCard_mcq_unsaved" class="content-card-unsaved" hidden data-i18n="adminContent.cards.unsaved">Unsaved</span>
+              </div>
+            </div>
+            <button class="btn-secondary content-card-edit-btn" id="editBtn_mcq" data-i18n="adminContent.cards.editBtn">Edit</button>
+          </div>
+          <div id="contentCard_mcq_summary" class="content-card-summary empty"></div>
+        </div>
+
+        <div class="content-card" id="contentCard_submissionSchema">
+          <div class="content-card-header">
+            <div class="content-card-meta">
+              <span class="content-card-label" data-i18n="adminContent.cards.card.submissionSchema">Submission schema</span>
+              <div class="content-card-badges">
+                <span id="contentCard_submissionSchema_unsaved" class="content-card-unsaved" hidden data-i18n="adminContent.cards.unsaved">Unsaved</span>
+              </div>
+            </div>
+            <button class="btn-secondary content-card-edit-btn" id="editBtn_submissionSchema" data-i18n="adminContent.cards.editBtn">Edit</button>
+          </div>
+          <div id="contentCard_submissionSchema_summary" class="content-card-summary empty"></div>
+        </div>
+
+      </div>
+      <div class="button-row" id="contentCardsActions" style="display:none;margin-top:var(--space-2)">
+        <button id="saveAllCards" class="btn-primary" data-i18n="adminContent.cards.saveAll">Save all changes</button>
+        <button id="publishFromCards" class="btn-secondary" data-i18n="adminContent.cards.publish" hidden>Publish latest version</button>
+        <button id="previewCardsBtn" class="btn-secondary" data-i18n="adminContent.cards.preview">Preview</button>
+      </div>
+    </section>
+
+    <section class="card" id="sectionRubric">
+      <details class="json-fallback-panel">
+        <summary data-i18n="adminContent.jsonFallback.rubric">5) Rubrikk — rå JSON (avansert)</summary>
+        <div class="small" data-i18n="adminContent.help.rubricOverview">Defines how the participant submission quality is scored.</div>
+        <div><label for="rubricCriteriaJson" data-i18n="adminContent.rubric.criteria">Criteria JSON</label><textarea id="rubricCriteriaJson" rows="5"></textarea></div>
+        <div class="small" data-i18n="adminContent.help.rubricCriteria">Criterion keys should match the current evaluator contract unless code is changed.</div>
+        <div><label for="rubricScalingRuleJson" data-i18n="adminContent.rubric.scalingRule">Score scaling JSON</label><textarea id="rubricScalingRuleJson" rows="3"></textarea></div>
+        <div class="small" data-i18n="adminContent.help.rubricScalingRule">Controls score scaling (for example submission weight and maximum score).</div>
+        <div><label for="rubricPassRuleJson" data-i18n="adminContent.rubric.passRule">Pass/fail threshold JSON</label><textarea id="rubricPassRuleJson" rows="3"></textarea></div>
+        <div class="small" data-i18n="adminContent.help.rubricPassRule">Controls pass/fail thresholds and hard-stop rules.</div>
+      </details>
+    </section>
+
+    <section class="card" id="sectionPrompt">
+      <details class="json-fallback-panel">
+        <summary data-i18n="adminContent.jsonFallback.prompt">6) LLM prompt — raw JSON (advanced)</summary>
+        <div class="small" data-i18n="adminContent.help.promptOverview">Instruction used by the LLM during evaluation.</div>
+        <div><label for="promptSystemPrompt" data-i18n="adminContent.prompt.systemPrompt">System instruction to evaluator</label><textarea id="promptSystemPrompt" rows="3"></textarea></div>
+        <div class="small" data-i18n="adminContent.help.promptSystemPrompt">Global evaluator behavior and output constraints.</div>
+        <div><label for="promptUserPromptTemplate" data-i18n="adminContent.prompt.userPromptTemplate">Evaluation task instruction</label><textarea id="promptUserPromptTemplate" rows="3"></textarea></div>
+        <div class="small" data-i18n="adminContent.help.promptUserTemplate">Task-specific evaluation instruction. This is often called the module evaluation prompt.</div>
+        <div><label for="promptExamplesJson" data-i18n="adminContent.prompt.examplesJson">Optional examples JSON array</label><textarea id="promptExamplesJson" rows="4"></textarea></div>
+        <div class="small" data-i18n="adminContent.help.promptExamples">Optional few-shot examples. Keep these short and stable.</div>
+      </details>
+    </section>
+
+    <section class="card" id="sectionMcq">
+      <details class="json-fallback-panel">
+        <summary data-i18n="adminContent.jsonFallback.mcq">7) Multiple-choice test — raw JSON (advanced)</summary>
+        <div class="small" data-i18n="adminContent.help.mcqOverview">Defines the participant multiple-choice test.</div>
+        <div><label for="mcqSetTitle" data-i18n="adminContent.mcq.setTitle">Test title</label><input id="mcqSetTitle" /></div>
+        <div class="small" data-i18n="adminContent.help.mcqTitle">Shown in admin context and can be localized using locale JSON.</div>
+        <div><label for="mcqQuestionsJson" data-i18n="adminContent.mcq.questionsJson">Questions JSON array</label><textarea id="mcqQuestionsJson" rows="7"></textarea></div>
+        <div class="small" data-i18n="adminContent.help.mcqQuestions">Supports plain strings or locale objects per field: stem/options/correctAnswer/rationale.</div>
+      </details>
+    </section>
+
+    <section class="card" id="sectionModuleVersion">
+      <h2 data-i18n="adminContent.moduleVersion.title">8) Participant-facing module version</h2>
+      <div class="small" data-i18n="adminContent.help.moduleVersionOverview">Binds assignment text + scoring rules + evaluation instruction + test.</div>
+      <details class="json-fallback-panel">
+        <summary data-i18n="adminContent.jsonFallback.versionDetails">Oppgavetekst, veiledning og vurderingspolicy — rå JSON (avansert)</summary>
+        <div><label for="moduleVersionTaskText" data-i18n="adminContent.moduleVersion.taskText">Assignment shown to participant (submission task)</label><textarea id="moduleVersionTaskText" rows="3"></textarea></div>
+        <div class="small" data-i18n="adminContent.help.moduleTaskText">This is the assignment shown to participants before they submit.</div>
+        <div><label for="moduleVersionGuidanceText" data-i18n="adminContent.moduleVersion.guidanceText">What we expect in the submission</label><textarea id="moduleVersionGuidanceText" rows="2"></textarea></div>
+        <div class="small" data-i18n="adminContent.help.moduleGuidanceText">Describe what a good submission should contain. This is also sent to LLM as evaluation context.</div>
+        <div><label for="moduleVersionAssessmentPolicy" data-i18n="adminContent.moduleVersion.assessmentPolicyJson">Assessment policy (JSON, optional)</label><textarea id="moduleVersionAssessmentPolicy" rows="4"></textarea></div>
+        <div class="small" data-i18n="adminContent.help.assessmentPolicyJson">Override scoring weights and pass threshold for this module version. Example: <code>{"scoring":{"practicalWeight":60,"mcqWeight":40},"passRules":{"totalMin":65}}</code></div>
+      </details>
+      <details class="json-fallback-panel">
+        <summary data-i18n="adminContent.jsonFallback.submissionSchema">Submission form schema — raw JSON (advanced)</summary>
+        <div><label for="moduleVersionSubmissionSchema" data-i18n="adminContent.moduleVersion.submissionSchemaJson">Submission form schema (JSON, optional)</label><textarea id="moduleVersionSubmissionSchema" rows="4"></textarea></div>
+        <div class="small" data-i18n="adminContent.help.submissionSchemaJson">Defines the fields shown to participants. If empty, default 3-field form is used. Example: <code>{"fields":[{"id":"response","label":"Your answer","type":"textarea","required":true}]}</code></div>
+      </details>
+      <div class="row">
+        <div><label for="moduleVersionRubricVersionId" data-i18n="adminContent.moduleVersion.rubricVersionId">Scoring rules version ID</label><input id="moduleVersionRubricVersionId" /></div>
+        <div><label for="moduleVersionPromptTemplateVersionId" data-i18n="adminContent.moduleVersion.promptTemplateVersionId">Evaluation instruction version ID</label><input id="moduleVersionPromptTemplateVersionId" /></div>
+      </div>
+      <div class="small" data-i18n="adminContent.help.moduleVersionIds">IDs are auto-filled when you save steps 5-8.</div>
+      <div><label for="moduleVersionMcqSetVersionId" data-i18n="adminContent.moduleVersion.mcqSetVersionId">Test version ID</label><input id="moduleVersionMcqSetVersionId" /></div>
+      <div class="button-row">
+        <button id="saveContentBundle" class="btn-primary" data-i18n="adminContent.moduleVersion.saveBundle">Save new draft version (steps 5-8)</button>
+        <button id="previewCurrentDraft" class="btn-secondary" data-i18n="adminContent.moduleVersion.previewDraft">Open participant preview</button>
+      </div>
+      <div class="small" data-i18n="adminContent.help.previewDraft">Opens the current draft in participant preview mode in a new tab. Nothing is saved, submitted, or scored.</div>
+    </section>
+
+    <section class="card">
+      <h2 data-i18n="adminContent.publish.title">9) Publish module version</h2>
+      <div class="small" data-i18n="adminContent.help.publishOverview">Publishing makes this version active for participant submissions.</div>
+      <div><label for="publishModuleVersionId" data-i18n="adminContent.publish.moduleVersionId">Module version ID to publish</label><input id="publishModuleVersionId" /></div>
+      <button id="publishModuleVersion" class="btn-primary" data-i18n="adminContent.publish.publish">Publish version</button>
+    </section>
+
+    </div><!-- /modulesTab -->
+
+    <div id="coursesTab" hidden>
+      <section class="card">
+        <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:var(--space-1);flex-wrap:wrap">
+          <div>
+            <h2 data-i18n="adminContent.courses.title">Kurs</h2>
+            <p class="small" data-i18n="adminContent.courses.hint">Organiser moduler i kurs for å utstede kurssertifikat.</p>
+          </div>
+          <button id="createCourseBtn" class="btn-primary" style="width:auto;flex-shrink:0" data-i18n="adminContent.courses.createBtn">Opprett kurs</button>
+        </div>
+        <div id="courseList" class="course-list" style="margin-top:var(--space-2)"></div>
+      </section>
+    </div>
+
+    <div id="calibrationTab" hidden>
+      <section class="card">
+        <h2 data-i18n="calibration.filters.title">Calibration filters</h2>
+        <div class="row">
+          <div>
+            <label for="calibrationModuleId" data-i18n="calibration.filters.moduleId">Module ID</label>
+            <select id="calibrationModuleId"></select>
+          </div>
+          <div>
+            <label for="calibrationModuleVersionId" data-i18n="calibration.filters.moduleVersionId">Module version ID</label>
+            <input id="calibrationModuleVersionId" data-i18n-placeholder="calibration.filters.moduleVersionPlaceholder" placeholder="Optional module version ID" />
+          </div>
+        </div>
+        <div class="row">
+          <div>
+            <fieldset class="pill-group-fieldset">
+              <legend id="calibrationStatusesLegend" data-i18n="calibration.filters.statuses">Submission statuses</legend>
+              <div id="calibrationStatuses" class="pill-group" role="group" aria-labelledby="calibrationStatusesLegend"></div>
+            </fieldset>
+          </div>
+          <div>
+            <label for="calibrationLimit" data-i18n="calibration.filters.limit">Max outcomes</label>
+            <input id="calibrationLimit" type="number" min="1" max="500" />
+          </div>
+        </div>
+        <div class="row">
+          <div>
+            <label for="calibrationDateFrom" data-i18n="calibration.filters.dateFrom">Date from</label>
+            <input id="calibrationDateFrom" type="date" />
+          </div>
+          <div>
+            <label for="calibrationDateTo" data-i18n="calibration.filters.dateTo">Date to</label>
+            <input id="calibrationDateTo" type="date" />
+          </div>
+        </div>
+        <div class="row" style="margin-top: calc(var(--space-1) * 1.25);">
+          <div><button id="loadCalibration" class="btn-secondary" data-i18n="calibration.filters.load">Load calibration snapshot</button></div>
+          <div class="small" id="calibrationMeta"></div>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2 data-i18n="calibration.signals.title">Quality signals</h2>
+        <pre id="calibrationSignals"></pre>
+      </section>
+
+      <section id="thresholdEditorSection" class="card" style="display:none">
+        <h2 data-i18n="calibration.thresholds.title">Calibration thresholds</h2>
+        <p class="small" data-i18n="calibration.thresholds.subtitle">Effective thresholds for this module. These control how scores are routed to pass, manual review (yellow), or fail.</p>
+
+        <h3 data-i18n="calibration.thresholds.section.total">Total</h3>
+        <div class="row">
+          <div>
+            <label for="thresholdTotalMin" data-i18n="calibration.thresholds.totalMin">Pass score (min out of 100)</label>
+            <input id="thresholdTotalMin" type="number" min="0" max="100" step="1" />
+            <div class="small" data-i18n="calibration.thresholds.totalMinHelp">Minimum total score to pass.</div>
+          </div>
+        </div>
+
+        <h3 data-i18n="calibration.thresholds.section.manualReview">Manual review zone</h3>
+        <div class="row">
+          <div>
+            <label for="thresholdBorderlineMin" data-i18n="calibration.thresholds.borderlineMin">Yellow zone start</label>
+            <input id="thresholdBorderlineMin" type="number" min="0" max="100" step="1" />
+            <div class="small" data-i18n="calibration.thresholds.borderlineMinHelp">Scores at or above this value enter the yellow/manual-review zone.</div>
+          </div>
+          <div>
+            <label for="thresholdBorderlineMax" data-i18n="calibration.thresholds.borderlineMax">Yellow zone end</label>
+            <input id="thresholdBorderlineMax" type="number" min="0" max="100" step="1" />
+            <div class="small" data-i18n="calibration.thresholds.borderlineMaxHelp">Scores at or below this value stay in the yellow zone.</div>
+          </div>
+        </div>
+
+        <h3 data-i18n="calibration.thresholds.section.practical">Practical submission</h3>
+        <div class="row">
+          <div>
+            <label for="thresholdPracticalMinPercent" data-i18n="calibration.thresholds.practicalMinPercent">Submission min %</label>
+            <input id="thresholdPracticalMinPercent" type="number" min="0" max="100" step="1" />
+            <div class="small" data-i18n="calibration.thresholds.practicalMinPercentHelp">Minimum percentage of the submission maximum that the practical component must reach.</div>
+          </div>
+        </div>
+
+        <h3 data-i18n="calibration.thresholds.section.mcq">Multiple choice questions</h3>
+        <div class="row">
+          <div>
+            <label for="thresholdMcqMinPercent" data-i18n="calibration.thresholds.mcqMinPercent">MCQ min % correct</label>
+            <input id="thresholdMcqMinPercent" type="number" min="0" max="100" step="1" />
+            <div class="small" data-i18n="calibration.thresholds.mcqMinPercentHelp">Minimum percentage correct on the multiple choice questions.</div>
+          </div>
+        </div>
+
+        <div id="thresholdBandPreview" class="small" style="margin-top: var(--space-1)"></div>
+        <div id="thresholdValidationError" class="small" style="color:var(--color-error,red)"></div>
+
+        <div class="row" style="margin-top: calc(var(--space-1) * 1.25);">
+          <div>
+            <button id="publishThresholds" class="btn-secondary" data-i18n="calibration.thresholds.publish" disabled>Publish thresholds</button>
+          </div>
+        </div>
+
+        <div id="thresholdPublishResult" class="small"></div>
+      </section>
+
+      <section class="card">
+        <h2 data-i18n="calibration.outcomes.title">Historical outcomes</h2>
+        <div class="table-wrap" tabindex="0" role="region" aria-label="Historical outcomes">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col" data-i18n="calibration.outcomes.submissionId">Submission</th>
+                <th scope="col" data-i18n="calibration.outcomes.submittedAt">Submitted</th>
+                <th scope="col" data-i18n="calibration.outcomes.status">Status</th>
+                <th scope="col" data-i18n="calibration.outcomes.moduleVersion">Module version</th>
+                <th scope="col" data-i18n="calibration.outcomes.totalScore">Total score</th>
+                <th scope="col" data-i18n="calibration.outcomes.passFail">Pass/fail</th>
+                <th scope="col" data-i18n="calibration.outcomes.manualReview">Manual review signal</th>
+              </tr>
+            </thead>
+            <tbody id="calibrationOutcomesBody"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2 data-i18n="calibration.anchors.title">Benchmark anchors</h2>
+        <div class="table-wrap" tabindex="0" role="region" aria-label="Benchmark anchors">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col" data-i18n="calibration.anchors.promptVersion">Prompt version</th>
+                <th scope="col" data-i18n="calibration.anchors.benchmarkCount">Benchmark examples</th>
+                <th scope="col" data-i18n="calibration.anchors.sourcePromptVersion">Source prompt version</th>
+                <th scope="col" data-i18n="calibration.anchors.sourceModuleVersion">Source module version</th>
+                <th scope="col" data-i18n="calibration.anchors.createdAt">Created</th>
+              </tr>
+            </thead>
+            <tbody id="calibrationAnchorsBody"></tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+
+    <section class="card">
+      <h2 data-i18n="output.title">System response</h2>
+
+      <div class="small" id="outputStatus" aria-live="polite" aria-atomic="true"></div>
+      <details id="outputDetails">
+        <summary>View raw response</summary>
+        <pre id="output" class="pre-content"></pre>
+      </details>
+    </section>
+
+    </main>
+
+    <dialog id="dialogCourse" aria-labelledby="dialogCourseTitle" class="field-dialog">
+      <div class="field-dialog-header">
+        <h2 id="dialogCourseTitle" class="field-dialog-title" data-i18n="adminContent.courses.dialog.createTitle">Opprett kurs</h2>
+      </div>
+      <div class="dialog-locale-tabs" role="tablist">
+        <button type="button" role="tab" aria-selected="true" class="dialog-locale-tab active" data-locale-tab="en-GB">EN-GB</button>
+        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nb">NB</button>
+        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nn">NN</button>
+      </div>
+      <div class="dialog-locale-pane active" data-locale-pane="en-GB">
+        <div><label for="dlgCourse_title_enGB" data-i18n="adminContent.courses.dialog.titleField">Title</label><input id="dlgCourse_title_enGB" autocomplete="off" /></div>
+        <div><label for="dlgCourse_desc_enGB" data-i18n="adminContent.courses.dialog.descField">Description</label><textarea id="dlgCourse_desc_enGB" rows="2"></textarea></div>
+      </div>
+      <div class="dialog-locale-pane" data-locale-pane="nb">
+        <div><label for="dlgCourse_title_nb" data-i18n="adminContent.courses.dialog.titleField">Title</label><input id="dlgCourse_title_nb" autocomplete="off" /></div>
+        <div><label for="dlgCourse_desc_nb" data-i18n="adminContent.courses.dialog.descField">Description</label><textarea id="dlgCourse_desc_nb" rows="2"></textarea></div>
+      </div>
+      <div class="dialog-locale-pane" data-locale-pane="nn">
+        <div><label for="dlgCourse_title_nn" data-i18n="adminContent.courses.dialog.titleField">Title</label><input id="dlgCourse_title_nn" autocomplete="off" /></div>
+        <div><label for="dlgCourse_desc_nn" data-i18n="adminContent.courses.dialog.descField">Description</label><textarea id="dlgCourse_desc_nn" rows="2"></textarea></div>
+      </div>
+      <div style="margin-top:var(--space-1)">
+        <label for="dlgCourse_certLevel" data-i18n="adminContent.courses.dialog.certLevel">Certification level</label>
+        <input id="dlgCourse_certLevel" autocomplete="off" />
+        <div class="small" data-i18n="adminContent.courses.dialog.certLevelHint">Plain text, e.g. foundation.</div>
+      </div>
+      <div class="dialog-section-label" data-i18n="adminContent.courses.dialog.modulesSection">Modules</div>
+      <div id="dlgCourse_moduleList"></div>
+      <div style="display:flex;gap:var(--space-1);align-items:flex-end;margin-top:var(--space-1)">
+        <div style="flex:1">
+          <label for="dlgCourse_moduleDropdown" data-i18n="adminContent.courses.dialog.addModule">Add module</label>
+          <select id="dlgCourse_moduleDropdown"></select>
+        </div>
+        <button type="button" id="dlgCourse_addModuleBtn" class="btn-secondary" style="width:auto" data-i18n="adminContent.courses.dialog.addModuleBtn">Legg til</button>
+      </div>
+      <div class="dialog-footer">
+        <button type="button" id="dialogCourseCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Avbryt</button>
+        <button type="button" id="dialogCourseSave" class="btn-primary" data-i18n="adminContent.courses.dialog.save">Lagre</button>
+      </div>
+    </dialog>
+
+    <dialog id="dialogModuleDetails" aria-labelledby="dialogModuleDetailsTitle" class="field-dialog">
+      <div class="field-dialog-header">
+        <h2 id="dialogModuleDetailsTitle" class="field-dialog-title" data-i18n="adminContent.dialog.moduleDetails.title">Edit module details</h2>
+        
+      </div>
+      <div class="dialog-locale-tabs" role="tablist">
+        <button type="button" role="tab" aria-selected="true" class="dialog-locale-tab active" data-locale-tab="en-GB" aria-controls="dlgMDPane_enGB">EN-GB</button>
+        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nb" aria-controls="dlgMDPane_nb">NB</button>
+        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nn" aria-controls="dlgMDPane_nn">NN</button>
+      </div>
+      <div id="dlgMDPane_enGB" class="dialog-locale-pane active" role="tabpanel" data-locale-pane="en-GB">
+        <div><label for="dlgMD_title_enGB" data-i18n="adminContent.dialog.moduleDetails.titleField">Title</label><input id="dlgMD_title_enGB" autocomplete="off" /></div>
+        <div><label for="dlgMD_desc_enGB" data-i18n="adminContent.dialog.moduleDetails.descriptionField">Description</label><textarea id="dlgMD_desc_enGB" rows="2"></textarea></div>
+        <div><label for="dlgMD_cert_enGB" data-i18n="adminContent.dialog.moduleDetails.certLevel">Certification level</label><input id="dlgMD_cert_enGB" autocomplete="off" /></div>
+      </div>
+      <div id="dlgMDPane_nb" class="dialog-locale-pane" role="tabpanel" data-locale-pane="nb">
+        <div><label for="dlgMD_title_nb" data-i18n="adminContent.dialog.moduleDetails.titleField">Title</label><input id="dlgMD_title_nb" autocomplete="off" /></div>
+        <div><label for="dlgMD_desc_nb" data-i18n="adminContent.dialog.moduleDetails.descriptionField">Description</label><textarea id="dlgMD_desc_nb" rows="2"></textarea></div>
+        <div><label for="dlgMD_cert_nb" data-i18n="adminContent.dialog.moduleDetails.certLevel">Certification level</label><input id="dlgMD_cert_nb" autocomplete="off" /></div>
+      </div>
+      <div id="dlgMDPane_nn" class="dialog-locale-pane" role="tabpanel" data-locale-pane="nn">
+        <div><label for="dlgMD_title_nn" data-i18n="adminContent.dialog.moduleDetails.titleField">Title</label><input id="dlgMD_title_nn" autocomplete="off" /></div>
+        <div><label for="dlgMD_desc_nn" data-i18n="adminContent.dialog.moduleDetails.descriptionField">Description</label><textarea id="dlgMD_desc_nn" rows="2"></textarea></div>
+        <div><label for="dlgMD_cert_nn" data-i18n="adminContent.dialog.moduleDetails.certLevel">Certification level</label><input id="dlgMD_cert_nn" autocomplete="off" /></div>
+      </div>
+      <div class="row" style="margin-top:var(--space-1)">
+        <div><label for="dlgMD_validFrom" data-i18n="adminContent.dialog.moduleDetails.validFrom">Available from</label><input id="dlgMD_validFrom" type="date" /></div>
+        <div><label for="dlgMD_validTo" data-i18n="adminContent.dialog.moduleDetails.validTo">Available until</label><input id="dlgMD_validTo" type="date" /></div>
+      </div>
+      <div class="dialog-footer">
+        <button type="button" id="dialogModuleDetailsCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Cancel</button>
+        <button type="button" id="dialogModuleDetailsApply" class="btn-primary" data-i18n="adminContent.dialog.apply">Update draft</button>
+      </div>
+    </dialog>
+
+    <dialog id="dialogVersionDetails" aria-labelledby="dialogVersionDetailsTitle" class="field-dialog">
+      <div class="field-dialog-header">
+        <h2 id="dialogVersionDetailsTitle" class="field-dialog-title" data-i18n="adminContent.dialog.versionDetails.title">Edit version details</h2>
+        
+      </div>
+      <div class="dialog-locale-tabs" role="tablist">
+        <button type="button" role="tab" aria-selected="true" class="dialog-locale-tab active" data-locale-tab="en-GB" aria-controls="dlgVDPane_enGB">EN-GB</button>
+        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nb" aria-controls="dlgVDPane_nb">NB</button>
+        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nn" aria-controls="dlgVDPane_nn">NN</button>
+      </div>
+      <div id="dlgVDPane_enGB" class="dialog-locale-pane active" role="tabpanel" data-locale-pane="en-GB">
+        <div><label for="dlgVD_task_enGB" data-i18n="adminContent.dialog.versionDetails.taskText">Assignment text</label><textarea id="dlgVD_task_enGB" rows="4"></textarea></div>
+        <div><label for="dlgVD_guidance_enGB" data-i18n="adminContent.dialog.versionDetails.guidanceText">Guidance text</label><textarea id="dlgVD_guidance_enGB" rows="4"></textarea></div>
+      </div>
+      <div id="dlgVDPane_nb" class="dialog-locale-pane" role="tabpanel" data-locale-pane="nb">
+        <div><label for="dlgVD_task_nb" data-i18n="adminContent.dialog.versionDetails.taskText">Assignment text</label><textarea id="dlgVD_task_nb" rows="4"></textarea></div>
+        <div><label for="dlgVD_guidance_nb" data-i18n="adminContent.dialog.versionDetails.guidanceText">Guidance text</label><textarea id="dlgVD_guidance_nb" rows="4"></textarea></div>
+      </div>
+      <div id="dlgVDPane_nn" class="dialog-locale-pane" role="tabpanel" data-locale-pane="nn">
+        <div><label for="dlgVD_task_nn" data-i18n="adminContent.dialog.versionDetails.taskText">Assignment text</label><textarea id="dlgVD_task_nn" rows="4"></textarea></div>
+        <div><label for="dlgVD_guidance_nn" data-i18n="adminContent.dialog.versionDetails.guidanceText">Guidance text</label><textarea id="dlgVD_guidance_nn" rows="4"></textarea></div>
+      </div>
+      <div class="dialog-footer">
+        <button type="button" id="dialogVersionDetailsCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Cancel</button>
+        <button type="button" id="dialogVersionDetailsApply" class="btn-primary" data-i18n="adminContent.dialog.apply">Update draft</button>
+      </div>
+    </dialog>
+
+    <dialog id="dialogAssessmentPolicy" aria-labelledby="dialogAssessmentPolicyTitle" class="field-dialog">
+      <div class="field-dialog-header">
+        <h2 id="dialogAssessmentPolicyTitle" class="field-dialog-title" data-i18n="adminContent.dialog.assessmentPolicy.title">Edit assessment policy</h2>
+        
+      </div>
+
+      <div class="dialog-section-label" data-i18n="adminContent.dialog.assessmentPolicy.sectionScoring">Scoring weights</div>
+      <div class="row">
+        <div>
+          <label for="dlgAP_practicalWeight" data-i18n="adminContent.dialog.assessmentPolicy.practicalWeight">Practical weight (0–100)</label>
+          <input id="dlgAP_practicalWeight" type="number" min="0" max="100" step="1" autocomplete="off" />
+        </div>
+        <div>
+          <label for="dlgAP_mcqWeight" data-i18n="adminContent.dialog.assessmentPolicy.mcqWeight">MCQ weight (0–100)</label>
+          <input id="dlgAP_mcqWeight" type="number" min="0" max="100" step="1" autocomplete="off" />
+        </div>
+      </div>
+
+      <div class="dialog-section-label" data-i18n="adminContent.dialog.assessmentPolicy.sectionPassRules">Pass rules</div>
+      <div class="row">
+        <div>
+          <label for="dlgAP_totalMin" data-i18n="adminContent.dialog.assessmentPolicy.totalMin">Total min score (0–100)</label>
+          <input id="dlgAP_totalMin" type="number" min="0" max="100" step="1" autocomplete="off" />
+        </div>
+        <div>
+          <label for="dlgAP_practicalMin" data-i18n="adminContent.dialog.assessmentPolicy.practicalMin">Practical min % (opt.)</label>
+          <input id="dlgAP_practicalMin" type="number" min="0" max="100" step="1" autocomplete="off" />
+        </div>
+      </div>
+      <div class="row">
+        <div>
+          <label for="dlgAP_mcqMin" data-i18n="adminContent.dialog.assessmentPolicy.mcqMin">MCQ min % (opt.)</label>
+          <input id="dlgAP_mcqMin" type="number" min="0" max="100" step="1" autocomplete="off" />
+        </div>
+        <div></div>
+      </div>
+
+      <div class="dialog-section-label" data-i18n="adminContent.dialog.assessmentPolicy.sectionBorderline">Borderline window (opt.)</div>
+      <div class="row">
+        <div>
+          <label for="dlgAP_borderlineMin" data-i18n="adminContent.dialog.assessmentPolicy.borderlineMin">From score</label>
+          <input id="dlgAP_borderlineMin" type="number" min="0" max="100" step="1" autocomplete="off" />
+        </div>
+        <div>
+          <label for="dlgAP_borderlineMax" data-i18n="adminContent.dialog.assessmentPolicy.borderlineMax">To score</label>
+          <input id="dlgAP_borderlineMax" type="number" min="0" max="100" step="1" autocomplete="off" />
+        </div>
+      </div>
+
+      <div class="dialog-footer">
+        <button type="button" id="dialogAssessmentPolicyCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Cancel</button>
+        <button type="button" id="dialogAssessmentPolicyApply" class="btn-primary" data-i18n="adminContent.dialog.apply">Update draft</button>
+      </div>
+    </dialog>
+
+    <dialog id="dialogRubric" aria-labelledby="dialogRubricTitle" class="field-dialog">
+      <div class="field-dialog-header">
+        <h2 id="dialogRubricTitle" class="field-dialog-title" data-i18n="adminContent.dialog.rubric.title">Edit rubric</h2>
+        
+      </div>
+
+      <div class="dialog-section-label" data-i18n="adminContent.dialog.rubric.sectionCriteria">Criteria</div>
+      <div id="dlgRubric_criteriaList"></div>
+      <button type="button" id="dlgRubric_addCriterion" class="btn-secondary" style="margin-bottom:var(--space-1);width:auto">+ <span data-i18n="adminContent.dialog.rubric.addCriterion">Add criterion</span></button>
+
+      <div class="dialog-section-label" data-i18n="adminContent.dialog.rubric.sectionPassRule">Pass rule</div>
+      <div class="row">
+        <div>
+          <label for="dlgRubric_minScore" data-i18n="adminContent.dialog.rubric.minScore">Minimum score (0–100)</label>
+          <input id="dlgRubric_minScore" type="number" min="0" max="100" step="1" autocomplete="off" />
+        </div>
+        <div>
+          <label for="dlgRubric_criteriaMin" data-i18n="adminContent.dialog.rubric.criteriaMin">All criteria above (opt.)</label>
+          <input id="dlgRubric_criteriaMin" type="number" min="0" max="100" step="1" autocomplete="off" />
+        </div>
+      </div>
+
+      <div class="dialog-section-label" data-i18n="adminContent.dialog.rubric.sectionScalingRule">Scaling rule</div>
+      <div class="row">
+        <div>
+          <label for="dlgRubric_scalingType" data-i18n="adminContent.dialog.rubric.scalingType">Type</label>
+          <input id="dlgRubric_scalingType" autocomplete="off" />
+        </div>
+        <div>
+          <label for="dlgRubric_maxScore" data-i18n="adminContent.dialog.rubric.maxScore">Max score</label>
+          <input id="dlgRubric_maxScore" type="number" min="1" step="1" autocomplete="off" />
+        </div>
+      </div>
+
+      <div class="dialog-footer">
+        <button type="button" id="dialogRubricCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Cancel</button>
+        <button type="button" id="dialogRubricApply" class="btn-primary" data-i18n="adminContent.dialog.apply">Update draft</button>
+      </div>
+    </dialog>
+
+    <dialog id="dialogPrompt" aria-labelledby="dialogPromptTitle" class="field-dialog">
+      <div class="field-dialog-header">
+        <h2 id="dialogPromptTitle" class="field-dialog-title" data-i18n="adminContent.dialog.prompt.title">Edit LLM prompt</h2>
+        
+      </div>
+      <div class="dialog-locale-tabs" role="tablist">
+        <button type="button" role="tab" aria-selected="true" class="dialog-locale-tab active" data-locale-tab="en-GB" aria-controls="dlgPRPane_enGB">EN-GB</button>
+        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nb" aria-controls="dlgPRPane_nb">NB</button>
+        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nn" aria-controls="dlgPRPane_nn">NN</button>
+      </div>
+      <div id="dlgPRPane_enGB" class="dialog-locale-pane active" role="tabpanel" data-locale-pane="en-GB">
+        <div><label for="dlgPR_sys_enGB" data-i18n="adminContent.dialog.prompt.systemPrompt">System prompt</label><textarea id="dlgPR_sys_enGB" rows="5"></textarea></div>
+        <div><label for="dlgPR_user_enGB" data-i18n="adminContent.dialog.prompt.userPromptTemplate">User prompt template</label><textarea id="dlgPR_user_enGB" rows="5"></textarea></div>
+      </div>
+      <div id="dlgPRPane_nb" class="dialog-locale-pane" role="tabpanel" data-locale-pane="nb">
+        <div><label for="dlgPR_sys_nb" data-i18n="adminContent.dialog.prompt.systemPrompt">System prompt</label><textarea id="dlgPR_sys_nb" rows="5"></textarea></div>
+        <div><label for="dlgPR_user_nb" data-i18n="adminContent.dialog.prompt.userPromptTemplate">User prompt template</label><textarea id="dlgPR_user_nb" rows="5"></textarea></div>
+      </div>
+      <div id="dlgPRPane_nn" class="dialog-locale-pane" role="tabpanel" data-locale-pane="nn">
+        <div><label for="dlgPR_sys_nn" data-i18n="adminContent.dialog.prompt.systemPrompt">System prompt</label><textarea id="dlgPR_sys_nn" rows="5"></textarea></div>
+        <div><label for="dlgPR_user_nn" data-i18n="adminContent.dialog.prompt.userPromptTemplate">User prompt template</label><textarea id="dlgPR_user_nn" rows="5"></textarea></div>
+      </div>
+      <div class="dialog-section-label" data-i18n="adminContent.dialog.prompt.sectionExamples">Examples (optional)</div>
+      <div id="dlgPR_examplesList"></div>
+      <button type="button" id="dlgPR_addExample" class="btn-secondary" style="margin-bottom:var(--space-1);width:auto">+ <span data-i18n="adminContent.dialog.prompt.addExample">Add example</span></button>
+      <div class="dialog-footer">
+        <button type="button" id="dialogPromptCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Cancel</button>
+        <button type="button" id="dialogPromptApply" class="btn-primary" data-i18n="adminContent.dialog.apply">Update draft</button>
+      </div>
+    </dialog>
+
+    <dialog id="dialogMcq" aria-labelledby="dialogMcqTitle" class="field-dialog">
+      <div class="field-dialog-header">
+        <h2 id="dialogMcqTitle" class="field-dialog-title" data-i18n="adminContent.dialog.mcq.title">Edit multiple-choice test</h2>
+        
+      </div>
+      <div>
+        <label for="dlgMCQ_setTitle" data-i18n="adminContent.dialog.mcq.setTitle">Test title</label>
+        <input id="dlgMCQ_setTitle" autocomplete="off" />
+      </div>
+      <div class="dialog-locale-tabs" role="tablist" style="margin-top:var(--space-1)">
+        <button type="button" role="tab" aria-selected="true" class="dialog-locale-tab active" data-locale-tab="en-GB">EN-GB</button>
+        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nb">NB</button>
+        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nn">NN</button>
+      </div>
+      <div class="dialog-section-label" data-i18n="adminContent.dialog.mcq.sectionQuestions">Questions</div>
+      <div id="dlgMCQ_questionsList"></div>
+      <button type="button" id="dlgMCQ_addQuestion" class="btn-secondary" style="margin-bottom:var(--space-1);width:auto">+ <span data-i18n="adminContent.dialog.mcq.addQuestion">Add question</span></button>
+      <div class="dialog-footer">
+        <button type="button" id="dialogMcqCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Cancel</button>
+        <button type="button" id="dialogMcqApply" class="btn-primary" data-i18n="adminContent.dialog.apply">Update draft</button>
+      </div>
+    </dialog>
+
+    <dialog id="dialogSubmissionSchema" aria-labelledby="dialogSubmissionSchemaTitle" class="field-dialog">
+      <div class="field-dialog-header">
+        <h2 id="dialogSubmissionSchemaTitle" class="field-dialog-title" data-i18n="adminContent.dialog.submissionSchema.title">Edit submission form</h2>
+        
+      </div>
+      <div class="dialog-locale-tabs" role="tablist">
+        <button type="button" role="tab" aria-selected="true" class="dialog-locale-tab active" data-locale-tab="en-GB">EN-GB</button>
+        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nb">NB</button>
+        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nn">NN</button>
+      </div>
+      <div class="dialog-section-label" data-i18n="adminContent.dialog.submissionSchema.sectionFields">Fields</div>
+      <div id="dlgSS_fieldsList"></div>
+      <button type="button" id="dlgSS_addField" class="btn-secondary" style="margin-bottom:var(--space-1);width:auto">+ <span data-i18n="adminContent.dialog.submissionSchema.addField">Add field</span></button>
+      <div class="dialog-footer">
+        <button type="button" id="dialogSubmissionSchemaCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Cancel</button>
+        <button type="button" id="dialogSubmissionSchemaApply" class="btn-primary" data-i18n="adminContent.dialog.apply">Update draft</button>
+      </div>
+    </dialog>
+
+    <dialog id="authoringPromptDialog" aria-labelledby="authoringPromptDialogTitle">
+      <form method="dialog">
+        <h2 id="authoringPromptDialogTitle" data-i18n="adminContent.promptDialog.title">Authoring prompt options</h2>
+        <div>
+          <label for="promptCertificationLevel" data-i18n="adminContent.promptDialog.certificationLevel">Certification level</label>
+          <select id="promptCertificationLevel">
+            <option value="" data-i18n="adminContent.promptDialog.certificationLevelBlank">— not specified —</option>
+            <option value="basic" data-i18n="adminContent.promptDialog.certificationLevelBasic">Basic</option>
+            <option value="intermediate" data-i18n="adminContent.promptDialog.certificationLevelIntermediate">Intermediate</option>
+            <option value="advanced" data-i18n="adminContent.promptDialog.certificationLevelAdvanced">Advanced</option>
+          </select>
+        </div>
+        <div>
+          <label for="promptMcqCount" data-i18n="adminContent.promptDialog.mcqCount">Number of MCQ questions</label>
+          <input id="promptMcqCount" type="number" value="10" min="1" max="50" autocomplete="off" />
+        </div>
+        <fieldset class="pill-group-fieldset" style="margin-top: var(--space-1);">
+          <legend data-i18n="adminContent.promptDialog.fieldLabel">Submission fields to include</legend>
+          <label class="checkbox-label"><input type="checkbox" id="promptFieldResponse" checked /> <span data-i18n="adminContent.promptDialog.fieldResponse">Response</span></label>
+          <label class="checkbox-label"><input type="checkbox" id="promptFieldReflection" checked /> <span data-i18n="adminContent.promptDialog.fieldReflection">Reflection</span></label>
+          <label class="checkbox-label"><input type="checkbox" id="promptFieldPromptExcerpt" checked /> <span data-i18n="adminContent.promptDialog.fieldPromptExcerpt">Prompt excerpt</span></label>
+        </fieldset>
+        <div style="margin-top: var(--space-1);">
+          <label for="promptCustomFields" data-i18n="adminContent.promptDialog.customFields">Custom fields JSON (overrides checkboxes)</label>
+          <textarea id="promptCustomFields" rows="5" data-i18n-placeholder="adminContent.promptDialog.customFieldsPlaceholder" placeholder="[{&quot;id&quot;:&quot;response&quot;,&quot;type&quot;:&quot;textarea&quot;,&quot;required&quot;:true}]"></textarea>
+          <div class="small" data-i18n="adminContent.promptDialog.customFieldsHint">Leave empty to use the checkboxes above.</div>
+        </div>
+        <div class="row" style="margin-top: var(--space-2);">
+          <div><button type="submit" id="promptDialogCopy" class="btn-primary" data-i18n="adminContent.promptDialog.copy">Copy</button></div>
+          <div><button type="button" id="promptDialogCancel" class="btn-secondary" data-i18n="adminContent.promptDialog.cancel">Cancel</button></div>
+        </div>
+      </form>
+    </dialog>
+
+    <script src="/static/i18n/admin-content-translations.js" type="module"></script>
+    <script src="/static/admin-content.js" type="module"></script>
+  </body>
+</html>

--- a/public/admin-content.html
+++ b/public/admin-content.html
@@ -3,947 +3,103 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>A2 Content Setup Workspace</title>
+    <title>A2 Content Workspace</title>
     <link rel="stylesheet" href="/static/shared.css" />
     <link rel="stylesheet" href="/static/loading.css" />
     <link rel="stylesheet" href="/static/toast.css" />
     <style>
-      .selected-module-summary { border: 1px solid var(--color-module-summary-border); background: var(--color-module-summary-bg); border-radius: var(--space-1); padding: var(--space-1); min-height: calc(var(--space-1) * 4.625); }
-      .stack { display: grid; gap: var(--space-2); }
-      .action-cluster { display: grid; gap: var(--space-1); margin-top: var(--space-2); }
-      .button-row { display: flex; flex-wrap: wrap; gap: var(--space-1); }
-      .button-row .btn-primary,
-      .button-row .btn-secondary,
-      .button-row .btn-danger { width: auto; }
-      .module-status-card { display: grid; gap: var(--space-2); border: 1px solid var(--color-module-summary-border); background: linear-gradient(180deg, #f8fbff 0%, #fcfdff 100%); border-radius: var(--radius-card); padding: var(--space-2); }
-      .module-status-header { display: flex; justify-content: space-between; align-items: flex-start; gap: var(--space-2); }
-      .module-status-title { font-size: 20px; font-weight: 700; color: var(--color-text); }
-      .module-status-summary { color: var(--color-text); line-height: 1.5; }
-      .module-status-description { color: var(--color-meta); line-height: 1.5; }
-      .module-status-badge { display: inline-flex; align-items: center; justify-content: center; border-radius: 999px; padding: 6px 12px; font-size: 12px; font-weight: 700; white-space: nowrap; }
+      /* ── Shell layout ─────────────────────────────────────────────────────── */
+      .shell-header { display: flex; justify-content: space-between; align-items: baseline; gap: var(--space-2); flex-wrap: wrap; margin-bottom: var(--space-2); }
+      .shell-header h1 { margin: 0; font-size: 22px; }
+      .advanced-link { font-size: 13px; color: var(--color-meta); text-decoration: none; white-space: nowrap; }
+      .advanced-link:hover { color: var(--color-link-active); text-decoration: underline; }
+
+      .workspace-shell { display: grid; grid-template-columns: 1fr 380px; gap: var(--space-2); align-items: start; }
+      @media (max-width: 900px) { .workspace-shell { grid-template-columns: 1fr; } }
+
+      /* ── Preview pane ─────────────────────────────────────────────────────── */
+      .preview-pane { position: sticky; top: var(--space-2); }
+      .preview-locale-bar { display: flex; gap: 4px; margin-bottom: var(--space-1); }
+      .preview-locale-btn { background: var(--color-surface); border: 1px solid var(--color-border-soft); border-radius: 999px; padding: 4px 12px; font-size: 12px; font-weight: 600; color: var(--color-meta); cursor: pointer; }
+      .preview-locale-btn.active { background: var(--color-blue-light); border-color: var(--color-blue); color: var(--color-link-active); }
+      .preview-locale-btn:hover:not(.active) { border-color: var(--color-link-hover-border); color: var(--color-text); }
+
+      .preview-module-header { display: flex; justify-content: space-between; align-items: flex-start; gap: var(--space-1); margin-bottom: 8px; }
+      .preview-module-title { font-size: 18px; font-weight: 700; color: var(--color-text); }
+      .preview-description { font-size: 13px; color: var(--color-meta); margin: 0 0 8px; }
+      .preview-version-chain { font-size: 12px; color: var(--color-link-active); font-weight: 600; margin: 0 0 var(--space-1); }
+      .preview-section-label { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: var(--color-meta); margin: var(--space-1) 0 4px; }
+      .preview-text-block { font-size: 14px; color: var(--color-text); line-height: 1.6; white-space: pre-wrap; background: var(--color-module-summary-bg); border: 1px solid var(--color-module-summary-border); border-radius: var(--radius-card); padding: var(--space-1); }
+      .preview-text-secondary { color: var(--color-meta); }
+      .preview-meta { font-size: 12px; color: var(--color-meta); margin: 8px 0 0; }
+      .preview-empty { color: var(--color-meta); font-style: italic; }
+
+      /* Module status badges (shared with advanced editor) */
+      .module-status-badge { display: inline-flex; align-items: center; border-radius: 999px; padding: 4px 12px; font-size: 12px; font-weight: 700; white-space: nowrap; }
       .module-status-badge.live { background: #e6f4ea; color: #12613a; }
       .module-status-badge.draft { background: #fff3db; color: #7a4b00; }
       .module-status-badge.shell { background: #edf1f7; color: #42526b; }
-      .module-status-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-2); }
-      .module-status-line { display: grid; gap: calc(var(--space-1) * 0.5); padding: var(--space-1); border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); background: var(--color-surface); }
-      .module-status-label { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.02em; color: var(--color-link-active); }
-      .module-status-value { line-height: 1.5; color: var(--color-text); }
-      .version-badge { display: inline-flex; align-items: center; justify-content: center; min-width: 34px; border-radius: 999px; padding: 4px 10px; background: var(--color-blue-light); color: var(--color-link-active); font-size: 12px; font-weight: 700; }
-      .status-chain { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
-      .status-separator { color: var(--color-meta); }
-      .import-panel textarea { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; }
-      .import-controls { display: grid; gap: var(--space-1); }
-      .import-file { display: grid; gap: calc(var(--space-1) * 0.5); }
-      textarea { overflow-y: hidden; resize: vertical; }
-      .manual-shell-row textarea { min-height: 88px; }
-      .start-mode-nav { display: flex; flex-wrap: wrap; gap: var(--space-1); margin-bottom: var(--space-2); }
-      .start-mode-tab { display: inline-flex; align-items: center; width: auto; padding: 10px 16px; border: 1px solid var(--color-border-soft); border-radius: 999px; background: var(--color-surface); color: var(--color-navy); cursor: pointer; font-size: 14px; font-weight: 600; }
-      .start-mode-tab.active { border-color: var(--color-blue); background: var(--color-blue-light); color: var(--color-link-active); }
-      .start-mode-tab:hover:not(.active) { border-color: var(--color-link-hover-border); background: var(--color-blue-light); }
-      .start-mode-tab:focus-visible { outline: 3px solid var(--color-focus); outline-offset: 2px; }
-      @media (max-width: 900px) {
-        .module-status-header { flex-direction: column; }
-        .module-status-grid { grid-template-columns: 1fr; }
-      }
-      /* Content cards */
-      .content-cards-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-2); }
-      .content-card { display: grid; gap: calc(var(--space-1) * 0.5); border: 1px solid var(--color-module-summary-border); border-radius: var(--radius-card); padding: var(--space-2); background: var(--color-surface); }
-      .content-card-header { display: flex; justify-content: space-between; align-items: center; gap: var(--space-1); }
-      .content-card-meta { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
-      .content-card-label { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.02em; color: var(--color-link-active); }
-      .content-card-badges { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
-      .content-card-unsaved { display: inline-flex; align-items: center; border-radius: 999px; padding: 2px 8px; background: #fff3db; color: #7a4b00; font-size: 11px; font-weight: 700; }
-      .content-card-edit-btn { flex-shrink: 0; width: auto !important; padding: 4px 12px !important; font-size: 13px !important; }
-      .content-card-summary { font-size: 13px; color: var(--color-meta); line-height: 1.5; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; min-height: 2.5em; }
-      .content-card-summary.empty { font-style: italic; }
-      @media (max-width: 700px) { .content-cards-grid { grid-template-columns: 1fr; } }
-      /* Field dialogs */
-      .field-dialog { border: 1px solid var(--color-module-summary-border); border-radius: var(--radius-card); padding: var(--space-2); max-width: 600px; width: calc(100vw - 2rem); box-shadow: 0 8px 32px rgba(0,0,0,0.18); max-height: 90vh; overflow-y: auto; }
-      .field-dialog::backdrop { background: rgba(0,0,0,0.35); }
-      .field-dialog-header { margin-bottom: var(--space-2); }
-      .field-dialog-title { font-size: 16px; font-weight: 700; color: var(--color-text); margin: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-      .dialog-locale-tabs { display: flex; gap: 2px; margin-bottom: var(--space-2); border-bottom: 1px solid var(--color-border-soft); }
-      .dialog-locale-tab { background: none; border: none; border-bottom: 2px solid transparent; padding: 6px 14px; font-size: 13px; font-weight: 600; color: var(--color-meta); cursor: pointer; margin-bottom: -1px; }
-      .dialog-locale-tab.active { color: var(--color-link-active); border-bottom-color: var(--color-blue); }
-      .dialog-locale-tab:hover:not(.active) { color: var(--color-text); }
-      .dialog-locale-pane { display: none; gap: var(--space-1); }
-      .dialog-locale-pane.active { display: grid; }
-      .dialog-footer { display: flex; justify-content: flex-end; gap: var(--space-1); margin-top: var(--space-2); padding-top: var(--space-1); border-top: 1px solid var(--color-border-soft); }
-      .dialog-footer .btn-primary, .dialog-footer .btn-secondary { width: auto; }
-      .dialog-section-label { font-size: 12px; font-weight: 700; color: var(--color-meta); text-transform: uppercase; letter-spacing: 0.05em; margin: var(--space-2) 0 6px; border-bottom: 1px solid var(--color-border-soft); padding-bottom: 4px; }
-      .rubric-criterion-row { display: grid; grid-template-columns: 90px 1fr 64px 28px; gap: 6px; align-items: end; margin-bottom: 8px; }
-      .rubric-criterion-row label { font-size: 11px; margin-bottom: 2px; }
-      .json-fallback-panel > summary { font-size: 13px; font-weight: 600; color: var(--color-meta); cursor: pointer; padding: 4px 0; user-select: none; list-style: revert; }
-      .json-fallback-panel > summary:hover { color: var(--color-text); }
-      .json-fallback-panel[open] > summary { margin-bottom: var(--space-1); border-bottom: 1px solid var(--color-border-soft); padding-bottom: var(--space-1); }
-      .mcq-question-item { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-1); margin-bottom: var(--space-1); }
-      .mcq-q-header { display: flex; justify-content: space-between; align-items: center; font-weight: 700; font-size: 13px; margin-bottom: 8px; }
-      .mcq-q-remove, .mcq-opt-remove, .prompt-ex-remove, .ss-field-remove { background: none; border: none; color: var(--color-error); cursor: pointer; padding: 2px 6px; font-size: 14px; line-height: 1; border-radius: 4px; opacity: 0.7; }
-      .mcq-q-remove:hover, .mcq-opt-remove:hover, .prompt-ex-remove:hover, .ss-field-remove:hover { opacity: 1; }
-      .mcq-option-row { display: grid; grid-template-columns: 20px 1fr 24px; gap: 6px; align-items: center; margin-bottom: 6px; }
-      .mcq-option-row input[type="radio"] { margin: 0; }
-      .prompt-example-row { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-1); margin-bottom: var(--space-1); }
-      .prompt-example-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; font-size: 12px; font-weight: 700; color: var(--color-meta); text-transform: uppercase; letter-spacing: 0.05em; }
-      .ss-field-row { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-1); margin-bottom: var(--space-1); }
-      .ss-field-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
-      /* Content tabs (Moduler / Kurs) */
-      .content-tab-nav { display: flex; gap: 0; border-bottom: 2px solid var(--color-border-soft); margin-top: var(--space-2); margin-bottom: var(--space-2); }
-      .content-tab { background: none; border: none; border-bottom: 3px solid transparent; padding: 10px 24px; font-size: 15px; font-weight: 600; color: var(--color-meta); cursor: pointer; margin-bottom: -2px; }
-      .content-tab.active { color: var(--color-link-active); border-bottom-color: var(--color-blue); }
-      .content-tab:hover:not(.active) { color: var(--color-text); }
-      /* Course list */
-      .course-list { display: grid; gap: var(--space-2); }
-      .course-card { border: 1px solid var(--color-module-summary-border); border-radius: var(--radius-card); padding: var(--space-2); background: var(--color-surface); display: grid; gap: var(--space-1); }
-      .course-card-header { display: flex; justify-content: space-between; align-items: flex-start; gap: var(--space-2); }
-      .course-card-title { font-size: 16px; font-weight: 700; color: var(--color-text); }
-      .course-card-meta { font-size: 12px; color: var(--color-meta); }
-      .course-module-chips { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
-      .course-module-chip { background: var(--color-blue-light); color: var(--color-link-active); border-radius: 999px; padding: 2px 10px; font-size: 12px; font-weight: 600; }
-      /* Course dialog module ordering */
-      .course-module-order-row { display: flex; align-items: center; gap: 8px; padding: 6px 10px; border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); background: var(--color-surface); margin-bottom: 4px; }
-      .course-module-order-label { flex: 1; font-size: 14px; color: var(--color-text); }
-      .course-module-order-btn { background: none; border: 1px solid var(--color-border-soft); border-radius: 4px; padding: 1px 7px; cursor: pointer; color: var(--color-meta); font-size: 13px; line-height: 1.6; }
-      .course-module-order-btn:hover:not(:disabled) { color: var(--color-text); border-color: var(--color-text); }
-      .course-module-order-btn:disabled { opacity: 0.4; cursor: default; }
-      .course-module-order-remove { background: none; border: none; color: var(--color-error); cursor: pointer; padding: 2px 8px; font-size: 16px; opacity: 0.7; line-height: 1; }
-      .course-module-order-remove:hover { opacity: 1; }
-      .table-wrap { overflow-x: auto; border: 1px solid var(--color-table-wrap-border); border-radius: var(--space-1); margin-top: calc(var(--space-1) * 1.25); max-height: 360px; overflow-y: auto; }
-      table { width: 100%; border-collapse: collapse; min-width: 920px; }
-      th, td { border-bottom: 1px solid var(--color-table-border); padding: var(--space-1); font-size: 12px; text-align: left; vertical-align: top; }
-      tr:hover { background: var(--color-row-hover); }
+
+      /* ── Chat pane ────────────────────────────────────────────────────────── */
+      .chat-pane { display: flex; flex-direction: column; min-height: 60vh; }
+      .chat-messages { flex: 1; display: flex; flex-direction: column; gap: var(--space-1); padding: var(--space-1); overflow-y: auto; min-height: 200px; }
+
+      .chat-msg { display: flex; }
+      .chat-msg--bot { justify-content: flex-start; }
+      .chat-msg--user { justify-content: flex-end; }
+
+      .chat-bubble { max-width: 90%; padding: 10px 14px; border-radius: 16px; font-size: 14px; line-height: 1.5; }
+      .chat-msg--bot .chat-bubble { background: var(--color-blue-light); color: var(--color-text); border-bottom-left-radius: 4px; }
+      .chat-msg--user .chat-bubble { background: var(--color-navy); color: #fff; border-bottom-right-radius: 4px; }
+      .chat-bubble--progress { display: flex; align-items: center; gap: 8px; color: var(--color-meta); }
+
+      .chat-spinner { display: inline-block; width: 14px; height: 14px; border: 2px solid var(--color-border-soft); border-top-color: var(--color-blue); border-radius: 50%; animation: spin 0.7s linear infinite; flex-shrink: 0; }
+      @keyframes spin { to { transform: rotate(360deg); } }
+
+      .chat-choices { display: flex; flex-wrap: wrap; gap: 6px; padding: 6px var(--space-1) var(--space-1); }
+      .chat-choices--column { flex-direction: column; align-items: flex-start; }
+      .chat-choice-btn { width: auto !important; padding: 6px 14px !important; font-size: 13px !important; border-radius: 999px !important; }
+      .chat-choice-btn:disabled { opacity: 0.45; cursor: default; }
+
+      .module-list { display: flex; flex-direction: column; gap: 4px; margin-top: 8px; }
+      .module-list-item { font-size: 13px; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
     </style>
   </head>
   <body>
     <a href="#main-content" class="skip-nav" data-i18n="nav.skipToContent">Skip to main content</a>
     <main id="main-content" class="layout-container">
-    <div class="page-top-bar">
-      <nav id="workspaceNav" class="workspace-nav"></nav>
-      <div class="locale-picker">
-        <span id="appVersion" class="version-badge">…</span>
-        <label for="localeSelect" class="sr-only" data-i18n="locale.label">Language</label>
-        <select id="localeSelect" class="locale-select-compact"></select>
-      </div>
-    </div>
-    <h1 data-i18n="adminContentPage.title">Content Setup Workspace</h1>
-    <p class="small" data-i18n="adminContentPage.subtitle">Define module content and scoring rules in a guided sequence.</p>
 
-    <section class="card mock-identity-card">
-      <details class="mock-identity-panel">
-        <summary><span data-i18n="identity.title">Test User</span><span class="mock-identity-dev-badge" data-i18n="identity.devOnlyBadge">Dev only</span></summary>
-        <div class="mock-identity-panel-body">
-          <div class="row">
-            <div><label for="userId" data-i18n="identity.userId">User Id</label><input id="userId" value="content-owner-1" autocomplete="off" /></div>
-            <div><label for="email" data-i18n="identity.email">Email</label><input id="email" value="content.owner@company.com" autocomplete="email" /></div>
-          </div>
-          <div class="row">
-            <div><label for="name" data-i18n="identity.name">Name</label><input id="name" value="Platform Content Owner" autocomplete="name" /></div>
-            <div><label for="department" data-i18n="identity.department">Department</label><input id="department" value="Learning" autocomplete="organization" /></div>
-          </div>
-          <div>
-            <label for="roles" data-i18n="identity.roles">Roles (comma-separated)</label>
-            <input id="roles" value="SUBJECT_MATTER_OWNER" autocomplete="off" />
-          </div>
-          <div id="mockRolePresetContainer">
-            <label for="mockRolePreset" data-i18n="identity.rolePreset">Role preset</label>
-            <select id="mockRolePreset"></select>
-            <div class="small" id="mockRolePresetHint"></div>
-          </div>
-          <button id="loadMe" class="btn-secondary" data-i18n="identity.loadMe">Show my user details</button>
-        </div>
-      </details>
-    </section>
-
-    <div role="note" style="border:1px solid #f5c37f;background:#fffbf0;border-radius:var(--radius-card);padding:var(--space-1) var(--space-2);margin-top:var(--space-2);margin-bottom:var(--space-2)">
-      <strong data-i18n="adminContent.privacy.warning.title">Special category data risk</strong>
-      <p class="small" style="margin-top:4px;color:var(--color-meta)" data-i18n="adminContent.privacy.warning.body">
-        Participants may include health information, political views, or other special category data in free-text submissions.
-      </p>
-    </div>
-
-    <div class="content-tab-nav" role="tablist">
-      <button type="button" id="tabModuler" role="tab" class="content-tab active" aria-selected="true" data-i18n="adminContent.tab.modules">Moduler</button>
-      <button type="button" id="tabKurs" role="tab" class="content-tab" aria-selected="false" data-i18n="adminContent.tab.courses">Kurs</button>
-      <button type="button" id="tabKalibrering" role="tab" class="content-tab" aria-selected="false" data-i18n="nav.calibration">Kalibrering</button>
-    </div>
-    <div id="modulesTab">
-    <div id="moduleStartModeTabs" class="start-mode-nav" role="tablist" aria-label="Module start paths">
-      <button type="button" id="startModeImportTab" class="start-mode-tab" role="tab" aria-selected="false" aria-controls="startModeImportPanel" data-i18n="adminContent.startMode.import">LLM draft</button>
-      <button type="button" id="startModeManualTab" class="start-mode-tab" role="tab" aria-selected="false" aria-controls="startModeManualPanel" data-i18n="adminContent.startMode.manual">Manual</button>
-      <button type="button" id="startModeExistingTab" class="start-mode-tab active" role="tab" aria-selected="true" aria-controls="startModeExistingPanel" data-i18n="adminContent.startMode.existing">Existing module</button>
-    </div>
-
-    <section class="card import-panel" id="startModeImportPanel" role="tabpanel" aria-labelledby="startModeImportTab" hidden>
-      <h2 data-i18n="adminContent.import.title">1) Start from draft JSON (optional)</h2>
-      <div class="small" data-i18n="adminContent.help.importOverview">Use this when your draft already includes both module shell fields and version content. Import only fills the editor. Review, save, and publish separately.</div>
-      <div class="row">
-        <div class="import-file">
-          <label for="importDraftFile" data-i18n="adminContent.import.file">Draft JSON file</label>
-          <input id="importDraftFile" type="file" accept=".json,application/json" />
+      <div class="page-top-bar">
+        <nav id="workspaceNav" class="workspace-nav"></nav>
+        <div class="locale-picker">
+          <span id="appVersion" class="version-badge">…</span>
+          <label for="localeSelect" class="sr-only">Language</label>
+          <select id="localeSelect" class="locale-select-compact"></select>
         </div>
       </div>
-      <div><label for="importDraftJson" data-i18n="adminContent.import.json">Draft JSON</label><textarea id="importDraftJson" rows="6"></textarea></div>
-      <div class="small" data-i18n="adminContent.help.importShape">Supports either exported module JSON or a simpler authoring draft with module, rubric, promptTemplate, mcqSet, and moduleVersion.</div>
-      <div class="button-row">
-        <button id="copyAuthoringPrompt" class="btn-secondary" data-i18n="adminContent.import.copyPrompt">Copy authoring prompt</button>
-        <button id="applyImportDraft" class="btn-primary" data-i18n="adminContent.import.applyDraft">Apply draft JSON</button>
+
+      <div class="shell-header">
+        <h1>Content Workspace</h1>
+        <a href="/admin-content/advanced" class="advanced-link">Avansert redigering ↗</a>
       </div>
-      <div class="small" data-i18n="adminContent.help.copyPrompt">The copied prompt ends with a placeholder/source section. Replace the source material references before sending it to an LLM.</div>
-    </section>
 
-    <section class="card" id="startModeManualPanel" role="tabpanel" aria-labelledby="startModeManualTab" hidden>
-      <h2 data-i18n="adminContent.module.title">2) Create module shell manually</h2>
-      <div class="small" data-i18n="adminContent.help.moduleOverview">Use this path when you want to create the module shell manually before adding scoring, evaluation instruction, and test.</div>
-      <div class="row manual-shell-row">
-        <div><label for="moduleTitle" data-i18n="adminContent.module.name">Module name shown to participants</label><textarea id="moduleTitle" rows="2"></textarea></div>
-        <div><label for="moduleCertificationLevel" data-i18n="adminContent.module.certificationLevel">Level (for example foundation)</label><textarea id="moduleCertificationLevel" rows="2"></textarea></div>
-      </div>
-      <div class="small" data-i18n="adminContent.help.moduleName">Use plain text or locale JSON: {&quot;en-GB&quot;:&quot;...&quot;,&quot;nb&quot;:&quot;...&quot;,&quot;nn&quot;:&quot;...&quot;}.</div>
-      <div><label for="moduleDescription" data-i18n="adminContent.module.description">Short module description</label><textarea id="moduleDescription" rows="2"></textarea></div>
-      <div class="small" data-i18n="adminContent.help.moduleDescription">Shown in module lists. Supports the same locale JSON format.</div>
-      <div class="row">
-        <div><label for="moduleValidFrom" data-i18n="adminContent.module.validFrom">Available from date</label><input id="moduleValidFrom" type="date" /></div>
-        <div><label for="moduleValidTo" data-i18n="adminContent.module.validTo">Available until date</label><input id="moduleValidTo" type="date" /></div>
-      </div>
-      <div class="small" data-i18n="adminContent.help.moduleValidity">Optional module-level availability window. A published version must still be active; these dates only control when the module is offered. Dates are interpreted as UTC midnight.</div>
-      <button id="createModule" class="btn-primary" data-i18n="adminContent.module.create">Create module</button>
-    </section>
+      <div class="workspace-shell">
 
-    <section class="card" id="startModeExistingPanel" role="tabpanel" aria-labelledby="startModeExistingTab">
-      <h2 data-i18n="adminContent.select.title">3) Open existing module</h2>
-      <div class="small" data-i18n="adminContent.help.selectOverview">Load an existing module, inspect what is live, and decide whether you are preparing a new draft.</div>
-      <div class="row">
-        <div>
-          <label for="selectedModuleId" data-i18n="adminContent.select.moduleId">Module ID</label>
-          <input id="selectedModuleId" />
-        </div>
-        <div>
-          <label for="moduleDropdown" data-i18n="adminContent.select.moduleDropdown">Available modules</label>
-          <select id="moduleDropdown"></select>
-        </div>
-      </div>
-      <div class="action-cluster">
-        <div class="button-row">
-          <button id="loadModules" class="btn-secondary" data-i18n="adminContent.select.loadModules">Refresh module list</button>
-          <button id="loadModuleContent" class="btn-primary" data-i18n="adminContent.select.loadContent">Load draft</button>
-        </div>
-        <div class="button-row">
-          <button id="exportModule" class="btn-secondary" data-i18n="adminContent.select.exportModule">Export selected module</button>
-          <button id="duplicateModule" class="btn-secondary" data-i18n="adminContent.select.duplicateModule">Duplicate module</button>
-          <button id="deleteModule" class="btn-danger" data-i18n="adminContent.select.deleteModule">Delete selected module</button>
-        </div>
-      </div>
-      <div class="small" data-i18n="adminContent.help.loadContent">Loads the saved rubric, prompt, MCQ, and module version into steps 3-7.</div>
-      <div class="small" data-i18n="adminContent.help.deleteModule">Deletes only empty modules without submissions, versions, or published content.</div>
-      <div class="small" id="selectedModuleMeta"></div>
-    </section>
+        <!-- Preview pane -->
+        <section class="card preview-pane" aria-label="Modulforhåndsvisning">
+          <div id="previewLocaleBar" class="preview-locale-bar"></div>
+          <div id="previewContent">
+            <p class="preview-empty">Ingen modul valgt.</p>
+          </div>
+        </section>
 
-    <section class="card" id="archiveLibrarySection">
-      <h2 data-i18n="adminContent.archive.title">Module archive library</h2>
-      <div class="small" data-i18n="adminContent.archive.hint">Archived modules are hidden from the main list. Search here to restore or inspect them.</div>
-      <div class="row" style="margin-top:var(--space-1)">
-        <div>
-          <label for="archiveSearchInput" data-i18n="adminContent.archive.searchLabel">Search by title</label>
-          <input id="archiveSearchInput" data-i18n-placeholder="adminContent.archive.searchPlaceholder" placeholder="Filter archived modules..." />
-        </div>
-        <div style="display:flex;align-items:flex-end">
-          <button id="archiveSearchBtn" class="btn-secondary" data-i18n="adminContent.archive.searchBtn">Search</button>
-        </div>
-      </div>
-      <div id="archiveLibraryList" style="margin-top:var(--space-1)"></div>
-    </section>
-
-    <section class="card">
-      <h2 data-i18n="adminContent.status.title">4) Module status</h2>
-      <div id="moduleStatusCard" class="module-status-card">
-        <div class="module-status-header">
-          <div class="stack">
-            <div id="moduleStatusTitle" class="module-status-title" data-i18n="adminContent.status.noneTitle">No module selected</div>
-            <div id="moduleStatusSummary" class="module-status-summary" data-i18n="adminContent.status.noneSummary">Choose a module to inspect live and draft versions.</div>
-          </div>
-          <div id="moduleStatusBadge" class="module-status-badge shell" data-i18n="adminContent.status.badge.none">No module selected</div>
-        </div>
-        <div id="moduleStatusDescription" class="module-status-description"></div>
-        <div class="module-status-grid">
-          <div class="module-status-line">
-            <div class="module-status-label" data-i18n="adminContent.status.liveChain">Live now</div>
-            <div id="moduleStatusLive" class="module-status-value" data-i18n="adminContent.status.noPublishedVersion">No published version.</div>
-          </div>
-          <div class="module-status-line">
-            <div class="module-status-label" data-i18n="adminContent.status.latestDraft">Latest saved draft</div>
-            <div id="moduleStatusDraft" class="module-status-value" data-i18n="adminContent.status.noDraftVersion">No unpublished draft.</div>
-          </div>
-          <div class="module-status-line">
-            <div class="module-status-label" data-i18n="adminContent.status.publishInfo">Published</div>
-            <div id="moduleStatusPublishedAt" class="module-status-value">-</div>
-          </div>
-          <div class="module-status-line">
-            <div class="module-status-label" data-i18n="adminContent.status.versionCounts">Saved versions</div>
-            <div id="moduleStatusCounts" class="module-status-value">-</div>
-          </div>
-        </div>
-        <button id="unpublishModuleBtn" class="btn-danger" hidden data-i18n="adminContent.status.unpublishBtn">Unpublish module</button>
-        <button id="archiveModuleBtn" class="btn-danger" hidden data-i18n="adminContent.status.archiveBtn">Archive module</button>
-        <details>
-          <summary data-i18n="adminContent.status.technicalDetails">Technical details</summary>
-          <pre id="moduleStatusDetails">-</pre>
-        </details>
-      </div>
-    </section>
-
-    <section class="card" id="contentCardsSection">
-      <h2 data-i18n="adminContent.cards.title">Content overview</h2>
-      <div class="small" id="contentCardsHint" data-i18n="adminContent.cards.noModule">Load a module to edit its content.</div>
-      <div id="contentCardsGrid" class="content-cards-grid" style="margin-top:var(--space-2)">
-
-        <div class="content-card" id="contentCard_moduleDetails">
-          <div class="content-card-header">
-            <div class="content-card-meta">
-              <span class="content-card-label" data-i18n="adminContent.cards.card.moduleDetails">Module details</span>
-              <div class="content-card-badges">
-                <span id="contentCard_moduleDetails_unsaved" class="content-card-unsaved" hidden data-i18n="adminContent.cards.unsaved">Unsaved</span>
-              </div>
-            </div>
-            <button id="editBtn_moduleDetails" class="btn-secondary content-card-edit-btn" data-i18n="adminContent.cards.editBtn">Edit</button>
-          </div>
-          <div id="contentCard_moduleDetails_summary" class="content-card-summary empty"></div>
-        </div>
-
-        <div class="content-card" id="contentCard_versionDetails">
-          <div class="content-card-header">
-            <div class="content-card-meta">
-              <span class="content-card-label" data-i18n="adminContent.cards.card.versionDetails">Version details</span>
-              <div class="content-card-badges">
-                <span id="contentCard_versionDetails_unsaved" class="content-card-unsaved" hidden data-i18n="adminContent.cards.unsaved">Unsaved</span>
-              </div>
-            </div>
-            <button id="editBtn_versionDetails" class="btn-secondary content-card-edit-btn" data-i18n="adminContent.cards.editBtn">Edit</button>
-          </div>
-          <div id="contentCard_versionDetails_summary" class="content-card-summary empty"></div>
-        </div>
-
-        <div class="content-card" id="contentCard_rubric">
-          <div class="content-card-header">
-            <div class="content-card-meta">
-              <span class="content-card-label" data-i18n="adminContent.cards.card.rubric">Submission scoring</span>
-              <div class="content-card-badges">
-                <span id="contentCard_rubric_unsaved" class="content-card-unsaved" hidden data-i18n="adminContent.cards.unsaved">Unsaved</span>
-              </div>
-            </div>
-            <button id="editBtn_rubric" class="btn-secondary content-card-edit-btn" data-i18n="adminContent.cards.editBtn">Edit</button>
-          </div>
-          <div id="contentCard_rubric_summary" class="content-card-summary empty"></div>
-        </div>
-
-        <div class="content-card" id="contentCard_assessmentPolicy">
-          <div class="content-card-header">
-            <div class="content-card-meta">
-              <span class="content-card-label" data-i18n="adminContent.cards.card.assessmentPolicy">Assessment policy</span>
-              <div class="content-card-badges">
-                <span id="contentCard_assessmentPolicy_unsaved" class="content-card-unsaved" hidden data-i18n="adminContent.cards.unsaved">Unsaved</span>
-              </div>
-            </div>
-            <button id="editBtn_assessmentPolicy" class="btn-secondary content-card-edit-btn" data-i18n="adminContent.cards.editBtn">Edit</button>
-          </div>
-          <div id="contentCard_assessmentPolicy_summary" class="content-card-summary empty"></div>
-        </div>
-
-        <div class="content-card" id="contentCard_prompt">
-          <div class="content-card-header">
-            <div class="content-card-meta">
-              <span class="content-card-label" data-i18n="adminContent.cards.card.prompt">LLM prompt</span>
-              <div class="content-card-badges">
-                <span id="contentCard_prompt_unsaved" class="content-card-unsaved" hidden data-i18n="adminContent.cards.unsaved">Unsaved</span>
-              </div>
-            </div>
-            <button class="btn-secondary content-card-edit-btn" id="editBtn_prompt" data-i18n="adminContent.cards.editBtn">Edit</button>
-          </div>
-          <div id="contentCard_prompt_summary" class="content-card-summary empty"></div>
-        </div>
-
-        <div class="content-card" id="contentCard_mcq">
-          <div class="content-card-header">
-            <div class="content-card-meta">
-              <span class="content-card-label" data-i18n="adminContent.cards.card.mcq">Multiple-choice test</span>
-              <div class="content-card-badges">
-                <span id="contentCard_mcq_unsaved" class="content-card-unsaved" hidden data-i18n="adminContent.cards.unsaved">Unsaved</span>
-              </div>
-            </div>
-            <button class="btn-secondary content-card-edit-btn" id="editBtn_mcq" data-i18n="adminContent.cards.editBtn">Edit</button>
-          </div>
-          <div id="contentCard_mcq_summary" class="content-card-summary empty"></div>
-        </div>
-
-        <div class="content-card" id="contentCard_submissionSchema">
-          <div class="content-card-header">
-            <div class="content-card-meta">
-              <span class="content-card-label" data-i18n="adminContent.cards.card.submissionSchema">Submission schema</span>
-              <div class="content-card-badges">
-                <span id="contentCard_submissionSchema_unsaved" class="content-card-unsaved" hidden data-i18n="adminContent.cards.unsaved">Unsaved</span>
-              </div>
-            </div>
-            <button class="btn-secondary content-card-edit-btn" id="editBtn_submissionSchema" data-i18n="adminContent.cards.editBtn">Edit</button>
-          </div>
-          <div id="contentCard_submissionSchema_summary" class="content-card-summary empty"></div>
-        </div>
+        <!-- Chat pane -->
+        <section class="card chat-pane" aria-label="Samtaleassistent">
+          <div id="chatMessages" class="chat-messages" aria-live="polite" aria-atomic="false"></div>
+        </section>
 
       </div>
-      <div class="button-row" id="contentCardsActions" style="display:none;margin-top:var(--space-2)">
-        <button id="saveAllCards" class="btn-primary" data-i18n="adminContent.cards.saveAll">Save all changes</button>
-        <button id="publishFromCards" class="btn-secondary" data-i18n="adminContent.cards.publish" hidden>Publish latest version</button>
-        <button id="previewCardsBtn" class="btn-secondary" data-i18n="adminContent.cards.preview">Preview</button>
-      </div>
-    </section>
-
-    <section class="card" id="sectionRubric">
-      <details class="json-fallback-panel">
-        <summary data-i18n="adminContent.jsonFallback.rubric">5) Rubrikk — rå JSON (avansert)</summary>
-        <div class="small" data-i18n="adminContent.help.rubricOverview">Defines how the participant submission quality is scored.</div>
-        <div><label for="rubricCriteriaJson" data-i18n="adminContent.rubric.criteria">Criteria JSON</label><textarea id="rubricCriteriaJson" rows="5"></textarea></div>
-        <div class="small" data-i18n="adminContent.help.rubricCriteria">Criterion keys should match the current evaluator contract unless code is changed.</div>
-        <div><label for="rubricScalingRuleJson" data-i18n="adminContent.rubric.scalingRule">Score scaling JSON</label><textarea id="rubricScalingRuleJson" rows="3"></textarea></div>
-        <div class="small" data-i18n="adminContent.help.rubricScalingRule">Controls score scaling (for example submission weight and maximum score).</div>
-        <div><label for="rubricPassRuleJson" data-i18n="adminContent.rubric.passRule">Pass/fail threshold JSON</label><textarea id="rubricPassRuleJson" rows="3"></textarea></div>
-        <div class="small" data-i18n="adminContent.help.rubricPassRule">Controls pass/fail thresholds and hard-stop rules.</div>
-      </details>
-    </section>
-
-    <section class="card" id="sectionPrompt">
-      <details class="json-fallback-panel">
-        <summary data-i18n="adminContent.jsonFallback.prompt">6) LLM prompt — raw JSON (advanced)</summary>
-        <div class="small" data-i18n="adminContent.help.promptOverview">Instruction used by the LLM during evaluation.</div>
-        <div><label for="promptSystemPrompt" data-i18n="adminContent.prompt.systemPrompt">System instruction to evaluator</label><textarea id="promptSystemPrompt" rows="3"></textarea></div>
-        <div class="small" data-i18n="adminContent.help.promptSystemPrompt">Global evaluator behavior and output constraints.</div>
-        <div><label for="promptUserPromptTemplate" data-i18n="adminContent.prompt.userPromptTemplate">Evaluation task instruction</label><textarea id="promptUserPromptTemplate" rows="3"></textarea></div>
-        <div class="small" data-i18n="adminContent.help.promptUserTemplate">Task-specific evaluation instruction. This is often called the module evaluation prompt.</div>
-        <div><label for="promptExamplesJson" data-i18n="adminContent.prompt.examplesJson">Optional examples JSON array</label><textarea id="promptExamplesJson" rows="4"></textarea></div>
-        <div class="small" data-i18n="adminContent.help.promptExamples">Optional few-shot examples. Keep these short and stable.</div>
-      </details>
-    </section>
-
-    <section class="card" id="sectionMcq">
-      <details class="json-fallback-panel">
-        <summary data-i18n="adminContent.jsonFallback.mcq">7) Multiple-choice test — raw JSON (advanced)</summary>
-        <div class="small" data-i18n="adminContent.help.mcqOverview">Defines the participant multiple-choice test.</div>
-        <div><label for="mcqSetTitle" data-i18n="adminContent.mcq.setTitle">Test title</label><input id="mcqSetTitle" /></div>
-        <div class="small" data-i18n="adminContent.help.mcqTitle">Shown in admin context and can be localized using locale JSON.</div>
-        <div><label for="mcqQuestionsJson" data-i18n="adminContent.mcq.questionsJson">Questions JSON array</label><textarea id="mcqQuestionsJson" rows="7"></textarea></div>
-        <div class="small" data-i18n="adminContent.help.mcqQuestions">Supports plain strings or locale objects per field: stem/options/correctAnswer/rationale.</div>
-      </details>
-    </section>
-
-    <section class="card" id="sectionModuleVersion">
-      <h2 data-i18n="adminContent.moduleVersion.title">8) Participant-facing module version</h2>
-      <div class="small" data-i18n="adminContent.help.moduleVersionOverview">Binds assignment text + scoring rules + evaluation instruction + test.</div>
-      <details class="json-fallback-panel">
-        <summary data-i18n="adminContent.jsonFallback.versionDetails">Oppgavetekst, veiledning og vurderingspolicy — rå JSON (avansert)</summary>
-        <div><label for="moduleVersionTaskText" data-i18n="adminContent.moduleVersion.taskText">Assignment shown to participant (submission task)</label><textarea id="moduleVersionTaskText" rows="3"></textarea></div>
-        <div class="small" data-i18n="adminContent.help.moduleTaskText">This is the assignment shown to participants before they submit.</div>
-        <div><label for="moduleVersionGuidanceText" data-i18n="adminContent.moduleVersion.guidanceText">What we expect in the submission</label><textarea id="moduleVersionGuidanceText" rows="2"></textarea></div>
-        <div class="small" data-i18n="adminContent.help.moduleGuidanceText">Describe what a good submission should contain. This is also sent to LLM as evaluation context.</div>
-        <div><label for="moduleVersionAssessmentPolicy" data-i18n="adminContent.moduleVersion.assessmentPolicyJson">Assessment policy (JSON, optional)</label><textarea id="moduleVersionAssessmentPolicy" rows="4"></textarea></div>
-        <div class="small" data-i18n="adminContent.help.assessmentPolicyJson">Override scoring weights and pass threshold for this module version. Example: <code>{"scoring":{"practicalWeight":60,"mcqWeight":40},"passRules":{"totalMin":65}}</code></div>
-      </details>
-      <details class="json-fallback-panel">
-        <summary data-i18n="adminContent.jsonFallback.submissionSchema">Submission form schema — raw JSON (advanced)</summary>
-        <div><label for="moduleVersionSubmissionSchema" data-i18n="adminContent.moduleVersion.submissionSchemaJson">Submission form schema (JSON, optional)</label><textarea id="moduleVersionSubmissionSchema" rows="4"></textarea></div>
-        <div class="small" data-i18n="adminContent.help.submissionSchemaJson">Defines the fields shown to participants. If empty, default 3-field form is used. Example: <code>{"fields":[{"id":"response","label":"Your answer","type":"textarea","required":true}]}</code></div>
-      </details>
-      <div class="row">
-        <div><label for="moduleVersionRubricVersionId" data-i18n="adminContent.moduleVersion.rubricVersionId">Scoring rules version ID</label><input id="moduleVersionRubricVersionId" /></div>
-        <div><label for="moduleVersionPromptTemplateVersionId" data-i18n="adminContent.moduleVersion.promptTemplateVersionId">Evaluation instruction version ID</label><input id="moduleVersionPromptTemplateVersionId" /></div>
-      </div>
-      <div class="small" data-i18n="adminContent.help.moduleVersionIds">IDs are auto-filled when you save steps 5-8.</div>
-      <div><label for="moduleVersionMcqSetVersionId" data-i18n="adminContent.moduleVersion.mcqSetVersionId">Test version ID</label><input id="moduleVersionMcqSetVersionId" /></div>
-      <div class="button-row">
-        <button id="saveContentBundle" class="btn-primary" data-i18n="adminContent.moduleVersion.saveBundle">Save new draft version (steps 5-8)</button>
-        <button id="previewCurrentDraft" class="btn-secondary" data-i18n="adminContent.moduleVersion.previewDraft">Open participant preview</button>
-      </div>
-      <div class="small" data-i18n="adminContent.help.previewDraft">Opens the current draft in participant preview mode in a new tab. Nothing is saved, submitted, or scored.</div>
-    </section>
-
-    <section class="card">
-      <h2 data-i18n="adminContent.publish.title">9) Publish module version</h2>
-      <div class="small" data-i18n="adminContent.help.publishOverview">Publishing makes this version active for participant submissions.</div>
-      <div><label for="publishModuleVersionId" data-i18n="adminContent.publish.moduleVersionId">Module version ID to publish</label><input id="publishModuleVersionId" /></div>
-      <button id="publishModuleVersion" class="btn-primary" data-i18n="adminContent.publish.publish">Publish version</button>
-    </section>
-
-    </div><!-- /modulesTab -->
-
-    <div id="coursesTab" hidden>
-      <section class="card">
-        <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:var(--space-1);flex-wrap:wrap">
-          <div>
-            <h2 data-i18n="adminContent.courses.title">Kurs</h2>
-            <p class="small" data-i18n="adminContent.courses.hint">Organiser moduler i kurs for å utstede kurssertifikat.</p>
-          </div>
-          <button id="createCourseBtn" class="btn-primary" style="width:auto;flex-shrink:0" data-i18n="adminContent.courses.createBtn">Opprett kurs</button>
-        </div>
-        <div id="courseList" class="course-list" style="margin-top:var(--space-2)"></div>
-      </section>
-    </div>
-
-    <div id="calibrationTab" hidden>
-      <section class="card">
-        <h2 data-i18n="calibration.filters.title">Calibration filters</h2>
-        <div class="row">
-          <div>
-            <label for="calibrationModuleId" data-i18n="calibration.filters.moduleId">Module ID</label>
-            <select id="calibrationModuleId"></select>
-          </div>
-          <div>
-            <label for="calibrationModuleVersionId" data-i18n="calibration.filters.moduleVersionId">Module version ID</label>
-            <input id="calibrationModuleVersionId" data-i18n-placeholder="calibration.filters.moduleVersionPlaceholder" placeholder="Optional module version ID" />
-          </div>
-        </div>
-        <div class="row">
-          <div>
-            <fieldset class="pill-group-fieldset">
-              <legend id="calibrationStatusesLegend" data-i18n="calibration.filters.statuses">Submission statuses</legend>
-              <div id="calibrationStatuses" class="pill-group" role="group" aria-labelledby="calibrationStatusesLegend"></div>
-            </fieldset>
-          </div>
-          <div>
-            <label for="calibrationLimit" data-i18n="calibration.filters.limit">Max outcomes</label>
-            <input id="calibrationLimit" type="number" min="1" max="500" />
-          </div>
-        </div>
-        <div class="row">
-          <div>
-            <label for="calibrationDateFrom" data-i18n="calibration.filters.dateFrom">Date from</label>
-            <input id="calibrationDateFrom" type="date" />
-          </div>
-          <div>
-            <label for="calibrationDateTo" data-i18n="calibration.filters.dateTo">Date to</label>
-            <input id="calibrationDateTo" type="date" />
-          </div>
-        </div>
-        <div class="row" style="margin-top: calc(var(--space-1) * 1.25);">
-          <div><button id="loadCalibration" class="btn-secondary" data-i18n="calibration.filters.load">Load calibration snapshot</button></div>
-          <div class="small" id="calibrationMeta"></div>
-        </div>
-      </section>
-
-      <section class="card">
-        <h2 data-i18n="calibration.signals.title">Quality signals</h2>
-        <pre id="calibrationSignals"></pre>
-      </section>
-
-      <section id="thresholdEditorSection" class="card" style="display:none">
-        <h2 data-i18n="calibration.thresholds.title">Calibration thresholds</h2>
-        <p class="small" data-i18n="calibration.thresholds.subtitle">Effective thresholds for this module. These control how scores are routed to pass, manual review (yellow), or fail.</p>
-
-        <h3 data-i18n="calibration.thresholds.section.total">Total</h3>
-        <div class="row">
-          <div>
-            <label for="thresholdTotalMin" data-i18n="calibration.thresholds.totalMin">Pass score (min out of 100)</label>
-            <input id="thresholdTotalMin" type="number" min="0" max="100" step="1" />
-            <div class="small" data-i18n="calibration.thresholds.totalMinHelp">Minimum total score to pass.</div>
-          </div>
-        </div>
-
-        <h3 data-i18n="calibration.thresholds.section.manualReview">Manual review zone</h3>
-        <div class="row">
-          <div>
-            <label for="thresholdBorderlineMin" data-i18n="calibration.thresholds.borderlineMin">Yellow zone start</label>
-            <input id="thresholdBorderlineMin" type="number" min="0" max="100" step="1" />
-            <div class="small" data-i18n="calibration.thresholds.borderlineMinHelp">Scores at or above this value enter the yellow/manual-review zone.</div>
-          </div>
-          <div>
-            <label for="thresholdBorderlineMax" data-i18n="calibration.thresholds.borderlineMax">Yellow zone end</label>
-            <input id="thresholdBorderlineMax" type="number" min="0" max="100" step="1" />
-            <div class="small" data-i18n="calibration.thresholds.borderlineMaxHelp">Scores at or below this value stay in the yellow zone.</div>
-          </div>
-        </div>
-
-        <h3 data-i18n="calibration.thresholds.section.practical">Practical submission</h3>
-        <div class="row">
-          <div>
-            <label for="thresholdPracticalMinPercent" data-i18n="calibration.thresholds.practicalMinPercent">Submission min %</label>
-            <input id="thresholdPracticalMinPercent" type="number" min="0" max="100" step="1" />
-            <div class="small" data-i18n="calibration.thresholds.practicalMinPercentHelp">Minimum percentage of the submission maximum that the practical component must reach.</div>
-          </div>
-        </div>
-
-        <h3 data-i18n="calibration.thresholds.section.mcq">Multiple choice questions</h3>
-        <div class="row">
-          <div>
-            <label for="thresholdMcqMinPercent" data-i18n="calibration.thresholds.mcqMinPercent">MCQ min % correct</label>
-            <input id="thresholdMcqMinPercent" type="number" min="0" max="100" step="1" />
-            <div class="small" data-i18n="calibration.thresholds.mcqMinPercentHelp">Minimum percentage correct on the multiple choice questions.</div>
-          </div>
-        </div>
-
-        <div id="thresholdBandPreview" class="small" style="margin-top: var(--space-1)"></div>
-        <div id="thresholdValidationError" class="small" style="color:var(--color-error,red)"></div>
-
-        <div class="row" style="margin-top: calc(var(--space-1) * 1.25);">
-          <div>
-            <button id="publishThresholds" class="btn-secondary" data-i18n="calibration.thresholds.publish" disabled>Publish thresholds</button>
-          </div>
-        </div>
-
-        <div id="thresholdPublishResult" class="small"></div>
-      </section>
-
-      <section class="card">
-        <h2 data-i18n="calibration.outcomes.title">Historical outcomes</h2>
-        <div class="table-wrap" tabindex="0" role="region" aria-label="Historical outcomes">
-          <table>
-            <thead>
-              <tr>
-                <th scope="col" data-i18n="calibration.outcomes.submissionId">Submission</th>
-                <th scope="col" data-i18n="calibration.outcomes.submittedAt">Submitted</th>
-                <th scope="col" data-i18n="calibration.outcomes.status">Status</th>
-                <th scope="col" data-i18n="calibration.outcomes.moduleVersion">Module version</th>
-                <th scope="col" data-i18n="calibration.outcomes.totalScore">Total score</th>
-                <th scope="col" data-i18n="calibration.outcomes.passFail">Pass/fail</th>
-                <th scope="col" data-i18n="calibration.outcomes.manualReview">Manual review signal</th>
-              </tr>
-            </thead>
-            <tbody id="calibrationOutcomesBody"></tbody>
-          </table>
-        </div>
-      </section>
-
-      <section class="card">
-        <h2 data-i18n="calibration.anchors.title">Benchmark anchors</h2>
-        <div class="table-wrap" tabindex="0" role="region" aria-label="Benchmark anchors">
-          <table>
-            <thead>
-              <tr>
-                <th scope="col" data-i18n="calibration.anchors.promptVersion">Prompt version</th>
-                <th scope="col" data-i18n="calibration.anchors.benchmarkCount">Benchmark examples</th>
-                <th scope="col" data-i18n="calibration.anchors.sourcePromptVersion">Source prompt version</th>
-                <th scope="col" data-i18n="calibration.anchors.sourceModuleVersion">Source module version</th>
-                <th scope="col" data-i18n="calibration.anchors.createdAt">Created</th>
-              </tr>
-            </thead>
-            <tbody id="calibrationAnchorsBody"></tbody>
-          </table>
-        </div>
-      </section>
-    </div>
-
-    <section class="card">
-      <h2 data-i18n="output.title">System response</h2>
-
-      <div class="small" id="outputStatus" aria-live="polite" aria-atomic="true"></div>
-      <details id="outputDetails">
-        <summary>View raw response</summary>
-        <pre id="output" class="pre-content"></pre>
-      </details>
-    </section>
-
     </main>
-
-    <dialog id="dialogCourse" aria-labelledby="dialogCourseTitle" class="field-dialog">
-      <div class="field-dialog-header">
-        <h2 id="dialogCourseTitle" class="field-dialog-title" data-i18n="adminContent.courses.dialog.createTitle">Opprett kurs</h2>
-      </div>
-      <div class="dialog-locale-tabs" role="tablist">
-        <button type="button" role="tab" aria-selected="true" class="dialog-locale-tab active" data-locale-tab="en-GB">EN-GB</button>
-        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nb">NB</button>
-        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nn">NN</button>
-      </div>
-      <div class="dialog-locale-pane active" data-locale-pane="en-GB">
-        <div><label for="dlgCourse_title_enGB" data-i18n="adminContent.courses.dialog.titleField">Title</label><input id="dlgCourse_title_enGB" autocomplete="off" /></div>
-        <div><label for="dlgCourse_desc_enGB" data-i18n="adminContent.courses.dialog.descField">Description</label><textarea id="dlgCourse_desc_enGB" rows="2"></textarea></div>
-      </div>
-      <div class="dialog-locale-pane" data-locale-pane="nb">
-        <div><label for="dlgCourse_title_nb" data-i18n="adminContent.courses.dialog.titleField">Title</label><input id="dlgCourse_title_nb" autocomplete="off" /></div>
-        <div><label for="dlgCourse_desc_nb" data-i18n="adminContent.courses.dialog.descField">Description</label><textarea id="dlgCourse_desc_nb" rows="2"></textarea></div>
-      </div>
-      <div class="dialog-locale-pane" data-locale-pane="nn">
-        <div><label for="dlgCourse_title_nn" data-i18n="adminContent.courses.dialog.titleField">Title</label><input id="dlgCourse_title_nn" autocomplete="off" /></div>
-        <div><label for="dlgCourse_desc_nn" data-i18n="adminContent.courses.dialog.descField">Description</label><textarea id="dlgCourse_desc_nn" rows="2"></textarea></div>
-      </div>
-      <div style="margin-top:var(--space-1)">
-        <label for="dlgCourse_certLevel" data-i18n="adminContent.courses.dialog.certLevel">Certification level</label>
-        <input id="dlgCourse_certLevel" autocomplete="off" />
-        <div class="small" data-i18n="adminContent.courses.dialog.certLevelHint">Plain text, e.g. foundation.</div>
-      </div>
-      <div class="dialog-section-label" data-i18n="adminContent.courses.dialog.modulesSection">Modules</div>
-      <div id="dlgCourse_moduleList"></div>
-      <div style="display:flex;gap:var(--space-1);align-items:flex-end;margin-top:var(--space-1)">
-        <div style="flex:1">
-          <label for="dlgCourse_moduleDropdown" data-i18n="adminContent.courses.dialog.addModule">Add module</label>
-          <select id="dlgCourse_moduleDropdown"></select>
-        </div>
-        <button type="button" id="dlgCourse_addModuleBtn" class="btn-secondary" style="width:auto" data-i18n="adminContent.courses.dialog.addModuleBtn">Legg til</button>
-      </div>
-      <div class="dialog-footer">
-        <button type="button" id="dialogCourseCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Avbryt</button>
-        <button type="button" id="dialogCourseSave" class="btn-primary" data-i18n="adminContent.courses.dialog.save">Lagre</button>
-      </div>
-    </dialog>
-
-    <dialog id="dialogModuleDetails" aria-labelledby="dialogModuleDetailsTitle" class="field-dialog">
-      <div class="field-dialog-header">
-        <h2 id="dialogModuleDetailsTitle" class="field-dialog-title" data-i18n="adminContent.dialog.moduleDetails.title">Edit module details</h2>
-        
-      </div>
-      <div class="dialog-locale-tabs" role="tablist">
-        <button type="button" role="tab" aria-selected="true" class="dialog-locale-tab active" data-locale-tab="en-GB" aria-controls="dlgMDPane_enGB">EN-GB</button>
-        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nb" aria-controls="dlgMDPane_nb">NB</button>
-        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nn" aria-controls="dlgMDPane_nn">NN</button>
-      </div>
-      <div id="dlgMDPane_enGB" class="dialog-locale-pane active" role="tabpanel" data-locale-pane="en-GB">
-        <div><label for="dlgMD_title_enGB" data-i18n="adminContent.dialog.moduleDetails.titleField">Title</label><input id="dlgMD_title_enGB" autocomplete="off" /></div>
-        <div><label for="dlgMD_desc_enGB" data-i18n="adminContent.dialog.moduleDetails.descriptionField">Description</label><textarea id="dlgMD_desc_enGB" rows="2"></textarea></div>
-        <div><label for="dlgMD_cert_enGB" data-i18n="adminContent.dialog.moduleDetails.certLevel">Certification level</label><input id="dlgMD_cert_enGB" autocomplete="off" /></div>
-      </div>
-      <div id="dlgMDPane_nb" class="dialog-locale-pane" role="tabpanel" data-locale-pane="nb">
-        <div><label for="dlgMD_title_nb" data-i18n="adminContent.dialog.moduleDetails.titleField">Title</label><input id="dlgMD_title_nb" autocomplete="off" /></div>
-        <div><label for="dlgMD_desc_nb" data-i18n="adminContent.dialog.moduleDetails.descriptionField">Description</label><textarea id="dlgMD_desc_nb" rows="2"></textarea></div>
-        <div><label for="dlgMD_cert_nb" data-i18n="adminContent.dialog.moduleDetails.certLevel">Certification level</label><input id="dlgMD_cert_nb" autocomplete="off" /></div>
-      </div>
-      <div id="dlgMDPane_nn" class="dialog-locale-pane" role="tabpanel" data-locale-pane="nn">
-        <div><label for="dlgMD_title_nn" data-i18n="adminContent.dialog.moduleDetails.titleField">Title</label><input id="dlgMD_title_nn" autocomplete="off" /></div>
-        <div><label for="dlgMD_desc_nn" data-i18n="adminContent.dialog.moduleDetails.descriptionField">Description</label><textarea id="dlgMD_desc_nn" rows="2"></textarea></div>
-        <div><label for="dlgMD_cert_nn" data-i18n="adminContent.dialog.moduleDetails.certLevel">Certification level</label><input id="dlgMD_cert_nn" autocomplete="off" /></div>
-      </div>
-      <div class="row" style="margin-top:var(--space-1)">
-        <div><label for="dlgMD_validFrom" data-i18n="adminContent.dialog.moduleDetails.validFrom">Available from</label><input id="dlgMD_validFrom" type="date" /></div>
-        <div><label for="dlgMD_validTo" data-i18n="adminContent.dialog.moduleDetails.validTo">Available until</label><input id="dlgMD_validTo" type="date" /></div>
-      </div>
-      <div class="dialog-footer">
-        <button type="button" id="dialogModuleDetailsCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Cancel</button>
-        <button type="button" id="dialogModuleDetailsApply" class="btn-primary" data-i18n="adminContent.dialog.apply">Update draft</button>
-      </div>
-    </dialog>
-
-    <dialog id="dialogVersionDetails" aria-labelledby="dialogVersionDetailsTitle" class="field-dialog">
-      <div class="field-dialog-header">
-        <h2 id="dialogVersionDetailsTitle" class="field-dialog-title" data-i18n="adminContent.dialog.versionDetails.title">Edit version details</h2>
-        
-      </div>
-      <div class="dialog-locale-tabs" role="tablist">
-        <button type="button" role="tab" aria-selected="true" class="dialog-locale-tab active" data-locale-tab="en-GB" aria-controls="dlgVDPane_enGB">EN-GB</button>
-        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nb" aria-controls="dlgVDPane_nb">NB</button>
-        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nn" aria-controls="dlgVDPane_nn">NN</button>
-      </div>
-      <div id="dlgVDPane_enGB" class="dialog-locale-pane active" role="tabpanel" data-locale-pane="en-GB">
-        <div><label for="dlgVD_task_enGB" data-i18n="adminContent.dialog.versionDetails.taskText">Assignment text</label><textarea id="dlgVD_task_enGB" rows="4"></textarea></div>
-        <div><label for="dlgVD_guidance_enGB" data-i18n="adminContent.dialog.versionDetails.guidanceText">Guidance text</label><textarea id="dlgVD_guidance_enGB" rows="4"></textarea></div>
-      </div>
-      <div id="dlgVDPane_nb" class="dialog-locale-pane" role="tabpanel" data-locale-pane="nb">
-        <div><label for="dlgVD_task_nb" data-i18n="adminContent.dialog.versionDetails.taskText">Assignment text</label><textarea id="dlgVD_task_nb" rows="4"></textarea></div>
-        <div><label for="dlgVD_guidance_nb" data-i18n="adminContent.dialog.versionDetails.guidanceText">Guidance text</label><textarea id="dlgVD_guidance_nb" rows="4"></textarea></div>
-      </div>
-      <div id="dlgVDPane_nn" class="dialog-locale-pane" role="tabpanel" data-locale-pane="nn">
-        <div><label for="dlgVD_task_nn" data-i18n="adminContent.dialog.versionDetails.taskText">Assignment text</label><textarea id="dlgVD_task_nn" rows="4"></textarea></div>
-        <div><label for="dlgVD_guidance_nn" data-i18n="adminContent.dialog.versionDetails.guidanceText">Guidance text</label><textarea id="dlgVD_guidance_nn" rows="4"></textarea></div>
-      </div>
-      <div class="dialog-footer">
-        <button type="button" id="dialogVersionDetailsCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Cancel</button>
-        <button type="button" id="dialogVersionDetailsApply" class="btn-primary" data-i18n="adminContent.dialog.apply">Update draft</button>
-      </div>
-    </dialog>
-
-    <dialog id="dialogAssessmentPolicy" aria-labelledby="dialogAssessmentPolicyTitle" class="field-dialog">
-      <div class="field-dialog-header">
-        <h2 id="dialogAssessmentPolicyTitle" class="field-dialog-title" data-i18n="adminContent.dialog.assessmentPolicy.title">Edit assessment policy</h2>
-        
-      </div>
-
-      <div class="dialog-section-label" data-i18n="adminContent.dialog.assessmentPolicy.sectionScoring">Scoring weights</div>
-      <div class="row">
-        <div>
-          <label for="dlgAP_practicalWeight" data-i18n="adminContent.dialog.assessmentPolicy.practicalWeight">Practical weight (0–100)</label>
-          <input id="dlgAP_practicalWeight" type="number" min="0" max="100" step="1" autocomplete="off" />
-        </div>
-        <div>
-          <label for="dlgAP_mcqWeight" data-i18n="adminContent.dialog.assessmentPolicy.mcqWeight">MCQ weight (0–100)</label>
-          <input id="dlgAP_mcqWeight" type="number" min="0" max="100" step="1" autocomplete="off" />
-        </div>
-      </div>
-
-      <div class="dialog-section-label" data-i18n="adminContent.dialog.assessmentPolicy.sectionPassRules">Pass rules</div>
-      <div class="row">
-        <div>
-          <label for="dlgAP_totalMin" data-i18n="adminContent.dialog.assessmentPolicy.totalMin">Total min score (0–100)</label>
-          <input id="dlgAP_totalMin" type="number" min="0" max="100" step="1" autocomplete="off" />
-        </div>
-        <div>
-          <label for="dlgAP_practicalMin" data-i18n="adminContent.dialog.assessmentPolicy.practicalMin">Practical min % (opt.)</label>
-          <input id="dlgAP_practicalMin" type="number" min="0" max="100" step="1" autocomplete="off" />
-        </div>
-      </div>
-      <div class="row">
-        <div>
-          <label for="dlgAP_mcqMin" data-i18n="adminContent.dialog.assessmentPolicy.mcqMin">MCQ min % (opt.)</label>
-          <input id="dlgAP_mcqMin" type="number" min="0" max="100" step="1" autocomplete="off" />
-        </div>
-        <div></div>
-      </div>
-
-      <div class="dialog-section-label" data-i18n="adminContent.dialog.assessmentPolicy.sectionBorderline">Borderline window (opt.)</div>
-      <div class="row">
-        <div>
-          <label for="dlgAP_borderlineMin" data-i18n="adminContent.dialog.assessmentPolicy.borderlineMin">From score</label>
-          <input id="dlgAP_borderlineMin" type="number" min="0" max="100" step="1" autocomplete="off" />
-        </div>
-        <div>
-          <label for="dlgAP_borderlineMax" data-i18n="adminContent.dialog.assessmentPolicy.borderlineMax">To score</label>
-          <input id="dlgAP_borderlineMax" type="number" min="0" max="100" step="1" autocomplete="off" />
-        </div>
-      </div>
-
-      <div class="dialog-footer">
-        <button type="button" id="dialogAssessmentPolicyCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Cancel</button>
-        <button type="button" id="dialogAssessmentPolicyApply" class="btn-primary" data-i18n="adminContent.dialog.apply">Update draft</button>
-      </div>
-    </dialog>
-
-    <dialog id="dialogRubric" aria-labelledby="dialogRubricTitle" class="field-dialog">
-      <div class="field-dialog-header">
-        <h2 id="dialogRubricTitle" class="field-dialog-title" data-i18n="adminContent.dialog.rubric.title">Edit rubric</h2>
-        
-      </div>
-
-      <div class="dialog-section-label" data-i18n="adminContent.dialog.rubric.sectionCriteria">Criteria</div>
-      <div id="dlgRubric_criteriaList"></div>
-      <button type="button" id="dlgRubric_addCriterion" class="btn-secondary" style="margin-bottom:var(--space-1);width:auto">+ <span data-i18n="adminContent.dialog.rubric.addCriterion">Add criterion</span></button>
-
-      <div class="dialog-section-label" data-i18n="adminContent.dialog.rubric.sectionPassRule">Pass rule</div>
-      <div class="row">
-        <div>
-          <label for="dlgRubric_minScore" data-i18n="adminContent.dialog.rubric.minScore">Minimum score (0–100)</label>
-          <input id="dlgRubric_minScore" type="number" min="0" max="100" step="1" autocomplete="off" />
-        </div>
-        <div>
-          <label for="dlgRubric_criteriaMin" data-i18n="adminContent.dialog.rubric.criteriaMin">All criteria above (opt.)</label>
-          <input id="dlgRubric_criteriaMin" type="number" min="0" max="100" step="1" autocomplete="off" />
-        </div>
-      </div>
-
-      <div class="dialog-section-label" data-i18n="adminContent.dialog.rubric.sectionScalingRule">Scaling rule</div>
-      <div class="row">
-        <div>
-          <label for="dlgRubric_scalingType" data-i18n="adminContent.dialog.rubric.scalingType">Type</label>
-          <input id="dlgRubric_scalingType" autocomplete="off" />
-        </div>
-        <div>
-          <label for="dlgRubric_maxScore" data-i18n="adminContent.dialog.rubric.maxScore">Max score</label>
-          <input id="dlgRubric_maxScore" type="number" min="1" step="1" autocomplete="off" />
-        </div>
-      </div>
-
-      <div class="dialog-footer">
-        <button type="button" id="dialogRubricCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Cancel</button>
-        <button type="button" id="dialogRubricApply" class="btn-primary" data-i18n="adminContent.dialog.apply">Update draft</button>
-      </div>
-    </dialog>
-
-    <dialog id="dialogPrompt" aria-labelledby="dialogPromptTitle" class="field-dialog">
-      <div class="field-dialog-header">
-        <h2 id="dialogPromptTitle" class="field-dialog-title" data-i18n="adminContent.dialog.prompt.title">Edit LLM prompt</h2>
-        
-      </div>
-      <div class="dialog-locale-tabs" role="tablist">
-        <button type="button" role="tab" aria-selected="true" class="dialog-locale-tab active" data-locale-tab="en-GB" aria-controls="dlgPRPane_enGB">EN-GB</button>
-        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nb" aria-controls="dlgPRPane_nb">NB</button>
-        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nn" aria-controls="dlgPRPane_nn">NN</button>
-      </div>
-      <div id="dlgPRPane_enGB" class="dialog-locale-pane active" role="tabpanel" data-locale-pane="en-GB">
-        <div><label for="dlgPR_sys_enGB" data-i18n="adminContent.dialog.prompt.systemPrompt">System prompt</label><textarea id="dlgPR_sys_enGB" rows="5"></textarea></div>
-        <div><label for="dlgPR_user_enGB" data-i18n="adminContent.dialog.prompt.userPromptTemplate">User prompt template</label><textarea id="dlgPR_user_enGB" rows="5"></textarea></div>
-      </div>
-      <div id="dlgPRPane_nb" class="dialog-locale-pane" role="tabpanel" data-locale-pane="nb">
-        <div><label for="dlgPR_sys_nb" data-i18n="adminContent.dialog.prompt.systemPrompt">System prompt</label><textarea id="dlgPR_sys_nb" rows="5"></textarea></div>
-        <div><label for="dlgPR_user_nb" data-i18n="adminContent.dialog.prompt.userPromptTemplate">User prompt template</label><textarea id="dlgPR_user_nb" rows="5"></textarea></div>
-      </div>
-      <div id="dlgPRPane_nn" class="dialog-locale-pane" role="tabpanel" data-locale-pane="nn">
-        <div><label for="dlgPR_sys_nn" data-i18n="adminContent.dialog.prompt.systemPrompt">System prompt</label><textarea id="dlgPR_sys_nn" rows="5"></textarea></div>
-        <div><label for="dlgPR_user_nn" data-i18n="adminContent.dialog.prompt.userPromptTemplate">User prompt template</label><textarea id="dlgPR_user_nn" rows="5"></textarea></div>
-      </div>
-      <div class="dialog-section-label" data-i18n="adminContent.dialog.prompt.sectionExamples">Examples (optional)</div>
-      <div id="dlgPR_examplesList"></div>
-      <button type="button" id="dlgPR_addExample" class="btn-secondary" style="margin-bottom:var(--space-1);width:auto">+ <span data-i18n="adminContent.dialog.prompt.addExample">Add example</span></button>
-      <div class="dialog-footer">
-        <button type="button" id="dialogPromptCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Cancel</button>
-        <button type="button" id="dialogPromptApply" class="btn-primary" data-i18n="adminContent.dialog.apply">Update draft</button>
-      </div>
-    </dialog>
-
-    <dialog id="dialogMcq" aria-labelledby="dialogMcqTitle" class="field-dialog">
-      <div class="field-dialog-header">
-        <h2 id="dialogMcqTitle" class="field-dialog-title" data-i18n="adminContent.dialog.mcq.title">Edit multiple-choice test</h2>
-        
-      </div>
-      <div>
-        <label for="dlgMCQ_setTitle" data-i18n="adminContent.dialog.mcq.setTitle">Test title</label>
-        <input id="dlgMCQ_setTitle" autocomplete="off" />
-      </div>
-      <div class="dialog-locale-tabs" role="tablist" style="margin-top:var(--space-1)">
-        <button type="button" role="tab" aria-selected="true" class="dialog-locale-tab active" data-locale-tab="en-GB">EN-GB</button>
-        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nb">NB</button>
-        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nn">NN</button>
-      </div>
-      <div class="dialog-section-label" data-i18n="adminContent.dialog.mcq.sectionQuestions">Questions</div>
-      <div id="dlgMCQ_questionsList"></div>
-      <button type="button" id="dlgMCQ_addQuestion" class="btn-secondary" style="margin-bottom:var(--space-1);width:auto">+ <span data-i18n="adminContent.dialog.mcq.addQuestion">Add question</span></button>
-      <div class="dialog-footer">
-        <button type="button" id="dialogMcqCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Cancel</button>
-        <button type="button" id="dialogMcqApply" class="btn-primary" data-i18n="adminContent.dialog.apply">Update draft</button>
-      </div>
-    </dialog>
-
-    <dialog id="dialogSubmissionSchema" aria-labelledby="dialogSubmissionSchemaTitle" class="field-dialog">
-      <div class="field-dialog-header">
-        <h2 id="dialogSubmissionSchemaTitle" class="field-dialog-title" data-i18n="adminContent.dialog.submissionSchema.title">Edit submission form</h2>
-        
-      </div>
-      <div class="dialog-locale-tabs" role="tablist">
-        <button type="button" role="tab" aria-selected="true" class="dialog-locale-tab active" data-locale-tab="en-GB">EN-GB</button>
-        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nb">NB</button>
-        <button type="button" role="tab" aria-selected="false" class="dialog-locale-tab" data-locale-tab="nn">NN</button>
-      </div>
-      <div class="dialog-section-label" data-i18n="adminContent.dialog.submissionSchema.sectionFields">Fields</div>
-      <div id="dlgSS_fieldsList"></div>
-      <button type="button" id="dlgSS_addField" class="btn-secondary" style="margin-bottom:var(--space-1);width:auto">+ <span data-i18n="adminContent.dialog.submissionSchema.addField">Add field</span></button>
-      <div class="dialog-footer">
-        <button type="button" id="dialogSubmissionSchemaCancel" class="btn-secondary" data-i18n="adminContent.dialog.cancel">Cancel</button>
-        <button type="button" id="dialogSubmissionSchemaApply" class="btn-primary" data-i18n="adminContent.dialog.apply">Update draft</button>
-      </div>
-    </dialog>
-
-    <dialog id="authoringPromptDialog" aria-labelledby="authoringPromptDialogTitle">
-      <form method="dialog">
-        <h2 id="authoringPromptDialogTitle" data-i18n="adminContent.promptDialog.title">Authoring prompt options</h2>
-        <div>
-          <label for="promptCertificationLevel" data-i18n="adminContent.promptDialog.certificationLevel">Certification level</label>
-          <select id="promptCertificationLevel">
-            <option value="" data-i18n="adminContent.promptDialog.certificationLevelBlank">— not specified —</option>
-            <option value="basic" data-i18n="adminContent.promptDialog.certificationLevelBasic">Basic</option>
-            <option value="intermediate" data-i18n="adminContent.promptDialog.certificationLevelIntermediate">Intermediate</option>
-            <option value="advanced" data-i18n="adminContent.promptDialog.certificationLevelAdvanced">Advanced</option>
-          </select>
-        </div>
-        <div>
-          <label for="promptMcqCount" data-i18n="adminContent.promptDialog.mcqCount">Number of MCQ questions</label>
-          <input id="promptMcqCount" type="number" value="10" min="1" max="50" autocomplete="off" />
-        </div>
-        <fieldset class="pill-group-fieldset" style="margin-top: var(--space-1);">
-          <legend data-i18n="adminContent.promptDialog.fieldLabel">Submission fields to include</legend>
-          <label class="checkbox-label"><input type="checkbox" id="promptFieldResponse" checked /> <span data-i18n="adminContent.promptDialog.fieldResponse">Response</span></label>
-          <label class="checkbox-label"><input type="checkbox" id="promptFieldReflection" checked /> <span data-i18n="adminContent.promptDialog.fieldReflection">Reflection</span></label>
-          <label class="checkbox-label"><input type="checkbox" id="promptFieldPromptExcerpt" checked /> <span data-i18n="adminContent.promptDialog.fieldPromptExcerpt">Prompt excerpt</span></label>
-        </fieldset>
-        <div style="margin-top: var(--space-1);">
-          <label for="promptCustomFields" data-i18n="adminContent.promptDialog.customFields">Custom fields JSON (overrides checkboxes)</label>
-          <textarea id="promptCustomFields" rows="5" data-i18n-placeholder="adminContent.promptDialog.customFieldsPlaceholder" placeholder="[{&quot;id&quot;:&quot;response&quot;,&quot;type&quot;:&quot;textarea&quot;,&quot;required&quot;:true}]"></textarea>
-          <div class="small" data-i18n="adminContent.promptDialog.customFieldsHint">Leave empty to use the checkboxes above.</div>
-        </div>
-        <div class="row" style="margin-top: var(--space-2);">
-          <div><button type="submit" id="promptDialogCopy" class="btn-primary" data-i18n="adminContent.promptDialog.copy">Copy</button></div>
-          <div><button type="button" id="promptDialogCancel" class="btn-secondary" data-i18n="adminContent.promptDialog.cancel">Cancel</button></div>
-        </div>
-      </form>
-    </dialog>
-
-    <script src="/static/i18n/admin-content-translations.js" type="module"></script>
-    <script src="/static/admin-content.js" type="module"></script>
+    <script type="module" src="/static/admin-content-shell.js"></script>
   </body>
 </html>

--- a/public/admin-content.js
+++ b/public/admin-content.js
@@ -3671,7 +3671,21 @@ setLocale(currentLocale);
 activateModuleStartMode(activeModuleStartMode);
 setDefaultFormValues();
 loadVersion();
-loadParticipantConsoleConfig();
+loadParticipantConsoleConfig().then(async () => {
+  const autoModuleId = new URLSearchParams(location.search).get("moduleId");
+  if (autoModuleId) {
+    try {
+      activateModuleStartMode("existing");
+      await loadModules();
+      if (modules.some((m) => m.id === autoModuleId)) {
+        setSelectedModule(autoModuleId);
+        await handleLoadSelectedModuleContent();
+      }
+    } catch {
+      // non-fatal – editor is still usable without auto-load
+    }
+  }
+});
 renderModuleDropdown();
 renderModuleMeta();
 renderModuleStatus();

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -1,0 +1,478 @@
+import {
+  supportedLocales,
+  localeLabels,
+  translations as adminContentTranslations,
+} from "/static/i18n/admin-content-translations.js";
+import {
+  apiFetch,
+  buildConsoleHeaders,
+  getConsoleConfig,
+  fetchQueueCounts,
+  applyNavReviewBadge,
+} from "/static/api-client.js";
+import {
+  resolveRoleSwitchState,
+  resolveWorkspaceNavigationItems,
+} from "/static/participant-console-state.js";
+import { showToast } from "/static/toast.js";
+
+// ---------------------------------------------------------------------------
+// i18n
+// ---------------------------------------------------------------------------
+
+const currentLocale = (() => {
+  const stored = localStorage.getItem("participant.locale");
+  if (stored && supportedLocales.includes(stored)) return stored;
+  const b = navigator.language?.toLowerCase() ?? "";
+  if (b.startsWith("nb")) return "nb";
+  if (b.startsWith("nn")) return "nn";
+  return "en-GB";
+})();
+
+function t(key) {
+  const map = adminContentTranslations[currentLocale] ?? adminContentTranslations["en-GB"] ?? {};
+  return map[key] ?? key;
+}
+
+function localizeValue(value) {
+  if (!value) return "";
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === "object") {
+        return parsed[previewLocale] ?? parsed["nb"] ?? parsed["en-GB"] ?? Object.values(parsed)[0] ?? "";
+      }
+    } catch {
+      // plain string
+    }
+    return value;
+  }
+  if (typeof value === "object") {
+    return value[previewLocale] ?? value["nb"] ?? value["en-GB"] ?? Object.values(value)[0] ?? "";
+  }
+  return String(value);
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+// session state: 'idle' | 'picking-module' | 'loading-module' | 'module-loaded'
+let sessionState = "idle";
+let modules = [];
+let selectedModuleId = null;
+let bundle = null;
+let previewLocale = currentLocale;
+let generationAbort = null;
+
+let headers = {};
+let participantRuntimeConfig = {
+  navigation: { workspaceItems: [], profileItem: null },
+  authMode: "mock",
+  identityDefaults: { userId: "content-owner-1", email: "content.owner@company.com", name: "Platform Content Owner", department: "Learning", roles: ["SUBJECT_MATTER_OWNER"] },
+};
+
+// ---------------------------------------------------------------------------
+// DOM refs
+// ---------------------------------------------------------------------------
+
+const chatMessages = document.getElementById("chatMessages");
+const previewPane = document.getElementById("previewPane");
+const previewLocaleBar = document.getElementById("previewLocaleBar");
+const previewContent = document.getElementById("previewContent");
+const workspaceNav = document.getElementById("workspaceNav");
+const appVersionLabel = document.getElementById("appVersion");
+const uiLocaleSelect = document.getElementById("localeSelect");
+
+// ---------------------------------------------------------------------------
+// Chat rendering
+// ---------------------------------------------------------------------------
+
+function pushBotMessage(html, choices = []) {
+  const msg = document.createElement("div");
+  msg.className = "chat-msg chat-msg--bot";
+  msg.innerHTML = `<div class="chat-bubble">${html}</div>`;
+  if (choices.length > 0) {
+    const row = document.createElement("div");
+    row.className = "chat-choices";
+    for (const c of choices) {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "btn-secondary chat-choice-btn";
+      btn.textContent = c.label;
+      btn.addEventListener("click", () => {
+        disableChoices();
+        pushUserMessage(c.label);
+        c.action();
+      });
+      row.appendChild(btn);
+    }
+    msg.appendChild(row);
+  }
+  chatMessages.appendChild(msg);
+  msg.scrollIntoView({ behavior: "smooth", block: "end" });
+  return msg;
+}
+
+function pushUserMessage(text) {
+  const msg = document.createElement("div");
+  msg.className = "chat-msg chat-msg--user";
+  msg.innerHTML = `<div class="chat-bubble">${escapeHtml(text)}</div>`;
+  chatMessages.appendChild(msg);
+  msg.scrollIntoView({ behavior: "smooth", block: "end" });
+}
+
+function pushBotProgress(text) {
+  const msg = document.createElement("div");
+  msg.className = "chat-msg chat-msg--bot";
+  msg.innerHTML = `<div class="chat-bubble chat-bubble--progress"><span class="chat-spinner"></span>${escapeHtml(text)}</div>`;
+  chatMessages.appendChild(msg);
+  msg.scrollIntoView({ behavior: "smooth", block: "end" });
+  return msg;
+}
+
+function replaceMessage(msgEl, html, choices = []) {
+  msgEl.innerHTML = `<div class="chat-bubble">${html}</div>`;
+  if (choices.length > 0) {
+    const row = document.createElement("div");
+    row.className = "chat-choices";
+    for (const c of choices) {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "btn-secondary chat-choice-btn";
+      btn.textContent = c.label;
+      btn.addEventListener("click", () => {
+        disableChoices();
+        pushUserMessage(c.label);
+        c.action();
+      });
+      row.appendChild(btn);
+    }
+    msgEl.appendChild(row);
+  }
+  msgEl.scrollIntoView({ behavior: "smooth", block: "end" });
+}
+
+function disableChoices() {
+  for (const btn of chatMessages.querySelectorAll(".chat-choice-btn")) {
+    btn.disabled = true;
+  }
+}
+
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// ---------------------------------------------------------------------------
+// Preview rendering
+// ---------------------------------------------------------------------------
+
+function renderPreviewLocaleBar() {
+  previewLocaleBar.innerHTML = "";
+  for (const loc of supportedLocales) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "preview-locale-btn" + (loc === previewLocale ? " active" : "");
+    btn.textContent = localeLabels[loc] ?? loc;
+    btn.setAttribute("aria-pressed", String(loc === previewLocale));
+    btn.addEventListener("click", () => {
+      previewLocale = loc;
+      renderPreviewLocaleBar();
+      renderPreview();
+    });
+    previewLocaleBar.appendChild(btn);
+  }
+}
+
+function renderPreview() {
+  if (!bundle) {
+    previewContent.innerHTML = `<p class="preview-empty">${escapeHtml(t("adminContent.status.noneTitle"))}</p>`;
+    return;
+  }
+
+  const mod = bundle.module;
+  const cfg = bundle.selectedConfiguration;
+  const isLive = !!mod.activeVersionId && cfg.moduleVersion?.id === mod.activeVersionId;
+  const isDraft = !!cfg.moduleVersion && !isLive;
+  const isShell = !cfg.moduleVersion;
+
+  const badgeClass = isLive ? "live" : isDraft ? "draft" : "shell";
+  const badgeText = isLive
+    ? t("adminContent.status.badge.live")
+    : isDraft
+    ? t("adminContent.status.badge.draft")
+    : t("adminContent.status.badge.none");
+
+  const title = localizeValue(mod.title) || mod.id;
+  const description = localizeValue(mod.description);
+  const taskText = cfg.moduleVersion ? localizeValue(cfg.moduleVersion.taskText) : "";
+  const guidanceText = cfg.moduleVersion ? localizeValue(cfg.moduleVersion.guidanceText) : "";
+
+  const versionChainParts = [];
+  if (cfg.moduleVersion) versionChainParts.push(`Modul v${cfg.moduleVersion.versionNo}`);
+  if (cfg.rubricVersion) versionChainParts.push(`Rubrikk v${cfg.rubricVersion.versionNo}`);
+  if (cfg.promptTemplateVersion) versionChainParts.push(`Prompt v${cfg.promptTemplateVersion.versionNo}`);
+  if (cfg.mcqSetVersion) versionChainParts.push(`MCQ v${cfg.mcqSetVersion.versionNo}`);
+  const versionChain = versionChainParts.join(" · ");
+
+  const mcqCount = cfg.mcqSetVersion?.questions?.length ?? 0;
+
+  previewContent.innerHTML = `
+    <div class="preview-module-header">
+      <div class="preview-module-title">${escapeHtml(title)}</div>
+      <span class="module-status-badge ${badgeClass}">${escapeHtml(badgeText)}</span>
+    </div>
+    ${description ? `<p class="preview-description">${escapeHtml(description)}</p>` : ""}
+    ${versionChain ? `<p class="preview-version-chain">${escapeHtml(versionChain)}</p>` : ""}
+    ${taskText ? `
+      <div class="preview-section-label">${escapeHtml(t("adminContent.moduleVersion.taskText"))}</div>
+      <div class="preview-text-block">${escapeHtml(taskText.slice(0, 400))}${taskText.length > 400 ? "…" : ""}</div>
+    ` : ""}
+    ${guidanceText ? `
+      <div class="preview-section-label">${escapeHtml(t("adminContent.moduleVersion.guidanceText"))}</div>
+      <div class="preview-text-block preview-text-secondary">${escapeHtml(guidanceText.slice(0, 300))}${guidanceText.length > 300 ? "…" : ""}</div>
+    ` : ""}
+    ${mcqCount > 0 ? `<p class="preview-meta">${mcqCount} flervalgsspørsmål</p>` : ""}
+  `.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Chat flows
+// ---------------------------------------------------------------------------
+
+function startIdle() {
+  sessionState = "idle";
+  bundle = null;
+  selectedModuleId = null;
+  renderPreview();
+  pushBotMessage("Hva vil du gjøre?", [
+    { label: "Åpne eksisterende modul", action: startModulePicker },
+    { label: "Opprett ny modul", action: startNewModule },
+  ]);
+}
+
+async function startModulePicker() {
+  sessionState = "picking-module";
+  const progress = pushBotProgress("Laster moduler…");
+
+  try {
+    const data = await apiFetch("/api/admin/content/modules", headers);
+    modules = Array.isArray(data) ? data : [];
+  } catch {
+    replaceMessage(progress, "Kunne ikke laste moduler. Prøv igjen.", [
+      { label: "Prøv igjen", action: startModulePicker },
+      { label: "Avbryt", action: startIdle },
+    ]);
+    return;
+  }
+
+  if (modules.length === 0) {
+    replaceMessage(progress, "Ingen moduler funnet.", [
+      { label: "Opprett ny modul", action: startNewModule },
+      { label: "Avbryt", action: startIdle },
+    ]);
+    return;
+  }
+
+  const listHtml = modules
+    .map((m) => `<div class="module-list-item"><strong>${escapeHtml(m.title || m.id)}</strong>${m.activeVersion ? ` <span class=\"module-status-badge live\" style=\"font-size:11px;padding:2px 8px\">Live v${m.activeVersion.versionNo}</span>` : ""}</div>`)
+    .join("");
+
+  replaceMessage(progress, `Velg en modul:<div class="module-list">${listHtml}</div>`);
+
+  // Render module choice buttons below
+  const choicesRow = document.createElement("div");
+  choicesRow.className = "chat-choices chat-choices--column";
+  for (const m of modules) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "btn-secondary chat-choice-btn";
+    btn.textContent = m.title || m.id;
+    if (m.activeVersion) {
+      const badge = document.createElement("span");
+      badge.className = "module-status-badge live";
+      badge.style.cssText = "font-size:11px;padding:2px 8px;margin-left:8px";
+      badge.textContent = `Live v${m.activeVersion.versionNo}`;
+      btn.appendChild(badge);
+    }
+    btn.addEventListener("click", () => {
+      disableChoices();
+      pushUserMessage(m.title || m.id);
+      loadModule(m.id);
+    });
+    choicesRow.appendChild(btn);
+  }
+  const cancelBtn = document.createElement("button");
+  cancelBtn.type = "button";
+  cancelBtn.className = "btn-secondary chat-choice-btn";
+  cancelBtn.textContent = "Avbryt";
+  cancelBtn.addEventListener("click", () => {
+    disableChoices();
+    pushUserMessage("Avbryt");
+    startIdle();
+  });
+  choicesRow.appendChild(cancelBtn);
+  chatMessages.appendChild(choicesRow);
+  choicesRow.scrollIntoView({ behavior: "smooth", block: "end" });
+}
+
+async function loadModule(moduleId) {
+  sessionState = "loading-module";
+  selectedModuleId = moduleId;
+  const progress = pushBotProgress("Laster modul…");
+
+  try {
+    bundle = await apiFetch(`/api/admin/content/modules/${encodeURIComponent(moduleId)}/export`, headers);
+  } catch {
+    replaceMessage(progress, "Kunne ikke laste modulen. Prøv igjen.", [
+      { label: "Velg annen modul", action: startModulePicker },
+      { label: "Avbryt", action: startIdle },
+    ]);
+    return;
+  }
+
+  sessionState = "module-loaded";
+  renderPreview();
+
+  const title = localizeValue(bundle.module.title) || moduleId;
+  const isLive = !!bundle.module.activeVersionId;
+  const statusNote = isLive
+    ? `Live – Modul v${bundle.selectedConfiguration.moduleVersion?.versionNo ?? "?"}`
+    : "Ingen publisert versjon";
+
+  replaceMessage(
+    progress,
+    `<strong>${escapeHtml(title)}</strong> er lastet.<br><span style="color:var(--color-meta);font-size:13px">${escapeHtml(statusNote)}</span>`,
+    [
+      { label: "Rediger innhold", action: () => openAdvancedEditor(moduleId) },
+      { label: "Velg annen modul", action: startModulePicker },
+    ],
+  );
+}
+
+function openAdvancedEditor(moduleId) {
+  const url = `/admin-content/advanced?moduleId=${encodeURIComponent(moduleId)}`;
+  pushBotMessage(`Åpner avansert editor for denne modulen…`);
+  setTimeout(() => { location.href = url; }, 400);
+}
+
+function startNewModule() {
+  pushBotMessage(
+    "Opprettelse av ny modul gjøres i den avanserte editoren.",
+    [{ label: "Åpne avansert editor", action: () => { location.href = "/admin-content/advanced"; } }],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Nav / version / locale
+// ---------------------------------------------------------------------------
+
+async function loadVersion() {
+  try {
+    const body = await apiFetch("/version", { headers: {} });
+    const version = body.version ?? "unknown";
+    document.title = `A2 Content Workspace v${version}`;
+    if (appVersionLabel) appVersionLabel.textContent = `v${version}`;
+  } catch {
+    if (appVersionLabel) appVersionLabel.textContent = "unknown";
+  }
+}
+
+function renderWorkspaceNavigation() {
+  if (!workspaceNav) return;
+  const roles = participantRuntimeConfig.identityDefaults?.roles?.join(",") ?? "SUBJECT_MATTER_OWNER";
+  const allItems = resolveWorkspaceNavigationItems(
+    participantRuntimeConfig?.navigation?.items,
+    roles,
+    window.location.pathname,
+  ).filter((item) => item.visible);
+
+  const profileItem = allItems.find((item) => item.id === "profile");
+  const items = allItems.filter((item) => item.id !== "profile");
+
+  workspaceNav.innerHTML = "";
+  workspaceNav.hidden = items.length === 0;
+  for (const item of items) {
+    const a = document.createElement("a");
+    a.href = item.path;
+    a.className = item.active ? "workspace-nav-link active" : "workspace-nav-link";
+    a.textContent = t(item.labelKey) || item.id;
+    workspaceNav.appendChild(a);
+  }
+
+  if (profileItem) {
+    const localePicker = document.querySelector(".locale-picker");
+    if (localePicker) {
+      let profileLink = document.getElementById("profileNavLink");
+      if (!profileLink) {
+        profileLink = document.createElement("a");
+        profileLink.id = "profileNavLink";
+        localePicker.appendChild(profileLink);
+      }
+      profileLink.href = profileItem.path;
+      profileLink.textContent = t(profileItem.labelKey);
+      profileLink.className = profileItem.active ? "workspace-nav-link active" : "workspace-nav-link";
+    }
+  }
+}
+
+function populateUiLocaleSelect() {
+  if (!uiLocaleSelect) return;
+  uiLocaleSelect.innerHTML = "";
+  for (const loc of supportedLocales) {
+    const opt = document.createElement("option");
+    opt.value = loc;
+    opt.textContent = localeLabels[loc] ?? loc;
+    opt.selected = loc === currentLocale;
+    uiLocaleSelect.appendChild(opt);
+  }
+}
+
+async function loadConsoleConfig() {
+  try {
+    const body = await getConsoleConfig();
+    if (body) {
+      participantRuntimeConfig = {
+        ...participantRuntimeConfig,
+        ...body,
+        navigation: { ...participantRuntimeConfig.navigation, ...(body?.navigation ?? {}) },
+        identityDefaults: { ...participantRuntimeConfig.identityDefaults, ...(body?.identityDefaults ?? {}) },
+      };
+      rebuildHeaders();
+    }
+  } catch {
+    // use defaults
+  }
+  renderWorkspaceNavigation();
+  if (workspaceNav) {
+    fetchQueueCounts(headers).then((counts) => applyNavReviewBadge(workspaceNav, counts)).catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+function rebuildHeaders() {
+  const d = participantRuntimeConfig.identityDefaults ?? {};
+  headers = buildConsoleHeaders({
+    userId: d.userId ?? "content-owner-1",
+    email: d.email ?? "content.owner@company.com",
+    name: d.name ?? "Platform Content Owner",
+    department: d.department ?? "Learning",
+    roles: Array.isArray(d.roles) ? d.roles.join(",") : (d.roles ?? "SUBJECT_MATTER_OWNER"),
+    locale: currentLocale,
+  });
+}
+rebuildHeaders();
+
+populateUiLocaleSelect();
+renderPreviewLocaleBar();
+renderPreview();
+loadVersion();
+loadConsoleConfig();
+startIdle();

--- a/src/app.ts
+++ b/src/app.ts
@@ -60,6 +60,10 @@ app.get("/admin-content", (_request, response) => {
   response.sendFile(path.resolve(process.cwd(), "public", "admin-content.html"));
 });
 
+app.get("/admin-content/advanced", (_request, response) => {
+  response.sendFile(path.resolve(process.cwd(), "public", "admin-content-advanced.html"));
+});
+
 app.get("/review", (_request, response) => {
   response.sendFile(path.resolve(process.cwd(), "public", "review.html"));
 });

--- a/test/participant-console-config.test.ts
+++ b/test/participant-console-config.test.ts
@@ -128,6 +128,13 @@ describe("participant console runtime config", () => {
     const response = await request(app).get("/admin-content");
 
     expect(response.status).toBe(200);
+    expect(response.text).toContain("admin-content-shell.js");
+  });
+
+  it("serves advanced admin content editor at /admin-content/advanced", async () => {
+    const response = await request(app).get("/admin-content/advanced");
+
+    expect(response.status).toBe(200);
     expect(response.text).toContain("admin-content.js");
   });
 
@@ -149,7 +156,9 @@ describe("participant console runtime config", () => {
       "/participant",
       "/participant/completed",
       "/review",
-      "/admin-content",
+      // /admin-content is the new conversational shell (no mock-identity-card panel)
+      // /admin-content/advanced is the full editor that retains the panel
+      "/admin-content/advanced",
       "/calibration",
     ];
 
@@ -223,7 +232,7 @@ describe("participant console runtime config", () => {
         expect(response.text).toContain('id="courseCertSection"');
       }
 
-      if (pagePath === "/admin-content") {
+      if (pagePath === "/admin-content/advanced") {
         expect(response.text).toContain('id="outputStatus"');
         expect(response.text).toContain('<details id="outputDetails">');
         expect(response.text).toContain("<summary>View raw response</summary>");

--- a/test/workspace-validation-accessibility.test.js
+++ b/test/workspace-validation-accessibility.test.js
@@ -38,10 +38,10 @@ describe("workspace validation accessibility", () => {
     // Course accordion mount point must exist for the participant course flow
     expect(participantHtml).toContain('id="courseAccordion"');
 
-    const adminContentHtml = readFile("public/admin-content.html");
-    // Course tab must exist in the admin content tab shell
-    expect(adminContentHtml).toContain('id="tabKurs"');
-    expect(adminContentHtml).toContain('id="coursesTab"');
+    // Course tab lives in the advanced editor (admin-content.html is the new conversational shell)
+    const adminContentAdvancedHtml = readFile("public/admin-content-advanced.html");
+    expect(adminContentAdvancedHtml).toContain('id="tabKurs"');
+    expect(adminContentAdvancedHtml).toContain('id="coursesTab"');
 
     const resultsHtml = readFile("public/results.html");
     // Course report body must be present in the results workspace


### PR DESCRIPTION
## Summary

- New `/admin-content` → split-pane conversational shell (preview + chat)
- `/admin-content/advanced` → existing editor moved here, unchanged
- `Avansert redigering ↗` link always visible in shell header during rollout
- `?moduleId=` param on advanced editor auto-selects and loads the module

## Shell (Slice 1 scope — structured choices, no free-text)

Chat flows implemented:
1. **Idle** → \"Åpne eksisterende modul\" or \"Opprett ny modul\"
2. **Module picker** → lists all modules with live/draft badge
3. **Module loaded** → preview populates, chat offers \"Rediger innhold\" (→ advanced editor) or \"Velg annen modul\"
4. **New module** → redirects to advanced editor (out of Slice 1 scope)

Preview pane:
- Locale switcher (nb / en-GB / nn)
- Module status badge (live / draft / shell)
- Version chain
- Task text and guidance text (first 400 / 300 chars)
- MCQ question count

LLM calls: none in Slice 1. All API calls are non-blocking behind progress cards.

## Test plan

- [ ] `/admin-content` loads the new shell without errors
- [ ] `/admin-content/advanced` loads the existing editor unchanged
- [ ] Module picker lists existing modules correctly
- [ ] Selecting a module populates the preview pane (try locale switching)
- [ ] \"Rediger innhold\" navigates to `/admin-content/advanced?moduleId=<id>` and auto-loads the module
- [ ] \"Avansert redigering ↗\" link in header navigates to advanced editor
- [ ] Workspace nav renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)