### PR TITLE
fix(security): type-safe MCQ answer key redaction on SMO module export

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,20 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.1.11 - 2026-05-16
+
+fix(security): type-safe MCQ answer key redaction on module export for SMOs
+
+- `src/routes/adminContent.ts`: Replaced `any`-typed in-place deletion with a
+  typed `redactMcqAnswerKeys` helper that uses destructuring to omit
+  `correctAnswer` and `rationale` from all MCQ questions in both
+  `selectedConfiguration.mcqSetVersion` and `versions.mcqSetVersions`. Admin
+  exports are unaffected. Also propagates `AppError` through the catch handler
+  so 403/404 responses from ownership checks are returned correctly.
+- `test/security-p1-392-smo-export-scope.test.ts`: Integration tests verifying
+  SMO-B cannot export SMO-A's module (403), SMO exports omit answer keys, and
+  admin exports retain full question data.
+
 ## 1.1.10 - 2026-05-16
 
 fix(security): harden XSS attack surface in admin content UI

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -170,6 +170,28 @@ adminContentRouter.delete("/modules/:moduleId", async (request, response) => {
   }
 });
 
+type McqSetVersionBundle = Awaited<ReturnType<typeof getModuleContentBundle>>["versions"]["mcqSetVersions"][number];
+
+function redactMcqAnswerKeys(bundle: Awaited<ReturnType<typeof getModuleContentBundle>>) {
+  const stripAnswers = (v: McqSetVersionBundle) => ({
+    ...v,
+    questions: v.questions.map(({ correctAnswer: _c, rationale: _r, ...rest }) => rest),
+  });
+  return {
+    ...bundle,
+    selectedConfiguration: {
+      ...bundle.selectedConfiguration,
+      mcqSetVersion: bundle.selectedConfiguration.mcqSetVersion
+        ? stripAnswers(bundle.selectedConfiguration.mcqSetVersion)
+        : null,
+    },
+    versions: {
+      ...bundle.versions,
+      mcqSetVersions: bundle.versions.mcqSetVersions.map(stripAnswers),
+    },
+  };
+}
+
 adminContentRouter.get("/modules/:moduleId/export", async (request, response) => {
   const actorId = request.context?.userId;
   if (!actorId) {
@@ -178,28 +200,16 @@ adminContentRouter.get("/modules/:moduleId/export", async (request, response) =>
   }
   try {
     await assertModuleOwnership(request.params.moduleId, actorId, request.context?.roles ?? []);
-    const moduleExport = await getModuleContentBundle(request.params.moduleId);
-
-    // Sikkerhetsfiks: Fjern fasit og begrunnelser for SMO-rollen (#13)
-    if (!request.context?.roles?.includes("ADMINISTRATOR")) {
-      if (moduleExport.selectedConfiguration?.mcqSetVersion?.questions) {
-        moduleExport.selectedConfiguration.mcqSetVersion.questions.forEach((q: any) => {
-          delete q.correctAnswer;
-          delete q.rationale;
-        });
-      }
-      if (Array.isArray(moduleExport.versions?.mcqSetVersions)) {
-        moduleExport.versions.mcqSetVersions.forEach((v: any) => {
-          v.questions?.forEach((q: any) => {
-            delete q.correctAnswer;
-            delete q.rationale;
-          });
-        });
-      }
-    }
-
+    const bundle = await getModuleContentBundle(request.params.moduleId);
+    const moduleExport = request.context?.roles?.includes("ADMINISTRATOR")
+      ? bundle
+      : redactMcqAnswerKeys(bundle);
     response.json({ moduleExport });
   } catch (error) {
+    if (error instanceof AppError) {
+      response.status(error.httpStatus).json({ error: error.code, message: error.message });
+      return;
+    }
     response.status(404).json({ error: "module_export_failed", message: "Could not export module." });
   }
 });

--- a/test/security-p1-392-smo-export-scope.test.ts
+++ b/test/security-p1-392-smo-export-scope.test.ts
@@ -1,0 +1,133 @@
+import request from "supertest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+
+const smoAHeaders = {
+  "x-user-id": "smo-export-a",
+  "x-user-email": "smo-export-a@company.com",
+  "x-user-name": "SMO Export Alpha",
+  "x-user-roles": "SUBJECT_MATTER_OWNER",
+};
+
+const smoBHeaders = {
+  "x-user-id": "smo-export-b",
+  "x-user-email": "smo-export-b@company.com",
+  "x-user-name": "SMO Export Beta",
+  "x-user-roles": "SUBJECT_MATTER_OWNER",
+};
+
+const adminHeaders = {
+  "x-user-id": "admin-export-1",
+  "x-user-email": "admin-export@company.com",
+  "x-user-name": "Platform Admin",
+  "x-user-roles": "ADMINISTRATOR",
+};
+
+const moduleBody = {
+  title: { "en-GB": "Export Scope Test Module", nb: "Eksportomfangsmodul", nn: "Eksportomfangsmodul" },
+};
+
+describe("Security P1 #392: SMO content scope and MCQ answer key protection on export", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("SMO-B is denied export of a module owned by SMO-A", async () => {
+    const createRes = await request(app)
+      .post("/api/admin/content/modules")
+      .set(smoAHeaders)
+      .send(moduleBody);
+    expect(createRes.status).toBe(201);
+    const moduleId = createRes.body.module.id as string;
+
+    const exportBRes = await request(app)
+      .get(`/api/admin/content/modules/${moduleId}/export`)
+      .set(smoBHeaders);
+    expect(exportBRes.status).toBe(403);
+
+    await request(app).delete(`/api/admin/content/modules/${moduleId}`).set(adminHeaders);
+  });
+
+  it("SMO export omits correctAnswer and rationale from MCQ questions; admin export includes them", async () => {
+    const createRes = await request(app)
+      .post("/api/admin/content/modules")
+      .set(smoAHeaders)
+      .send(moduleBody);
+    expect(createRes.status).toBe(201);
+    const moduleId = createRes.body.module.id as string;
+
+    // Create an MCQ set version with a question that has correctAnswer and rationale
+    const mcqRes = await request(app)
+      .post(`/api/admin/content/modules/${moduleId}/mcq-set-versions`)
+      .set(smoAHeaders)
+      .send({
+        title: { "en-GB": "Test MCQ Set", nb: "Test MCQ-sett", nn: "Test MCQ-sett" },
+        questions: [
+          {
+            stem: { "en-GB": "What is 2+2?", nb: "Hva er 2+2?", nn: "Kva er 2+2?" },
+            options: [
+              { "en-GB": "3", nb: "3", nn: "3" },
+              { "en-GB": "4", nb: "4", nn: "4" },
+              { "en-GB": "5", nb: "5", nn: "5" },
+            ],
+            correctAnswer: { "en-GB": "4", nb: "4", nn: "4" },
+            rationale: { "en-GB": "Because math.", nb: "Fordi matte.", nn: "Fordi matte." },
+          },
+        ],
+      });
+    expect(mcqRes.status).toBe(201);
+
+    // SMO export: correctAnswer and rationale must be absent
+    const smoExportRes = await request(app)
+      .get(`/api/admin/content/modules/${moduleId}/export`)
+      .set(smoAHeaders);
+    expect(smoExportRes.status).toBe(200);
+
+    const smoExport = smoExportRes.body.moduleExport;
+    const smoVersionQuestions = smoExport.versions.mcqSetVersions?.[0]?.questions ?? [];
+    expect(smoVersionQuestions.length).toBeGreaterThan(0);
+    for (const q of smoVersionQuestions) {
+      expect(q).not.toHaveProperty("correctAnswer");
+      expect(q).not.toHaveProperty("rationale");
+    }
+    if (smoExport.selectedConfiguration?.mcqSetVersion?.questions) {
+      for (const q of smoExport.selectedConfiguration.mcqSetVersion.questions) {
+        expect(q).not.toHaveProperty("correctAnswer");
+        expect(q).not.toHaveProperty("rationale");
+      }
+    }
+
+    // Admin export: correctAnswer and rationale must be present
+    const adminExportRes = await request(app)
+      .get(`/api/admin/content/modules/${moduleId}/export`)
+      .set(adminHeaders);
+    expect(adminExportRes.status).toBe(200);
+
+    const adminExport = adminExportRes.body.moduleExport;
+    const adminVersionQuestions = adminExport.versions.mcqSetVersions?.[0]?.questions ?? [];
+    expect(adminVersionQuestions.length).toBeGreaterThan(0);
+    for (const q of adminVersionQuestions) {
+      expect(q).toHaveProperty("correctAnswer");
+      expect(q).toHaveProperty("rationale");
+    }
+
+    await request(app).delete(`/api/admin/content/modules/${moduleId}`).set(adminHeaders);
+  });
+
+  it("admin can export any module regardless of ownership", async () => {
+    const createRes = await request(app)
+      .post("/api/admin/content/modules")
+      .set(smoAHeaders)
+      .send(moduleBody);
+    expect(createRes.status).toBe(201);
+    const moduleId = createRes.body.module.id as string;
+
+    const exportRes = await request(app)
+      .get(`/api/admin/content/modules/${moduleId}/export`)
+      .set(adminHeaders);
+    expect(exportRes.status).toBe(200);
+    expect(exportRes.body.moduleExport.module.id).toBe(moduleId);
+
+    await request(app).delete(`/api/admin/content/modules/${moduleId}`).set(adminHeaders);
+  });
+});


