### PR TITLE
fix(security): enforce MCQ and practical component pass gates (v1.1.14)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,34 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.1.14 - 2026-05-16
+
+fix(security): enforce MCQ and practical component pass gates in assessment decisions
+
+- `src/codecs/assessmentPolicyCodec.ts`: Added `mcqMinPercent` and
+  `practicalMinPercent` to `ModuleAssessmentPolicy.passRules`, enabling
+  per-component minimum thresholds that act as AND conditions alongside
+  `totalMin`.
+- `src/modules/assessment/decisionService.ts`: `resolveAssessmentDecision` now
+  checks both component gates — a submission fails if MCQ percent falls below
+  `mcqMinPercent` or practical percent falls below `practicalMinPercent`, even
+  when total score would otherwise pass. Dedicated fail reasons distinguish
+  component failures from threshold failures.
+- `src/routes/calibration.ts`: `publish-thresholds` endpoint now accepts
+  optional `mcqMinPercent` and `practicalMinPercent` fields.
+- `src/modules/adminContent/adminContentCommands.ts`: `publishModuleVersionWithThresholds`
+  persists the new per-component thresholds into the module's `assessmentPolicyJson`.
+- `src/modules/calibration/calibrationWorkspaceService.ts`: `effectiveThresholds`
+  in the workspace snapshot now includes `mcqMinPercent` and `practicalMinPercent`.
+- `public/calibration.html` + `public/calibration.js`: Calibration UI gains two
+  optional inputs for the new per-component thresholds.
+- `test/unit/decision-service.test.ts`: Rewrote `buildLlmResult` defaults to
+  have consistent `rubric_scores`/`rubric_total` (sum=14 matches default total),
+  updated score expectations to reflect server-side recomputation, and added 6
+  new tests for the component gate logic.
+- `test/unit/read-models.test.ts`: Fixed stale `rubric_scores: { evidence: 8 }`
+  test data that violated the `max(4)` codec constraint added in v1.1.13.
+
 ## 1.1.13 - 2026-05-16
 
 fix(security): recompute LLM assessment scores server-side to prevent prompt injection

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/calibration.html
+++ b/public/calibration.html
@@ -116,6 +116,18 @@
           <div class="small" data-i18n="calibration.thresholds.totalMinHelp">Minimum total score to pass.</div>
         </div>
       </div>
+      <div class="row">
+        <div>
+          <label for="thresholdMcqMinPercent" data-i18n="calibration.thresholds.mcqMinPercent">MCQ minimum (% correct, optional)</label>
+          <input id="thresholdMcqMinPercent" type="number" min="0" max="100" step="1" placeholder="None" />
+          <div class="small" data-i18n="calibration.thresholds.mcqMinPercentHelp">Participant must meet this MCQ % even if total score passes. Leave blank to disable.</div>
+        </div>
+        <div>
+          <label for="thresholdPracticalMinPercent" data-i18n="calibration.thresholds.practicalMinPercent">Practical minimum (% of rubric, optional)</label>
+          <input id="thresholdPracticalMinPercent" type="number" min="0" max="100" step="1" placeholder="None" />
+          <div class="small" data-i18n="calibration.thresholds.practicalMinPercentHelp">Participant must meet this practical rubric % even if total score passes. Leave blank to disable.</div>
+        </div>
+      </div>
 
       <div class="row" style="margin-top: calc(var(--space-1) * 1.25);">
         <div>

--- a/public/calibration.js
+++ b/public/calibration.js
@@ -32,6 +32,8 @@ const outcomesBody = document.getElementById("calibrationOutcomesBody");
 const anchorsBody = document.getElementById("calibrationAnchorsBody");
 const thresholdEditorSection = document.getElementById("thresholdEditorSection");
 const thresholdTotalMinInput = document.getElementById("thresholdTotalMin");
+const thresholdMcqMinPercentInput = document.getElementById("thresholdMcqMinPercent");
+const thresholdPracticalMinPercentInput = document.getElementById("thresholdPracticalMinPercent");
 const publishThresholdsButton = document.getElementById("publishThresholds");
 const thresholdPublishResult = document.getElementById("thresholdPublishResult");
 
