### PR TITLE
sec(frontend): participant console hardening — same-origin redirect + config exposure documented (#355)

### DIFF
--- a/doc/CONFIG_REFERENCE.md
+++ b/doc/CONFIG_REFERENCE.md
@@ -173,6 +173,24 @@ Controls how user records are reconciled when the org sync job runs (triggered v
 **Env override:** `PARTICIPANT_CONSOLE_CONFIG_FILE` (default: `config/participant-console.json`)
 **Used by:** `/participant/config` runtime config endpoint and frontend workspaces
 
+### Public exposure of `/participant/config` (#355 review)
+
+`/participant/config` is fetched **before authentication** — the SPA needs it to know how to authenticate (MSAL clientId/authority) and how to render the shell. Everything in the response is therefore reachable by an unauthenticated caller. The 2026-05-27 review (#355) walked every field; the rationale for each is recorded below so future audits do not have to re-derive it.
+
+| Field | Why it must be public | What an unauthenticated reader learns |
+|---|---|---|
+| `authMode` | The client must know whether to load MSAL (`entra`) or the mock switcher (`mock`) before calling MSAL.initialize() | `"entra"` or `"mock"` — same signal as the SPA bundle itself |
+| `entra.{clientId,authority,scopes}` | MSAL needs these to construct the login redirect; the SPA cannot authenticate without them | Public Entra metadata — clientId and authority are already public per the OAuth2 spec; the audience scope reveals the API resource id |
+| `debugMode` | Frontend gates dev-only UI affordances on this flag | Whether this build is a non-production env (always `false` in production — runtime asserted by `scripts/azure/smoke-web-runtime.mjs`) |
+| `mockRoleSwitchEnabled` + `mockRolePresets` + `identityDefaults` | Gated on `AUTH_MODE === "mock"` server-side; the mock role switcher is dev/test only and never exposed in production (`mockRolePresets: []`, `identityDefaults: undefined`) | Nothing in production (`mockRoleSwitchEnabled === false`, presets empty); in dev/test, the set of mock identities |
+| `navigation.items` | The SPA navigation bar is rendered from this contract; pages are not role-gated by Express, so the visible nav is the authoritative client-side workspace list | The set of workspace routes (`/admin-content`, `/results`, `/review`, …) — these are already discoverable from the SPA bundle and the marketing surface |
+| `drafts`, `flow` | Browser-side tuning constants (localStorage TTL, polling cadence, MCQ behavior) | Behavior constants — not user data, not access decisions |
+| `appealWorkspace`, `manualReviewWorkspace`, `calibrationWorkspace` | Workspace tuning + the `accessRoles` runtime override that the server *also* enforces via the RBAC matrix | The list of role names that can access each workspace (e.g. `SUBJECT_MATTER_OWNER`, `ADMINISTRATOR`) — role *names* are not secret; the server's RBAC matrix is the authoritative gate |
+
+**Minimization conclusion:** the response is already minimal for an unauthenticated startup endpoint. Mock-only fields are gated server-side (omitted/empty in production). No remaining field can be safely removed without breaking SPA startup or post-login workspace rendering. The companion hardening — same-origin/path validation of the MSAL redirect restore (`auth_intended_url`) — lives in `public/api-client.js` (`isSafeSameOriginRedirect`) with a unit test in `test/unit/auth-redirect-safety.test.ts`.
+
+**If a future change adds a new field here:** ask whether it really must be reachable pre-auth, or whether a new authenticated `/api/...` endpoint would serve it instead. Default to authenticated.
+
 Large composite config that drives browser-side runtime behavior. It no longer owns the canonical workspace navigation contract; navigation is derived from `src/config/capabilities.ts` and merged with runtime-tunable settings here.
 
 ### Sections

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,29 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.2.37 - 2026-05-29
+
+sec(frontend): participant console hardening — same-origin redirect-restore + dokumentert config-eksponering (#355)
+
+AC1 — `auth_intended_url`-restore validerer nå at lagret URL er same-origin + intern path
+før navigering, så en eventuelt forgiftet sessionStorage-verdi ikke blir en open-redirect.
+Ren funksjon `isSafeSameOriginRedirect(target, currentOrigin)` eksportert fra api-client.js
+med dedikert vitest-enhetstest (6/6 grønne) som dekker same-origin/positive, javascript:/
+data:/vbscript:-rejection, protocol-relative + relative path-rejection, port/scheme-mismatch,
+malformed input, og tom currentOrigin.
+
+AC2 — review av `/participant/config`: responsen er allerede minimal for et pre-auth-
+endpoint. Mock-only-feltene (mockRolePresets, identityDefaults) er server-side gated på
+`AUTH_MODE === "mock"` → tom/undefined i produksjon. Ingen gjenværende felt kan fjernes
+uten å brekke SPA-startup eller post-login workspace-rendering. Ingen kodeendringer
+trengtes; konklusjonen dokumenteres.
+
+AC3 — ny seksjon i `doc/CONFIG_REFERENCE.md` ("Public exposure of /participant/config")
+med per-felt-tabell: hvorfor hvert felt må være public, hva en uautentisert leser lærer.
+Default-policy ved nye felt: «default til authenticated, ikke /participant/config».
+
+Lukker #355.
+
 ## 1.2.36 - 2026-05-27
 
 fix(infra): kodifiser deploy-SP Key Vault Secrets User-grant i Bicep (#470, #410-durabilitet)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.2.36",
+  "version": "1.2.37",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/api-client.js
+++ b/public/api-client.js
@@ -2,6 +2,27 @@
 // MSAL (Entra auth)
 // ---------------------------------------------------------------------------
 
+// #355: validate that a sessionStorage-recovered URL targets our own origin + a sensible
+// internal path before navigating to it. sessionStorage is same-origin already, but a
+// defense-in-depth validation keeps a future code path that could write a poisoned value
+// (or a bug that stores an absolute external URL) from turning into an open redirect.
+// Pure function — exported for unit testing.
+export function isSafeSameOriginRedirect(target, currentOrigin) {
+  if (typeof target !== "string" || target.length === 0) return false;
+  if (typeof currentOrigin !== "string" || currentOrigin.length === 0) return false;
+  let url;
+  try {
+    url = new URL(target);
+  } catch {
+    return false;
+  }
+  if (url.origin !== currentOrigin) return false;
+  // pathname must be an absolute internal path; URL parsing with a non-special scheme would
+  // not surface here (URL() rejects javascript:/data: as opaque), but we double-check.
+  if (!url.pathname.startsWith("/")) return false;
+  return true;
+}
+
 let msalInstance = null;
 let msalScopes = null;
 
@@ -44,14 +65,14 @@ async function initMsal(entraConfig) {
   // Handle the token response after a redirect login
   const result = await msalInstance.handleRedirectPromise();
   if (result) {
-    // Restore the page the user was on before being sent to login
+    // Restore the page the user was on before being sent to login.
+    // #355: only navigate if the stored URL is same-origin + an internal path. Reject and
+    // drop the value silently otherwise so a poisoned sessionStorage entry can't redirect us.
     const intended = sessionStorage.getItem("auth_intended_url");
-    if (intended) {
-      sessionStorage.removeItem("auth_intended_url");
-      if (intended !== window.location.href) {
-        window.location.replace(intended);
-        return;
-      }
+    sessionStorage.removeItem("auth_intended_url");
+    if (intended && isSafeSameOriginRedirect(intended, window.location.origin) && intended !== window.location.href) {
+      window.location.replace(intended);
+      return;
     }
     return;
   }

--- a/test/unit/auth-redirect-safety.test.ts
+++ b/test/unit/auth-redirect-safety.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+//
+// #355: defense-in-depth validation of the sessionStorage-recovered redirect URL used
+// after MSAL handleRedirectPromise. The function must be pure (no DOM) and must reject
+// anything that is not a same-origin URL with an internal path.
+
+import { describe, expect, it } from "vitest";
+// @ts-expect-error — public/api-client.js is a browser ES module (no .d.ts); we import the
+// pure helper only and rely on the JS module's named export. The other code paths in the
+// file are not exercised here.
+import { isSafeSameOriginRedirect } from "../../public/api-client.js";
+
+const SELF = "https://app.example.com";
+
+describe("isSafeSameOriginRedirect", () => {
+  it("accepts same-origin internal paths", () => {
+    expect(isSafeSameOriginRedirect(`${SELF}/`, SELF)).toBe(true);
+    expect(isSafeSameOriginRedirect(`${SELF}/admin-content`, SELF)).toBe(true);
+    expect(isSafeSameOriginRedirect(`${SELF}/admin-content?id=5&tab=settings`, SELF)).toBe(true);
+    expect(isSafeSameOriginRedirect(`${SELF}/admin-content#section`, SELF)).toBe(true);
+  });
+
+  it("rejects different-origin URLs", () => {
+    expect(isSafeSameOriginRedirect("https://evil.example.com/", SELF)).toBe(false);
+    expect(isSafeSameOriginRedirect("https://app.example.com.evil.com/", SELF)).toBe(false);
+    expect(isSafeSameOriginRedirect("http://app.example.com/", SELF)).toBe(false); // wrong scheme
+    expect(isSafeSameOriginRedirect("https://app.example.com:8443/", SELF)).toBe(false); // wrong port
+  });
+
+  it("rejects javascript:, data:, and other opaque-origin schemes", () => {
+    expect(isSafeSameOriginRedirect("javascript:alert(1)", SELF)).toBe(false);
+    expect(isSafeSameOriginRedirect("data:text/html,<script>alert(1)</script>", SELF)).toBe(false);
+    expect(isSafeSameOriginRedirect("vbscript:msgbox(1)", SELF)).toBe(false);
+  });
+
+  it("rejects relative and protocol-relative URLs (no base URL is provided to new URL)", () => {
+    expect(isSafeSameOriginRedirect("/admin-content", SELF)).toBe(false);
+    expect(isSafeSameOriginRedirect("//evil.example.com/", SELF)).toBe(false);
+    expect(isSafeSameOriginRedirect("admin-content", SELF)).toBe(false);
+  });
+
+  it("rejects empty / non-string / malformed input", () => {
+    expect(isSafeSameOriginRedirect("", SELF)).toBe(false);
+    expect(isSafeSameOriginRedirect(null as unknown as string, SELF)).toBe(false);
+    expect(isSafeSameOriginRedirect(undefined as unknown as string, SELF)).toBe(false);
+    expect(isSafeSameOriginRedirect(42 as unknown as string, SELF)).toBe(false);
+    expect(isSafeSameOriginRedirect("not a url", SELF)).toBe(false);
+  });
+
+  it("rejects when currentOrigin is empty (guards a misused call site)", () => {
+    expect(isSafeSameOriginRedirect(`${SELF}/`, "")).toBe(false);
+    expect(isSafeSameOriginRedirect(`${SELF}/`, null as unknown as string)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #355.

## What

Addresses the three acceptance criteria from #355 (post-pilot frontend security review, p4).

### AC1 — `auth_intended_url` redirect-restore validation
New pure function `isSafeSameOriginRedirect(target, currentOrigin)` (exported from `public/api-client.js`) validates that the URL recovered from `sessionStorage` after MSAL `handleRedirectPromise` is **same-origin + an internal path** before calling `window.location.replace`. sessionStorage is same-origin already, but the validation defends against a future code path that could write a poisoned value (or a bug that stores an absolute external URL) being turned into an open redirect.

Unit-tested via `test/unit/auth-redirect-safety.test.ts` (6/6, node env, no DOM mocks — the function is pure). Covered cases:
- positive: same-origin internal paths incl. query/hash
- different-origin rejection (incl. confusable subdomain `app.example.com.evil.com`, wrong scheme, wrong port)
- `javascript:` / `data:` / `vbscript:` opaque-origin rejection
- relative / protocol-relative URL rejection (`new URL` requires absolute base)
- empty / non-string / malformed input
- empty `currentOrigin` argument

### AC2 — `/participant/config` exposure review and minimization
The 2026-05-27 review walked every field. Conclusion: the response is **already minimal** for an unauthenticated startup endpoint. Mock-only fields (`mockRolePresets`, `identityDefaults`) are server-side gated on `AUTH_MODE === \"mock\"` — empty/undefined in production. No remaining field can be safely removed without breaking SPA startup or post-login workspace rendering. **No code changes required.**

### AC3 — Documented rationale
New section in `doc/CONFIG_REFERENCE.md` (\"Public exposure of /participant/config (#355 review)\") with a per-field table: why each field must be public, what an unauthenticated reader actually learns, and a default policy for future additions (\"default to authenticated, not /participant/config\").

## Verification

- `npx tsc --noEmit` clean
- 19/19 vitest tests green (auth-redirect-safety 6, participant-console-config 11, participant-console-production-config 2) — re-ran with `.env.test` loaded
- No behavior change in production for the existing endpoint (the only runtime change is the validation at MSAL redirect-restore; existing valid redirects still navigate correctly)

## Rollback

Revert commit — validation disappears (reverts to pre-#355 behavior), no other footprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)