### PR TITLE
feat(course): seksjon-CRUD-API (v1.3.3, #485 B1)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,23 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.3 - 2026-06-15
+
+feat(course): seksjon-CRUD-API — B1 (#485)
+
+Fjerde skive av #476 (Tier 2 LMS, epic #478). REST-API for kurs-læringsseksjoner under
+`/api/admin/content/sections` (arver `admin_content`-autorisasjon):
+- `POST /` opprett (title + bodyMarkdown, begge lokaliserte) → seksjon + v1
+- `GET /` liste, `GET /:id` detalj (med aktiv versjons bodyMarkdown)
+- `PATCH /:id/title` oppdater tittel
+- `PUT /:id/content` ny innholdsversjon (immutabel, versionNo++, latest-wins)
+- `DELETE /:id` (blokkeres hvis seksjonen er knyttet til et kurs)
+
+Kommandoer i `src/modules/course/sectionCommands.ts` speiler Module/ModuleVersion-mønsteret.
+Integrasjonstest (`m2-admin-sections.test.ts`) dekker create→read→list→re-version→delete +
+delete-blokkering ved kurs-tilknytning. `tsc` rent; CI kjører mot Postgres. Ren backend —
+ingen UI ennå (U1 #488).
+
 ## 1.3.2 - 2026-06-15
 
 feat(course): CourseItem-polymorfi + backfill + dual-write — F1 expand-fase (#480)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -1,6 +1,14 @@
 export { checkAndIssueCourseCompletions } from "./courseCompletionService.js";
 export { getCourseReport, getCourseLearnerReport } from "./courseReport.js";
 export { createCourse, updateCourse, publishCourse, archiveCourse, setCourseModules, deleteCourse } from "./courseCommands.js";
+export {
+  createSection,
+  updateSectionTitle,
+  updateSectionContent,
+  getSection,
+  listSections,
+  deleteSection,
+} from "./sectionCommands.js";
 export { courseRepository, createCourseRepository } from "./courseRepository.js";
 export { computeCourseStatus } from "./courseQueries.js";
 export type {

--- a/src/modules/course/sectionCommands.ts
+++ b/src/modules/course/sectionCommands.ts
@@ -1,0 +1,98 @@
+import { prisma } from "../../db/prisma.js";
+import { runInTransaction } from "../../db/transaction.js";
+import { NotFoundError, ValidationError } from "../../errors/AppError.js";
+
+// Section CRUD + versioning (#485/B1) for course learning sections (#476).
+// Mirrors Module/ModuleVersion: editing content publishes an immutable new
+// version and re-points activeVersionId (latest-wins in v1.3.x). Localized
+// fields (title, bodyMarkdown) arrive already serialized to JSON strings by the
+// route layer, exactly like createCourse.
+
+export async function createSection(input: { title: string; bodyMarkdown: string; actorId?: string }) {
+  return runInTransaction(async (tx) => {
+    const section = await tx.courseSection.create({ data: { title: input.title } });
+    const version = await tx.courseSectionVersion.create({
+      data: {
+        sectionId: section.id,
+        versionNo: 1,
+        bodyMarkdown: input.bodyMarkdown,
+        publishedBy: input.actorId ?? null,
+        publishedAt: new Date(),
+      },
+    });
+    return tx.courseSection.update({
+      where: { id: section.id },
+      data: { activeVersionId: version.id },
+      include: { activeVersion: true },
+    });
+  });
+}
+
+export async function updateSectionTitle(sectionId: string, title: string) {
+  await assertSectionExists(sectionId);
+  return prisma.courseSection.update({
+    where: { id: sectionId },
+    data: { title },
+    include: { activeVersion: true },
+  });
+}
+
+export async function updateSectionContent(sectionId: string, bodyMarkdown: string, actorId?: string) {
+  await assertSectionExists(sectionId);
+  return runInTransaction(async (tx) => {
+    const last = await tx.courseSectionVersion.findFirst({
+      where: { sectionId },
+      orderBy: { versionNo: "desc" },
+      select: { versionNo: true },
+    });
+    const version = await tx.courseSectionVersion.create({
+      data: {
+        sectionId,
+        versionNo: (last?.versionNo ?? 0) + 1,
+        bodyMarkdown,
+        publishedBy: actorId ?? null,
+        publishedAt: new Date(),
+      },
+    });
+    return tx.courseSection.update({
+      where: { id: sectionId },
+      data: { activeVersionId: version.id, updatedAt: new Date() },
+      include: { activeVersion: true },
+    });
+  });
+}
+
+export function getSection(sectionId: string) {
+  return prisma.courseSection.findUnique({
+    where: { id: sectionId },
+    include: { activeVersion: true },
+  });
+}
+
+export function listSections() {
+  return prisma.courseSection.findMany({
+    orderBy: { updatedAt: "desc" },
+    include: { activeVersion: { select: { id: true, versionNo: true, publishedAt: true } } },
+  });
+}
+
+export async function deleteSection(sectionId: string) {
+  await assertSectionExists(sectionId);
+  const references = await prisma.courseItem.count({ where: { sectionId } });
+  if (references > 0) {
+    throw new ValidationError("Cannot delete a section that is used in one or more courses.");
+  }
+  await runInTransaction(async (tx) => {
+    // Detach activeVersion FK before deleting versions to avoid the self-reference.
+    await tx.courseSection.update({ where: { id: sectionId }, data: { activeVersionId: null } });
+    await tx.courseSectionVersion.deleteMany({ where: { sectionId } });
+    await tx.courseSection.delete({ where: { id: sectionId } });
+  });
+}
+
+async function assertSectionExists(sectionId: string) {
+  const section = await prisma.courseSection.findUnique({ where: { id: sectionId }, select: { id: true } });
+  if (!section) {
+    throw new NotFoundError("CourseSection", "section_not_found", "Course section not found.");
+  }
+}

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -72,6 +72,7 @@ import {
   toCreateModuleVersionInput,
 } from "../modules/adminContent/adminContentMapper.js";
 import { adminCoursesRouter } from "./adminCourses.js";
+import { adminSectionsRouter } from "./adminSections.js";
 import { generateLimiter, extractLimiter, intentLogLimiter } from "../middleware/rateLimiting.js";
 import { ForbiddenError, NotFoundError, AppError } from "../errors/AppError.js";
 
@@ -90,6 +91,7 @@ async function assertModuleOwnership(moduleId: string, actorId: string, roles: s
 }
 
 adminContentRouter.use("/courses", adminCoursesRouter);
+adminContentRouter.use("/sections", adminSectionsRouter);
 
 adminContentRouter.post("/modules", async (request, response) => {
   const { data, error } = parseRequest(moduleCreateBodySchema, request.body);

--- a/src/routes/adminSections.ts
+++ b/src/routes/adminSections.ts
@@ -1,0 +1,136 @@
+import { Router } from "express";
+import { z } from "zod";
+import {
+  createSection,
+  updateSectionTitle,
+  updateSectionContent,
+  getSection,
+  listSections,
+  deleteSection,
+} from "../modules/course/index.js";
+import { localizedTextPatchSchema } from "../modules/adminContent/adminContentSchemas.js";
+import { localizedTextCodec } from "../codecs/localizedTextCodec.js";
+import { NotFoundError } from "../errors/AppError.js";
+
+const adminSectionsRouter = Router();
+
+const createSectionSchema = z.object({
+  title: localizedTextPatchSchema,
+  bodyMarkdown: localizedTextPatchSchema,
+});
+const titleSchema = z.object({ title: localizedTextPatchSchema });
+const contentSchema = z.object({ bodyMarkdown: localizedTextPatchSchema });
+
+type SectionWithActiveVersion = {
+  id: string;
+  title: string;
+  activeVersionId: string | null;
+  archivedAt: Date | null;
+  updatedAt: Date;
+  activeVersion?: { bodyMarkdown?: string; versionNo: number } | null;
+};
+
+function toDetail(section: SectionWithActiveVersion) {
+  return {
+    id: section.id,
+    title: section.title,
+    activeVersionId: section.activeVersionId,
+    versionNo: section.activeVersion?.versionNo ?? null,
+    bodyMarkdown: section.activeVersion?.bodyMarkdown ?? null,
+    updatedAt: section.updatedAt.toISOString(),
+    archivedAt: section.archivedAt?.toISOString() ?? null,
+  };
+}
+
+adminSectionsRouter.post("/", async (request, response, next) => {
+  const parsed = createSectionSchema.safeParse(request.body);
+  if (!parsed.success) {
+    response.status(400).json({ error: "validation_error", issues: parsed.error.issues });
+    return;
+  }
+  try {
+    const section = await createSection({
+      title: localizedTextCodec.serialize(parsed.data.title),
+      bodyMarkdown: localizedTextCodec.serialize(parsed.data.bodyMarkdown),
+      actorId: request.context?.userId,
+    });
+    response.status(201).json({ section: toDetail(section) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminSectionsRouter.get("/", async (_request, response, next) => {
+  try {
+    const sections = await listSections();
+    response.json({
+      sections: sections.map((s) => ({
+        id: s.id,
+        title: s.title,
+        versionNo: s.activeVersion?.versionNo ?? null,
+        updatedAt: s.updatedAt.toISOString(),
+        archivedAt: s.archivedAt?.toISOString() ?? null,
+      })),
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminSectionsRouter.get("/:sectionId", async (request, response, next) => {
+  try {
+    const section = await getSection(request.params.sectionId);
+    if (!section) {
+      throw new NotFoundError("CourseSection", "section_not_found", "Course section not found.");
+    }
+    response.json({ section: toDetail(section) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminSectionsRouter.patch("/:sectionId/title", async (request, response, next) => {
+  const parsed = titleSchema.safeParse(request.body);
+  if (!parsed.success) {
+    response.status(400).json({ error: "validation_error", issues: parsed.error.issues });
+    return;
+  }
+  try {
+    const section = await updateSectionTitle(
+      request.params.sectionId,
+      localizedTextCodec.serialize(parsed.data.title),
+    );
+    response.json({ section: toDetail(section) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminSectionsRouter.put("/:sectionId/content", async (request, response, next) => {
+  const parsed = contentSchema.safeParse(request.body);
+  if (!parsed.success) {
+    response.status(400).json({ error: "validation_error", issues: parsed.error.issues });
+    return;
+  }
+  try {
+    const section = await updateSectionContent(
+      request.params.sectionId,
+      localizedTextCodec.serialize(parsed.data.bodyMarkdown),
+      request.context?.userId,
+    );
+    response.json({ section: toDetail(section) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminSectionsRouter.delete("/:sectionId", async (request, response, next) => {
+  try {
+    await deleteSection(request.params.sectionId);
+    response.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export { adminSectionsRouter };

--- a/test/m2-admin-sections.test.ts
+++ b/test/m2-admin-sections.test.ts
@@ -1,0 +1,100 @@
+import request from "supertest";
+import { afterAll, describe, expect, it } from "vitest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+
+const adminHeaders = {
+  "x-user-id": "admin-1",
+  "x-user-email": "admin@company.com",
+  "x-user-name": "Platform Admin",
+};
+
+// #485/B1 — course learning-section CRUD API.
+describe("Admin course-section management", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("creates, reads, lists, re-versions, and deletes a section", async () => {
+    const createResponse = await request(app)
+      .post("/api/admin/content/sections")
+      .set(adminHeaders)
+      .send({
+        title: { "en-GB": `Section ${Date.now()}`, nb: "Seksjon", nn: "Seksjon" },
+        bodyMarkdown: { "en-GB": "# Hello\n\nFirst body.", nb: "# Hei", nn: "# Hei" },
+      });
+    expect(createResponse.status).toBe(201);
+    const sectionId = createResponse.body.section.id as string;
+    expect(createResponse.body.section.versionNo).toBe(1);
+    expect(createResponse.body.section.bodyMarkdown).toContain("First body.");
+
+    const detailResponse = await request(app)
+      .get(`/api/admin/content/sections/${sectionId}`)
+      .set(adminHeaders);
+    expect(detailResponse.status).toBe(200);
+    expect(detailResponse.body.section.title).toContain("en-GB");
+
+    const listResponse = await request(app)
+      .get("/api/admin/content/sections")
+      .set(adminHeaders);
+    expect(listResponse.status).toBe(200);
+    expect((listResponse.body.sections as Array<{ id: string }>).some((s) => s.id === sectionId)).toBe(true);
+
+    // Editing content publishes a new immutable version (latest-wins).
+    const updateResponse = await request(app)
+      .put(`/api/admin/content/sections/${sectionId}/content`)
+      .set(adminHeaders)
+      .send({ bodyMarkdown: { "en-GB": "# Hello\n\nSecond body.", nb: "# Hei 2", nn: "# Hei 2" } });
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body.section.versionNo).toBe(2);
+    expect(updateResponse.body.section.bodyMarkdown).toContain("Second body.");
+
+    const versionCount = await prisma.courseSectionVersion.count({ where: { sectionId } });
+    expect(versionCount).toBe(2);
+
+    const titleResponse = await request(app)
+      .patch(`/api/admin/content/sections/${sectionId}/title`)
+      .set(adminHeaders)
+      .send({ title: { "en-GB": "Renamed section", nb: "Omdøpt", nn: "Omdøpt" } });
+    expect(titleResponse.status).toBe(200);
+    expect(titleResponse.body.section.title).toContain("Renamed section");
+
+    const deleteResponse = await request(app)
+      .delete(`/api/admin/content/sections/${sectionId}`)
+      .set(adminHeaders);
+    expect(deleteResponse.status).toBe(204);
+
+    const gone = await request(app)
+      .get(`/api/admin/content/sections/${sectionId}`)
+      .set(adminHeaders);
+    expect(gone.status).toBe(404);
+  });
+
+  it("refuses to delete a section that is attached to a course", async () => {
+    const create = await request(app)
+      .post("/api/admin/content/sections")
+      .set(adminHeaders)
+      .send({
+        title: { "en-GB": `Attached ${Date.now()}`, nb: "Festet", nn: "Festet" },
+        bodyMarkdown: { "en-GB": "body", nb: "body", nn: "body" },
+      });
+    const sectionId = create.body.section.id as string;
+
+    const course = await prisma.course.create({
+      data: { title: `Section Host ${Date.now()}` },
+      select: { id: true },
+    });
+    await prisma.courseItem.create({
+      data: { courseId: course.id, itemType: "SECTION", sectionId, sortOrder: 0 },
+    });
+
+    const blocked = await request(app)
+      .delete(`/api/admin/content/sections/${sectionId}`)
+      .set(adminHeaders);
+    expect(blocked.status).toBe(400);
+
+    // cleanup (course cascade removes the CourseItem, then section is deletable)
+    await prisma.course.delete({ where: { id: course.id } });
+    await request(app).delete(`/api/admin/content/sections/${sectionId}`).set(adminHeaders);
+  });
+});


### PR DESCRIPTION
## Hva

Fjerde skive av #476 (Tier 2 LMS, epic #478) — **B1 (#485)**: REST-API for kurs-læringsseksjoner.

Endepunkter under `/api/admin/content/sections` (arver `admin_content`-autorisasjon fra parent-mountet):
- `POST /` — opprett (lokalisert `title` + `bodyMarkdown`) → seksjon + versjon 1
- `GET /` — liste · `GET /:id` — detalj (med aktiv versjons `bodyMarkdown`)
- `PATCH /:id/title` — oppdater tittel
- `PUT /:id/content` — ny innholdsversjon (immutabel, `versionNo++`, latest-wins)
- `DELETE /:id` — blokkeres (400) hvis seksjonen er knyttet til et kurs

## Mønster

`src/modules/course/sectionCommands.ts` speiler `Module`/`ModuleVersion`: innhold publiseres som immutabel versjon, `activeVersionId` re-pekes. Lokaliserte felt serialiseres via `localizedTextCodec` i route-laget (som kurs).

## Verifisering

- `npx tsc --noEmit` rent
- Integrasjonstest `m2-admin-sections.test.ts`: create→read→list→re-version (v2)→title→delete, + delete-blokkering ved kurs-tilknytning. CI kjører mot Postgres.

## Scope

Ren backend — ingen UI (kommer i U1 #488). Bygger på F2 (#481, seksjons-modeller). Del av løkka B1→U1→U3/B2→P1 mot manuell staging-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
