### PR TITLE
fix(admin-content): «Importer kurs-pakke»-knappen åpner fil-velger i populert kursliste (v1.2.38)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ test-results/
 issue*_body.md
 doc/pentest/PENTEST-*.md
 .claude/worktrees/
+.claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,16 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.2.38 - 2026-06-04
+
+fix(admin-content): «Importer kurs-pakke»-knappen åpner nå fil-velgeren også når kurslisten ikke er tom
+
+Klikk-handleren på `importCoursePackageBtn` ble kun wiret i tom-liste-renderingen av
+kurslisten. I den populerte listeveien (minst ett kurs finnes) ble kun `change`-handleren
+på fil-inputen registrert, så knappen ga ingen respons ved klikk. La til samme
+`click → importCoursePackageFile.click()`-binding i den populerte veien
+(`public/static/admin-content-courses.js`).
+
 ## 1.2.37 - 2026-05-29
 
 sec(frontend): participant console hardening — same-origin redirect-restore + dokumentert config-eksponering (#355)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.2.37",
+  "version": "1.2.38",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -419,6 +419,9 @@ async function renderListView() {
 
   document.getElementById("coursesTableBody")?.addEventListener("click", handleListTableClick);
   document.getElementById("importCoursePackageFile")?.addEventListener("change", handleImportCoursePackageFile);
+  document.getElementById("importCoursePackageBtn")?.addEventListener("click", () => {
+    document.getElementById("importCoursePackageFile")?.click();
+  });
 }
 
 // #433 phase 4b — course export download. Calls /export-package and saves the


### PR DESCRIPTION
## Hva

«Importer kurs-pakke»-knappen i Admin Content → Kurs ga ingen respons når kurslisten ikke var tom.

## Rotårsak

Knappen rendres i to kodeveier i `public/static/admin-content-courses.js`:

- **Tom liste:** både `change`-handleren på fil-inputen og `click`-handleren på knappen ble wiret. ✅
- **Populert liste (≥1 kurs):** kun `change`-handleren ble registrert — `click`-handleren på `importCoursePackageBtn` manglet, så knappen kalte aldri `importCoursePackageFile.click()`.

Brukere med minst ett kurs fikk derfor «ingen respons» ved klikk.

## Fiks

La til samme `click → importCoursePackageFile.click()`-binding i den populerte listeveien.

## Test

- Manuell: knappen åpner nå fil-velgeren i begge tilstander (tom + populert liste).
- Code-only (kun `public/static/`), ingen infra/Bicep/workflow — deployes via `deploy-app.yml`.

## Versjon

v1.2.38 (`package.json` + `doc/VERSIONS.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
