### PR TITLE
fix(security): prevent MCQ submission lifecycle abuse and old-submission renewal

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,23 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.1.12 - 2026-05-16
+
+fix(security): prevent MCQ submission lifecycle abuse and old-submission renewal
+
+- `src/modules/assessment/mcqService.ts`: Gate `startMcqAttempt` and
+  `submitMcqAttempt` on submission status. Both throw if status is SCORED,
+  COMPLETED, UNDER_REVIEW, or REJECTED. `startMcqAttempt` additionally throws
+  if status is PROCESSING and no open attempt exists, preventing MCQ restart
+  after the previous attempt was already scored. Allows resuming an existing
+  open attempt when status is PROCESSING.
+- `src/routes/modules.ts`: Removed dead code branch that tried to delete
+  `correctAnswer`/`rationale` from a `responses` field that never exists in
+  the `submitMcqAttempt` return value.
+- `test/unit/mcq-service.test.ts`: Added parameterized tests for all four
+  terminal statuses on both start and submit; added PROCESSING-without-open-attempt
+  rejection; added PROCESSING-with-open-attempt resume test.
+
 ## 1.1.11 - 2026-05-16
 
 fix(security): type-safe MCQ answer key redaction on module export for SMOs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/assessment/mcqService.ts
+++ b/src/modules/assessment/mcqService.ts
@@ -12,6 +12,13 @@ import {
   matchesLocalizedContentVariant,
 } from "../../i18n/content.js";
 