### PR DESCRIPTION
Closes #392

## Summary
- **adminContent.ts**: Replaces `any`-typed in-place `delete` mutations with a typed `redactMcqAnswerKeys` helper. Uses destructuring (`{ correctAnswer: _c, rationale: _r, ...rest }`) so `correctAnswer` and `rationale` are absent from the response shape rather than just deleted from a mutated object. Covers both `selectedConfiguration.mcqSetVersion.questions` and all `versions.mcqSetVersions[*].questions`. Admin exports are returned as-is. AppError is now also propagated from the catch handler so ownership failures return 403 instead of 404.
- **security-p1-392-smo-export-scope.test.ts**: Three integration tests: SMO-B denied export of SMO-A module (403), SMO export omits `correctAnswer`/`rationale`, admin export retains them.

The underlying ownership check (`assertModuleOwnership`) and the redaction gate were already in place from v1.1.1; this PR hardens the types and adds test coverage.

## Test plan
- [ ] TypeScript: `npx tsc --noEmit` -- zero errors (verified locally)
- [ ] CI: `security-p1-392-smo-export-scope.test.ts` all 3 tests green
- [ ] Manual: SMO export of own module -- verify `correctAnswer` absent in response
- [ ] Manual: Admin export of same module -- verify `correctAnswer` present

Generated with [Claude Code](https://claude.com/claude-code)