### PR TITLE
fix(security): harden P0 workflows secrets and auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ PORT=3000
 DATABASE_URL=postgresql://a2_app:a2_local_dev_password@127.0.0.1:54329/a2_assessment_dev?schema=public
 
 # auth modes: mock | entra
+# mock is local/test only; shared Azure environments must use entra
 AUTH_MODE=mock
 
 # used in AUTH_MODE=entra

--- a/.github/workflows/activate-staging-app-layer.yml
+++ b/.github/workflows/activate-staging-app-layer.yml
@@ -2,30 +2,23 @@ name: Activate Staging App Layer
 
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        description: "Git ref to deploy into staging"
-        required: false
-        default: "main"
-        type: string
 
 permissions:
   id-token: write
   contents: read
 
 concurrency:
-  group: activate-staging-app-layer-${{ github.event.inputs.ref || github.ref }}
+  group: activate-staging-app-layer-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   activate-staging-app-layer:
+    if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     environment: staging
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -34,7 +27,25 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Build deployment package
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_path="$RUNNER_TEMP/a2-assessment-staging.zip"
+          package_root="$RUNNER_TEMP/a2-assessment-package"
+          rm -rf "$package_root" "$package_path"
+          mkdir -p "$package_root"
+          git archive --format=tar HEAD | tar -x -C "$package_root"
+          cd "$package_root"
+          npm ci --ignore-scripts
+          npm run prisma:generate
+          npm run build
+          npm prune --omit=dev --ignore-scripts
+          zip -r -q "$package_path" .
+          echo "path=$package_path" >> "$GITHUB_OUTPUT"
 
       - name: Azure login (OIDC)
         uses: azure/login@v2
@@ -74,7 +85,7 @@ jobs:
             -PostgresBackupRetentionDays "${{ vars.POSTGRES_BACKUP_RETENTION_DAYS || '7' }}" `
             -PostgresGeoRedundantBackup "${{ vars.POSTGRES_GEO_REDUNDANT_BACKUP || 'Disabled' }}" `
             -PostgresHighAvailabilityMode "${{ vars.POSTGRES_HIGH_AVAILABILITY_MODE || 'Disabled' }}" `
-            -AuthMode "${{ vars.AUTH_MODE }}" `
+            -AuthMode "${{ vars.AUTH_MODE || 'entra' }}" `
             -EntraTenantId "${{ vars.ENTRA_TENANT_ID }}" `
             -EntraClientId "${{ vars.ENTRA_CLIENT_ID }}" `
             -EntraAudience "${{ vars.ENTRA_AUDIENCE }}" `
@@ -103,7 +114,8 @@ jobs:
             -AcsEmailSenderDisplayName "${{ vars.ACS_EMAIL_SENDER_DISPLAY_NAME || 'A2 Assessment Platform' }}" `
             -BudgetContactEmail "${{ vars.BUDGET_CONTACT_EMAIL }}" `
             -MonthlyBudgetAmount "${{ vars.MONTHLY_BUDGET_AMOUNT }}" `
-            -ParserWorkerAuthKey "${{ secrets.PARSER_WORKER_AUTH_KEY }}"
+            -ParserWorkerAuthKey "${{ secrets.PARSER_WORKER_AUTH_KEY }}" `
+            -PackagePath "${{ steps.package.outputs.path }}"
 
       - name: Verify staging app layer
         shell: pwsh
@@ -158,4 +170,4 @@ jobs:
           echo "PostgreSQL compute was started before deploy, then the normal staging deployment recreated the App Service layer." >> "$GITHUB_STEP_SUMMARY"
           echo "Verification confirmed PostgreSQL, App Service, and alert resources were restored." >> "$GITHUB_STEP_SUMMARY"
         env:
-          DEPLOY_REF: ${{ github.event.inputs.ref || github.ref }}
+          DEPLOY_REF: ${{ github.ref }}

--- a/.github/workflows/benchmark-models.yml
+++ b/.github/workflows/benchmark-models.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,24 +33,47 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Generate Prisma client
         run: npm run prisma:generate
         env:
           DATABASE_URL: postgresql://dummy:dummy@localhost/dummy
 
-      - name: Run benchmark
+      - name: Validate workflow inputs
+        shell: bash
         run: |
-          CASES_ARG=""
-          if [ -n "$INPUT_CASES" ]; then
-            CASES_ARG="--cases=$INPUT_CASES"
+          set -euo pipefail
+          if ! [[ "$INPUT_REPEAT" =~ ^[0-9]+$ ]] || [ "$INPUT_REPEAT" -lt 1 ] || [ "$INPUT_REPEAT" -gt 100 ]; then
+            echo "repeat must be an integer from 1 to 100." >&2
+            exit 1
           fi
-          npx tsx src/scripts/runModelComparisonBenchmark.ts \
-            --repeat="$INPUT_REPEAT" \
-            --models="$INPUT_MODELS" \
-            --output=doc/benchmarks/model-comparison-$(date +%Y-%m-%d) \
-            $CASES_ARG
+          if ! [[ "$INPUT_MODELS" =~ ^[A-Za-z0-9_.-]+:[A-Za-z0-9_.-]+(,[A-Za-z0-9_.-]+:[A-Za-z0-9_.-]+)*$ ]]; then
+            echo "models must be comma-separated label:deployment entries using alphanumeric, dot, underscore, and hyphen characters." >&2
+            exit 1
+          fi
+          if [ -n "$INPUT_CASES" ] && ! [[ "$INPUT_CASES" =~ ^[A-Za-z0-9_.-]+(,[A-Za-z0-9_.-]+)*$ ]]; then
+            echo "cases must be blank or comma-separated case ids using alphanumeric, dot, underscore, and hyphen characters." >&2
+            exit 1
+          fi
+        env:
+          INPUT_CASES: ${{ inputs.cases }}
+          INPUT_REPEAT: ${{ inputs.repeat }}
+          INPUT_MODELS: ${{ inputs.models }}
+
+      - name: Run benchmark
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(
+            "--repeat=$INPUT_REPEAT"
+            "--models=$INPUT_MODELS"
+            "--output=doc/benchmarks/model-comparison-$(date +%Y-%m-%d)"
+          )
+          if [ -n "$INPUT_CASES" ]; then
+            args+=("--cases=$INPUT_CASES")
+          fi
+          npx tsx src/scripts/runModelComparisonBenchmark.ts "${args[@]}"
         env:
           INPUT_CASES: ${{ inputs.cases }}
           INPUT_REPEAT: ${{ inputs.repeat }}
@@ -74,13 +97,3 @@ jobs:
           name: benchmark-results-${{ github.run_id }}
           path: doc/benchmarks/
           retention-days: 90
-
-      - name: Commit markdown report
-        if: success()
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add doc/benchmarks/
-          git diff --staged --quiet || git commit -m "benchmark: model comparison results $(date +%Y-%m-%d) [skip ci]"
-          git pull --rebase origin main
-          git push

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -10,10 +10,6 @@ on:
         description: "Deploy production after staging (requires environment approval)"
         required: false
         default: "false"
-      ref:
-        description: "Git ref to deploy"
-        required: false
-        default: "main"
 
 permissions:
   id-token: write
