### PR TITLE
fix(infra): App Service settings as separate child resources after KV + role assignments (#416)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,38 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.2.35 - 2026-05-27
+
+fix(infra): App Service-settings som separate child-ressurser etter KV + role assignments (#416)
+
+Mai-2026-rotårsak: appSettings lå inline i app-ressursenes siteConfig, så de deployet i samme
+ARM-operasjon som app-en — før KV-secrets og role assignments var ferdig provisjonert. MSI-
+sidecaren kunne forsøke å resolve KV-referanser før read-rollen var på plass → app crashet ved
+første boot.
+
+Fiks: appSettings for webApp, workerApp og parserApp er trukket ut til separate
+`Microsoft.Web/sites/config@2023-12-01`-child-ressurser (`name: 'appsettings'`) med eksplisitt
+`dependsOn`:
+- webApp/workerApp → [kvSecretAppRuntime, <app>RuntimeSecretReader] (begge refererer kun
+  APP-RUNTIME-SECRETS-bundelen, #431 Stage 2)
+- parserApp → [kvSecretParserWorkerAuthKey, parserAppParserAuthSecretReader]
+
+Hvorfor child-ressurs og ikke `dependsOn` på selve app-en: role assignment-en trenger
+app-ens MSI `principalId`, så app-en kan ikke avhenge av sin egen role assignment (syklus).
+Child-config-ressursen opprettes etter app-en (identitet finnes) og etter role assignment-en,
+så KV-referanser først resolves når rollen er på plass.
+
+Settings-arrayene er flyttet VERBATIM (ikke gjenskrevet) og konvertert til den flate mappen
+config-ressursen krever via `toObject(array, e => e.name, e => e.value)` — null risiko for
+tapte settings fra manuell array→map-omskriving. Ingen `connectionStrings` finnes.
+dependsOn på `!skipRoleAssignments`-betingede readers er trygt (Bicep ignorerer dependsOn på
+ikke-deployet betinget ressurs — gjelder dagens prod SKIP_ROLE_ASSIGNMENTS=true).
+
+Verifisert: `az bicep build` rent, infra-lint grønn, 3/3 config-ressurser, 0 gjenværende inline
+appSettings. ARM what-if (staging + prod) reviewes før merge per invariant #11.
+
+Rollback: revert Bicep-commit (inline-appSettings = nåværende prod-state).
+
 ## 1.2.34 - 2026-05-27
 
 fix(infra): PG pre-flight uavhengig av App Service + credential-drift-guard (#411, #410)

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -551,7 +551,24 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
       healthCheckPath: '/healthz'
       ftpsState: 'Disabled'
       minTlsVersion: '1.2'
-      appSettings: [
+    }
+  }
+}
+
+// #416: App settings extracted into a separate child resource that depends on the bundled KV
+// secret AND the web MSI's read-role assignment, so KV references only resolve after the role
+// exists (the May 2026 MSI-sidecar crash root cause). This breaks the dependency cycle —
+// webAppRuntimeSecretReader needs webApp.identity.principalId, so webApp itself cannot depend
+// on its own role assignment. The settings array is unchanged; toObject() converts it to the
+// flat map the config resource requires.
+resource webAppSettingsConfig 'Microsoft.Web/sites/config@2023-12-01' = {
+  parent: webApp
+  name: 'appsettings'
+  dependsOn: [
+    kvSecretAppRuntime
+    webAppRuntimeSecretReader
+  ]
+  properties: toObject([
         {
           name: 'PROCESS_ROLE'
           value: 'web'
@@ -725,9 +742,7 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
           name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
           value: appInsights.properties.ConnectionString
         }
-      ]
-    }
-  }
+  ], (entry) => entry.name, (entry) => entry.value)
 }
 
 resource webAppDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
