### PR TITLE
feat(course): CourseItem-polymorfi + backfill + dual-write (v1.3.2, #480 expand)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,25 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.2 - 2026-06-15
+
+feat(course): CourseItem-polymorfi + backfill + dual-write — F1 expand-fase (#480)
+
+Tredje skive av #476 (Tier 2 LMS, epic #478). Innfører polymorf `CourseItem`
+(courseId, itemType MODULE|SECTION, sortOrder, moduleId?/sectionId?) som skal erstatte
+`CourseModule`-join og la moduler + læringsseksjoner interleaves i ett ordnet forløp.
+
+Expand-contract (trygt, reversibelt): migrering `20260615000002_add_course_item` oppretter
+tabellen, backfiller hver eksisterende `CourseModule` → `CourseItem(type=MODULE)` med bevart
+`sortOrder` (gen_random_uuid for id), og har en XOR-CHECK som sikrer at nøyaktig én av
+moduleId/sectionId er satt per itemType. `CourseModule` beholdes urørt; `setCourseModules`
+dual-writer nå MODULE-items i parallell i samme transaksjon (SECTION-items bevares ved
+re-ordering). Lese-pathene er UENDRET → null regresjon på eksisterende kurs-oppførsel.
+
+Lese-cutover (flytt alle `course.modules`-konsumenter til `CourseItem`) + drop av
+`CourseModule` følger som egen contract-fase. Integrasjonstest dekker dual-write +
+SECTION-bevaring; CI kjører migrering + full suite mot Postgres. `tsc` + `prisma validate` rene.
+
 ## 1.3.1 - 2026-06-15
 
 feat(course): CourseSection + CourseSectionVersion-modeller — F2 (#481)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260615000002_add_course_item/migration.sql
+++ b/prisma/migrations/20260615000002_add_course_item/migration.sql
@@ -1,0 +1,45 @@
+-- CreateEnum
+CREATE TYPE "CourseItemType" AS ENUM ('MODULE', 'SECTION');
+
+-- CreateTable
+CREATE TABLE "CourseItem" (
+    "id" TEXT NOT NULL,
+    "courseId" TEXT NOT NULL,
+    "itemType" "CourseItemType" NOT NULL,
+    "sortOrder" INTEGER NOT NULL,
+    "moduleId" TEXT,
+    "sectionId" TEXT,
+
+    CONSTRAINT "CourseItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CourseItem_courseId_sortOrder_idx" ON "CourseItem"("courseId", "sortOrder");
+
+-- CreateIndex
+CREATE INDEX "CourseItem_moduleId_idx" ON "CourseItem"("moduleId");
+
+-- CreateIndex
+CREATE INDEX "CourseItem_sectionId_idx" ON "CourseItem"("sectionId");
+
+-- AddForeignKey
+ALTER TABLE "CourseItem" ADD CONSTRAINT "CourseItem_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CourseItem" ADD CONSTRAINT "CourseItem_moduleId_fkey" FOREIGN KEY ("moduleId") REFERENCES "Module"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CourseItem" ADD CONSTRAINT "CourseItem_sectionId_fkey" FOREIGN KEY ("sectionId") REFERENCES "CourseSection"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Enforce that exactly one polymorphic target is set, matching itemType.
+ALTER TABLE "CourseItem" ADD CONSTRAINT "CourseItem_target_xor_chk" CHECK (
+    ("itemType" = 'MODULE' AND "moduleId" IS NOT NULL AND "sectionId" IS NULL)
+    OR ("itemType" = 'SECTION' AND "sectionId" IS NOT NULL AND "moduleId" IS NULL)
+);
+
+-- Backfill: every existing CourseModule row becomes a MODULE CourseItem with the
+-- same ordering. gen_random_uuid() is built in on PostgreSQL 13+ (Azure Flexible
+-- Server) so no extension is required.
+INSERT INTO "CourseItem" ("id", "courseId", "itemType", "sortOrder", "moduleId")
+SELECT gen_random_uuid()::text, "courseId", 'MODULE', "sortOrder", "moduleId"
+FROM "CourseModule";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -160,6 +160,7 @@ model Module {
   rubricVersions         RubricVersion[]
   promptTemplateVersions PromptTemplateVersion[]
   courseModules          CourseModule[]
+  courseItems            CourseItem[]
 }
 
 model ModuleVersion {
@@ -459,7 +460,8 @@ model Course {
   archivedAt         DateTime?
   createdAt          DateTime           @default(now())
   updatedAt          DateTime           @updatedAt
-  modules            CourseModule[]
+  modules            CourseModule[]     // deprecated av CourseItem (#480) — beholdt under expand-contract til lese-cutover + drop
+  items              CourseItem[]
   completions        CourseCompletion[]
 }
 
@@ -499,6 +501,33 @@ model CourseSection {
   updatedAt       DateTime               @updatedAt
   versions        CourseSectionVersion[] @relation("CourseSectionVersions")
   activeVersion   CourseSectionVersion?  @relation("ActiveCourseSectionVersion", fields: [activeVersionId], references: [id], onDelete: SetNull)
+  courseItems     CourseItem[]
+}
+
+enum CourseItemType {
+  MODULE
+  SECTION
+}
+
+// Polymorf kurs-element (#480/F1): erstatter CourseModule-join og lar moduler og
+// læringsseksjoner interleaves i ett ordnet forløp. Under expand-contract skrives
+// MODULE-items i parallell med CourseModule (dual-write i setCourseModules) inntil
+// lese-pathene er kuttet over og CourseModule droppes. Nøyaktig én av moduleId/
+// sectionId er satt, styrt av itemType (DB-CHECK i migreringen).
+model CourseItem {
+  id        String         @id @default(cuid())
+  courseId  String
+  itemType  CourseItemType
+  sortOrder Int
+  moduleId  String?
+  sectionId String?
+  course    Course         @relation(fields: [courseId], references: [id], onDelete: Cascade)
+  module    Module?        @relation(fields: [moduleId], references: [id], onDelete: Restrict)
+  section   CourseSection? @relation(fields: [sectionId], references: [id], onDelete: Restrict)
+
+  @@index([courseId, sortOrder])
+  @@index([moduleId])
+  @@index([sectionId])
 }
 
 model CourseSectionVersion {

--- a/src/modules/course/courseCommands.ts
+++ b/src/modules/course/courseCommands.ts
@@ -103,9 +103,20 @@ export async function setCourseModules(
 ) {
   return runInTransaction(async (tx) => {
     await tx.courseModule.deleteMany({ where: { courseId } });
+    // Dual-write to CourseItem (#480 expand-contract). Only MODULE items are
+    // managed here so any future SECTION items survive a module re-order.
+    await tx.courseItem.deleteMany({ where: { courseId, itemType: "MODULE" } });
     if (modules.length > 0) {
       await tx.courseModule.createMany({
         data: modules.map((m) => ({ courseId, moduleId: m.moduleId, sortOrder: m.sortOrder })),
+      });
+      await tx.courseItem.createMany({
+        data: modules.map((m) => ({
+          courseId,
+          itemType: "MODULE" as const,
+          moduleId: m.moduleId,
+          sortOrder: m.sortOrder,
+        })),
       });
     }
     await tx.course.update({

--- a/test/m2-course-item-dual-write.test.ts
+++ b/test/m2-course-item-dual-write.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { setCourseModules } from "../src/modules/course/courseCommands.js";
+import { prisma } from "../src/db/prisma.js";
+
+// #480 expand-contract: setCourseModules dual-writes MODULE CourseItem rows in
+// parallel with CourseModule, while leaving any SECTION CourseItems intact.
+describe("CourseItem dual-write (#480)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("mirrors modules into CourseItem with order preserved, and re-syncs on re-set", async () => {
+    const course = await prisma.course.create({
+      data: { title: `DualWrite ${Date.now()}` },
+      select: { id: true },
+    });
+    const moduleA = await prisma.module.create({
+      data: { title: `DW Module A ${Date.now()}` },
+      select: { id: true },
+    });
+    const moduleB = await prisma.module.create({
+      data: { title: `DW Module B ${Date.now()}` },
+      select: { id: true },
+    });
+
+    await setCourseModules(course.id, [
+      { moduleId: moduleA.id, sortOrder: 2 },
+      { moduleId: moduleB.id, sortOrder: 1 },
+    ]);
+
+    const courseModules = await prisma.courseModule.findMany({
+      where: { courseId: course.id },
+      orderBy: { sortOrder: "asc" },
+    });
+    const courseItems = await prisma.courseItem.findMany({
+      where: { courseId: course.id },
+      orderBy: { sortOrder: "asc" },
+    });
+
+    expect(courseModules.map((c) => c.moduleId)).toEqual([moduleB.id, moduleA.id]);
+    expect(courseItems).toHaveLength(2);
+    expect(courseItems.map((i) => i.moduleId)).toEqual([moduleB.id, moduleA.id]);
+    expect(courseItems.every((i) => i.itemType === "MODULE")).toBe(true);
+    expect(courseItems.every((i) => i.sectionId === null)).toBe(true);
+
+    // Re-setting modules replaces the MODULE CourseItem rows.
+    await setCourseModules(course.id, [{ moduleId: moduleA.id, sortOrder: 1 }]);
+    const afterItems = await prisma.courseItem.findMany({ where: { courseId: course.id } });
+    expect(afterItems).toHaveLength(1);
+    expect(afterItems[0]).toMatchObject({ moduleId: moduleA.id, sortOrder: 1, itemType: "MODULE" });
+
+    await prisma.course.delete({ where: { id: course.id } });
+  });
+
+  it("does not touch SECTION CourseItems when modules are re-set", async () => {
+    const course = await prisma.course.create({
+      data: { title: `DualWrite Section ${Date.now()}` },
+      select: { id: true },
+    });
+    const section = await prisma.courseSection.create({
+      data: { title: `DW Section ${Date.now()}` },
+      select: { id: true },
+    });
+    const mod = await prisma.module.create({
+      data: { title: `DW Module ${Date.now()}` },
+      select: { id: true },
+    });
+    await prisma.courseItem.create({
+      data: { courseId: course.id, itemType: "SECTION", sectionId: section.id, sortOrder: 5 },
+    });
+
+    await setCourseModules(course.id, [{ moduleId: mod.id, sortOrder: 1 }]);
+
+    const items = await prisma.courseItem.findMany({ where: { courseId: course.id } });
+    const sectionItems = items.filter((i) => i.itemType === "SECTION");
+    const moduleItems = items.filter((i) => i.itemType === "MODULE");
+    expect(sectionItems).toHaveLength(1);
+    expect(sectionItems[0].sectionId).toBe(section.id);
+    expect(moduleItems).toHaveLength(1);
+    expect(moduleItems[0].moduleId).toBe(mod.id);
+
+    await prisma.course.delete({ where: { id: course.id } });
+    await prisma.courseSection.delete({ where: { id: section.id } });
+  });
+});


### PR DESCRIPTION
## Hva

Tredje skive av #476 (Tier 2 LMS, epic #478) — **expand-fasen** av #480. Innfører polymorf `CourseItem` som skal erstatte `CourseModule`-join og la moduler + læringsseksjoner interleaves i ett ordnet forløp.

## Expand-contract (trygt, reversibelt)

Per avtale: staging-data er ekspanderbart + rollback tilgjengelig — men dette er likevel gjort ikke-destruktivt:

- **Migrering `20260615000002_add_course_item`:** oppretter `CourseItem` (itemType `MODULE`|`SECTION`, sortOrder, moduleId?/sectionId?), backfiller hver eksisterende `CourseModule` → `CourseItem(type=MODULE)` med bevart `sortOrder`, og legger en **XOR-CHECK** som sikrer nøyaktig én polymorf target per itemType.
- **`CourseModule` beholdes urørt.** `setCourseModules` **dual-writer** MODULE-items i parallell i samme transaksjon, og bevarer SECTION-items ved re-ordering.
- **Lese-pathene er UENDRET** → null regresjon på eksisterende kurs-oppførsel.

## Hva som IKKE er her (egen contract-fase)

Lese-cutover (flytt alle `course.modules`-konsumenter — repository/report/completion/adminContent/route — til `CourseItem`) + drop av `CourseModule`. Holdes separat for små, trygge PR-er.

## Verifisering

- `npx tsc --noEmit` + `prisma validate` rene lokalt
- CI `verify` kjører migreringen (`db:reset`) + **full testsuite mot Postgres**, inkl. ny integrasjonstest `m2-course-item-dual-write.test.ts` (dual-write + order + SECTION-bevaring) og eksisterende kurs-integrasjonstester (regresjon)

## Rollback

Revert PR → `CourseItem` blir en ubrukt tabell (lese-pathene rørte den aldri). Ingen eksisterende tabell endret. Trygt.

Lukker #480 (expand-fase; contract-fase spores separat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