@@ -27,14 +23,12 @@ jobs:
   deploy-staging:
     # Only run on manual workflow_dispatch — push to main deploys production directly.
     # This prevents main-branch commits from overwriting a feature-branch staging deploy.
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     environment: staging
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -42,7 +36,25 @@ jobs:
           node-version: 22
           cache: npm
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Build deployment package
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_path="$RUNNER_TEMP/a2-assessment-staging.zip"
+          package_root="$RUNNER_TEMP/a2-assessment-package"
+          rm -rf "$package_root" "$package_path"
+          mkdir -p "$package_root"
+          git archive --format=tar HEAD | tar -x -C "$package_root"
+          cd "$package_root"
+          npm ci --ignore-scripts
+          npm run prisma:generate
+          npm run build
+          npm prune --omit=dev --ignore-scripts
+          zip -r -q "$package_path" .
+          echo "path=$package_path" >> "$GITHUB_OUTPUT"
 
       - name: Azure login (OIDC)
         uses: azure/login@v2
@@ -73,7 +85,7 @@ jobs:
             -PostgresBackupRetentionDays "${{ vars.POSTGRES_BACKUP_RETENTION_DAYS || '7' }}" `
             -PostgresGeoRedundantBackup "${{ vars.POSTGRES_GEO_REDUNDANT_BACKUP || 'Disabled' }}" `
             -PostgresHighAvailabilityMode "${{ vars.POSTGRES_HIGH_AVAILABILITY_MODE || 'Disabled' }}" `
-            -AuthMode "${{ vars.AUTH_MODE }}" `
+            -AuthMode "${{ vars.AUTH_MODE || 'entra' }}" `
             -EntraTenantId "${{ vars.ENTRA_TENANT_ID }}" `
             -EntraClientId "${{ vars.ENTRA_CLIENT_ID }}" `
             -EntraAudience "${{ vars.ENTRA_AUDIENCE }}" `
@@ -102,13 +114,15 @@ jobs:
             -AcsEmailSenderDisplayName "${{ vars.ACS_EMAIL_SENDER_DISPLAY_NAME || 'A2 Assessment Platform' }}" `
             -BudgetContactEmail "${{ vars.BUDGET_CONTACT_EMAIL }}" `
             -MonthlyBudgetAmount "${{ vars.MONTHLY_BUDGET_AMOUNT }}" `
-            -ParserWorkerAuthKey "${{ secrets.PARSER_WORKER_AUTH_KEY }}"
+            -ParserWorkerAuthKey "${{ secrets.PARSER_WORKER_AUTH_KEY }}" `
+            -PackagePath "${{ steps.package.outputs.path }}"
 
   deploy-production:
     # Only runs on manual workflow_dispatch when deploy_production=true AND staging succeeded.
     # Production never deploys automatically on push to main.
     if: |
       github.event_name == 'workflow_dispatch' &&
+      github.ref_name == github.event.repository.default_branch &&
       github.event.inputs.deploy_production == 'true' &&
       needs.deploy-staging.result == 'success'
     needs: deploy-staging
@@ -117,8 +131,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -126,7 +138,25 @@ jobs:
           node-version: 22
           cache: npm
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Build deployment package
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_path="$RUNNER_TEMP/a2-assessment-production.zip"
+          package_root="$RUNNER_TEMP/a2-assessment-package"
+          rm -rf "$package_root" "$package_path"
+          mkdir -p "$package_root"
+          git archive --format=tar HEAD | tar -x -C "$package_root"
+          cd "$package_root"
+          npm ci --ignore-scripts
+          npm run prisma:generate
+          npm run build
+          npm prune --omit=dev --ignore-scripts
+          zip -r -q "$package_path" .
+          echo "path=$package_path" >> "$GITHUB_OUTPUT"
 
       - name: Azure login (OIDC)
         uses: azure/login@v2
@@ -157,7 +187,7 @@ jobs:
             -PostgresBackupRetentionDays "${{ vars.POSTGRES_BACKUP_RETENTION_DAYS || '7' }}" `
             -PostgresGeoRedundantBackup "${{ vars.POSTGRES_GEO_REDUNDANT_BACKUP || 'Disabled' }}" `
             -PostgresHighAvailabilityMode "${{ vars.POSTGRES_HIGH_AVAILABILITY_MODE || 'Disabled' }}" `
-            -AuthMode "${{ vars.AUTH_MODE }}" `
+            -AuthMode "${{ vars.AUTH_MODE || 'entra' }}" `
             -EntraTenantId "${{ vars.ENTRA_TENANT_ID }}" `
             -EntraClientId "${{ vars.ENTRA_CLIENT_ID }}" `
             -EntraAudience "${{ vars.ENTRA_AUDIENCE }}" `
@@ -186,4 +216,5 @@ jobs:
             -AcsEmailSenderDisplayName "${{ vars.ACS_EMAIL_SENDER_DISPLAY_NAME || 'A2 Assessment Platform' }}" `
             -BudgetContactEmail "${{ vars.BUDGET_CONTACT_EMAIL }}" `
             -MonthlyBudgetAmount "${{ vars.MONTHLY_BUDGET_AMOUNT }}" `
-            -ParserWorkerAuthKey "${{ secrets.PARSER_WORKER_AUTH_KEY }}"
+            -ParserWorkerAuthKey "${{ secrets.PARSER_WORKER_AUTH_KEY }}" `
+            -PackagePath "${{ steps.package.outputs.path }}"

--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # API Reference
 
-All `/api/*` routes require authentication. In `AUTH_MODE=mock`, use the `x-user-roles` header to set roles. In `AUTH_MODE=entra`, a valid JWT is required.
+All `/api/*` routes require authentication. In local/test `AUTH_MODE=mock`, use the `x-user-roles` header to set roles. Shared Azure environments must use `AUTH_MODE=entra`, where a valid JWT is required and mock identity headers are ignored.
 
 ## Source of truth
 

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -71,7 +71,7 @@ param postgresHighAvailabilityMode string = 'Disabled'
   'mock'
   'entra'
 ])
-param authMode string = 'mock'
+param authMode string = 'entra'
 
 @description('Entra tenant id when authMode=entra.')
 param entraTenantId string = ''
@@ -414,8 +414,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   properties: {
     sku: { family: 'A', name: 'standard' }
     tenantId: tenant().tenantId
-    enableRbacAuthorization: false
-    accessPolicies: []
+    enableRbacAuthorization: true
     enableSoftDelete: true
     softDeleteRetentionInDays: 7
     enablePurgeProtection: environmentName == 'production' ? true : null
@@ -455,6 +454,14 @@ resource kvSecretParserWorkerAuthKey 'Microsoft.KeyVault/vaults/secrets@2023-07-
   }
 }
 
