### PR TITLE
fix(security): harden XSS attack surface in admin content UI

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,23 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.1.10 - 2026-05-16
+
+fix(security): harden XSS attack surface in admin content UI
+
+- `src/modules/adminContent/adminContentSchemas.ts`: Added `safeShortString`
+  validator (max 100 chars, rejects `<>"'&`) and `certificationLevelInputSchema`
+  which applies it to all locales. `moduleCreateBodySchema.certificationLevel`
+  now uses this schema instead of the unrestricted `localizedTextSchema`, closing
+  a stored-XSS vector where an attacker with admin access could inject HTML via
+  the certification level field.
+- `src/modules/adminContent/adminContentQueries.ts`: Fixed `listArchivedModules`
+  to localise `certificationLevel` through `localizeContentText` (was returning
+  the raw DB value, bypassing the localization pipeline).
+- `public/static/admin-content-courses.js`: Changed `appendConvUserBubble` from
+  `innerHTML` to `textContent`, removing a reflected-XSS sink in the conversation
+  flow UI.
+
 ## 1.1.9 - 2026-05-16
 
 fix(security): Redact assessor-only guidanceText from participant module APIs (#387)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -496,7 +496,7 @@ async function renderNewCourseConversational() {
     convTitle = val;
     if (titleInput) titleInput.disabled = true;
     if (titleNext) titleNext.disabled = true;
-    appendConvUserBubble(escapeHtml(convTitle));
+    appendConvUserBubble(convTitle);
     showConvCertStep();
   }
 
@@ -505,12 +505,12 @@ async function renderNewCourseConversational() {
   titleInput?.focus();
 }
 
-function appendConvUserBubble(html) {
+function appendConvUserBubble(text) {
   const flow = document.getElementById("convFlow");
   if (!flow) return;
   const bubble = document.createElement("div");
   bubble.className = "conv-user-bubble";
-  bubble.innerHTML = html;
+  bubble.textContent = text;
   flow.insertBefore(bubble, document.getElementById("convAfterTitle"));
 }
 

--- a/src/modules/adminContent/adminContentQueries.ts
+++ b/src/modules/adminContent/adminContentQueries.ts
@@ -47,7 +47,7 @@ export async function listArchivedModules(locale: SupportedLocale = "en-GB", sea
     id: module.id,
     title: localizeContentText(locale, module.title) ?? module.title,
     description: localizeContentText(locale, module.description),
-    certificationLevel: module.certificationLevel,
+    certificationLevel: localizeContentText(locale, module.certificationLevel) ?? module.certificationLevel ?? null,
     archivedAt: module.archivedAt,
   }));
 }

--- a/src/modules/adminContent/adminContentSchemas.ts
+++ b/src/modules/adminContent/adminContentSchemas.ts
@@ -21,10 +21,20 @@ export function localizedTextIdentity(value: LocalizedText): string {
   return `locale:${value["en-GB"] ?? ""}|${value.nb ?? ""}|${value.nn ?? ""}`;
 }
 
+const safeShortString = z.string().trim().max(100).refine(
+  (v) => !/[<>"'&]/.test(v),
+  { message: "Value must not contain HTML special characters." },
+);
+
+export const certificationLevelInputSchema = z.union([
+  safeShortString,
+  z.record(z.string(), safeShortString),
+]).optional();
+
 export const moduleCreateBodySchema = z.object({
   title: localizedTextSchema,
   description: localizedTextSchema.optional(),
-  certificationLevel: localizedTextSchema.optional(),
+  certificationLevel: certificationLevelInputSchema,
   validFrom: z.string().trim().optional(),
   validTo: z.string().trim().optional(),
 });


### PR DESCRIPTION
Closes #391

## Summary
- **adminContentSchemas.ts**: Added `safeShortString` validator (max 100 chars, rejects HTML special chars) and `certificationLevelInputSchema`. `moduleCreateBodySchema.certificationLevel` now uses this schema instead of unrestricted `localizedTextSchema`, closing a stored-XSS vector where an admin could inject arbitrary HTML via the certification level field.
- **adminContentQueries.ts**: Fixed `listArchivedModules` to localise `certificationLevel` via `localizeContentText` (was returning the raw DB value, bypassing localization).
- **admin-content-courses.js**: Changed `appendConvUserBubble` from `innerHTML` to `textContent`, eliminating a reflected-XSS sink in the conversation flow UI.

## Test plan
- [ ] TypeScript: `npx tsc --noEmit` -- zero errors (verified locally)
- [ ] POST /admin/content/modules with `certificationLevel: <script>alert(1)</script>` returns 400
- [ ] GET /admin/content/modules/archived returns localized certificationLevel string, not raw DB value
- [ ] Admin UI: type a title with HTML tags in the conversation flow -- verify it renders as literal text, not HTML

Generated with [Claude Code](https://claude.com/claude-code)