### PR TITLE
fix(infra): codify deploy-SP Key Vault Secrets User grant in Bicep (#470)

### DIFF
--- a/.github/workflows/bicep-whatif-prod.yml
+++ b/.github/workflows/bicep-whatif-prod.yml
@@ -77,6 +77,7 @@ jobs:
               postgresSkuName="${{ vars.POSTGRES_SKU_NAME }}" \
               postgresSkuTier="${{ vars.POSTGRES_SKU_TIER }}" \
               parserWorkerAuthKey="whatif-only-placeholder-not-deployed" \
+              deployPrincipalId="${{ vars.DEPLOY_PRINCIPAL_ID }}" \
               skipRoleAssignments="${{ vars.SKIP_ROLE_ASSIGNMENTS || 'true' }}" \
             2>&1 || true)
           echo "result<<EOF" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/bicep-whatif.yml
+++ b/.github/workflows/bicep-whatif.yml
@@ -49,6 +49,7 @@ jobs:
               postgresSkuName="${{ vars.POSTGRES_SKU_NAME }}" \
               postgresSkuTier="${{ vars.POSTGRES_SKU_TIER }}" \
               parserWorkerAuthKey="whatif-only-placeholder-not-deployed" \
+              deployPrincipalId="${{ vars.DEPLOY_PRINCIPAL_ID }}" \
               skipRoleAssignments="${{ vars.SKIP_ROLE_ASSIGNMENTS || 'false' }}" \
             2>&1 || true)
           echo "result<<EOF" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -118,6 +118,7 @@ jobs:
             -BudgetContactEmail "${{ vars.BUDGET_CONTACT_EMAIL }}" `
             -MonthlyBudgetAmount "${{ vars.MONTHLY_BUDGET_AMOUNT }}" `
             -ParserWorkerAuthKey "${{ secrets.PARSER_WORKER_AUTH_KEY }}" `
+            -DeployPrincipalId "${{ vars.DEPLOY_PRINCIPAL_ID }}" `
             -PackagePath "${{ steps.package.outputs.path }}" `
             -AzureFederatedClientId "${{ secrets.AZURE_CLIENT_ID }}" `
             -AzureFederatedTenantId "${{ secrets.AZURE_TENANT_ID }}"