+resource kvSecretParticipantNotificationWebhookUrl 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(participantNotificationWebhookUrl)) {
+  parent: keyVault
+  name: 'PARTICIPANT-NOTIFICATION-WEBHOOK-URL'
+  properties: {
+    value: participantNotificationWebhookUrl
+  }
+}
+
 resource webApp 'Microsoft.Web/sites@2023-12-01' = {
   name: webAppName
   location: location
@@ -488,7 +495,7 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
         }
         {
           name: 'NODE_ENV'
-          value: environmentName == 'production' ? 'production' : 'development'
+          value: 'production'
         }
         {
           name: 'PORT'
@@ -600,7 +607,7 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
         }
         {
           name: 'PARTICIPANT_NOTIFICATION_WEBHOOK_URL'
-          value: participantNotificationWebhookUrl
+          value: !empty(participantNotificationWebhookUrl) ? '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=PARTICIPANT-NOTIFICATION-WEBHOOK-URL)' : ''
         }
         {
           name: 'PARTICIPANT_NOTIFICATION_WEBHOOK_TIMEOUT_MS'
@@ -703,7 +710,7 @@ resource workerApp 'Microsoft.Web/sites@2023-12-01' = {
         }
         {
           name: 'NODE_ENV'
-          value: environmentName == 'production' ? 'production' : 'development'
+          value: 'production'
         }
         {
           name: 'PORT'
@@ -787,7 +794,7 @@ resource workerApp 'Microsoft.Web/sites@2023-12-01' = {
         }
         {
           name: 'PARTICIPANT_NOTIFICATION_WEBHOOK_URL'
-          value: participantNotificationWebhookUrl
+          value: !empty(participantNotificationWebhookUrl) ? '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=PARTICIPANT-NOTIFICATION-WEBHOOK-URL)' : ''
         }
         {
           name: 'PARTICIPANT_NOTIFICATION_WEBHOOK_TIMEOUT_MS'
@@ -875,7 +882,7 @@ resource parserApp 'Microsoft.Web/sites@2023-12-01' = {
         }
         {
           name: 'NODE_ENV'
-          value: environmentName == 'production' ? 'production' : 'development'
+          value: 'production'
         }
         {
           name: 'PORT'
@@ -935,31 +942,108 @@ resource parserAppDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-
 }
 
 // ---------------------------------------------------------------------------
-// Key Vault access policies — get permission for all app managed identities
-// Uses access policies instead of RBAC so deploys only need Contributor role.
+// Key Vault RBAC - secret-scoped read access for managed identities
 // ---------------------------------------------------------------------------
 
-resource kvAccessPolicies 'Microsoft.KeyVault/vaults/accessPolicies@2023-07-01' = {
-  parent: keyVault
-  name: 'add'
+var keyVaultSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6'
+
+resource webAppDatabaseSecretReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: kvSecretDatabaseUrl
+  name: guid(kvSecretDatabaseUrl.id, webApp.id, keyVaultSecretsUserRoleId)
   properties: {
-    accessPolicies: [
-      {
-        tenantId: tenant().tenantId
-        objectId: webApp.identity.principalId
-        permissions: { secrets: ['get'] }
-      }
-      {
-        tenantId: tenant().tenantId
-        objectId: workerApp.identity.principalId
-        permissions: { secrets: ['get'] }
-      }
-      {
-        tenantId: tenant().tenantId
-        objectId: parserApp.identity.principalId
-        permissions: { secrets: ['get'] }
-      }
-    ]
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: webApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource workerAppDatabaseSecretReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: kvSecretDatabaseUrl
+  name: guid(kvSecretDatabaseUrl.id, workerApp.id, keyVaultSecretsUserRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: workerApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource webAppOpenAiSecretReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(azureOpenAiApiKey)) {
+  scope: kvSecretOpenAiKey
+  name: guid(kvSecretOpenAiKey.id, webApp.id, keyVaultSecretsUserRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: webApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource workerAppOpenAiSecretReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(azureOpenAiApiKey)) {
+  scope: kvSecretOpenAiKey
+  name: guid(kvSecretOpenAiKey.id, workerApp.id, keyVaultSecretsUserRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: workerApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource webAppAcsSecretReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createAcsEmail) {
+  scope: kvSecretAcsConnection
+  name: guid(kvSecretAcsConnection.id, webApp.id, keyVaultSecretsUserRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: webApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource workerAppAcsSecretReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (createAcsEmail) {
+  scope: kvSecretAcsConnection
+  name: guid(kvSecretAcsConnection.id, workerApp.id, keyVaultSecretsUserRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: workerApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource webAppNotificationWebhookSecretReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(participantNotificationWebhookUrl)) {
+  scope: kvSecretParticipantNotificationWebhookUrl
+  name: guid(kvSecretParticipantNotificationWebhookUrl.id, webApp.id, keyVaultSecretsUserRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: webApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource workerAppNotificationWebhookSecretReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(participantNotificationWebhookUrl)) {
+  scope: kvSecretParticipantNotificationWebhookUrl
+  name: guid(kvSecretParticipantNotificationWebhookUrl.id, workerApp.id, keyVaultSecretsUserRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: workerApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource webAppParserAuthSecretReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: kvSecretParserWorkerAuthKey
+  name: guid(kvSecretParserWorkerAuthKey.id, webApp.id, keyVaultSecretsUserRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: webApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource parserAppParserAuthSecretReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: kvSecretParserWorkerAuthKey
+  name: guid(kvSecretParserWorkerAuthKey.id, parserApp.id, keyVaultSecretsUserRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: parserApp.identity.principalId
+    principalType: 'ServicePrincipal'
   }
 }
 

--- a/scripts/azure/bootstrap-sp-permissions.ps1
+++ b/scripts/azure/bootstrap-sp-permissions.ps1
@@ -7,9 +7,10 @@ param(
 )
 
 # Run once by a subscription Owner/Admin before the first production deploy.
-# Grants the GitHub Actions service principal User Access Administrator on the
-# production resource group so that Bicep roleAssignments/write succeeds during
-# Key Vault managed-identity role assignment creation.
+# Grants the GitHub Actions service principal Role Based Access Control
+# Administrator on the production resource group so Bicep roleAssignments/write
+# succeeds during Key Vault managed-identity role assignment creation without
+# granting broader User Access Administrator permissions.
 #
 # This step cannot be performed by the deploy workflow itself because the SP
 # lacks roleAssignments/write until after this script runs.
@@ -17,7 +18,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-$userAccessAdminRoleId = "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
+$rbacAdministratorRoleId = "f1a07417-d97a-45cb-824c-7a7467783830"
 
 Write-Host "Authenticating to tenant $TenantId..."
 az login --use-device-code --tenant $TenantId
@@ -47,10 +48,10 @@ if (-not $rgId) { throw "Could not retrieve resource group ID" }
 
 $assignmentGuid = (node -e "const {randomUUID}=require('crypto');console.log(randomUUID())").Trim()
 
-Write-Host "Granting User Access Administrator to SP $ServicePrincipalObjectId on $ResourceGroupName..."
+Write-Host "Granting Role Based Access Control Administrator to SP $ServicePrincipalObjectId on $ResourceGroupName..."
 $body = @{
   properties = @{
-    roleDefinitionId = "/subscriptions/$SubscriptionId/providers/Microsoft.Authorization/roleDefinitions/$userAccessAdminRoleId"
+    roleDefinitionId = "/subscriptions/$SubscriptionId/providers/Microsoft.Authorization/roleDefinitions/$rbacAdministratorRoleId"
     principalId      = $ServicePrincipalObjectId
     principalType    = "ServicePrincipal"
   }
@@ -73,5 +74,5 @@ if ($LASTEXITCODE -ne 0) {
 
 Write-Host ""
 Write-Host "Bootstrap complete. GitHub Actions SP $ServicePrincipalObjectId now has"
-Write-Host "User Access Administrator on resource group $ResourceGroupName."
+Write-Host "Role Based Access Control Administrator on resource group $ResourceGroupName."
 Write-Host "You can now trigger the production deploy workflow."

--- a/scripts/azure/deploy-environment.ps1
+++ b/scripts/azure/deploy-environment.ps1
@@ -21,7 +21,7 @@ param(
   [int]$PostgresBackupRetentionDays = 7,
   [string]$PostgresGeoRedundantBackup = "Disabled",
   [string]$PostgresHighAvailabilityMode = "Disabled",
-  [string]$AuthMode = "mock",
+  [string]$AuthMode = "entra",
   [string]$EntraTenantId = "",
   [string]$EntraClientId = "",
   [string]$EntraAudience = "",
@@ -50,7 +50,8 @@ param(
   [string]$AcsEmailSenderDisplayName = "A2 Assessment Platform",
   [string]$BudgetContactEmail = "",
   [double]$MonthlyBudgetAmount = 30,
-  [string]$ParserWorkerAuthKey = ""
+  [string]$ParserWorkerAuthKey = "",
+  [string]$PackagePath = ""
 )
 
 Set-StrictMode -Version Latest
@@ -70,6 +71,18 @@ if (-not ($IsLinux -or $IsMacOS)) {
 
 if (-not $ResourceGroupName) {
   $ResourceGroupName = "rg-a2-assessment-$EnvironmentName"
+}
+
+if ([string]::IsNullOrWhiteSpace($AuthMode)) {
+  $AuthMode = "entra"
+}
+
+if (@("staging", "production") -contains $EnvironmentName -and $AuthMode -eq "mock") {
+  throw "AUTH_MODE=mock is not allowed for shared Azure environments. Configure Entra settings and deploy with -AuthMode entra."
+}
+
+if ($AuthMode -eq "entra" -and ([string]::IsNullOrWhiteSpace($EntraTenantId) -or [string]::IsNullOrWhiteSpace($EntraClientId) -or [string]::IsNullOrWhiteSpace($EntraAudience))) {
+  throw "ENTRA_TENANT_ID, ENTRA_CLIENT_ID, and ENTRA_AUDIENCE are required when -AuthMode entra."
 }
 
 if (-not $ParserWorkerAuthKey) {
@@ -152,6 +165,12 @@ function Invoke-WebAppDeploy([string]$ResourceGroup, [string]$AppName, [string]$
     }
   }
   throw "az webapp deploy to $AppName failed after $maxAttempts attempts."
+}
+
+function Restart-WebAppForKeyVaultReferences([string]$ResourceGroup, [string]$AppName) {
+  Write-Host "Restarting $AppName to refresh Key Vault references..."
+  az webapp restart --resource-group $ResourceGroup --name $AppName | Out-Null
+  Assert-LastExitCode "restart $AppName"
 }
 
 function Copy-DeploymentSources([string]$destinationRoot) {
@@ -327,44 +346,52 @@ if (-not $parserAppName) {
 }
 
 $tempBasePath = Get-TempBasePath
-$tmpRoot = Join-Path $tempBasePath "a2-assessment-deploy-$EnvironmentName"
-if (Test-Path $tmpRoot) {
-  Remove-Item $tmpRoot -Recurse -Force
-}
-New-Item -Path $tmpRoot -ItemType Directory | Out-Null
+if ($PackagePath) {
+  $zipPath = [System.IO.Path]::GetFullPath($PackagePath)
+  if (-not (Test-Path -LiteralPath $zipPath -PathType Leaf)) {
+    throw "PackagePath does not exist: $zipPath"
+  }
+  Write-Host "Using prebuilt deployment package: $zipPath"
+} else {
+  $tmpRoot = Join-Path $tempBasePath "a2-assessment-deploy-$EnvironmentName"
+  if (Test-Path $tmpRoot) {
+    Remove-Item $tmpRoot -Recurse -Force
+  }
+  New-Item -Path $tmpRoot -ItemType Directory | Out-Null
 
-Copy-DeploymentSources -destinationRoot $tmpRoot
+  Copy-DeploymentSources -destinationRoot $tmpRoot
 
-Push-Location $tmpRoot
-try {
-  Write-Host "Building deployment artifact in: $tmpRoot"
-  npm ci
-  Assert-LastExitCode "npm ci"
-  npm run prisma:generate
-  Assert-LastExitCode "npm run prisma:generate"
-  npm run build
-  Assert-LastExitCode "npm run build"
-  npm prune --omit=dev
-  Assert-LastExitCode "npm prune --omit=dev"
-} finally {
-  Pop-Location
-}
-
-$zipPath = Join-Path $tempBasePath "a2-assessment-$EnvironmentName.zip"
-if (Test-Path $zipPath) {
-  Remove-Item $zipPath -Force
-}
-
-if ($IsLinux -or $IsMacOS) {
   Push-Location $tmpRoot
   try {
-    zip -r -q $zipPath .
-    Assert-LastExitCode "zip package"
+    Write-Host "Building deployment artifact in: $tmpRoot"
+    npm ci --ignore-scripts
+    Assert-LastExitCode "npm ci --ignore-scripts"
+    npm run prisma:generate
+    Assert-LastExitCode "npm run prisma:generate"
+    npm run build
+    Assert-LastExitCode "npm run build"
+    npm prune --omit=dev --ignore-scripts
+    Assert-LastExitCode "npm prune --omit=dev --ignore-scripts"
   } finally {
     Pop-Location
   }
-} else {
-  New-ZipArchiveFromDirectory -sourceDirectory $tmpRoot -zipPath $zipPath
+
+  $zipPath = Join-Path $tempBasePath "a2-assessment-$EnvironmentName.zip"
+  if (Test-Path $zipPath) {
+    Remove-Item $zipPath -Force
+  }
+
+  if ($IsLinux -or $IsMacOS) {
+    Push-Location $tmpRoot
+    try {
+      zip -r -q $zipPath .
+      Assert-LastExitCode "zip package"
+    } finally {
+      Pop-Location
+    }
+  } else {
+    New-ZipArchiveFromDirectory -sourceDirectory $tmpRoot -zipPath $zipPath
+  }
 }
 
 # Staging runs web, worker, and parser on the same small App Service plan.
@@ -373,59 +400,14 @@ Invoke-WebAppDeploy -ResourceGroup $ResourceGroupName -AppName $workerAppName -Z
 Invoke-WebAppDeploy -ResourceGroup $ResourceGroupName -AppName $parserAppName -ZipPath $zipPath
 Invoke-WebAppDeploy -ResourceGroup $ResourceGroupName -AppName $webAppName -ZipPath $zipPath
 
-# Key Vault RBAC role assignments for managed identities take 30–120 s to propagate after
-# the Bicep deployment completes. If the app starts before propagation finishes, the KV
-# references in app settings resolve to the raw reference string instead of the secret
-# value, causing 500 errors on any database or OpenAI call.
-# Fix: inject the resolved values directly as app settings after zip deploy. The app
-# restarts once more (settings change triggers restart), and starts with correct values.
-Write-Host "Resolving secrets and injecting directly into app settings (KV RBAC propagation fix)..."
-
-$encodedPgPassword = [Uri]::EscapeDataString($PostgresAdministratorPassword)
-$resolvedDatabaseUrl = "postgresql://${PostgresAdministratorLogin}:${encodedPgPassword}@${postgresServerName}.postgres.database.azure.com:5432/${postgresDatabaseName}?schema=public&sslmode=require"
-
-$acsResourceName = (az resource list `
-  --resource-group $ResourceGroupName `
-  --resource-type "Microsoft.Communication/communicationServices" `
-  --query "[0].name" -o tsv 2>$null).Trim()
-$resolvedAcsConn = ""
-if ($acsResourceName) {
-  $resolvedAcsConn = (az communication list-key `
-    --name $acsResourceName `
-    --resource-group $ResourceGroupName `
-    --query "primaryConnectionString" -o tsv 2>$null).Trim()
-}
-
-$sharedSecrets = [System.Collections.Generic.List[hashtable]]::new()
-$sharedSecrets.Add(@{ name = "DATABASE_URL"; value = $resolvedDatabaseUrl; slotSetting = $false })
-if (-not [string]::IsNullOrEmpty($AzureOpenAiApiKey)) {
-  $sharedSecrets.Add(@{ name = "AZURE_OPENAI_API_KEY"; value = $AzureOpenAiApiKey; slotSetting = $false })
-}
-if (-not [string]::IsNullOrEmpty($resolvedAcsConn)) {
-  $sharedSecrets.Add(@{ name = "AZURE_COMMUNICATION_SERVICES_CONNECTION_STRING"; value = $resolvedAcsConn; slotSetting = $false })
-}
-$sharedSecrets.Add(@{ name = "PARSER_WORKER_AUTH_KEY"; value = $ParserWorkerAuthKey; slotSetting = $false })
-
-$sharedSecretsFile = Join-Path $tempBasePath "resolved-secrets.json"
-# Use UTF-8 without BOM. Out-File -Encoding utf8 writes BOM in PowerShell 5.1 and some 7.x
-# versions, which causes az CLI to store BOM as the first character of secret values.
-# BOM (U+FEFF) in e.g. AZURE_OPENAI_API_KEY breaks Node.js fetch() header validation
-# (ByteString restriction) and causes 500 errors on every LLM generation request.
-[System.IO.File]::WriteAllText($sharedSecretsFile, ($sharedSecrets | ConvertTo-Json), [System.Text.UTF8Encoding]::new($false))
-
-az webapp config appsettings set --name $webAppName --resource-group $ResourceGroupName --settings "@$sharedSecretsFile" | Out-Null
-Assert-LastExitCode "inject secrets into web app"
-az webapp config appsettings set --name $workerAppName --resource-group $ResourceGroupName --settings "@$sharedSecretsFile" | Out-Null
-Assert-LastExitCode "inject secrets into worker app"
-
-$parserSecretsFile = Join-Path $tempBasePath "parser-resolved-secrets.json"
-[System.IO.File]::WriteAllText($parserSecretsFile, (@(@{ name = "PARSER_WORKER_AUTH_KEY"; value = $ParserWorkerAuthKey; slotSetting = $false }) | ConvertTo-Json), [System.Text.UTF8Encoding]::new($false))
-az webapp config appsettings set --name $parserAppName --resource-group $ResourceGroupName --settings "@$parserSecretsFile" | Out-Null
-Assert-LastExitCode "inject secrets into parser app"
-
-Remove-Item $sharedSecretsFile -ErrorAction SilentlyContinue
-Remove-Item $parserSecretsFile -ErrorAction SilentlyContinue
-Write-Host "Secrets injected. Apps restarting with resolved values."
+# Key Vault RBAC role assignments for managed identities can take 30-120 s to
+# propagate. Keep App Service settings as Key Vault references and refresh the
+# apps after propagation instead of writing raw secret values into app settings.
+Write-Host "Waiting for Key Vault RBAC propagation before refreshing app runtimes..."
+Start-Sleep -Seconds 90
+Restart-WebAppForKeyVaultReferences -ResourceGroup $ResourceGroupName -AppName $workerAppName
+Restart-WebAppForKeyVaultReferences -ResourceGroup $ResourceGroupName -AppName $parserAppName
+Restart-WebAppForKeyVaultReferences -ResourceGroup $ResourceGroupName -AppName $webAppName
 
 function Get-WebAppState {
   param([string]$ResourceGroup, [string]$AppName)

--- a/src/auth/authenticate.ts
+++ b/src/auth/authenticate.ts
@@ -40,6 +40,15 @@ function parseRoleNames(input: string[] | undefined): AppRole[] {
     .filter((role) => valid.has(role)) as AppRole[];
 }
 
+function isIdentityReconciliationError(error: unknown): error is { code: string } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "identity_reconciliation_conflict"
+  );
+}
+
 function principalFromMockHeaders(request: Request): AuthPrincipal {
   const headerRoles = request.header("x-user-roles");
   const roleHints = headerRoles ? headerRoles.split(",") : [];
@@ -174,6 +183,15 @@ export async function authenticate(request: Request, response: Response, next: N
 
     next();
   } catch (error) {
+    if (isIdentityReconciliationError(error)) {
+      console.warn("Blocked login because the email is already linked to a different external identity.");
+      response.status(403).json({
+        error: "identity_conflict",
+        message: "This email is already linked to a different identity.",
+      });
+      return;
+    }
+
     console.error("Authentication backend failed.", error);
     next(new AppError("internal_error", 500, "Internal server error."));
   }

--- a/src/auth/authenticate.ts
+++ b/src/auth/authenticate.ts
@@ -49,6 +49,18 @@ function isIdentityReconciliationError(error: unknown): error is { code: string 
   );
 }
 
+function isIdempotentPseudonymizationRequest(request: Request): boolean {
+  if (request.method !== "POST") {
+    return false;
+  }
+
+  const paths = [request.path, request.url, request.originalUrl]
+    .filter((value): value is string => typeof value === "string")
+    .map((value) => value.split("?")[0]);
+
+  return paths.some((path) => path === "/me/deletion" || path === "/api/me/deletion");
+}
+
 function principalFromMockHeaders(request: Request): AuthPrincipal {
   const headerRoles = request.header("x-user-roles");
   const roleHints = headerRoles ? headerRoles.split(",") : [];
@@ -141,6 +153,19 @@ export async function authenticate(request: Request, response: Response, next: N
 
     // Sikkerhetsfiks: Hindre tilgang for brukere som er deaktivert via org-sync (#15)
     if (user.activeStatus === false) {
+      if (user.isAnonymized === true && isIdempotentPseudonymizationRequest(request)) {
+        const correlationId = request.context?.correlationId;
+        request.context = {
+          correlationId,
+          principal,
+          userId: user.id,
+          roles: [],
+          locale,
+        };
+        next();
+        return;
+      }
+
       console.warn(`Access denied for deactivated user: ${user.id}`);
       response.status(403).json({
         error: "forbidden",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -78,6 +78,14 @@ if (!parsed.success) {
 }
 
 const env = parsed.data;
+const isAzureAppServiceRuntime = Boolean(process.env.WEBSITE_SITE_NAME || process.env.WEBSITE_INSTANCE_ID);
+const isMockAuthRuntimeAllowed =
+  env.NODE_ENV === "test" || (env.NODE_ENV === "development" && !isAzureAppServiceRuntime);
+
+if (env.AUTH_MODE === "mock" && !isMockAuthRuntimeAllowed) {
+  console.error("AUTH_MODE=mock is only allowed for local development and automated tests.");
+  process.exit(1);
+}
 
 if (env.AUTH_MODE === "entra" && (!env.ENTRA_TENANT_ID || !env.ENTRA_CLIENT_ID || !env.ENTRA_AUDIENCE)) {
   console.error("ENTRA_TENANT_ID, ENTRA_CLIENT_ID and ENTRA_AUDIENCE are required when AUTH_MODE=entra");
@@ -114,4 +122,4 @@ if (env.PARSER_WORKER_URL && !env.PARSER_WORKER_AUTH_KEY) {
   process.exit(1);
 }
 
-export { env };
+export { env, isMockAuthRuntimeAllowed };

--- a/src/config/participantConsole.ts
+++ b/src/config/participantConsole.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { z } from "zod";
-import { env } from "./env.js";
+import { env, isMockAuthRuntimeAllowed } from "./env.js";
 import { buildWorkspaceNavigationItems, type WorkspaceNavigationItem } from "./capabilities.js";
 
 const mockRoleSchema = z.enum([
@@ -125,11 +125,12 @@ function getParticipantConsoleConfig(): ParticipantConsoleConfig {
 
 export function getParticipantConsoleRuntimeConfig(): ParticipantConsoleRuntimeConfig {
   const config = getParticipantConsoleConfig();
+  const mockRoleSwitchEnabled = env.AUTH_MODE === "mock" && isMockAuthRuntimeAllowed;
   return {
     authMode: env.AUTH_MODE,
     debugMode: resolveParticipantConsoleDebugMode(),
-    mockRoleSwitchEnabled: env.AUTH_MODE === "mock",
-    mockRolePresets: config.mockRolePresets,
+    mockRoleSwitchEnabled,
+    mockRolePresets: mockRoleSwitchEnabled ? config.mockRolePresets : [],
     navigation: {
       // calibrationWorkspace.accessRoles is the runtime override for calibration access — see capabilities.ts
       items: buildWorkspaceNavigationItems(config.calibrationWorkspace.accessRoles),
@@ -139,7 +140,7 @@ export function getParticipantConsoleRuntimeConfig(): ParticipantConsoleRuntimeC
     manualReviewWorkspace: config.manualReviewWorkspace,
     flow: config.flow,
     calibrationWorkspace: config.calibrationWorkspace,
-    identityDefaults: config.identityDefaults,
+    identityDefaults: mockRoleSwitchEnabled ? config.identityDefaults : undefined,
     entra:
       env.AUTH_MODE === "entra" && env.ENTRA_CLIENT_ID && env.ENTRA_TENANT_ID && env.ENTRA_AUDIENCE
         ? {

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -28,7 +28,7 @@ export class IdentityReconciliationError extends Error {
 export async function upsertUserFromPrincipal(principal: AuthPrincipal) {
   const existingByExternalId = await prisma.user.findUnique({
     where: { externalId: principal.externalId },
-    select: { id: true, email: true, activeStatus: true },
+    select: { id: true, email: true, activeStatus: true, isAnonymized: true },
   });
   const existingByEmail = await prisma.user.findUnique({
     where: { email: principal.email },
@@ -38,6 +38,10 @@ export async function upsertUserFromPrincipal(principal: AuthPrincipal) {
   const now = new Date();
 
   if (existingByExternalId) {
+    if (existingByExternalId.isAnonymized) {
+      return existingByExternalId;
+    }
+
     const emailTakenByDifferentUser =
       existingByEmail && existingByEmail.id !== existingByExternalId.id;
 

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -16,14 +16,23 @@ function isUniqueConstraintError(error: unknown): error is { code: string } {
   );
 }
 
+export class IdentityReconciliationError extends Error {
+  code = "identity_reconciliation_conflict";
+
+  constructor(message = "Email is already linked to a different external identity.") {
+    super(message);
+    this.name = "IdentityReconciliationError";
+  }
+}
+
 export async function upsertUserFromPrincipal(principal: AuthPrincipal) {
   const existingByExternalId = await prisma.user.findUnique({
     where: { externalId: principal.externalId },
-    select: { id: true, email: true },
+    select: { id: true, email: true, activeStatus: true },
   });
   const existingByEmail = await prisma.user.findUnique({
     where: { email: principal.email },
-    select: { id: true },
+    select: { id: true, externalId: true },
   });
 
   const now = new Date();
@@ -38,23 +47,13 @@ export async function upsertUserFromPrincipal(principal: AuthPrincipal) {
         ...(emailTakenByDifferentUser ? {} : { email: principal.email }),
         name: principal.name,
         department: principal.department,
-        activeStatus: true,
         lastLoginAt: now,
       },
     });
   }
 
   if (existingByEmail) {
-    return prisma.user.update({
-      where: { id: existingByEmail.id },
-      data: {
-        externalId: principal.externalId,
-        name: principal.name,
-        department: principal.department,
-        activeStatus: true,
-        lastLoginAt: now,
-      },
-    });
+    throw new IdentityReconciliationError();
   }
 
   try {
@@ -73,28 +72,30 @@ export async function upsertUserFromPrincipal(principal: AuthPrincipal) {
       throw error;
     }
 
-    const createdDuringRace =
-      (await prisma.user.findUnique({
-        where: { externalId: principal.externalId },
-        select: { id: true },
-      })) ??
-      (await prisma.user.findUnique({
+    const createdByExternalId = await prisma.user.findUnique({
+      where: { externalId: principal.externalId },
+      select: { id: true },
+    });
+
+    if (!createdByExternalId) {
+      const createdByEmail = await prisma.user.findUnique({
         where: { email: principal.email },
         select: { id: true },
-      }));
-
-    if (!createdDuringRace) {
+      });
+      if (createdByEmail) {
+        throw new IdentityReconciliationError();
+      }
       throw error;
     }
 
     return prisma.user.update({
-      where: { id: createdDuringRace.id },
+      where: { id: createdByExternalId.id },
       data: {
         externalId: principal.externalId,
         email: principal.email,
         name: principal.name,
         department: principal.department,
-        activeStatus: true,
+        lastLoginAt: now,
       },
     });
   }

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -53,6 +53,17 @@ export async function upsertUserFromPrincipal(principal: AuthPrincipal) {
   }
 
   if (existingByEmail) {
+    if (env.AUTH_MODE === "mock") {
+      return prisma.user.update({
+        where: { id: existingByEmail.id },
+        data: {
+          externalId: principal.externalId,
+          name: principal.name,
+          department: principal.department,
+          lastLoginAt: now,
+        },
+      });
+    }
     throw new IdentityReconciliationError();
   }
 
@@ -83,6 +94,18 @@ export async function upsertUserFromPrincipal(principal: AuthPrincipal) {
         select: { id: true },
       });
       if (createdByEmail) {
+        if (env.AUTH_MODE === "mock") {
+          return prisma.user.update({
+            where: { id: createdByEmail.id },
+            data: {
+              externalId: principal.externalId,
+              email: principal.email,
+              name: principal.name,
+              department: principal.department,
+              lastLoginAt: now,
+            },
+          });
+        }
         throw new IdentityReconciliationError();
       }
       throw error;

--- a/test/authenticate-middleware.test.ts
+++ b/test/authenticate-middleware.test.ts
@@ -1,11 +1,19 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-function buildRequest(headers: Record<string, string> = {}) {
+function buildRequest(
+  headers: Record<string, string> = {},
+  options: { method?: string; path?: string; originalUrl?: string; url?: string } = {},
+) {
   const normalized = Object.fromEntries(
     Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
   );
+  const path = options.path ?? "/";
 
   return {
+    method: options.method ?? "GET",
+    path,
+    originalUrl: options.originalUrl ?? path,
+    url: options.url ?? path,
     header(name: string) {
       return normalized[name.toLowerCase()];
     },
@@ -153,6 +161,60 @@ describe("authenticate middleware", () => {
     expect(syncEntraGroupRoles).not.toHaveBeenCalled();
     expect(getActiveRoles).not.toHaveBeenCalled();
     expect(next).not.toHaveBeenCalled();
+  });
+
+  it("allows pseudonymized users to reach the idempotent deletion endpoint", async () => {
+    const upsertUserFromPrincipal = vi.fn().mockResolvedValue({
+      id: "user-1",
+      activeStatus: false,
+      isAnonymized: true,
+    });
+    const syncEntraGroupRoles = vi.fn().mockResolvedValue(undefined);
+    const getActiveRoles = vi.fn().mockResolvedValue(["PARTICIPANT"]);
+
+    vi.doMock("../src/config/env.js", () => ({
+      env: {
+        AUTH_MODE: "mock",
+        ENTRA_TENANT_ID: undefined,
+        ENTRA_AUDIENCE: undefined,
+        DEFAULT_LOCALE: "en-GB",
+        MOCK_DEFAULT_USER_ID: "participant-1",
+        MOCK_DEFAULT_EMAIL: "participant@company.com",
+        MOCK_DEFAULT_NAME: "Platform Participant",
+        MOCK_DEFAULT_DEPARTMENT: "Consulting",
+      },
+    }));
+    vi.doMock("../src/repositories/userRepository.js", () => ({
+      upsertUserFromPrincipal,
+      syncEntraGroupRoles,
+      getActiveRoles,
+    }));
+
+    const { authenticate } = await import("../src/auth/authenticate.js");
+    const request = buildRequest(
+      {
+        "x-user-id": "participant-1",
+        "x-user-email": "participant@company.com",
+        "x-user-name": "Platform Participant",
+        "x-user-department": "Consulting",
+        "x-user-roles": "PARTICIPANT",
+      },
+      { method: "POST", path: "/me/deletion", originalUrl: "/api/me/deletion" },
+    );
+    const response = buildResponse();
+    const next = vi.fn();
+
+    await authenticate(request as never, response as never, next);
+
+    expect(response.status).not.toHaveBeenCalled();
+    expect(response.json).not.toHaveBeenCalled();
+    expect(syncEntraGroupRoles).not.toHaveBeenCalled();
+    expect(getActiveRoles).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith();
+    expect(request.context).toMatchObject({
+      userId: "user-1",
+      roles: [],
+    });
   });
 
   it("returns 403 when login email is linked to a different external identity", async () => {

--- a/test/authenticate-middleware.test.ts
+++ b/test/authenticate-middleware.test.ts
@@ -109,6 +109,101 @@ describe("authenticate middleware", () => {
     });
   });
 
+  it("blocks inactive users before role evaluation", async () => {
+    const upsertUserFromPrincipal = vi.fn().mockResolvedValue({ id: "user-1", activeStatus: false });
+    const syncEntraGroupRoles = vi.fn().mockResolvedValue(undefined);
+    const getActiveRoles = vi.fn().mockResolvedValue(["PARTICIPANT"]);
+
+    vi.doMock("../src/config/env.js", () => ({
+      env: {
+        AUTH_MODE: "mock",
+        ENTRA_TENANT_ID: undefined,
+        ENTRA_AUDIENCE: undefined,
+        DEFAULT_LOCALE: "en-GB",
+        MOCK_DEFAULT_USER_ID: "participant-1",
+        MOCK_DEFAULT_EMAIL: "participant@company.com",
+        MOCK_DEFAULT_NAME: "Platform Participant",
+        MOCK_DEFAULT_DEPARTMENT: "Consulting",
+      },
+    }));
+    vi.doMock("../src/repositories/userRepository.js", () => ({
+      upsertUserFromPrincipal,
+      syncEntraGroupRoles,
+      getActiveRoles,
+    }));
+
+    const { authenticate } = await import("../src/auth/authenticate.js");
+    const request = buildRequest({
+      "x-user-id": "participant-1",
+      "x-user-email": "participant@company.com",
+      "x-user-name": "Platform Participant",
+      "x-user-department": "Consulting",
+      "x-user-roles": "PARTICIPANT",
+    });
+    const response = buildResponse();
+    const next = vi.fn();
+
+    await authenticate(request as never, response as never, next);
+
+    expect(response.status).toHaveBeenCalledWith(403);
+    expect(response.json).toHaveBeenCalledWith({
+      error: "forbidden",
+      message: "Your account has been deactivated.",
+    });
+    expect(syncEntraGroupRoles).not.toHaveBeenCalled();
+    expect(getActiveRoles).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when login email is linked to a different external identity", async () => {
+    const conflict = Object.assign(new Error("Email is already linked."), {
+      code: "identity_reconciliation_conflict",
+    });
+    const upsertUserFromPrincipal = vi.fn().mockRejectedValue(conflict);
+    const syncEntraGroupRoles = vi.fn().mockResolvedValue(undefined);
+    const getActiveRoles = vi.fn().mockResolvedValue(["PARTICIPANT"]);
+
+    vi.doMock("../src/config/env.js", () => ({
+      env: {
+        AUTH_MODE: "mock",
+        ENTRA_TENANT_ID: undefined,
+        ENTRA_AUDIENCE: undefined,
+        DEFAULT_LOCALE: "en-GB",
+        MOCK_DEFAULT_USER_ID: "participant-1",
+        MOCK_DEFAULT_EMAIL: "participant@company.com",
+        MOCK_DEFAULT_NAME: "Platform Participant",
+        MOCK_DEFAULT_DEPARTMENT: "Consulting",
+      },
+    }));
+    vi.doMock("../src/repositories/userRepository.js", () => ({
+      upsertUserFromPrincipal,
+      syncEntraGroupRoles,
+      getActiveRoles,
+    }));
+
+    const { authenticate } = await import("../src/auth/authenticate.js");
+    const request = buildRequest({
+      "x-user-id": "attacker-external-id",
+      "x-user-email": "participant@company.com",
+      "x-user-name": "Platform Participant",
+      "x-user-department": "Consulting",
+      "x-user-roles": "PARTICIPANT",
+    });
+    const response = buildResponse();
+    const next = vi.fn();
+
+    await authenticate(request as never, response as never, next);
+
+    expect(response.status).toHaveBeenCalledWith(403);
+    expect(response.json).toHaveBeenCalledWith({
+      error: "identity_conflict",
+      message: "This email is already linked to a different identity.",
+    });
+    expect(syncEntraGroupRoles).not.toHaveBeenCalled();
+    expect(getActiveRoles).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it("merges Entra JWT token roles with DB-assigned roles in Entra mode", async () => {
     const upsertUserFromPrincipal = vi.fn().mockResolvedValue({ id: "user-1" });
     const syncEntraGroupRoles = vi.fn().mockResolvedValue(undefined);

--- a/test/participant-console-production-config.test.ts
+++ b/test/participant-console-production-config.test.ts
@@ -9,11 +9,17 @@ beforeEach(() => {
 afterEach(() => {
   process.env.NODE_ENV = originalNodeEnv;
   vi.resetModules();
+  vi.unstubAllEnvs();
 });
 
 describe("participant console runtime config in production mode", () => {
   it("returns debugMode false when NODE_ENV is production", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("AUTH_MODE", "entra");
+    vi.stubEnv("DATABASE_URL", process.env.DATABASE_URL ?? "postgresql://test:test@localhost:5432/test");
+    vi.stubEnv("ENTRA_TENANT_ID", "tenant-id");
+    vi.stubEnv("ENTRA_CLIENT_ID", "client-id");
+    vi.stubEnv("ENTRA_AUDIENCE", "api://assessment-api");
     vi.resetModules();
 
     const { getParticipantConsoleRuntimeConfig } = await import("../src/config/participantConsole.js");
@@ -23,8 +29,13 @@ describe("participant console runtime config in production mode", () => {
   });
 
   it("allows Azure-style env override to force debugMode on in production", async () => {
-    process.env.NODE_ENV = "production";
-    process.env.PARTICIPANT_CONSOLE_DEBUG_MODE = "true";
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("AUTH_MODE", "entra");
+    vi.stubEnv("DATABASE_URL", process.env.DATABASE_URL ?? "postgresql://test:test@localhost:5432/test");
+    vi.stubEnv("ENTRA_TENANT_ID", "tenant-id");
+    vi.stubEnv("ENTRA_CLIENT_ID", "client-id");
+    vi.stubEnv("ENTRA_AUDIENCE", "api://assessment-api");
+    vi.stubEnv("PARTICIPANT_CONSOLE_DEBUG_MODE", "true");
     vi.resetModules();
 
     const { getParticipantConsoleRuntimeConfig } = await import("../src/config/participantConsole.js");

--- a/test/unit/user-repository.test.ts
+++ b/test/unit/user-repository.test.ts
@@ -114,7 +114,12 @@ describe("user repository", () => {
 
   it("does not reactivate inactive users when their external identity logs in", async () => {
     findUnique
-      .mockResolvedValueOnce({ id: "user-1", email: "participant@company.com", activeStatus: false })
+      .mockResolvedValueOnce({
+        id: "user-1",
+        email: "participant@company.com",
+        activeStatus: false,
+        isAnonymized: false,
+      })
       .mockResolvedValueOnce({ id: "user-1", externalId: "participant-1" });
     update.mockResolvedValueOnce({
       id: "user-1",
@@ -143,5 +148,34 @@ describe("user repository", () => {
       },
     });
     expect(result.activeStatus).toBe(false);
+  });
+
+  it("does not restore identifying fields for pseudonymized users", async () => {
+    findUnique
+      .mockResolvedValueOnce({
+        id: "user-1",
+        email: "pseudo-0000000000000000@deleted.invalid",
+        activeStatus: false,
+        isAnonymized: true,
+      })
+      .mockResolvedValueOnce(null);
+
+    const { upsertUserFromPrincipal } = await import("../../src/repositories/userRepository.js");
+
+    const result = await upsertUserFromPrincipal({
+      externalId: "participant-1",
+      email: "participant@company.com",
+      name: "Platform Participant",
+      department: "Consulting",
+      tokenRoles: ["PARTICIPANT"],
+    });
+
+    expect(update).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      id: "user-1",
+      email: "pseudo-0000000000000000@deleted.invalid",
+      activeStatus: false,
+      isAnonymized: true,
+    });
   });
 });

--- a/test/unit/user-repository.test.ts
+++ b/test/unit/user-repository.test.ts
@@ -33,9 +33,8 @@ afterEach(() => {
 });
 
 describe("user repository", () => {
-  it("recovers from a concurrent create on email/externalId collision", async () => {
+  it("recovers from a concurrent create on externalId collision without reactivating the user", async () => {
     findUnique
-      .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce({ id: "user-1" });
@@ -64,7 +63,7 @@ describe("user repository", () => {
         email: "participant@company.com",
         name: "Platform Participant",
         department: "Consulting",
-        activeStatus: true,
+        lastLoginAt: expect.any(Date),
       },
     });
     expect(result).toEqual({
@@ -89,5 +88,60 @@ describe("user repository", () => {
         tokenRoles: ["PARTICIPANT"],
       }),
     ).rejects.toThrow("disk I/O error");
+  });
+
+  it("does not link a new external identity to an existing email during login", async () => {
+    findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "existing-user", externalId: "original-external-id" });
+
+    const { upsertUserFromPrincipal } = await import("../../src/repositories/userRepository.js");
+
+    await expect(
+      upsertUserFromPrincipal({
+        externalId: "attacker-external-id",
+        email: "participant@company.com",
+        name: "Platform Participant",
+        department: "Consulting",
+        tokenRoles: ["PARTICIPANT"],
+      }),
+    ).rejects.toMatchObject({
+      code: "identity_reconciliation_conflict",
+    });
+
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("does not reactivate inactive users when their external identity logs in", async () => {
+    findUnique
+      .mockResolvedValueOnce({ id: "user-1", email: "participant@company.com", activeStatus: false })
+      .mockResolvedValueOnce({ id: "user-1", externalId: "participant-1" });
+    update.mockResolvedValueOnce({
+      id: "user-1",
+      externalId: "participant-1",
+      email: "participant@company.com",
+      activeStatus: false,
+    });
+
+    const { upsertUserFromPrincipal } = await import("../../src/repositories/userRepository.js");
+
+    const result = await upsertUserFromPrincipal({
+      externalId: "participant-1",
+      email: "participant@company.com",
+      name: "Platform Participant",
+      department: "Consulting",
+      tokenRoles: ["PARTICIPANT"],
+    });
+
+    expect(update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: {
+        email: "participant@company.com",
+        name: "Platform Participant",
+        department: "Consulting",
+        lastLoginAt: expect.any(Date),
+      },
+    });
+    expect(result.activeStatus).toBe(false);
   });
 });


### PR DESCRIPTION
﻿## Summary

This PR addresses the P0 Codex security remediation set in one CI-sized change:

- Hardens privileged GitHub Actions workflows by removing untrusted ref checkout, requiring default-branch dispatch for Azure jobs, validating benchmark inputs, reducing benchmark token permissions, and building deployment packages before Azure login.
- Restores Key Vault RBAC mode, replaces vault-wide parser access with secret-scoped role assignments, keeps App Service settings as Key Vault references, and removes post-deploy raw secret injection.
- Disables mock auth outside local/test runtimes, removes mock identity defaults from non-local runtime config, preserves offboarding state on login, and blocks email-only identity reconciliation.

Closes #380
Closes #381
Closes #382
Closes #383
Closes #384
Closes #385
Closes #386

## Validation

- npm run prisma:generate
- npm run lint
- npm run test:unit
- npx dotenv -e .env.test -- vitest run test/authenticate-middleware.test.ts test/participant-console-config.test.ts
- az bicep build --file infra/azure/main.bicep --stdout
- git diff --check

## Notes

- `az bicep build` succeeds with existing ACS conditional-resource warnings.
- The DB-backed `test/mock-auth-identity-reconciliation.test.ts` could not run locally because Docker/PostgreSQL is unavailable on this machine; CI should cover it.
- `npx actionlint` was not available via npm here, so workflow YAML validation is left to GitHub CI.
