### PR TITLE
fix(security): re-validate URL fetch redirects to prevent SSRF bypass

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,19 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.2.2 - 2026-05-23
+
+fix(security): stop URL fetch redirects to private/internal addresses
+
+`fetchUrlAsSourceMaterial` followed redirects automatically after validating only the
+initial URL. This allowed SSRF bypass via attacker-controlled redirect targets
+(e.g. `127.0.0.1`, RFC1918, metadata ranges).
+
+Fix: switched to manual redirect handling and re-run `assertSafeUrl` on each
+redirect target before any subsequent fetch. Redirect chains are capped to 5 hops.
+
+Added unit-test coverage for redirect-to-loopback blocking.
+
 ## 1.2.1 - 2026-05-23
 
 fix(admin): flytt `jsdom` til dependencies (#454 Phase 1 hotfix)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a2-assessment-platform",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "dependencies": {
         "@azure/communication-email": "^1.1.0",
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/urlFetchService.ts
+++ b/src/modules/adminContent/urlFetchService.ts
@@ -126,42 +126,62 @@ async function assertSafeUrl(rawUrl: string): Promise<URL> {
 }
 
 // Fetches the URL with a strict byte cap. Streams response into a buffer; aborts if cap exceeded.
+const MAX_REDIRECTS = 5;
+
 async function fetchWithLimit(parsedUrl: URL, signal: AbortSignal): Promise<{ buffer: Buffer; contentType: string }> {
-  const response = await fetch(parsedUrl.toString(), {
-    method: "GET",
-    redirect: "follow",
-    signal,
-    headers: {
-      // Be polite: identify ourselves
-      "user-agent": "A2AssessmentPlatform/url-fetch (+https://github.com/jkosmo/a2-assessment-platform)",
-      accept: "text/html, application/xhtml+xml, text/plain;q=0.9, */*;q=0.5",
-    },
-  });
-  if (!response.ok) {
-    throw new UrlFetchError("http_error", `Upstream returned ${response.status}.`);
-  }
-  const contentType = (response.headers.get("content-type") ?? "").toLowerCase();
-  const baseType = contentType.split(";")[0].trim();
-  if (!ALLOWED_CONTENT_TYPES.includes(baseType)) {
-    throw new UrlFetchError("unsupported_content_type", `Content-Type ${baseType || "(missing)"} is not supported.`);
-  }
-  if (!response.body) {
-    throw new UrlFetchError("empty_response", "Upstream returned no body.");
-  }
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    total += value.byteLength;
-    if (total > SOURCE_MATERIAL_MAX_BYTES) {
-      try { await reader.cancel(); } catch {}
-      throw new UrlFetchError("too_large", `Response exceeds ${SOURCE_MATERIAL_MAX_BYTES} bytes.`);
+  let currentUrl = parsedUrl;
+  for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
+    const response = await fetch(currentUrl.toString(), {
+      method: "GET",
+      redirect: "manual",
+      signal,
+      headers: {
+        // Be polite: identify ourselves
+        "user-agent": "A2AssessmentPlatform/url-fetch (+https://github.com/jkosmo/a2-assessment-platform)",
+        accept: "text/html, application/xhtml+xml, text/plain;q=0.9, */*;q=0.5",
+      },
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      if (!location) {
+        throw new UrlFetchError("invalid_redirect", "Upstream redirect response missing Location header.");
+      }
+      if (redirectCount === MAX_REDIRECTS) {
+        throw new UrlFetchError("too_many_redirects", `Too many redirects (max ${MAX_REDIRECTS}).`);
+      }
+      const redirectedUrl = new URL(location, currentUrl);
+      currentUrl = await assertSafeUrl(redirectedUrl.toString());
+      continue;
     }
-    chunks.push(value);
+    if (!response.ok) {
+      throw new UrlFetchError("http_error", `Upstream returned ${response.status}.`);
+    }
+    const contentType = (response.headers.get("content-type") ?? "").toLowerCase();
+    const baseType = contentType.split(";")[0].trim();
+    if (!ALLOWED_CONTENT_TYPES.includes(baseType)) {
+      throw new UrlFetchError("unsupported_content_type", `Content-Type ${baseType || "(missing)"} is not supported.`);
+    }
+    if (!response.body) {
+      throw new UrlFetchError("empty_response", "Upstream returned no body.");
+    }
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > SOURCE_MATERIAL_MAX_BYTES) {
+        try { await reader.cancel(); } catch {}
+        throw new UrlFetchError("too_large", `Response exceeds ${SOURCE_MATERIAL_MAX_BYTES} bytes.`);
+      }
+      chunks.push(value);
+    }
+    return { buffer: Buffer.concat(chunks.map((c) => Buffer.from(c))), contentType: baseType };
   }
-  return { buffer: Buffer.concat(chunks.map((c) => Buffer.from(c))), contentType: baseType };
+
+  throw new UrlFetchError("too_many_redirects", `Too many redirects (max ${MAX_REDIRECTS}).`);
 }
 
 async function extractMainText(buffer: Buffer, contentType: string, sourceUrl: string): Promise<string> {

--- a/test/unit/url-fetch-service.test.ts
+++ b/test/unit/url-fetch-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { fetchUrlAsSourceMaterial, UrlFetchError, checkAndConsumeRateLimit } from "../../src/modules/adminContent/urlFetchService.js";
 
 // #454 Phase 1: SSRF-guard tests. These are the critical security tests — they validate
@@ -56,6 +56,25 @@ describe("urlFetchService SSRF protection", () => {
     await expect(fetchUrlAsSourceMaterial("http://[fe80::1]/")).rejects.toMatchObject({
       code: "private_address",
     });
+  });
+
+
+
+  it("rejects redirects to private/internal addresses", async () => {
+    const originalFetch = global.fetch;
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 302, headers: { location: "http://127.0.0.1/internal" } }));
+    global.fetch = fetchMock as typeof fetch;
+
+    try {
+      await expect(fetchUrlAsSourceMaterial("https://93.184.216.34/start")).rejects.toMatchObject({
+        code: "private_address",
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      global.fetch = originalFetch;
+    }
   });
 
   it("rejects hostnames that map to private addresses (localhost variants)", async () => {


### PR DESCRIPTION
### Motivation
- Close an SSRF bypass where `fetchUrlAsSourceMaterial` validated only the initial hostname but followed redirects automatically, allowing attacker-controlled redirects into private/internal addresses to be fetched and parsed (the `jsdom` production dependency made this exploitable at runtime). 
- Prevent disclosure of internal HTML content reachable from the server by ensuring every redirect target is re-checked against the existing SSRF policy.

### Description
- Replace automatic redirect-following with manual redirect handling by using `fetch(..., redirect: "manual")` and iterating redirect responses. 
- Re-validate each redirect target by calling `assertSafeUrl(...)` before following it and cap redirect chains with `MAX_REDIRECTS = 5`, returning explicit errors `invalid_redirect` and `too_many_redirects` on failure. 
- Add a unit test that mocks a `302` redirect to `127.0.0.1` to ensure redirect-to-loopback is blocked. 
- Bump the app version to `1.2.2` and update `doc/VERSIONS.md` and `package-lock.json` to document the security fix.

### Testing
- `npx vitest run test/unit/url-fetch-service.test.ts` was executed and the unit tests passed (8 tests). 
- Running `npm run test -- test/unit/url-fetch-service.test.ts` in the local environment failed during `pretest` because Docker is required by the repository's PostgreSQL bootstrap step and was not available; this is an environment issue and not related to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a11582e1e58832d84520b1688a526b2)