### PR TITLE
feat(course): blandet CourseItem-ordering-API (v1.3.4, #486 B2)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,22 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.4 - 2026-06-15
+
+feat(course): blandet CourseItem-ordering-API — B2 (#486)
+
+Femte skive av #476 (Tier 2 LMS, epic #478). API for å sette/lese den fulle ordnede
+sekvensen av et kurs — moduler og læringsseksjoner om hverandre:
+- `PUT /api/admin/content/courses/:courseId/items` — sett ordnet liste (sortOrder = posisjon);
+  validerer at ids finnes og at modul/seksjon ikke gjentas
+- `GET /api/admin/content/courses/:courseId/items` — les ordnet liste (med tittel/arkivstatus)
+
+`setCourseItems` re-synker `CourseModule` fra MODULE-items i samme transaksjon, så de
+ikke-cutover-de lese-pathene (#502) fortsatt stemmer under expand-contract. Integrasjonstest
+(`m2-course-items.test.ts`) dekker interleaved sekvens + CourseModule-synk + validering
+(ukjent id, duplikat). `tsc` rent; CI kjører mot Postgres. Ren backend — bygger på F1 (#480)
++ F2 (#481).
+
 ## 1.3.3 - 2026-06-15
 
 feat(course): seksjon-CRUD-API — B1 (#485)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/course/courseCommands.ts
+++ b/src/modules/course/courseCommands.ts
@@ -97,6 +97,60 @@ export async function deleteCourse(courseId: string, actorId?: string) {
   });
 }
 
+export type CourseItemInput =
+  | { type: "MODULE"; moduleId: string }
+  | { type: "SECTION"; sectionId: string };
+
+// Sets the full ordered sequence of a course's items — modules and learning
+// sections interleaved (#486/B2). sortOrder follows array position. During the
+// expand-contract transition this also re-syncs CourseModule from the MODULE
+// items so the not-yet-cut-over read paths stay correct.
+export async function setCourseItems(courseId: string, items: CourseItemInput[]) {
+  const course = await prisma.course.findUnique({ where: { id: courseId }, select: { id: true } });
+  if (!course) throw new NotFoundError("Course", "course_not_found", "Course not found.");
+
+  const moduleIds = items.flatMap((i) => (i.type === "MODULE" ? [i.moduleId] : []));
+  const sectionIds = items.flatMap((i) => (i.type === "SECTION" ? [i.sectionId] : []));
+  if (new Set(moduleIds).size !== moduleIds.length) {
+    throw new ValidationError("A module may appear only once in a course.");
+  }
+  if (new Set(sectionIds).size !== sectionIds.length) {
+    throw new ValidationError("A section may appear only once in a course.");
+  }
+  if (moduleIds.length > 0) {
+    const found = await prisma.module.count({ where: { id: { in: moduleIds } } });
+    if (found !== moduleIds.length) throw new ValidationError("One or more modules do not exist.");
+  }
+  if (sectionIds.length > 0) {
+    const found = await prisma.courseSection.count({ where: { id: { in: sectionIds } } });
+    if (found !== sectionIds.length) throw new ValidationError("One or more sections do not exist.");
+  }
+
+  return runInTransaction(async (tx) => {
+    await tx.courseItem.deleteMany({ where: { courseId } });
+    await tx.courseModule.deleteMany({ where: { courseId } });
+    if (items.length > 0) {
+      await tx.courseItem.createMany({
+        data: items.map((item, index) => ({
+          courseId,
+          sortOrder: index,
+          itemType: item.type,
+          moduleId: item.type === "MODULE" ? item.moduleId : null,
+          sectionId: item.type === "SECTION" ? item.sectionId : null,
+        })),
+      });
+      const moduleRows = items
+        .map((item, index) => ({ item, index }))
+        .filter((entry): entry is { item: { type: "MODULE"; moduleId: string }; index: number } => entry.item.type === "MODULE")
+        .map(({ item, index }) => ({ courseId, moduleId: item.moduleId, sortOrder: index }));
+      if (moduleRows.length > 0) {
+        await tx.courseModule.createMany({ data: moduleRows });
+      }
+    }
+    await tx.course.update({ where: { id: courseId }, data: { updatedAt: new Date() } });
+  });
+}
+
 export async function setCourseModules(
   courseId: string,
   modules: Array<{ moduleId: string; sortOrder: number }>,

--- a/src/modules/course/courseCompletionService.ts
+++ b/src/modules/course/courseCompletionService.ts
@@ -6,7 +6,7 @@ import type { DbTransactionClient } from "../../db/transaction.js";
 
 type CompletionTxClient = Pick<
   DbTransactionClient,
-  "course" | "courseModule" | "courseCompletion" | "certificationStatus" | "auditEvent" | "submission"
+  "course" | "courseModule" | "courseItem" | "courseCompletion" | "certificationStatus" | "auditEvent" | "submission"
 >;
 
 export async function checkAndIssueCourseCompletions(

--- a/src/modules/course/courseRepository.ts
+++ b/src/modules/course/courseRepository.ts
@@ -45,7 +45,7 @@ function buildCertificationWhere(filters: Pick<ReportFilters, "dateFrom" | "date
 
 type CourseRepositoryClient = Pick<
   typeof prisma,
-  "course" | "courseModule" | "courseCompletion" | "certificationStatus" | "submission"
+  "course" | "courseModule" | "courseItem" | "courseCompletion" | "certificationStatus" | "submission"
 >;
 
 export function createCourseRepository(client: CourseRepositoryClient = prisma) {
@@ -102,6 +102,17 @@ export function createCourseRepository(client: CourseRepositoryClient = prisma) 
       return client.course.findMany({
         orderBy: { createdAt: "desc" },
         include: { _count: { select: { modules: true } } },
+      });
+    },
+
+    findCourseItems(courseId: string) {
+      return client.courseItem.findMany({
+        where: { courseId },
+        orderBy: { sortOrder: "asc" },
+        include: {
+          module: { select: { id: true, title: true, archivedAt: true } },
+          section: { select: { id: true, title: true, archivedAt: true } },
+        },
       });
     },
 

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -1,6 +1,7 @@
 export { checkAndIssueCourseCompletions } from "./courseCompletionService.js";
 export { getCourseReport, getCourseLearnerReport } from "./courseReport.js";
-export { createCourse, updateCourse, publishCourse, archiveCourse, setCourseModules, deleteCourse } from "./courseCommands.js";
+export { createCourse, updateCourse, publishCourse, archiveCourse, setCourseModules, setCourseItems, deleteCourse } from "./courseCommands.js";
+export type { CourseItemInput } from "./courseCommands.js";
 export {
   createSection,
   updateSectionTitle,

--- a/src/routes/adminCourses.ts
+++ b/src/routes/adminCourses.ts
@@ -6,6 +6,7 @@ import {
   publishCourse,
   archiveCourse,
   setCourseModules,
+  setCourseItems,
   deleteCourse,
   courseRepository,
 } from "../modules/course/index.js";
@@ -32,6 +33,15 @@ const setCourseModulesBodySchema = z.object({
       moduleId: z.string().min(1),
       sortOrder: z.number().int().min(0),
     }),
+  ),
+});
+
+const setCourseItemsBodySchema = z.object({
+  items: z.array(
+    z.discriminatedUnion("type", [
+      z.object({ type: z.literal("MODULE"), moduleId: z.string().min(1) }),
+      z.object({ type: z.literal("SECTION"), sectionId: z.string().min(1) }),
+    ]),
   ),
 });
 
@@ -237,6 +247,41 @@ adminCoursesRouter.put("/:courseId/modules", async (request, response, next) => 
 
   try {
     await setCourseModules(request.params.courseId, parsed.data.modules);
+    response.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Mixed item ordering — modules and learning sections interleaved (#486/B2).
+adminCoursesRouter.get("/:courseId/items", async (request, response, next) => {
+  try {
+    const items = await courseRepository.findCourseItems(request.params.courseId);
+    response.json({
+      items: items.map((item) => ({
+        id: item.id,
+        type: item.itemType,
+        sortOrder: item.sortOrder,
+        moduleId: item.moduleId,
+        sectionId: item.sectionId,
+        title: item.module?.title ?? item.section?.title ?? null,
+        archivedAt:
+          (item.module?.archivedAt ?? item.section?.archivedAt)?.toISOString() ?? null,
+      })),
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminCoursesRouter.put("/:courseId/items", async (request, response, next) => {
+  const parsed = setCourseItemsBodySchema.safeParse(request.body);
+  if (!parsed.success) {
+    response.status(400).json({ error: "validation_error", issues: parsed.error.issues });
+    return;
+  }
+  try {
+    await setCourseItems(request.params.courseId, parsed.data.items);
     response.status(204).send();
   } catch (error) {
     next(error);

--- a/test/m2-course-items.test.ts
+++ b/test/m2-course-items.test.ts
@@ -1,0 +1,77 @@
+import request from "supertest";
+import { afterAll, describe, expect, it } from "vitest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+
+const adminHeaders = {
+  "x-user-id": "admin-1",
+  "x-user-email": "admin@company.com",
+  "x-user-name": "Platform Admin",
+};
+
+// #486/B2 — mixed CourseItem ordering (modules + sections interleaved).
+describe("Admin course item ordering", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("sets and reads an interleaved module/section sequence and re-syncs CourseModule", async () => {
+    const moduleA = await prisma.module.create({ data: { title: `Item Mod A ${Date.now()}` }, select: { id: true } });
+    const moduleB = await prisma.module.create({ data: { title: `Item Mod B ${Date.now()}` }, select: { id: true } });
+    const section = await prisma.courseSection.create({ data: { title: `Item Sec ${Date.now()}` }, select: { id: true } });
+    const course = await prisma.course.create({ data: { title: `Item Course ${Date.now()}` }, select: { id: true } });
+
+    const setResponse = await request(app)
+      .put(`/api/admin/content/courses/${course.id}/items`)
+      .set(adminHeaders)
+      .send({
+        items: [
+          { type: "MODULE", moduleId: moduleA.id },
+          { type: "SECTION", sectionId: section.id },
+          { type: "MODULE", moduleId: moduleB.id },
+        ],
+      });
+    expect(setResponse.status).toBe(204);
+
+    const getResponse = await request(app)
+      .get(`/api/admin/content/courses/${course.id}/items`)
+      .set(adminHeaders);
+    expect(getResponse.status).toBe(200);
+    const items = getResponse.body.items as Array<{ type: string; moduleId: string | null; sectionId: string | null; sortOrder: number }>;
+    expect(items.map((i) => i.type)).toEqual(["MODULE", "SECTION", "MODULE"]);
+    expect(items.map((i) => i.sortOrder)).toEqual([0, 1, 2]);
+    expect(items[0].moduleId).toBe(moduleA.id);
+    expect(items[1].sectionId).toBe(section.id);
+    expect(items[2].moduleId).toBe(moduleB.id);
+
+    // CourseModule is re-synced from the MODULE items (read-path compatibility).
+    const courseModules = await prisma.courseModule.findMany({
+      where: { courseId: course.id },
+      orderBy: { sortOrder: "asc" },
+    });
+    expect(courseModules.map((c) => c.moduleId)).toEqual([moduleA.id, moduleB.id]);
+    expect(courseModules.map((c) => c.sortOrder)).toEqual([0, 2]);
+
+    await prisma.course.delete({ where: { id: course.id } });
+    await prisma.courseSection.delete({ where: { id: section.id } });
+  });
+
+  it("rejects unknown ids and duplicate modules", async () => {
+    const course = await prisma.course.create({ data: { title: `Item Course V ${Date.now()}` }, select: { id: true } });
+    const mod = await prisma.module.create({ data: { title: `Item Mod V ${Date.now()}` }, select: { id: true } });
+
+    const unknown = await request(app)
+      .put(`/api/admin/content/courses/${course.id}/items`)
+      .set(adminHeaders)
+      .send({ items: [{ type: "MODULE", moduleId: "does-not-exist" }] });
+    expect(unknown.status).toBe(400);
+
+    const duplicate = await request(app)
+      .put(`/api/admin/content/courses/${course.id}/items`)
+      .set(adminHeaders)
+      .send({ items: [{ type: "MODULE", moduleId: mod.id }, { type: "MODULE", moduleId: mod.id }] });
+    expect(duplicate.status).toBe(400);
+
+    await prisma.course.delete({ where: { id: course.id } });
+  });
+});


### PR DESCRIPTION
## Hva

Femte skive av #476 (Tier 2 LMS, epic #478) — **B2 (#486)**: API for blandet kurs-element-rekkefølge (moduler + læringsseksjoner om hverandre).

- `PUT /api/admin/content/courses/:courseId/items` — sett ordnet liste (`sortOrder` = array-posisjon). Validerer at alle ids finnes og at en modul/seksjon ikke gjentas.
- `GET /api/admin/content/courses/:courseId/items` — les ordnet liste (id, type, sortOrder, tittel, arkivstatus) for kursbyggeren (U3).

## Expand-contract-synk

`setCourseItems` re-synker `CourseModule` fra MODULE-items i samme transaksjon → de ennå ikke cutover-de lese-pathene (#502) ser fortsatt riktige moduler. Trygt under transisjonen; fjernes i contract-fasen.

## Verifisering

- `npx tsc --noEmit` rent (inkl. utvidet `CourseRepositoryClient`/`CompletionTxClient` med `courseItem`)
- Integrasjonstest `m2-course-items.test.ts`: interleaved MODULE/SECTION-sekvens, `CourseModule`-synk, validering (ukjent id → 400, duplikat → 400). CI kjører mot Postgres.

## Scope

Ren backend. Med B1 (#485) + B2 er API-laget for forfatter→deltaker-løkka komplett. UI (U1/U3/P1) følger etter D1-skissen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