@@ -396,12 +398,20 @@ function populateStatusOptions() {
 }
 
 function getThresholdInputValues() {
-  return { totalMin: Number(thresholdTotalMinInput.value) };
+  const mcqRaw = thresholdMcqMinPercentInput.value.trim();
+  const practicalRaw = thresholdPracticalMinPercentInput.value.trim();
+  return {
+    totalMin: Number(thresholdTotalMinInput.value),
+    mcqMinPercent: mcqRaw !== "" ? Number(mcqRaw) : undefined,
+    practicalMinPercent: practicalRaw !== "" ? Number(practicalRaw) : undefined,
+  };
 }
 
 function renderThresholds(effectiveThresholds) {
   if (!effectiveThresholds) return;
   thresholdTotalMinInput.value = String(effectiveThresholds.totalMin);
+  thresholdMcqMinPercentInput.value = effectiveThresholds.mcqMinPercent != null ? String(effectiveThresholds.mcqMinPercent) : "";
+  thresholdPracticalMinPercentInput.value = effectiveThresholds.practicalMinPercent != null ? String(effectiveThresholds.practicalMinPercent) : "";
   const sourceKey =
     effectiveThresholds.source === "module_policy"
       ? "calibration.thresholds.source.module"
@@ -428,7 +438,12 @@ publishThresholdsButton.addEventListener("click", async () => {
           ...headers(),
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ moduleId, totalMin: values.totalMin }),
+        body: JSON.stringify({
+          moduleId,
+          totalMin: values.totalMin,
+          ...(values.mcqMinPercent !== undefined && { mcqMinPercent: values.mcqMinPercent }),
+          ...(values.practicalMinPercent !== undefined && { practicalMinPercent: values.practicalMinPercent }),
+        }),
       });
       thresholdPublishResult.textContent = t("calibration.thresholds.publishSuccess");
       log(body);

--- a/src/codecs/assessmentPolicyCodec.ts
+++ b/src/codecs/assessmentPolicyCodec.ts
@@ -5,6 +5,8 @@ export type ModuleAssessmentPolicy = {
   };
   passRules?: {
     totalMin?: number;
+    mcqMinPercent?: number;
+    practicalMinPercent?: number;
   };
 };
 

--- a/src/modules/adminContent/adminContentCommands.ts
+++ b/src/modules/adminContent/adminContentCommands.ts
@@ -491,6 +491,8 @@ export async function publishModuleVersion(moduleId: string, moduleVersionId: st
 type PublishThresholdsInput = {
   moduleId: string;
   totalMin: number;
+  mcqMinPercent?: number;
+  practicalMinPercent?: number;
   actorId: string;
 };
 
@@ -509,12 +511,20 @@ export async function publishModuleVersionWithThresholds(input: PublishThreshold
 
   const existingPolicy: ModuleAssessmentPolicy = assessmentPolicyCodec.parse(sourceVersion.assessmentPolicyJson) ?? {};
 
+  const newPassRules: ModuleAssessmentPolicy["passRules"] = {
+    ...(existingPolicy.passRules ?? {}),
+    totalMin: input.totalMin,
+  };
+  if (input.mcqMinPercent !== undefined) {
+    newPassRules.mcqMinPercent = input.mcqMinPercent;
+  }
+  if (input.practicalMinPercent !== undefined) {
+    newPassRules.practicalMinPercent = input.practicalMinPercent;
+  }
+
   const newPolicy: ModuleAssessmentPolicy = {
     ...existingPolicy,
-    passRules: {
-      ...(existingPolicy.passRules ?? {}),
-      totalMin: input.totalMin,
-    },
+    passRules: newPassRules,
   };
 
   const versionNo = await getNextVersionNo("module", input.moduleId);
@@ -549,6 +559,8 @@ export async function publishModuleVersionWithThresholds(input: PublishThreshold
       versionNo: newVersion.versionNo,
       sourceVersionId: sourceVersion.id,
       totalMin: input.totalMin,
+      mcqMinPercent: input.mcqMinPercent ?? null,
+      practicalMinPercent: input.practicalMinPercent ?? null,
       publishedAt: published.publishedAt?.toISOString() ?? null,
     },
   });

--- a/src/modules/assessment/decisionService.ts
+++ b/src/modules/assessment/decisionService.ts
@@ -82,10 +82,20 @@ export function resolveAssessmentDecision(input: ResolveAssessmentDecisionInput)
   const totalScore = Number((effectivePracticalScaledScore + effectiveMcqScaledScore).toFixed(2));
   const practicalPercent = rubricMaxTotal > 0 ? (recomputedRubricTotal / rubricMaxTotal) * 100 : null;
 