@@ -218,6 +219,7 @@ jobs:
             -BudgetContactEmail "${{ vars.BUDGET_CONTACT_EMAIL }}" `
             -MonthlyBudgetAmount "${{ vars.MONTHLY_BUDGET_AMOUNT }}" `
             -ParserWorkerAuthKey "${{ secrets.PARSER_WORKER_AUTH_KEY }}" `
+            -DeployPrincipalId "${{ vars.DEPLOY_PRINCIPAL_ID }}" `
             -PackagePath "${{ steps.package.outputs.path }}" `
             -AzureFederatedClientId "${{ secrets.AZURE_CLIENT_ID }}" `
             -AzureFederatedTenantId "${{ secrets.AZURE_TENANT_ID }}" `

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,33 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.2.36 - 2026-05-27
+
+fix(infra): kodifiser deploy-SP Key Vault Secrets User-grant i Bicep (#470, #410-durabilitet)
+
+#410-credential-guarden trenger lesetilgang til DATABASE-URL-secreten for å avgjøre om
+skipPostgresUpdate er trygt. Deploy-SP-en hadde bare control-plane-roller (ikke KV data-plane
+read) → guarden fikk `kvRead=secret-read-failed` og tvang PG-server-update på hver deploy
+(ServerIsBusy-risiko). En manuell staging-grant (az rest PUT) bekreftet fiksen, men forsvinner
+ved RG-recreate.
+
+Kodifiserer grant-en i `infra/azure/main.bicep`: ny ressurs `deployPrincipalDatabaseSecretReader`
+gir deploy-SP-en (param `deployPrincipalId`) **Key Vault Secrets User** scopet til DATABASE-URL-
+secreten (least-privilege — guarden leser kun den). Betinget på `!skipRoleAssignments && !empty(deployPrincipalId)`.
+Deploy-SP-en har User Access Administrator → oppretter assignment for seg selv.
+
+Plumbing: `deployPrincipalId` param i Bicep ← `-DeployPrincipalId` i deploy-environment.ps1 ←
+`${{ vars.DEPLOY_PRINCIPAL_ID }}` i deploy-azure.yml (begge miljø-jobber). GitHub env-vars satt:
+staging=36b2fabb…, production=cba285e6…. What-if-workflowene passer også param-et.
+
+Selvheling: pre-flighten kjører FØR Bicep, så første deploy med dette tvinger fortsatt update
+(rollen finnes ikke ennå); Bicep oppretter den; påfølgende deploys leser og skipper. Idempotent
+re-deploy dekkes av eksisterende RoleAssignmentExists-toleranse. Dekker både staging og prod.
+
+Oppfølging: fjern den manuelle staging-assignmenten (guid 23be1dd0…) når Bicep eier grant-en.
+
+Rollback: revert commit (grant forsvinner → guard over-fyrer igjen, men trygt — ingen drift).
+
 ## 1.2.35 - 2026-05-27
 
 fix(infra): App Service-settings som separate child-ressurser etter KV + role assignments (#416)

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -199,6 +199,9 @@ param dbAllowedIpAddresses array = []
 @secure()
 param parserWorkerAuthKey string
 
+@description('Object ID of the deploy service principal (CI/CD). When non-empty, grants it Key Vault Secrets User on the DATABASE-URL secret so the deploy-environment.ps1 pre-flight (#410) can read the existing password, detect rotation, and skip unchanged PostgreSQL server updates (avoids ServerIsBusy). Without it the #410 guard cannot read the secret and conservatively forces a server update on every deploy. The deploy SP has User Access Administrator, so it creates this assignment for itself. Set per environment via the DEPLOY_PRINCIPAL_ID variable; empty = skip the grant. See #470.')
+param deployPrincipalId string = ''
+
 var envCode = environmentName == 'production' ? 'prd' : 'stg'
 var suffix = substring(uniqueString(subscription().subscriptionId, resourceGroup().name), 0, 6)
 var appServicePlanName = toLower('${appNamePrefix}-${envCode}-plan-${suffix}')
@@ -1082,6 +1085,24 @@ resource parserAppDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-
 // ---------------------------------------------------------------------------
 
 var keyVaultSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6'
+
+// #470: grant the deploy service principal read on the DATABASE-URL secret so the
+// deploy-environment.ps1 pre-flight (#410) can compare the existing password and skip the
+// PostgreSQL server update when unchanged (avoids ServerIsBusy on routine deploys). Without
+// this the guard gets kvRead=secret-read-failed and conservatively forces the update every
+// deploy. The deploy SP has User Access Administrator, so it creates this assignment itself.
+// Self-heals: the pre-flight runs before this deploy applies, so the FIRST deploy after this
+// change still forces the update; subsequent deploys read and skip. Conditional on a non-empty
+// objectId (DEPLOY_PRINCIPAL_ID per environment).
+resource deployPrincipalDatabaseSecretReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!skipRoleAssignments && !empty(deployPrincipalId)) {
+  scope: kvSecretDatabaseUrl
+  name: empty(roleAssignmentSalt) ? guid(subscription().subscriptionId, environmentName, 'deployPrincipal-databaseUrl-kvSecretsUser') : guid(subscription().subscriptionId, environmentName, 'deployPrincipal-databaseUrl-kvSecretsUser', roleAssignmentSalt)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: deployPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
 
 // Role assignments for bundled secret (#431). Web and worker apps need read access to the
 // bundled APP-RUNTIME-SECRETS so MSI sidecar can resolve the single KV reference at startup.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.2.35",
+  "version": "1.2.36",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/scripts/azure/deploy-environment.ps1
+++ b/scripts/azure/deploy-environment.ps1
@@ -56,6 +56,9 @@ param(
   [string]$BudgetContactEmail = "",
   [double]$MonthlyBudgetAmount = 30,
   [string]$ParserWorkerAuthKey = "",
+  # #470: object ID of the deploy SP, passed through to Bicep so it can grant itself Key Vault
+  # Secrets User on DATABASE-URL (lets the #410 pre-flight read the secret). Empty = skip grant.
+  [string]$DeployPrincipalId = "",
   [string]$PackagePath = "",
   [string]$AzureFederatedClientId = "",
   [string]$AzureFederatedTenantId = "",
@@ -686,6 +689,7 @@ az deployment group create `
               participantNotificationWebhookTimeoutMs=$ParticipantNotificationWebhookTimeoutMs `
               acsEmailSenderDisplayName=$AcsEmailSenderDisplayName `
               parserWorkerAuthKey=$ParserWorkerAuthKey `
+              deployPrincipalId=$DeployPrincipalId `
   --parameters "@$ipParamsFile" `
   --no-wait | Out-Null
 Assert-LastExitCode "az deployment group create"


### PR DESCRIPTION
Closes #470.

## What
Codify the deploy service principal's Key Vault data-plane read (needed by the #410
credential-drift guard) in Bicep, replacing the manual staging grant and covering prod.

New `deployPrincipalDatabaseSecretReader` role assignment grants **Key Vault Secrets User**
to `param deployPrincipalId`, scoped to the **DATABASE-URL secret** (least-privilege — the
guard only reads that one). Conditional on `!skipRoleAssignments && !empty(deployPrincipalId)`.
The deploy SP has User Access Administrator, so it creates this assignment for itself.

## Why
Without data-plane read, the #410 guard gets `kvRead=secret-read-failed` and forces a PG
server update on every deploy (re-exposes ServerIsBusy). A manual `az rest` grant confirmed
the fix on staging but is lost on RG-recreate. This makes it durable + covers prod.

## Plumbing
`deployPrincipalId` (Bicep) ← `-DeployPrincipalId` (deploy-environment.ps1) ←
`${{ vars.DEPLOY_PRINCIPAL_ID }}` (deploy-azure.yml, both env jobs). GitHub env vars set:
staging `36b2fabb-…`, production `cba285e6-…`. What-if workflows also pass it.

## Self-healing
The pre-flight runs *before* this deploy applies, so the FIRST deploy after merge still forces
the PG update (role not yet created); Bicep creates it; subsequent deploys read and skip.
Idempotent re-deploy covered by the existing RoleAssignmentExists tolerance.

## Verification
- `az bicep build` clean, infra-lint green, PS syntax OK.
- ⏳ staging + prod what-if (review before merge) — should show `deployPrincipalDatabaseSecretReader` as Create scoped to DATABASE-URL.
- After merge: full staging deploy already proven to log `kvRead=secret-read` / `skip is safe` with the (manual) grant in place; Bicep grant produces the same.

## Follow-up
Remove the manual staging assignment (guid `23be1dd0-…`) once Bicep owns the grant.

## Rollback
Revert the commit — grant disappears, guard reverts to safe over-firing (no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)