### PR TITLE
feat(course): seksjons-editor (U1) + IA-design (D1) (v1.3.5, #488, #484)

### DIFF
--- a/doc/DESIGN_476_LMS_SECTIONS_IA.md
+++ b/doc/DESIGN_476_LMS_SECTIONS_IA.md
@@ -1,0 +1,74 @@
+# Design: Læringsseksjoner — IA + wireframes (#476 / D1 #484)
+
+Godkjent 2026-06-15. Styrer UI-byggingen av U1 (#488), U3 (#490), P1 (#491).
+Ingen ny topp-navigasjon — flatene henger på eksisterende sider og mønstre
+(`shared.css`-tokens, `content-area-nav`-faner, 720px innholdskolonne).
+
+## Informasjonsarkitektur
+
+- **Authoring — Seksjoner:** ny fane «Seksjoner» i `content-area-nav` ved siden av
+  Moduler/Kurs. Seksjoner er et **bibliotek** (frittstående, gjenbrukbare på tvers av
+  kurs) — speiler hvordan moduler fungerer.
+- **Authoring — Kursbygger:** dagens kurs-detalj-side; modul-lista blir en blandet
+  element-liste (moduler + seksjoner). «Legg til seksjon» = **velg fra bibliotek** (a).
+- **Delivery — Deltaker:** ny lese-side i kursflyten, mellom modul-sidene.
+
+## Besluttede valg
+
+1. **Editor = laptop** (side-ved-side markdown + forhåndsvisning). **Deltaker (P1) =
+   mobil-først responsiv** — studenter kan være på mobil.
+2. **Editor:** eksplisitt språk-veksling (nb/nn/en-GB), forfatter sjekker/redigerer hvert
+   språk manuelt (jf. lærer-styrt locale). **Deltaker:** ingen inline språkvelger; rendrer
+   språket fra studentens profil.
+3. **«Legg til seksjon» = velg fra bibliotek** (gjenbruk på tvers av kurs; B1/B2 støtter det).
+
+## Wireframes
+
+### U1 — Seksjons-editor (`/admin-content/sections`, laptop)
+```
+Moduler │ Kurs │ [Seksjoner]                      content-area-nav
+Seksjoner                              [+ Ny seksjon]
+┌─ tabell (maxW 720) ────────────────────────────┐
+│ Tittel            │ Versjon │ Sist endret │ ✎ 🗑 │
+└─────────────────────────────────────────────────┘
+
+— Editor —
+[← Tilbake]  Tittel: [____]   språk: (nb)(nn)(en-GB)
+┌── Markdown (~350px) ──┐ ┌── Forhåndsvisning (~350px) ─┐
+│ # Overskrift          │ │ Overskrift                  │
+│ **fet**, {{asset:x}}  │ │ fet, [bilde]                │
+└───────────────────────┘ └─────────────────────────────┘
+[Lagre ny versjon]   (preview = samme F3-sanitiseringspolicy)
+```
+
+### U3 — Kursbygger med blandede elementer (kurs-detalj-side)
+```
+Kurs: «HMS-grunnkurs»                         [Publiser]
+Elementer (dra for rekkefølge):               maxW 720
+┌─────────────────────────────────────────────────┐
+│ ⠿ 1  [MODUL]    Brannvern              ✎         │
+│ ⠿ 2  [SEKSJON]  Intro til HMS          ✎         │
+│ ⠿ 3  [MODUL]    Førstehjelp            ✎         │
+└─────────────────────────────────────────────────┘
+[+ Legg til modul]   [+ Legg til seksjon ▾ (bibliotek)]
+   → lagrer via PUT /courses/:id/items (B2)
+```
+
+### P1 — Deltaker-visning (mobil-først, i kursflyten)
+```
+HMS-grunnkurs · steg 2 av 3                    full bredde mobil
+┌─────────────────────────────────────────────────┐
+│ Intro til HMS                                     │ sanitisert HTML (F3/X1)
+│ (rendret markdown: tekst, bilder, evt. video)     │ skalerbar tekst,
+│ ...                                               │ alt-tekst på bilder
+└─────────────────────────────────────────────────┘
+[← Forrige]                         [Marker lest →]
+   (Marker lest = P2 senere; nå bare navigasjon)
+```
+
+## API-kobling (allerede bygget)
+
+- U1: `POST/GET/PATCH/PUT/DELETE /api/admin/content/sections` (B1 #485)
+- U3: `GET/PUT /api/admin/content/courses/:id/items` (B2 #486)
+- P1: leser kursets items + aktiv seksjonsversjons `bodyMarkdown`, rendrer via
+  `renderSectionMarkdown` (F3 #482 / X1 #493) med studentens profil-locale.

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,26 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.5 - 2026-06-15
+
+feat(course): seksjons-editor (U1) + IA-design (D1) — #488, #484
+
+Sjette skive av #476 (Tier 2 LMS, epic #478). Første UI for læringsseksjoner.
+
+D1 (#484): `doc/DESIGN_476_LMS_SECTIONS_IA.md` — godkjent IA + wireframes (editor=laptop,
+deltaker=mobil-først, eksplisitt språk-veksling i editor, «velg fra bibliotek» for seksjoner).
+
+U1 (#488): ny «Seksjoner»-fane (`/admin-content/sections`):
+- Liste over seksjoner (tittel/versjon/sist endret) + opprett/rediger/slett
+- Editor med språk-faner (nb/nn/en-GB) — forfatter redigerer hvert språk manuelt
+- Side-ved-side markdown + **live forhåndsvisning** via nytt
+  `POST /api/admin/content/sections/preview` som rendrer med samme F3/X1-sanitiseringspolicy
+  som deltaker-visningen vil bruke (server-side, ingen klient-side render-stack)
+- «Seksjoner»-lenke lagt til i kurs-sidens content-area-nav
+
+Ren additiv UI + ett lese-endepunkt. `tsc` + `build` rene. Manuell testing følger ved
+staging-deploy sammen med U3 (#490) + P1 (#491).
+
 ## 1.3.4 - 2026-06-15
 
 feat(course): blandet CourseItem-ordering-API — B2 (#486)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-courses.html
+++ b/public/admin-content-courses.html
@@ -408,6 +408,7 @@
       <nav id="contentAreaNav" class="content-area-nav" aria-label="Innholdsadministrasjon">
         <a href="/admin-content" class="content-area-nav-link" id="navModuler">Moduler</a>
         <a href="/admin-content/courses" class="content-area-nav-link active" id="navKurs">Kurs</a>
+        <a href="/admin-content/sections" class="content-area-nav-link" id="navSeksjoner">Seksjoner</a>
         <a href="/admin-content/calibration" class="content-area-nav-link" id="navKalibrering" hidden>Kalibrering</a>
       </nav>
 

--- a/public/admin-content-sections.html
+++ b/public/admin-content-sections.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en-GB">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Seksjoner – A2 Content</title>
+    <link rel="stylesheet" href="/static/shared.css" />
+    <link rel="stylesheet" href="/static/loading.css" />
+    <link rel="stylesheet" href="/static/toast.css" />
+    <style>
+      .content-area-nav {
+        display: flex;
+        gap: 0;
+        border-bottom: 2px solid var(--color-border-soft);
+        margin-bottom: var(--space-3);
+      }
+      .content-area-nav-link {
+        padding: 10px var(--space-2);
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--color-meta);
+        text-decoration: none;
+        border-bottom: 2px solid transparent;
+        margin-bottom: -2px;
+        white-space: nowrap;
+      }
+      .content-area-nav-link:hover { color: var(--color-text); }
+      .content-area-nav-link.active { color: var(--color-link-active); border-bottom-color: var(--color-blue); }
+
+      .page-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-2);
+        margin-bottom: var(--space-3);
+        flex-wrap: wrap;
+      }
+      .page-header h1 { margin: 0; font-size: 22px; }
+      .page-header-back { margin-bottom: var(--space-2); }
+      .back-link { font-size: 13px; color: var(--color-meta); text-decoration: none; }
+      .back-link:hover { color: var(--color-text); }
+
+      .sections-table-wrap { overflow-x: auto; border: 1px solid var(--color-table-wrap-border); border-radius: var(--radius-card); max-width: 720px; }
+      .sections-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+      .sections-table th, .sections-table td { text-align: left; padding: 10px var(--space-2); border-bottom: 1px solid var(--color-border-soft); }
+      .sections-table th { font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-meta); }
+      .sections-table .col-actions { text-align: right; white-space: nowrap; }
+      .row-action-btn { background: none; border: 1px solid var(--color-border-soft); border-radius: var(--radius-btn); padding: 4px 8px; font-size: 13px; cursor: pointer; color: var(--color-text); }
+      .row-action-btn:hover { background: var(--color-row-hover); }
+      .row-action-btn.destructive { color: var(--color-error); border-color: #f5c0bb; }
+
+      /* Editor */
+      .section-editor { max-width: 720px; }
+      .editor-field { margin-bottom: var(--space-2); }
+      .editor-field label { display: block; font-size: 13px; font-weight: 600; margin-bottom: 4px; }
+      .editor-field input[type="text"] { width: 100%; padding: 8px; border: 1px solid var(--color-border-soft); border-radius: var(--radius-btn); font-size: 14px; }
+      .lang-tabs { display: flex; gap: 4px; margin-bottom: var(--space-2); }
+      .lang-tab { padding: 6px 12px; font-size: 13px; font-weight: 600; border: 1px solid var(--color-border-soft); background: none; border-radius: var(--radius-btn); cursor: pointer; color: var(--color-meta); }
+      .lang-tab.active { color: var(--color-link-active); border-color: var(--color-blue); background: var(--color-row-hover); }
+      .editor-cols { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-2); }
+      @media (max-width: 760px) { .editor-cols { grid-template-columns: 1fr; } }
+      .editor-cols textarea { width: 100%; min-height: 320px; padding: var(--space-2); border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); font-family: var(--font-mono, monospace); font-size: 13px; resize: vertical; }
+      .editor-pane-label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-meta); margin-bottom: 4px; }
+      .preview-pane { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-2); min-height: 320px; overflow-y: auto; }
+      .preview-pane img { max-width: 100%; height: auto; }
+      .preview-pane iframe { max-width: 100%; }
+      .editor-actions { margin-top: var(--space-3); display: flex; gap: var(--space-2); align-items: center; }
+      .editor-status { font-size: 13px; color: var(--color-meta); }
+    </style>
+  </head>
+  <body>
+    <a href="#main-content" class="skip-nav" data-i18n="nav.skipToContent">Skip to main content</a>
+    <main id="main-content" class="layout-container">
+      <div class="page-top-bar">
+        <nav id="workspaceNav" class="workspace-nav"></nav>
+        <div class="locale-picker">
+          <span id="appVersion" class="version-badge">…</span>
+          <label for="localeSelect" class="sr-only">Language</label>
+          <select id="localeSelect" class="locale-select-compact"></select>
+        </div>
+      </div>
+
+      <nav id="contentAreaNav" class="content-area-nav" aria-label="Innholdsadministrasjon">
+        <a href="/admin-content" class="content-area-nav-link" id="navModuler">Moduler</a>
+        <a href="/admin-content/courses" class="content-area-nav-link" id="navKurs">Kurs</a>
+        <a href="/admin-content/sections" class="content-area-nav-link active" id="navSeksjoner">Seksjoner</a>
+      </nav>
+
+      <div id="pageContent">
+        <div class="page-loading">Laster…</div>
+      </div>
+    </main>
+
+    <script type="module" src="/static/admin-content-sections.js"></script>
+    <script type="module" src="/static/workspace-help.js"></script>
+  </body>
+</html>

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -1,0 +1,360 @@
+import {
+  supportedLocales,
+  localeLabels,
+  translations as adminContentTranslations,
+} from "/static/i18n/admin-content-translations.js";
+import { apiFetch, buildConsoleHeaders, getConsoleConfig } from "/static/api-client.js";
+import { resolveWorkspaceNavigationItems } from "/static/participant-console-state.js";
+import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
+import { showToast } from "/static/toast.js";
+
+// ---------------------------------------------------------------------------
+// Section editor (U1 / #488). Library of reusable course learning sections.
+// ---------------------------------------------------------------------------
+
+const EDITOR_LOCALES = ["nb", "nn", "en-GB"];
+
+// Self-contained labels for this workspace's own UI (kept local to avoid
+// threading dozens of keys through the shared translations file).
+const LABELS = {
+  "en-GB": {
+    heading: "Sections", newSection: "+ New section", colTitle: "Title", colVersion: "Version",
+    colUpdated: "Last changed", edit: "Edit", del: "Delete", empty: "No sections yet.",
+    back: "← Back", titleLabel: "Title", markdown: "Markdown", preview: "Preview",
+    save: "Save new version", saved: "Section saved.", deleted: "Section deleted.",
+    confirmDelete: "Delete this section?", loadError: "Could not load sections.",
+  },
+  nb: {
+    heading: "Seksjoner", newSection: "+ Ny seksjon", colTitle: "Tittel", colVersion: "Versjon",
+    colUpdated: "Sist endret", edit: "Rediger", del: "Slett", empty: "Ingen seksjoner ennå.",
+    back: "← Tilbake", titleLabel: "Tittel", markdown: "Markdown", preview: "Forhåndsvisning",
+    save: "Lagre ny versjon", saved: "Seksjon lagret.", deleted: "Seksjon slettet.",
+    confirmDelete: "Slette denne seksjonen?", loadError: "Kunne ikke laste seksjoner.",
+  },
+  nn: {
+    heading: "Seksjonar", newSection: "+ Ny seksjon", colTitle: "Tittel", colVersion: "Versjon",
+    colUpdated: "Sist endra", edit: "Rediger", del: "Slett", empty: "Ingen seksjonar enno.",
+    back: "← Tilbake", titleLabel: "Tittel", markdown: "Markdown", preview: "Førehandsvising",
+    save: "Lagre ny versjon", saved: "Seksjon lagra.", deleted: "Seksjon sletta.",
+    confirmDelete: "Slette denne seksjonen?", loadError: "Kunne ikkje laste seksjonar.",
+  },
+};
+
+let currentLocale = (() => {
+  const stored = localStorage.getItem("participant.locale");
+  if (stored && supportedLocales.includes(stored)) return stored;
+  const b = navigator.language?.toLowerCase() ?? "";
+  if (b.startsWith("nb")) return "nb";
+  if (b.startsWith("nn")) return "nn";
+  return "en-GB";
+})();
+
+function L(key) {
+  return LABELS[currentLocale]?.[key] ?? LABELS["en-GB"][key] ?? key;
+}
+function tNav(key) {
+  return adminContentTranslations[currentLocale]?.[key] ?? adminContentTranslations["en-GB"]?.[key] ?? key;
+}
+
+let participantRuntimeConfig = {};
+let _headerValues = {};
+function getHeaders() { return _headerValues; }
+
+const pageContent = document.getElementById("pageContent");
+const workspaceNav = document.getElementById("workspaceNav");
+const localePicker = document.querySelector(".locale-picker");
+const localeSelect = document.getElementById("localeSelect");
+const appVersionLabel = document.getElementById("appVersion");
+
+function escapeHtml(value) {
+  return String(value ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+// Localized stored values arrive as JSON strings ({locale:value}) or plain text.
+function parseLocalized(raw) {
+  const out = { nb: "", nn: "", "en-GB": "" };
+  if (typeof raw !== "string" || raw.length === 0) return out;
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      for (const loc of EDITOR_LOCALES) if (typeof parsed[loc] === "string") out[loc] = parsed[loc];
+      return out;
+    } catch { /* fall through */ }
+  }
+  out[currentLocale] = raw;
+  return out;
+}
+
+function displayTitle(rawTitle) {
+  const t = parseLocalized(rawTitle);
+  return t[currentLocale] || t["en-GB"] || t.nb || t.nn || "(uten tittel)";
+}
+
+// ---------------------------------------------------------------------------
+// Routing: list vs editor (?id=… or ?new)
+// ---------------------------------------------------------------------------
+
+function detectRoute() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.has("new")) return { view: "editor", sectionId: null };
+  const id = params.get("id");
+  if (id) return { view: "editor", sectionId: id };
+  return { view: "list" };
+}
+
+function goTo(view, sectionId) {
+  const url = view === "list"
+    ? "/admin-content/sections"
+    : sectionId
+      ? `/admin-content/sections?id=${encodeURIComponent(sectionId)}`
+      : "/admin-content/sections?new";
+  history.pushState({}, "", url);
+  renderRoute();
+}
+
+// ---------------------------------------------------------------------------
+// List view
+// ---------------------------------------------------------------------------
+
+async function renderListView() {
+  let sections;
+  try {
+    const data = await apiFetch("/api/admin/content/sections", getHeaders);
+    sections = data.sections ?? [];
+  } catch (err) {
+    pageContent.innerHTML = `<div class="empty-state"><p class="empty-state-title">${escapeHtml(L("loadError"))}</p><p class="empty-state-text">${escapeHtml(err?.message ?? "")}</p></div>`;
+    return;
+  }
+
+  const rows = sections.map((s) => `<tr>
+      <td>${escapeHtml(displayTitle(s.title))}</td>
+      <td>v${escapeHtml(s.versionNo ?? "1")}</td>
+      <td>${escapeHtml(new Date(s.updatedAt).toLocaleDateString(currentLocale))}</td>
+      <td class="col-actions">
+        <button class="row-action-btn" data-action="edit" data-id="${escapeHtml(s.id)}">${escapeHtml(L("edit"))}</button>
+        <button class="row-action-btn destructive" data-action="delete" data-id="${escapeHtml(s.id)}">${escapeHtml(L("del"))}</button>
+      </td>
+    </tr>`).join("");
+
+  pageContent.innerHTML = `
+    <div class="page-header">
+      <h1>${escapeHtml(L("heading"))}</h1>
+      <button type="button" id="newSectionBtn" class="btn btn-primary">${escapeHtml(L("newSection"))}</button>
+    </div>
+    ${sections.length === 0
+      ? `<div class="empty-state"><p class="empty-state-text">${escapeHtml(L("empty"))}</p></div>`
+      : `<div class="sections-table-wrap"><table class="sections-table">
+          <thead><tr><th>${escapeHtml(L("colTitle"))}</th><th>${escapeHtml(L("colVersion"))}</th><th>${escapeHtml(L("colUpdated"))}</th><th class="col-actions"></th></tr></thead>
+          <tbody id="sectionsTableBody">${rows}</tbody></table></div>`}`;
+
+  document.getElementById("newSectionBtn")?.addEventListener("click", () => goTo("editor", null));
+  document.getElementById("sectionsTableBody")?.addEventListener("click", (event) => {
+    const btn = event.target.closest("[data-action]");
+    if (!btn) return;
+    if (btn.dataset.action === "edit") goTo("editor", btn.dataset.id);
+    else if (btn.dataset.action === "delete") deleteSection(btn.dataset.id);
+  });
+}
+
+async function deleteSection(sectionId) {
+  if (!window.confirm(L("confirmDelete"))) return;
+  try {
+    await apiFetch(`/api/admin/content/sections/${encodeURIComponent(sectionId)}`, getHeaders, { method: "DELETE" });
+    showToast(L("deleted"));
+    renderListView();
+  } catch (err) {
+    showToast(err?.message ?? "Error", "error");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Editor view
+// ---------------------------------------------------------------------------
+
+let editing = null; // { id, title:{}, body:{}, editLocale }
+let previewTimer = null;
+
+async function renderEditorView(sectionId) {
+  editing = { id: sectionId, title: { nb: "", nn: "", "en-GB": "" }, body: { nb: "", nn: "", "en-GB": "" }, editLocale: currentLocale };
+
+  if (sectionId) {
+    try {
+      const data = await apiFetch(`/api/admin/content/sections/${encodeURIComponent(sectionId)}`, getHeaders);
+      editing.title = parseLocalized(data.section.title);
+      editing.body = parseLocalized(data.section.bodyMarkdown);
+    } catch (err) {
+      pageContent.innerHTML = `<div class="empty-state"><p class="empty-state-title">${escapeHtml(err?.message ?? "Error")}</p></div>`;
+      return;
+    }
+  }
+
+  pageContent.innerHTML = `
+    <div class="page-header-back"><a href="#" class="back-link" id="backLink">${escapeHtml(L("back"))}</a></div>
+    <div class="section-editor">
+      <div class="lang-tabs" id="langTabs">
+        ${EDITOR_LOCALES.map((loc) => `<button type="button" class="lang-tab${loc === editing.editLocale ? " active" : ""}" data-locale="${loc}">${escapeHtml(localeLabels[loc] ?? loc)}</button>`).join("")}
+      </div>
+      <div class="editor-field">
+        <label for="titleInput">${escapeHtml(L("titleLabel"))}</label>
+        <input type="text" id="titleInput" value="${escapeHtml(editing.title[editing.editLocale])}" />
+      </div>
+      <div class="editor-cols">
+        <div>
+          <div class="editor-pane-label">${escapeHtml(L("markdown"))}</div>
+          <textarea id="markdownInput">${escapeHtml(editing.body[editing.editLocale])}</textarea>
+        </div>
+        <div>
+          <div class="editor-pane-label">${escapeHtml(L("preview"))}</div>
+          <div class="preview-pane" id="previewPane"></div>
+        </div>
+      </div>
+      <div class="editor-actions">
+        <button type="button" id="saveBtn" class="btn btn-primary">${escapeHtml(L("save"))}</button>
+        <span class="editor-status" id="editorStatus"></span>
+      </div>
+    </div>`;
+
+  document.getElementById("backLink")?.addEventListener("click", (e) => { e.preventDefault(); goTo("list"); });
+  document.getElementById("langTabs")?.addEventListener("click", (event) => {
+    const tab = event.target.closest("[data-locale]");
+    if (!tab) return;
+    captureInputs();
+    editing.editLocale = tab.dataset.locale;
+    renderEditorFields();
+  });
+  document.getElementById("titleInput")?.addEventListener("input", captureInputs);
+  document.getElementById("markdownInput")?.addEventListener("input", () => { captureInputs(); schedulePreview(); });
+  document.getElementById("saveBtn")?.addEventListener("click", saveSection);
+  refreshPreview();
+}
+
+function captureInputs() {
+  if (!editing) return;
+  const title = document.getElementById("titleInput");
+  const md = document.getElementById("markdownInput");
+  if (title) editing.title[editing.editLocale] = title.value;
+  if (md) editing.body[editing.editLocale] = md.value;
+}
+
+function renderEditorFields() {
+  document.querySelectorAll(".lang-tab").forEach((t) => t.classList.toggle("active", t.dataset.locale === editing.editLocale));
+  const title = document.getElementById("titleInput");
+  const md = document.getElementById("markdownInput");
+  if (title) title.value = editing.title[editing.editLocale];
+  if (md) md.value = editing.body[editing.editLocale];
+  refreshPreview();
+}
+
+function schedulePreview() {
+  clearTimeout(previewTimer);
+  previewTimer = setTimeout(refreshPreview, 300);
+}
+
+async function refreshPreview() {
+  const pane = document.getElementById("previewPane");
+  if (!pane) return;
+  try {
+    const data = await apiFetch("/api/admin/content/sections/preview", getHeaders, {
+      method: "POST",
+      body: JSON.stringify({ markdown: editing.body[editing.editLocale] ?? "" }),
+    });
+    pane.innerHTML = data.html ?? "";
+  } catch {
+    /* leave previous preview on transient error */
+  }
+}
+
+async function saveSection() {
+  captureInputs();
+  const status = document.getElementById("editorStatus");
+  try {
+    if (!editing.id) {
+      const data = await apiFetch("/api/admin/content/sections", getHeaders, {
+        method: "POST",
+        body: JSON.stringify({ title: editing.title, bodyMarkdown: editing.body }),
+      });
+      editing.id = data.section.id;
+      history.replaceState({}, "", `/admin-content/sections?id=${encodeURIComponent(editing.id)}`);
+    } else {
+      await apiFetch(`/api/admin/content/sections/${encodeURIComponent(editing.id)}/title`, getHeaders, {
+        method: "PATCH",
+        body: JSON.stringify({ title: editing.title }),
+      });
+      await apiFetch(`/api/admin/content/sections/${encodeURIComponent(editing.id)}/content`, getHeaders, {
+        method: "PUT",
+        body: JSON.stringify({ bodyMarkdown: editing.body }),
+      });
+    }
+    showToast(L("saved"));
+    if (status) status.textContent = L("saved");
+  } catch (err) {
+    showToast(err?.message ?? "Error", "error");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Boot
+// ---------------------------------------------------------------------------
+
+function renderRoute() {
+  const route = detectRoute();
+  if (route.view === "editor") renderEditorView(route.sectionId);
+  else renderListView();
+}
+
+function buildLocaleSelector() {
+  if (!localeSelect) return;
+  localeSelect.innerHTML = supportedLocales.map((l) => `<option value="${l}"${l === currentLocale ? " selected" : ""}>${localeLabels[l] ?? l}</option>`).join("");
+  localeSelect.addEventListener("change", () => {
+    currentLocale = localeSelect.value;
+    localStorage.setItem("participant.locale", currentLocale);
+    if (_headerValues && typeof _headerValues === "object") _headerValues["x-locale"] = currentLocale;
+    renderRoute();
+  });
+}
+
+function renderWorkspaceNavigation() {
+  if (!workspaceNav) return;
+  const items = resolveWorkspaceNavigationItems(
+    participantRuntimeConfig?.navigation?.items,
+    "",
+    window.location.pathname,
+  );
+  renderWorkspaceNavigationWithProfile({ workspaceNav, localePicker, items, buildLabel: (item) => tNav(item.labelKey) || item.id });
+}
+
+async function init() {
+  try {
+    const cfg = await getConsoleConfig();
+    participantRuntimeConfig = cfg;
+    const defaults = cfg?.identityDefaults?.contentAdmin ?? cfg?.identityDefaults ?? {};
+    _headerValues = buildConsoleHeaders({
+      userId: defaults.userId,
+      email: defaults.email,
+      name: defaults.name,
+      department: defaults.department,
+      roles: Array.isArray(defaults.roles) ? defaults.roles.join(",") : defaults.roles,
+      locale: currentLocale,
+    });
+  } catch {
+    _headerValues = {};
+  }
+
+  buildLocaleSelector();
+  renderWorkspaceNavigation();
+
+  try {
+    const body = await apiFetch("/version", { headers: {} });
+    const version = body.version ?? "unknown";
+    document.title = `Seksjoner – A2 v${version}`;
+    if (appVersionLabel) appVersionLabel.textContent = `v${version}`;
+  } catch {
+    if (appVersionLabel) appVersionLabel.textContent = "unknown";
+  }
+
+  window.addEventListener("popstate", renderRoute);
+  renderRoute();
+}
+
+init();

--- a/src/app.ts
+++ b/src/app.ts
@@ -103,6 +103,11 @@ app.get("/admin-content/courses/:courseId", (_request, response) => {
   response.sendFile(path.resolve(process.cwd(), "public", "admin-content-courses.html"));
 });
 
+// Sections workspace (#476 / U1)
+app.get("/admin-content/sections", (_request, response) => {
+  response.sendFile(path.resolve(process.cwd(), "public", "admin-content-sections.html"));
+});
+
 // Calibration workspace (Issue #326)
 app.get("/admin-content/calibration", (_request, response) => {
   response.sendFile(path.resolve(process.cwd(), "public", "admin-content-calibration.html"));

--- a/src/routes/adminSections.ts
+++ b/src/routes/adminSections.ts
@@ -11,6 +11,7 @@ import {
 import { localizedTextPatchSchema } from "../modules/adminContent/adminContentSchemas.js";
 import { localizedTextCodec } from "../codecs/localizedTextCodec.js";
 import { NotFoundError } from "../errors/AppError.js";
+import { renderSectionMarkdown } from "../modules/course/sectionContent.js";
 
 const adminSectionsRouter = Router();
 
@@ -20,6 +21,7 @@ const createSectionSchema = z.object({
 });
 const titleSchema = z.object({ title: localizedTextPatchSchema });
 const contentSchema = z.object({ bodyMarkdown: localizedTextPatchSchema });
+const previewSchema = z.object({ markdown: z.string() });
 
 type SectionWithActiveVersion = {
   id: string;
@@ -55,6 +57,21 @@ adminSectionsRouter.post("/", async (request, response, next) => {
       actorId: request.context?.userId,
     });
     response.status(201).json({ section: toDetail(section) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Live preview for the editor (U1) — renders markdown to sanitised HTML with the
+// exact same F3/X1 policy the participant view will use, so authors see the truth.
+adminSectionsRouter.post("/preview", async (request, response, next) => {
+  const parsed = previewSchema.safeParse(request.body);
+  if (!parsed.success) {
+    response.status(400).json({ error: "validation_error", issues: parsed.error.issues });
+    return;
+  }
+  try {
+    response.json({ html: renderSectionMarkdown(parsed.data.markdown) });
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
## Hva

Sjette skive av #476 (Tier 2 LMS, epic #478) — **D1 (#484)** design + **U1 (#488)** seksjons-editor.

### D1 (#484) — IA + wireframes (godkjent)
`doc/DESIGN_476_LMS_SECTIONS_IA.md`: editor=laptop, deltaker=mobil-først, eksplisitt språk-veksling i editor, «velg fra bibliotek» for seksjoner i kursbygger.

### U1 (#488) — seksjons-editor
Ny «Seksjoner»-fane på `/admin-content/sections`:
- Liste (tittel/versjon/sist endret) + opprett/rediger/slett
- Editor med språk-faner (nb/nn/en-GB) — forfatter redigerer hvert språk manuelt
- Side-ved-side markdown + **live forhåndsvisning** via nytt `POST /api/admin/content/sections/preview`, som rendrer med **samme F3/X1-sanitiseringspolicy** (server-side) som deltaker-visningen vil bruke
- «Seksjoner»-lenke i kurs-sidens `content-area-nav`

## Verifisering

- `npx tsc --noEmit` + `npm run build` rene
- Backend-endepunktet gjenbruker `renderSectionMarkdown` (allerede testdekket i #499)
- **UI testes manuelt** ved staging-deploy sammen med U3 (#490) + P1 (#491) — per avtalt plan for forfatter→deltaker-løkka

## Scope / notat

- Editorens egne etiketter ligger i en lokal i18n-map i JS-en (ikke i den 2000-linjers delte translations-filen) — bevisst for å holde PR-en fokusert; kan konsolideres senere.
- Ren additiv UI; ingen endring i eksisterende sider utover én nav-lenke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