+  const mcqMinPercent = input.assessmentPolicy?.passRules?.mcqMinPercent ?? null;
+  const practicalMinPercent = input.assessmentPolicy?.passRules?.practicalMinPercent ?? null;
+
   const hasOpenRedFlag = hasForcingRedFlag(input.llmResult, rules.manualReview.redFlagSeverities);
   const hasOnlyInsufficientEvidenceFlags = hasOnlyInsufficientEvidenceRedFlags(input.llmResult);
 
-  const passesThresholds = totalScore >= totalMin && !hasOpenRedFlag;
+  const mcqGatePasses = mcqMinPercent === null || input.mcqPercentScore >= mcqMinPercent;
+  const practicalGatePasses =
+    practicalMinPercent === null ||
+    (practicalPercent !== null && practicalPercent >= practicalMinPercent);
+
+  const passesThresholds =
+    totalScore >= totalMin && !hasOpenRedFlag && mcqGatePasses && practicalGatePasses;
+
   const llmRecommendsManualReview = recommendsManualReview(input.llmResult);
 
   const autoFailForInsufficientEvidence =
@@ -100,6 +110,12 @@ export function resolveAssessmentDecision(input: ResolveAssessmentDecisionInput)
     hasOpenRedFlag ||
     (llmRecommendsManualReview && !autoFailForInsufficientEvidence);
 