+const TERMINAL_SUBMISSION_STATUSES: ReadonlySet<(typeof SubmissionStatus)[keyof typeof SubmissionStatus]> = new Set([
+  SubmissionStatus.SCORED,
+  SubmissionStatus.COMPLETED,
+  SubmissionStatus.UNDER_REVIEW,
+  SubmissionStatus.REJECTED,
+]);
+
 export async function startMcqAttempt(
   moduleId: string,
   submissionId: string,
@@ -24,9 +31,16 @@ export async function startMcqAttempt(
     throw new Error("Submission not found for module.");
   }
 
+  if (TERMINAL_SUBMISSION_STATUSES.has(submission.submissionStatus)) {
+    throw new Error("MCQ attempt cannot be started: assessment is already completed or under review.");
+  }
+
   let attempt = await mcqRepository.findOpenAttemptForSubmission(submission.id);
 
   if (!attempt) {
+    if (submission.submissionStatus === SubmissionStatus.PROCESSING) {
+      throw new Error("MCQ attempt cannot be started: submission has already been processed.");
+    }
     attempt = await mcqRepository.createAttempt({
       submissionId: submission.id,
       mcqSetVersionId: submission.moduleVersion.mcqSetVersionId,
@@ -59,6 +73,10 @@ export async function submitMcqAttempt(input: {
   const submission = await mcqRepository.findSubmissionForModuleMcq(input.submissionId, input.userId, input.moduleId);
   if (!submission) {
     throw new Error("Submission not found for module.");
+  }
+
+  if (TERMINAL_SUBMISSION_STATUSES.has(submission.submissionStatus)) {
+    throw new Error("MCQ cannot be submitted: assessment is already completed or under review.");
   }
 
   const attempt = await mcqRepository.findAttemptForSubmission(input.attemptId, submission.id);

--- a/src/routes/modules.ts
+++ b/src/routes/modules.ts
@@ -181,15 +181,6 @@ modulesRouter.post("/:moduleId/mcq/submit", mcqSubmitLimiter, async (request, re
       userId,
       ...parsed.data,
     });
-
-    // Sikkerhetsfiks: Fjern fasitdetaljer fra resultatet vist til deltaker (#22)
-    if (result && (result as any).responses) {
-      (result as any).responses.forEach((r: any) => {
-        delete r.correctAnswer;
-        delete r.rationale;
-      });
-    }
-
     response.json(result);
   } catch (error) {
     next(error);

--- a/test/unit/mcq-service.test.ts
+++ b/test/unit/mcq-service.test.ts
@@ -46,6 +46,7 @@ vi.mock("../../src/services/auditService.js", () => ({
 describe("mcq service — submitMcqAttempt", () => {
   const baseSubmission = {
     id: "submission-1",
+    submissionStatus: "SUBMITTED" as const,
     moduleVersion: { mcqSetVersionId: "mcq-set-1" },
   };
   const baseAttempt = {
@@ -202,6 +203,93 @@ describe("mcq service — submitMcqAttempt", () => {
       }),
     );
   });
+
+  it.each(["SCORED", "COMPLETED", "UNDER_REVIEW", "REJECTED"] as const)(
+    "throws when submission status is terminal (%s)",
+    async (status) => {
+      findSubmissionForModuleMcq.mockResolvedValue({ ...baseSubmission, submissionStatus: status });
+
+      const { submitMcqAttempt } = await import("../../src/modules/assessment/mcqService.js");
+
+      await expect(
+        submitMcqAttempt({
+          moduleId: "module-1",
+          submissionId: "submission-1",
+          attemptId: "attempt-1",
+          userId: "user-1",
+          responses: [{ questionId: "q-1", selectedAnswer: "4" }],
+        }),
+      ).rejects.toThrow("MCQ cannot be submitted: assessment is already completed or under review.");
+    },
+  );
+});
+
+describe("mcq service — startMcqAttempt lifecycle guards", () => {
+  beforeEach(() => {
+    findSubmissionForModuleMcq.mockReset();
+    findOpenAttemptForSubmission.mockReset();
+    createAttempt.mockReset();
+    findActiveQuestionsForSet.mockReset();
+  });
+
+  it.each(["SCORED", "COMPLETED", "UNDER_REVIEW", "REJECTED"] as const)(
+    "throws when submission status is terminal (%s)",
+    async (status) => {
+      findSubmissionForModuleMcq.mockResolvedValue({
+        id: "submission-1",
+        submissionStatus: status,
+        moduleVersion: { mcqSetVersionId: "mcq-set-1" },
+      });
+
+      const { startMcqAttempt } = await import("../../src/modules/assessment/mcqService.js");
+
+      await expect(
+        startMcqAttempt("module-1", "submission-1", "user-1"),
+      ).rejects.toThrow("MCQ attempt cannot be started: assessment is already completed or under review.");
+    },
+  );
+
+  it("throws when submission is PROCESSING and no open attempt exists", async () => {
+    findSubmissionForModuleMcq.mockResolvedValue({
+      id: "submission-1",
+      submissionStatus: "PROCESSING",
+      moduleVersion: { mcqSetVersionId: "mcq-set-1" },
+    });
+    findOpenAttemptForSubmission.mockResolvedValue(null);
+
+    const { startMcqAttempt } = await import("../../src/modules/assessment/mcqService.js");
+
+    await expect(
+      startMcqAttempt("module-1", "submission-1", "user-1"),
+    ).rejects.toThrow("MCQ attempt cannot be started: submission has already been processed.");
+  });
+
+  it("allows resuming an open attempt when submission is PROCESSING", async () => {
+    findSubmissionForModuleMcq.mockResolvedValue({
+      id: "submission-1",
+      submissionStatus: "PROCESSING",
+      moduleVersion: { mcqSetVersionId: "mcq-set-1" },
+    });
+    findOpenAttemptForSubmission.mockResolvedValue({
+      id: "attempt-1",
+      mcqSetVersionId: "mcq-set-1",
+    });
+    findActiveQuestionsForSet.mockResolvedValue([
+      {
+        id: "q-1",
+        stem: "What is 2+2?",
+        optionsJson: JSON.stringify(["3", "4", "5"]),
+        correctAnswer: "4",
+        active: true,
+      },
+    ]);
+
+    const { startMcqAttempt } = await import("../../src/modules/assessment/mcqService.js");
+    const result = await startMcqAttempt("module-1", "submission-1", "user-1");
+
+    expect(result.attemptId).toBe("attempt-1");
+    expect(result.questions).toHaveLength(1);
+  });
 });
 
 describe("mcq service — shuffle behaviour via startMcqAttempt", () => {
@@ -215,6 +303,7 @@ describe("mcq service — shuffle behaviour via startMcqAttempt", () => {
   it("returns the same number of options as stored for each question", async () => {
     findSubmissionForModuleMcq.mockResolvedValue({
       id: "submission-1",
+      submissionStatus: "SUBMITTED",
       moduleVersion: { mcqSetVersionId: "mcq-set-1" },
     });
     findOpenAttemptForSubmission.mockResolvedValue({
@@ -253,6 +342,7 @@ describe("mcq service — shuffle behaviour via startMcqAttempt", () => {
 
     findSubmissionForModuleMcq.mockResolvedValue({
       id: "submission-1",
+      submissionStatus: "SUBMITTED",
       moduleVersion: { mcqSetVersionId: "mcq-set-1" },
     });
     findOpenAttemptForSubmission.mockResolvedValue({
@@ -284,6 +374,7 @@ describe("mcq service — shuffle behaviour via startMcqAttempt", () => {
 
     findSubmissionForModuleMcq.mockResolvedValue({
       id: "submission-1",
+      submissionStatus: "SUBMITTED",
       moduleVersion: { mcqSetVersionId: "mcq-set-1" },
     });
     findOpenAttemptForSubmission.mockResolvedValue({


### PR DESCRIPTION
Closes #389

## Summary
- **mcqService.ts**: Both `startMcqAttempt` and `submitMcqAttempt` now check submission status against a terminal-states set (SCORED, COMPLETED, UNDER_REVIEW, REJECTED) and throw if matched, blocking reuse of old submissions for certification renewal. `startMcqAttempt` additionally throws if status is PROCESSING and no open attempt exists (MCQ was already submitted); allows resume when an open attempt exists.
- **modules.ts**: Removed dead code block that tried to delete `correctAnswer`/`rationale` from a `responses` field that never exists in `submitMcqAttempt`'s return value.
- **mcq-service.test.ts**: Added parameterized tests (`it.each`) for all four terminal statuses on both start and submit paths; added PROCESSING-without-open-attempt rejection test; added PROCESSING-with-open-attempt resume test.

Note: MCQ scoring was already server-side (client sends only `selectedAnswer`, server compares against stored `correctAnswer`). This PR closes the lifecycle-abuse vector without changing the scoring logic.

## Test plan
- [ ] TypeScript: `npx tsc --noEmit` -- zero errors (verified locally)
- [ ] Unit: `vitest run test/unit/mcq-service.test.ts` -- all tests pass including 8 new ones
- [ ] Integration: attempt to start MCQ on a submission with status COMPLETED -- verify 500 error from lifecycle guard

Generated with [Claude Code](https://claude.com/claude-code)