### PR TITLE
fix(security): redact assessor-only guidanceText from participant module APIs

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,18 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.1.9 - 2026-05-16
+
+fix(security): Redact assessor-only guidanceText from participant module APIs (#387)
+
+- `src/modules/module/moduleService.ts`: Conditionally omit `guidanceText`
+  from all participant-facing response paths (`listModules`, `getModuleById`,
+  `getActiveModuleVersion`) when `participantFacing=true`. Admin/assessor
+  workflows with `?adminFacing=true` still receive the field.
+- `test/security-p1-387-redact-assessor-guidance.test.ts`: Response-shape
+  tests verifying the field is absent for PARTICIPANT role and present for
+  ADMINISTRATOR with `?adminFacing=true`.
+
 ## 1.1.8 - 2026-05-16
 
 fix(deploy): refresh OIDC during long ARM deployments

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/module/moduleService.ts
+++ b/src/modules/module/moduleService.ts
@@ -42,7 +42,8 @@ export async function listModules(
   options: ListModulesOptions = {},
 ) {
   const now = new Date();
-  const adminRead = options.participantFacing ? false : hasAdminRead(roles);
+  const participantFacing = options.participantFacing ?? false;
+  const adminRead = participantFacing ? false : hasAdminRead(roles);
   const modules = await queryModules(adminRead, now);
 
   if (!userId) {
@@ -51,7 +52,7 @@ export async function listModules(
       title: localizeContentText(locale, module.title) ?? module.title,
       description: localizeContentText(locale, module.description),
       taskText: localizeContentText(locale, module.activeVersion?.taskText) ?? module.activeVersion?.taskText ?? null,
-      guidanceText: localizeContentText(locale, module.activeVersion?.guidanceText),
+      ...(participantFacing ? {} : { guidanceText: localizeContentText(locale, module.activeVersion?.guidanceText) }),
       candidateTaskConstraints: localizeContentText(locale, module.activeVersion?.candidateTaskConstraints),
       submissionSchema: submissionSchemaCodec.parse(module.activeVersion?.submissionSchemaJson),
       assessmentPolicy: assessmentPolicyCodec.parse(module.activeVersion?.assessmentPolicyJson),
@@ -91,7 +92,7 @@ export async function listModules(
       title: localizeContentText(locale, module.title) ?? module.title,
       description: localizeContentText(locale, module.description),
       taskText: localizeContentText(locale, module.activeVersion?.taskText) ?? module.activeVersion?.taskText ?? null,
-      guidanceText: localizeContentText(locale, module.activeVersion?.guidanceText),
+      ...(participantFacing ? {} : { guidanceText: localizeContentText(locale, module.activeVersion?.guidanceText) }),
       candidateTaskConstraints: localizeContentText(locale, module.activeVersion?.candidateTaskConstraints),
       submissionSchema: submissionSchemaCodec.parse(module.activeVersion?.submissionSchemaJson),
       assessmentPolicy: assessmentPolicyCodec.parse(module.activeVersion?.assessmentPolicyJson),
@@ -164,7 +165,8 @@ export async function getModuleById(
   options: { participantFacing?: boolean } = {},
 ) {
   const now = new Date();
-  const adminRead = options.participantFacing ? false : hasAdminRead(roles);
+  const participantFacing = options.participantFacing ?? false;
+  const adminRead = participantFacing ? false : hasAdminRead(roles);
   const module = await queryModuleById(moduleId, adminRead, now);
 
   if (!module) {
@@ -176,7 +178,7 @@ export async function getModuleById(
     title: localizeContentText(locale, module.title) ?? module.title,
     description: localizeContentText(locale, module.description),
     taskText: localizeContentText(locale, module.activeVersion?.taskText) ?? module.activeVersion?.taskText ?? null,
-    guidanceText: localizeContentText(locale, module.activeVersion?.guidanceText),
+    ...(participantFacing ? {} : { guidanceText: localizeContentText(locale, module.activeVersion?.guidanceText) }),
     candidateTaskConstraints: localizeContentText(locale, module.activeVersion?.candidateTaskConstraints),
   };
 }
@@ -187,6 +189,7 @@ export async function getActiveModuleVersion(
   locale: SupportedLocale = "en-GB",
   options: { participantFacing?: boolean } = {},
 ) {
+  const participantFacing = options.participantFacing ?? false;
   const module = await getModuleById(moduleId, roles, locale, options);
   if (!module?.activeVersion) {
     return null;
@@ -200,7 +203,7 @@ export async function getActiveModuleVersion(
   return {
     ...activeVersion,
     taskText: localizeContentText(locale, activeVersion.taskText) ?? activeVersion.taskText,
-    guidanceText: localizeContentText(locale, activeVersion.guidanceText),
+    ...(participantFacing ? {} : { guidanceText: localizeContentText(locale, activeVersion.guidanceText) }),
     candidateTaskConstraints: localizeContentText(locale, activeVersion.candidateTaskConstraints),
     submissionSchema: submissionSchemaCodec.parse(activeVersion.submissionSchemaJson),
     assessmentPolicy: assessmentPolicyCodec.parse(activeVersion.assessmentPolicyJson),

--- a/src/modules/module/moduleService.ts
+++ b/src/modules/module/moduleService.ts
@@ -200,8 +200,9 @@ export async function getActiveModuleVersion(
     return null;
   }
 
+  const { guidanceText: _gt, ...activeVersionBase } = activeVersion;
   return {
-    ...activeVersion,
+    ...activeVersionBase,
     taskText: localizeContentText(locale, activeVersion.taskText) ?? activeVersion.taskText,
     ...(participantFacing ? {} : { guidanceText: localizeContentText(locale, activeVersion.guidanceText) }),
     candidateTaskConstraints: localizeContentText(locale, activeVersion.candidateTaskConstraints),

--- a/test/m2-i18n-baseline.test.ts
+++ b/test/m2-i18n-baseline.test.ts
@@ -205,7 +205,8 @@ describe("MVP i18n baseline", () => {
     expect(moduleNb.body.module.taskText).toBe(
       "Vurder styringsrisiko og dokumenter en praktisk tilnærming til risikoreduserende tiltak.",
     );
-    expect(moduleNb.body.module.guidanceText).toBe("Beskriv konkrete kontroller, ansvarlige og oppfølgingsaktiviteter.");
+    // guidanceText is assessor-only; participant-facing endpoint omits it
+    expect(moduleNb.body.module).not.toHaveProperty("guidanceText");
 
     const submissionResponse = await request(app)
       .post("/api/submissions")
@@ -290,10 +291,10 @@ describe("MVP i18n baseline", () => {
     expect(modulesNb.status).toBe(200);
 
     const localizedModule = (
-      modulesNb.body.modules as Array<{ id: string; taskText?: string; guidanceText?: string }>
+      modulesNb.body.modules as Array<{ id: string; taskText?: string }>
     ).find((module) => module.id === seedModule.id);
     expect(localizedModule?.taskText).toBe("Norsk oppgavekontekst.");
-    expect(localizedModule?.guidanceText).toBe("Norsk veiledningskontekst.");
+    // guidanceText is assessor-only; participant list endpoint omits it
 
     env.LLM_MODE = "azure_openai";
     env.AZURE_OPENAI_ENDPOINT = "https://example.openai.azure.com";

--- a/test/security-p1-387-redact-assessor-guidance.test.ts
+++ b/test/security-p1-387-redact-assessor-guidance.test.ts
@@ -1,0 +1,74 @@
+import request from "supertest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+
+const participantHeaders = {
+  "x-user-id": "participant-1",
+  "x-user-email": "participant@company.com",
+  "x-user-name": "Platform Participant",
+  "x-user-roles": "PARTICIPANT",
+};
+
+const adminHeaders = {
+  "x-user-id": "admin-1",
+  "x-user-email": "admin@company.com",
+  "x-user-name": "Platform Admin",
+  "x-user-roles": "ADMINISTRATOR",
+};
+
+describe("[Security P1 #387] Assessor guidance redaction from participant module APIs", () => {
+  let moduleId: string;
+
+  beforeAll(async () => {
+    const mod = await prisma.module.findFirst({
+      where: { activeVersionId: { not: null } },
+      include: { activeVersion: { select: { guidanceText: true } } },
+    });
+    if (!mod || !mod.activeVersion?.guidanceText) {
+      throw new Error("No seed module with guidanceText found — check seedCore.ts.");
+    }
+    moduleId = mod.id;
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("GET /api/modules — participant response never includes guidanceText", async () => {
+    const res = await request(app)
+      .get("/api/modules?includeCompleted=true")
+      .set(participantHeaders);
+    expect(res.status).toBe(200);
+    for (const mod of res.body.modules as Record<string, unknown>[]) {
+      expect(mod).not.toHaveProperty("guidanceText");
+    }
+  });
+
+  it("GET /api/modules/:id — participant response never includes guidanceText", async () => {
+    const res = await request(app)
+      .get(`/api/modules/${moduleId}`)
+      .set(participantHeaders);
+    expect(res.status).toBe(200);
+    expect(res.body.module).not.toHaveProperty("guidanceText");
+  });
+
+  it("GET /api/modules/:id/active-version — participant response never includes guidanceText", async () => {
+    const res = await request(app)
+      .get(`/api/modules/${moduleId}/active-version`)
+      .set(participantHeaders);
+    expect(res.status).toBe(200);
+    expect(res.body.activeVersion).not.toHaveProperty("guidanceText");
+  });
+
+  it("GET /api/modules?adminFacing=true — admin/assessor response includes guidanceText", async () => {
+    const res = await request(app)
+      .get("/api/modules?adminFacing=true&includeCompleted=true")
+      .set(adminHeaders);
+    expect(res.status).toBe(200);
+    const targetModule = (res.body.modules as Record<string, unknown>[]).find(
+      (m) => m.id === moduleId,
+    );
+    expect(targetModule).toBeDefined();
+    expect(targetModule).toHaveProperty("guidanceText");
+  });
+});


### PR DESCRIPTION
Closes #387

## Summary

- `moduleService.ts`: Conditionally omit `guidanceText` in all three participant-facing response paths (`listModules` both branches, `getModuleById`, `getActiveModuleVersion`) when `participantFacing=true`. Admin/assessor requests with `?adminFacing=true` still receive the field unchanged.
- No route changes required — routes already pass `participantFacing: true` for all public module endpoints.
- Added 4 response-shape integration tests verifying the field is absent for `PARTICIPANT` role and present for `ADMINISTRATOR` with `?adminFacing=true`.

## Test plan

- [ ] `GET /api/modules` with PARTICIPANT role → no module has `guidanceText`
- [ ] `GET /api/modules/:id` with PARTICIPANT role → no `guidanceText`
- [ ] `GET /api/modules/:id/active-version` with PARTICIPANT role → no `guidanceText`
- [ ] `GET /api/modules?adminFacing=true` with ADMINISTRATOR → `guidanceText` present
- [ ] Existing integration tests pass (m1-core-flow, m2-module-archive, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)