+  const componentFailReason = !mcqGatePasses
+    ? "Automatic fail: MCQ score below required minimum."
+    : !practicalGatePasses
+      ? "Automatic fail: practical score below required minimum."
+      : null;
+
   const decisionReason = needsManualReview
     ? input.forceManualReviewReason ??
       (totalsInconsistent
@@ -109,7 +125,7 @@ export function resolveAssessmentDecision(input: ResolveAssessmentDecisionInput)
       ? "Automatic fail due to insufficient submission evidence."
       : passesThresholds
         ? "Automatic pass by threshold rules."
-        : "Automatic fail by threshold rules.";
+        : componentFailReason ?? "Automatic fail by threshold rules.";
 
   return {
     totalScore,

--- a/src/modules/calibration/calibrationWorkspaceService.ts
+++ b/src/modules/calibration/calibrationWorkspaceService.ts
@@ -235,10 +235,15 @@ export async function getCalibrationWorkspaceSnapshot(input: CalibrationWorkspac
 
   const rules = getAssessmentRules();
   const modulePolicy = safeParsePolicy(module.activeVersion?.assessmentPolicyJson);
-  const hasModuleOverrides = modulePolicy?.passRules?.totalMin != null;
+  const hasModuleOverrides =
+    modulePolicy?.passRules?.totalMin != null ||
+    modulePolicy?.passRules?.mcqMinPercent != null ||
+    modulePolicy?.passRules?.practicalMinPercent != null;
 
   const effectiveThresholds = {
     totalMin: modulePolicy?.passRules?.totalMin ?? rules.thresholds.totalMin,
+    mcqMinPercent: modulePolicy?.passRules?.mcqMinPercent ?? null,
+    practicalMinPercent: modulePolicy?.passRules?.practicalMinPercent ?? null,
     source: hasModuleOverrides ? ("module_policy" as const) : ("global_defaults" as const),
   };
 

--- a/src/routes/calibration.ts
+++ b/src/routes/calibration.ts
@@ -86,6 +86,8 @@ calibrationRouter.get("/workspace", async (request, response, next) => {
 const publishThresholdsBodySchema = z.object({
   moduleId: z.string().trim().min(1),
   totalMin: z.number().min(0).max(100),
+  mcqMinPercent: z.number().min(0).max(100).optional(),
+  practicalMinPercent: z.number().min(0).max(100).optional(),
 });
 
 calibrationRouter.post("/workspace/publish-thresholds", async (request, response, next) => {
@@ -114,6 +116,8 @@ calibrationRouter.post("/workspace/publish-thresholds", async (request, response
     const published = await publishModuleVersionWithThresholds({
       moduleId: parsed.data.moduleId,
       totalMin: parsed.data.totalMin,
+      mcqMinPercent: parsed.data.mcqMinPercent,
+      practicalMinPercent: parsed.data.practicalMinPercent,
       actorId,
     });
     response.status(200).json({ moduleVersion: published });

--- a/test/m2-calibration-workspace.test.ts
+++ b/test/m2-calibration-workspace.test.ts
@@ -81,7 +81,7 @@ describe("Calibration workspace Phase A", () => {
     });
     expect(module).toBeTruthy();
 
-    // 1. Snapshot shape: only totalMin + source in effectiveThresholds
+    // 1. Snapshot shape: effectiveThresholds has known fields; component minimums default to null
     const snap1 = await request(app)
       .get(`/api/calibration/workspace?moduleId=${encodeURIComponent(module!.id)}&limit=1`)
       .set(subjectMatterOwnerHeaders);
@@ -89,8 +89,8 @@ describe("Calibration workspace Phase A", () => {
     const thresholds = snap1.body.effectiveThresholds;
     expect(thresholds).toHaveProperty("totalMin");
     expect(thresholds).toHaveProperty("source");
-    expect(thresholds).not.toHaveProperty("practicalMinPercent");
-    expect(thresholds).not.toHaveProperty("mcqMinPercent");
+    expect(thresholds).toHaveProperty("mcqMinPercent", null);
+    expect(thresholds).toHaveProperty("practicalMinPercent", null);
     expect(thresholds).not.toHaveProperty("borderlineMin");
     expect(thresholds).not.toHaveProperty("borderlineMax");
 

--- a/test/unit/decision-service.test.ts
+++ b/test/unit/decision-service.test.ts
@@ -688,6 +688,113 @@ describe("decision service", () => {
     });
   });
 
+  describe("resolveAssessmentDecision — component pass gates", () => {
+    it("fails when MCQ percent is below mcqMinPercent even if total score passes", async () => {
+      // sum=12, rubricMaxTotal=20: practical=42; mcqScaled=30 → total=72 passes global 70
+      // but mcqPercentScore=40 < mcqMinPercent=50 → gate fails
+      const { resolveAssessmentDecision } = await import("../../src/modules/assessment/decisionService.js");
+      const result = resolveAssessmentDecision({
+        mcqScaledScore: 30,
+        mcqPercentScore: 40,
+        llmResult: buildLlmResult({
+          rubric_scores: { relevance_for_case: 3, quality_and_utility: 3, iteration_and_improvement: 2, human_quality_assurance: 2, responsible_use: 2 },
+          rubric_total: 12,
+          practical_score_scaled: 42,
+        }),
+        assessmentPolicy: { passRules: { totalMin: 70, mcqMinPercent: 50 } },
+      });
+      expect(result.passesThresholds).toBe(false);
+      expect(result.passFailTotal).toBe(false);
+      expect(result.decisionReason).toBe("Automatic fail: MCQ score below required minimum.");
+    });
+
+    it("passes when MCQ percent meets mcqMinPercent exactly", async () => {
+      // mcqPercentScore=50 >= mcqMinPercent=50 → gate passes; total=72 passes
+      const { resolveAssessmentDecision } = await import("../../src/modules/assessment/decisionService.js");
+      const result = resolveAssessmentDecision({
+        mcqScaledScore: 30,
+        mcqPercentScore: 50,
+        llmResult: buildLlmResult({
+          rubric_scores: { relevance_for_case: 3, quality_and_utility: 3, iteration_and_improvement: 2, human_quality_assurance: 2, responsible_use: 2 },
+          rubric_total: 12,
+          practical_score_scaled: 42,
+        }),
+        assessmentPolicy: { passRules: { totalMin: 70, mcqMinPercent: 50 } },
+      });
+      expect(result.passesThresholds).toBe(true);
+      expect(result.passFailTotal).toBe(true);
+    });
+
+    it("fails when practical percent is below practicalMinPercent even if total score passes", async () => {
+      // sum=8, rubricMaxTotal=20: practicalPercent=40 < practicalMinPercent=50 → gate fails
+      const { resolveAssessmentDecision } = await import("../../src/modules/assessment/decisionService.js");
+      const result = resolveAssessmentDecision({
+        mcqScaledScore: 30,
+        mcqPercentScore: 100,
+        llmResult: buildLlmResult({
+          rubric_scores: { relevance_for_case: 1, quality_and_utility: 1, iteration_and_improvement: 2, human_quality_assurance: 2, responsible_use: 2 },
+          rubric_total: 8,
+          practical_score_scaled: 28,
+        }),
+        assessmentPolicy: { passRules: { totalMin: 50, practicalMinPercent: 50 } },
+        rubricMaxTotal: 20,
+      });
+      expect(result.practicalPercent).toBe(40);
+      expect(result.passesThresholds).toBe(false);
+      expect(result.passFailTotal).toBe(false);
+      expect(result.decisionReason).toBe("Automatic fail: practical score below required minimum.");
+    });
+
+    it("passes when practical percent meets practicalMinPercent exactly", async () => {
+      // sum=10, rubricMaxTotal=20: practicalPercent=50 >= practicalMinPercent=50 → gate passes
+      const { resolveAssessmentDecision } = await import("../../src/modules/assessment/decisionService.js");
+      const result = resolveAssessmentDecision({
+        mcqScaledScore: 30,
+        mcqPercentScore: 100,
+        llmResult: buildLlmResult({
+          rubric_scores: { relevance_for_case: 2, quality_and_utility: 2, iteration_and_improvement: 2, human_quality_assurance: 2, responsible_use: 2 },
+          rubric_total: 10,
+          practical_score_scaled: 35,
+        }),
+        assessmentPolicy: { passRules: { totalMin: 50, practicalMinPercent: 50 } },
+        rubricMaxTotal: 20,
+      });
+      expect(result.practicalPercent).toBe(50);
+      expect(result.passesThresholds).toBe(true);
+      expect(result.passFailTotal).toBe(true);
+    });
+
+    it("applies both mcqMinPercent and practicalMinPercent as AND conditions", async () => {
+      // mcqPercentScore=60>=50 (passes), practicalPercent=(8/20)*100=40<50 (fails)
+      const { resolveAssessmentDecision } = await import("../../src/modules/assessment/decisionService.js");
+      const result = resolveAssessmentDecision({
+        mcqScaledScore: 25,
+        mcqPercentScore: 60,
+        llmResult: buildLlmResult({
+          rubric_scores: { relevance_for_case: 1, quality_and_utility: 1, iteration_and_improvement: 2, human_quality_assurance: 2, responsible_use: 2 },
+          rubric_total: 8,
+          practical_score_scaled: 28,
+        }),
+        assessmentPolicy: { passRules: { totalMin: 50, mcqMinPercent: 50, practicalMinPercent: 50 } },
+        rubricMaxTotal: 20,
+      });
+      expect(result.passesThresholds).toBe(false);
+      expect(result.decisionReason).toBe("Automatic fail: practical score below required minimum.");
+    });
+
+    it("skips component gates when neither is set in policy", async () => {
+      // Default buildLlmResult (sum=14), total=79; no component gates → passes on total alone
+      const { resolveAssessmentDecision } = await import("../../src/modules/assessment/decisionService.js");
+      const result = resolveAssessmentDecision({
+        mcqScaledScore: 30,
+        mcqPercentScore: 30,
+        llmResult: buildLlmResult(),
+        assessmentPolicy: { passRules: { totalMin: 70 } },
+      });
+      expect(result.passesThresholds).toBe(true);
+    });
+  });
+
   describe("resolveAssessmentDecision — red flag routing", () => {
     it("sets hasOpenRedFlag=true and passesThresholds=false even when total score is above threshold", async () => {
       const { resolveAssessmentDecision } = await import("../../src/modules/assessment/decisionService.js");


### PR DESCRIPTION
## Summary

Closes #388.

- **`assessmentPolicyCodec.ts`**: Added `mcqMinPercent` and `practicalMinPercent` to `ModuleAssessmentPolicy.passRules`
- **`decisionService.ts`**: `resolveAssessmentDecision` now enforces both component gates as AND conditions — failing if MCQ percent < `mcqMinPercent` or practical percent < `practicalMinPercent`, even when total score passes. Dedicated fail reason strings distinguish component failures.
- **`calibration.ts` + `adminContentCommands.ts`**: Calibration publish endpoint and command accept and persist the new thresholds into `assessmentPolicyJson`.
- **`calibrationWorkspaceService.ts`**: `effectiveThresholds` in the workspace snapshot now includes both new fields.
- **`calibration.html` + `calibration.js`**: Calibration UI gains optional MCQ/practical minimum inputs.
- **Test fixes**: `decision-service.test.ts` rewritten to have consistent `rubric_scores`/`rubric_total` (pre-existing inconsistency from v1.1.13 recomputation changes); `read-models.test.ts` fixed stale `rubric_scores: { evidence: 8 }` violating the `max(4)` codec constraint.

## Test plan

- [x] `npm run lint` — 0 TS errors
- [x] `npm run test:unit` — 409/409 tests passing (including 6 new component gate tests)
- [ ] CI green on this PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)