### PR TITLE
feat(course): deltaker-visning av læringsseksjoner (v1.3.7, #491 P1)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,28 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.7 - 2026-06-16
+
+feat(course): deltaker-visning av læringsseksjoner — P1 (#491)
+
+Åttende skive av #476 (Tier 2 LMS, epic #478). Fullfører forfatter→deltaker-løkka.
+
+Backend:
+- Deltaker-kurs-detalj (`GET /api/courses/:id`) returnerer nå `items` — den blandede
+  modul/seksjon-sekvensen i rekkefølge (modul-status bevart, seksjoner med tittel)
+- Nytt `GET /api/courses/:id/sections/:sectionId` — validerer at seksjonen tilhører det
+  publiserte kurset, returnerer sanitisert HTML (F3/X1) + tittel i deltakerens locale
+
+Front-end (`participant.js`):
+- Kurs-detalj rendrer den blandede sekvensen; seksjons-rader åpner en mobil-først
+  leser-overlay som viser server-rendret, sanitisert innhold (fallback til modul-only)
+
+Integrasjonstest (`m2-course-section-participant.test.ts`): seksjon i sekvensen +
+sanitisert HTML (script strippet) + 404 for seksjon utenfor kurset. `tsc` + `node --check`
++ CI mot Postgres rene.
+
+Closes #491
+
 ## 1.3.6 - 2026-06-16
 
 feat(course): kursbygger med blandede moduler + seksjoner — U3 (#490)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/participant.js
+++ b/public/participant.js
@@ -2767,13 +2767,34 @@ async function loadCourseDetail(courseId) {
 
 function renderCourseDetailModules(courseId, course) {
   const container = document.getElementById(`courseDetail_${courseId}`);
-  if (!container || !Array.isArray(course?.modules)) return;
+  if (!container) return;
+  // Prefer the mixed module/section sequence (#491); fall back to modules-only.
+  const sequence = Array.isArray(course?.items) && course.items.length > 0
+    ? course.items
+    : (Array.isArray(course?.modules) ? course.modules.map((m) => ({ type: "MODULE", ...m })) : null);
+  if (!sequence) return;
   container.innerHTML = "";
-  if (course.modules.length === 0) {
+  if (sequence.length === 0) {
     container.innerHTML = `<p class="small" style="color:var(--color-meta)">${escapeHtmlP(t("courses.noModules"))}</p>`;
     return;
   }
-  for (const m of course.modules) {
+  for (const entry of sequence) {
+    if (entry.type === "SECTION") {
+      const sectionRow = document.createElement("button");
+      sectionRow.type = "button";
+      sectionRow.className = "btn-secondary course-module-row course-module-button";
+      sectionRow.addEventListener("click", () => openSectionReader(courseId, entry.sectionId));
+      sectionRow.innerHTML = `
+        <span class="course-module-row-copy">
+          <span class="course-module-row-title">${escapeHtmlP(localizePreviewText(entry.title))}</span>
+          <span class="course-module-row-action">${escapeHtmlP(t("courses.section.read") || "Les")}</span>
+        </span>
+        <span class="module-status-badge" style="font-size:11px;padding:2px 8px;flex-shrink:0">${escapeHtmlP(t("courses.section.label") || "Seksjon")}</span>
+      `;
+      container.appendChild(sectionRow);
+      continue;
+    }
+    const m = entry;
     const passed = m.moduleStatus === "PASSED";
     const inProgress = m.moduleStatus === "IN_PROGRESS";
     const badgeText = passed ? t("courses.module.passed") : inProgress ? t("courses.module.inProgress") : t("courses.module.notStarted");
@@ -2802,5 +2823,46 @@ function renderCourseDetailModules(courseId, course) {
       <span class="module-status-badge ${badgeClass}" style="font-size:11px;padding:2px 8px;flex-shrink:0">${escapeHtmlP(badgeText)}</span>
     `;
     container.appendChild(row);
+  }
+}
+
+// #491/P1 — open a learning section in a mobile-friendly reader overlay with
+// server-rendered, sanitised HTML in the participant's locale.
+async function openSectionReader(courseId, sectionId) {
+  const existing = document.getElementById("sectionReaderOverlay");
+  if (existing) existing.remove();
+
+  const overlay = document.createElement("div");
+  overlay.id = "sectionReaderOverlay";
+  overlay.setAttribute("role", "dialog");
+  overlay.setAttribute("aria-modal", "true");
+  overlay.style.cssText = "position:fixed;inset:0;background:rgba(0,0,0,0.5);display:flex;justify-content:center;align-items:flex-start;overflow-y:auto;z-index:1000;padding:0;";
+  overlay.innerHTML = `
+    <div style="background:var(--color-surface,#fff);width:100%;max-width:760px;min-height:100%;margin:0 auto;padding:var(--space-3,16px);box-sizing:border-box;">
+      <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;margin-bottom:var(--space-2,12px)">
+        <h2 id="sectionReaderTitle" style="margin:0;font-size:20px">…</h2>
+        <button type="button" id="sectionReaderClose" class="btn-secondary" style="flex-shrink:0">${escapeHtmlP(t("common.close") || "Lukk")}</button>
+      </div>
+      <div id="sectionReaderBody" class="section-reader-body">${escapeHtmlP(t("common.loading") || "Laster…")}</div>
+    </div>`;
+  document.body.appendChild(overlay);
+
+  const close = () => overlay.remove();
+  overlay.querySelector("#sectionReaderClose")?.addEventListener("click", close);
+  overlay.addEventListener("click", (e) => { if (e.target === overlay) close(); });
+  document.addEventListener("keydown", function onKey(e) {
+    if (e.key === "Escape") { close(); document.removeEventListener("keydown", onKey); }
+  });
+
+  try {
+    const body = await apiFetch(`/api/courses/${encodeURIComponent(courseId)}/sections/${encodeURIComponent(sectionId)}`, headers());
+    const titleEl = overlay.querySelector("#sectionReaderTitle");
+    const bodyEl = overlay.querySelector("#sectionReaderBody");
+    if (titleEl) titleEl.textContent = body.title ?? "";
+    // body.html is already sanitised server-side with the F3/X1 policy.
+    if (bodyEl) bodyEl.innerHTML = body.html ?? "";
+  } catch (error) {
+    const bodyEl = overlay.querySelector("#sectionReaderBody");
+    if (bodyEl) bodyEl.textContent = error instanceof Error ? error.message : t("courses.loadError");
   }
 }

--- a/src/modules/course/courseReadModels.ts
+++ b/src/modules/course/courseReadModels.ts
@@ -19,10 +19,17 @@ export interface CourseModuleEntry {
   moduleStatus: "NOT_STARTED" | "PASSED" | "IN_PROGRESS";
 }
 
+// A single step in the participant course sequence — either a module or a
+// learning section (#491/P1), in sortOrder.
+export type CourseSequenceItem =
+  | { type: "MODULE"; sortOrder: number; moduleId: string; title: string; moduleStatus: "NOT_STARTED" | "PASSED" | "IN_PROGRESS" }
+  | { type: "SECTION"; sortOrder: number; sectionId: string; title: string };
+
 export interface CourseDetail extends CourseListItem {
   certificationLevel: string | null;
   publishedAt: string | null;
   modules: CourseModuleEntry[];
+  items: CourseSequenceItem[];
 }
 
 export interface AdminCourseListItem {

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -17,6 +17,7 @@ export type {
   CourseListItem,
   CourseDetail,
   CourseModuleEntry,
+  CourseSequenceItem,
   AdminCourseListItem,
   AdminCourseDetail,
 } from "./courseReadModels.js";

--- a/src/routes/courses.ts
+++ b/src/routes/courses.ts
@@ -1,9 +1,10 @@
 import { Router } from "express";
-import { courseRepository, computeCourseStatus } from "../modules/course/index.js";
+import { courseRepository, computeCourseStatus, getSection } from "../modules/course/index.js";
+import { renderSectionMarkdown } from "../modules/course/sectionContent.js";
 import { localizeContentText } from "../i18n/content.js";
 import { normalizeLocale } from "../i18n/locale.js";
 import { NotFoundError } from "../errors/AppError.js";
-import type { CourseListItem, CourseDetail } from "../modules/course/index.js";
+import type { CourseListItem, CourseDetail, CourseSequenceItem } from "../modules/course/index.js";
 import { queryLatestSubmissionsForModules } from "../modules/submission/submissionRepository.js";
 
 const coursesRouter = Router();
@@ -110,6 +111,30 @@ coursesRouter.get("/:courseId", async (request, response, next) => {
       }
     }
 
+    // Mixed module/section sequence (#491/P1).
+    const courseItems = await courseRepository.findCourseItems(course.id);
+    const items: CourseSequenceItem[] = courseItems.map((item) => {
+      if (item.itemType === "SECTION" && item.section) {
+        return {
+          type: "SECTION",
+          sortOrder: item.sortOrder,
+          sectionId: item.section.id,
+          title: localizeContentText(locale, item.section.title) ?? item.section.title,
+        };
+      }
+      const moduleId = item.moduleId ?? item.module?.id ?? "";
+      const certStatus = certStatusByModuleId.get(moduleId);
+      const passed = certStatus !== undefined && certStatus !== "NOT_CERTIFIED";
+      const hasStarted = latestSubmissionByModuleId.has(moduleId);
+      return {
+        type: "MODULE",
+        sortOrder: item.sortOrder,
+        moduleId,
+        title: localizeContentText(locale, item.module?.title ?? "") ?? item.module?.title ?? moduleId,
+        moduleStatus: passed ? "PASSED" : hasStarted ? "IN_PROGRESS" : "NOT_STARTED",
+      };
+    });
+
     const detail: CourseDetail = {
       id: course.id,
       title: localizeContentText(locale, course.title) ?? course.title,
@@ -133,9 +158,44 @@ coursesRouter.get("/:courseId", async (request, response, next) => {
           moduleStatus: passed ? "PASSED" : hasStarted ? "IN_PROGRESS" : "NOT_STARTED",
         };
       }),
+      items,
     };
 
     response.json({ course: detail });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Rendered learning-section content for a participant (#491/P1). Validates the
+// section belongs to the published course, then returns sanitised HTML in the
+// participant's locale.
+coursesRouter.get("/:courseId/sections/:sectionId", async (request, response, next) => {
+  const userId = request.context?.userId;
+  if (!userId) {
+    response.status(401).json({ error: "unauthorized" });
+    return;
+  }
+  const locale = normalizeLocale(request.context?.locale) ?? "en-GB";
+  try {
+    const course = await courseRepository.findCourseById(request.params.courseId);
+    if (!course || !course.publishedAt || course.archivedAt) {
+      throw new NotFoundError("Course", "course_not_found", "Course not found.");
+    }
+    const courseItems = await courseRepository.findCourseItems(course.id);
+    const belongs = courseItems.some(
+      (item) => item.itemType === "SECTION" && item.sectionId === request.params.sectionId,
+    );
+    if (!belongs) {
+      throw new NotFoundError("CourseSection", "section_not_found", "Section not found in this course.");
+    }
+    const section = await getSection(request.params.sectionId);
+    if (!section) {
+      throw new NotFoundError("CourseSection", "section_not_found", "Section not found.");
+    }
+    const localizedTitle = localizeContentText(locale, section.title) ?? section.title;
+    const localizedBody = localizeContentText(locale, section.activeVersion?.bodyMarkdown ?? "") ?? "";
+    response.json({ title: localizedTitle, html: renderSectionMarkdown(localizedBody) });
   } catch (error) {
     next(error);
   }

--- a/test/m2-course-section-participant.test.ts
+++ b/test/m2-course-section-participant.test.ts
@@ -65,6 +65,8 @@ describe("Participant course section view", () => {
     expect(content.body.html).not.toContain("alert(1)");
 
     await prisma.course.delete({ where: { id: course.id } });
+    await prisma.courseSection.update({ where: { id: section.id }, data: { activeVersionId: null } });
+    await prisma.courseSectionVersion.deleteMany({ where: { sectionId: section.id } });
     await prisma.courseSection.delete({ where: { id: section.id } });
   });
 

--- a/test/m2-course-section-participant.test.ts
+++ b/test/m2-course-section-participant.test.ts
@@ -1,0 +1,89 @@
+import request from "supertest";
+import { afterAll, describe, expect, it } from "vitest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+
+const participantHeaders = {
+  "x-user-id": "participant-1",
+  "x-user-email": "participant@company.com",
+  "x-user-name": "Platform Participant",
+  "x-user-roles": "PARTICIPANT",
+};
+
+// #491/P1 — participant sees sections in the course sequence and reads rendered,
+// sanitised content.
+describe("Participant course section view", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("exposes a section in the course sequence and serves sanitised HTML", async () => {
+    const course = await prisma.course.create({
+      data: { title: `P1 Course ${Date.now()}`, publishedAt: new Date() },
+      select: { id: true },
+    });
+    const section = await prisma.courseSection.create({
+      data: { title: JSON.stringify({ "en-GB": "Intro", nb: "Intro", nn: "Intro" }) },
+      select: { id: true },
+    });
+    const version = await prisma.courseSectionVersion.create({
+      data: {
+        sectionId: section.id,
+        versionNo: 1,
+        bodyMarkdown: JSON.stringify({
+          "en-GB": "# Welcome\n\nRead this <script>alert(1)</script> first.",
+          nb: "# Velkommen",
+          nn: "# Velkomen",
+        }),
+        publishedAt: new Date(),
+      },
+      select: { id: true },
+    });
+    await prisma.courseSection.update({ where: { id: section.id }, data: { activeVersionId: version.id } });
+    await prisma.courseItem.create({
+      data: { courseId: course.id, itemType: "SECTION", sectionId: section.id, sortOrder: 0 },
+    });
+
+    const detail = await request(app)
+      .get(`/api/courses/${course.id}`)
+      .set(participantHeaders);
+    expect(detail.status).toBe(200);
+    const items = detail.body.course.items as Array<{ type: string; sectionId?: string; title?: string }>;
+    const sectionItem = items.find((i) => i.type === "SECTION");
+    expect(sectionItem?.sectionId).toBe(section.id);
+    expect(sectionItem?.title).toBe("Intro");
+
+    const content = await request(app)
+      .get(`/api/courses/${course.id}/sections/${section.id}`)
+      .set(participantHeaders);
+    expect(content.status).toBe(200);
+    expect(content.body.title).toBe("Intro");
+    expect(content.body.html).toContain("Welcome");
+    expect(content.body.html).toContain("Read this");
+    // Sanitised: the embedded script must be stripped.
+    expect(content.body.html).not.toContain("<script");
+    expect(content.body.html).not.toContain("alert(1)");
+
+    await prisma.course.delete({ where: { id: course.id } });
+    await prisma.courseSection.delete({ where: { id: section.id } });
+  });
+
+  it("returns 404 for a section that is not part of the course", async () => {
+    const course = await prisma.course.create({
+      data: { title: `P1 Course Empty ${Date.now()}`, publishedAt: new Date() },
+      select: { id: true },
+    });
+    const orphan = await prisma.courseSection.create({
+      data: { title: JSON.stringify({ "en-GB": "Orphan" }) },
+      select: { id: true },
+    });
+
+    const res = await request(app)
+      .get(`/api/courses/${course.id}/sections/${orphan.id}`)
+      .set(participantHeaders);
+    expect(res.status).toBe(404);
+
+    await prisma.course.delete({ where: { id: course.id } });
+    await prisma.courseSection.delete({ where: { id: orphan.id } });
+  });
+});


### PR DESCRIPTION
## Hva

Åttende skive av #476 (Tier 2 LMS, epic #478) — **P1 (#491)**: deltaker ser og leser læringsseksjoner i kursforløpet. **Fullfører forfatter→deltaker-løkka.**

### Backend
- `GET /api/courses/:id` returnerer nå **`items`** — den blandede modul/seksjon-sekvensen i rekkefølge (modul-status bevart; seksjoner med tittel). `modules` beholdt for bakoverkompat.
- Nytt **`GET /api/courses/:id/sections/:sectionId`** — validerer at seksjonen tilhører det publiserte kurset, returnerer **sanitisert HTML (F3/X1)** + tittel i deltakerens locale.

### Front-end (`participant.js`)
- Kurs-detalj rendrer den blandede sekvensen; **seksjons-rader åpner en mobil-først leser-overlay** med server-rendret, sanitisert innhold. Graceful fallback til modul-only.

## Verifisering
- `npx tsc --noEmit` + `node --check` rene
- Integrasjonstest `m2-course-section-participant.test.ts`: seksjon i sekvensen, sanitisert HTML (innebygd `<script>` strippet), 404 for seksjon utenfor kurset. CI mot Postgres.
- Full UI-flyt testes manuelt ved staging-deploy.

## Etter denne: klar for staging-deploy
B1→U1→U3→P1 er nå komplett. Forfatter kan opprette seksjon (U1), legge den i et kurs (U3), og deltaker ser/leser den (P1).

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)