@@ -775,7 +790,20 @@ resource workerApp 'Microsoft.Web/sites@2023-12-01' = {
       healthCheckPath: '/healthz'
       ftpsState: 'Disabled'
       minTlsVersion: '1.2'
-      appSettings: [
+    }
+  }
+}
+
+// #416: worker app settings extracted to a separate child resource (see webAppSettingsConfig
+// for the full rationale — breaks the MSI role-assignment dependency cycle).
+resource workerAppSettingsConfig 'Microsoft.Web/sites/config@2023-12-01' = {
+  parent: workerApp
+  name: 'appsettings'
+  dependsOn: [
+    kvSecretAppRuntime
+    workerAppRuntimeSecretReader
+  ]
+  properties: toObject([
         {
           name: 'PROCESS_ROLE'
           value: 'worker'
@@ -916,9 +944,7 @@ resource workerApp 'Microsoft.Web/sites@2023-12-01' = {
           name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
           value: appInsights.properties.ConnectionString
         }
-      ]
-    }
-  }
+  ], (entry) => entry.name, (entry) => entry.value)
 }
 
 resource workerAppDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
@@ -967,7 +993,20 @@ resource parserApp 'Microsoft.Web/sites@2023-12-01' = {
       healthCheckPath: '/health'
       ftpsState: 'Disabled'
       minTlsVersion: '1.2'
-      appSettings: [
+    }
+  }
+}
+
+// #416: parser app settings extracted to a separate child resource (see webAppSettingsConfig
+// for the full rationale). Parser only references the PARSER-WORKER-AUTH-KEY secret.
+resource parserAppSettingsConfig 'Microsoft.Web/sites/config@2023-12-01' = {
+  parent: parserApp
+  name: 'appsettings'
+  dependsOn: [
+    kvSecretParserWorkerAuthKey
+    parserAppParserAuthSecretReader
+  ]
+  properties: toObject([
         {
           name: 'APP_ROLE'
           value: 'parser'
@@ -1015,9 +1054,7 @@ resource parserApp 'Microsoft.Web/sites@2023-12-01' = {
           name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
           value: appInsights.properties.ConnectionString
         }
-      ]
-    }
-  }
+  ], (entry) => entry.name, (entry) => entry.value)
 }
 
 resource parserAppDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.2.34",
+  "version": "1.2.35",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",


### PR DESCRIPTION
Closes #416 (pending what-if review + staging verify).

## What

Extract `appSettings` for webApp, workerApp, parserApp out of each app's inline `siteConfig`
into separate `Microsoft.Web/sites/config@2023-12-01` ('appsettings') child resources with
explicit `dependsOn` on the KV secret each app references + that app's MSI read-role assignment.

## Why

May 2026 root cause: inline `appSettings` deploy in the same ARM op as the App Service, before
KV secrets and role assignments are committed → MSI sidecar can try to resolve KV references
before the read-role exists → app crashes at first boot. Extracting to a child resource forces
the settings (and thus KV-ref resolution) to apply only after the secret + role assignment.

**Why a child resource and not `dependsOn` on the app:** the role assignment needs the app's
MSI `principalId`, so the app cannot depend on its own role assignment (cycle). The child
config resource is created after the app (identity exists) and after the role assignment.

## dependsOn mapping

- `webAppSettingsConfig` → `[kvSecretAppRuntime, webAppRuntimeSecretReader]`
- `workerAppSettingsConfig` → `[kvSecretAppRuntime, workerAppRuntimeSecretReader]`
- `parserAppSettingsConfig` → `[kvSecretParserWorkerAuthKey, parserAppParserAuthSecretReader]`

web/worker reference only the bundled `APP-RUNTIME-SECRETS` secret (#431 Stage 2); parser only
`PARSER-WORKER-AUTH-KEY`. No `connectionStrings` exist.

## Safety

- Settings arrays moved **verbatim** and converted with `toObject(arr, e => e.name, e => e.value)`
  — no manual array→map rewrite, so no risk of silently dropped settings. The what-if diff is
  the final confirmation that no setting changes unexpectedly.
- `dependsOn` on the `!skipRoleAssignments`-conditional readers is safe: Bicep ignores a
  dependsOn on a non-deployed conditional resource (covers current prod `SKIP_ROLE_ASSIGNMENTS=true`).
- The `appsettings` child resource is authoritative (replaces all settings) — verified 0
  remaining inline `appSettings` so there is exactly one writer.

## Verification

- `az bicep build` clean, infra-lint green, 3/3 config resources, 0 inline appSettings.
- ⏳ Staging what-if (auto on this PR) + prod what-if (`bicep-whatif-prod.yml`) — **review before merge** (invariant #11).
- After merge: full staging deploy → verify `/healthz`, MSI sidecar, KV-ref resolution.

## Rollback

Revert the Bicep commit — inline-appSettings is the current prod state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)