### PR TITLE
feat(course): export/import tar med læringsseksjoner (v1.3.12, #512)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,28 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.12 - 2026-06-16
+
+feat(course): export/import tar med læringsseksjoner (#512)
+
+Tetter datatap-gapet: kurs-eksport/-import håndterte kun moduler, så seksjoner forsvant ved
+overføring mellom miljøer. Nå bevares den fulle modul/seksjon-sekvensen.
+
+- Envelope-format (additivt, bakoverkompatibelt på `v1`): valgfri `items`-sekvens med
+  diskriminert MODULE/SECTION; ny `sectionExportPayloadSchema` (lokalisert title + bodyMarkdown).
+  `modules` beholdt (nå valgfri) som subset for v1-importører.
+- Eksport (`buildCourseExportEnvelope`): bygger `items` fra `CourseItem` i rekkefølge, inliner
+  hver seksjons aktive versjons markdown; emitterer både `items` + `modules`-subset.
+- Import (`importCourseFromEnvelope`): foretrekker `items` (gjenskaper seksjoner via
+  `createSection` + bevarer rekkefølge via `setCourseItems`); faller tilbake til legacy
+  `modules`-vei for v1-filer.
+- Assets (#483/F4) ennå ikke inlinet — markdown-only foreløpig (notert i #512).
+
+Integrasjonstest: round-trip av kurs med interleaved seksjon (eksport → import → ny seksjon
+gjenskapt i rekkefølge). `tsc` + CI mot Postgres rene.
+
+Closes #512
+
 ## 1.3.11 - 2026-06-16
 
 fix(course): UI-polish for seksjoner etter testtilbakemelding (#488/#490/#492 follow-up)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/adminContentQueries.ts
+++ b/src/modules/adminContent/adminContentQueries.ts
@@ -194,21 +194,36 @@ export async function buildCourseExportEnvelope(
   courseId: string,
   exportedBy: { userId?: string | null; email?: string | null },
 ): Promise<import("./adminContentSchemas.js").ExportEnvelope> {
-  const course = await (await import("../course/courseRepository.js")).courseRepository.findCourseById(courseId);
+  const courseRepo = (await import("../course/courseRepository.js")).courseRepository;
+  const course = await courseRepo.findCourseById(courseId);
   if (!course) {
     throw new Error("Course not found.");
   }
-  if (!course.modules || course.modules.length === 0) {
-    throw new Error("Course has no modules to export.");
+
+  // Full mixed sequence — modules + learning sections in order (#512).
+  const courseItems = await courseRepo.findCourseItems(courseId);
+  if (courseItems.length === 0) {
+    throw new Error("Course has no items to export.");
   }
 
-  const sortedModules = [...course.modules].sort((a, b) => a.sortOrder - b.sortOrder);
-  const modulePayloads = await Promise.all(
-    sortedModules.map(async (cm) => ({
-      sortOrder: cm.sortOrder,
-      module: await buildModuleExportPayload(cm.moduleId),
-    })),
+  const itemPayloads = await Promise.all(
+    [...courseItems]
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .map(async (item) => {
+        if (item.itemType === "SECTION" && item.section) {
+          const sectionVersion = await buildSectionExportPayload(item.section.id);
+          return { type: "SECTION" as const, sortOrder: item.sortOrder, section: sectionVersion };
+        }
+        const moduleId = item.moduleId ?? item.module?.id;
+        if (!moduleId) throw new Error("Course item is missing its module reference.");
+        return { type: "MODULE" as const, sortOrder: item.sortOrder, module: await buildModuleExportPayload(moduleId) };
+      }),
   );
+
+  // Module-only subset for backward-compatible v1 importers.
+  const modulePayloads = itemPayloads
+    .filter((p): p is Extract<typeof p, { type: "MODULE" }> => p.type === "MODULE")
+    .map((p) => ({ sortOrder: p.sortOrder, module: p.module }));
 
   return {
     exportFormat: "a2-content-export/v1",
@@ -228,7 +243,27 @@ export async function buildCourseExportEnvelope(
           sourceVersionNo: null,
         },
         modules: modulePayloads,
+        items: itemPayloads as never,
       },
+    },
+  };
+}
+
+// Inline a learning section's title + active-version markdown for export (#512).
+async function buildSectionExportPayload(sectionId: string): Promise<import("./adminContentSchemas.js").SectionExportPayload> {
+  const { getSection } = await import("../course/sectionCommands.js");
+  const section = await getSection(sectionId);
+  if (!section) throw new Error("Section not found for export.");
+  return {
+    title: (decodeLocalizedText(section.title) as never) ?? (section.title as never),
+    bodyMarkdown: (section.activeVersion?.bodyMarkdown
+      ? decodeLocalizedText(section.activeVersion.bodyMarkdown)
+      : "") as never,
+    audit: {
+      publishedAt: section.activeVersion?.publishedAt ? new Date(section.activeVersion.publishedAt).toISOString() : null,
+      publishedBy: null,
+      publishedByEmail: null,
+      sourceVersionNo: section.activeVersion?.versionNo ?? null,
     },
   };
 }

--- a/src/modules/adminContent/adminContentSchemas.ts
+++ b/src/modules/adminContent/adminContentSchemas.ts
@@ -315,7 +315,7 @@ export const courseExportPayloadSchema = z.object({
   course: z.object({
     title: localizedTextSchema,
     description: localizedTextSchema.nullable().optional(),
-    certificationLevel: certificationLevelInputSchema,
+    certificationLevel: certificationLevelInputSchema.nullable(),
     audit: exportAuditSchema,
     modules: z.array(z.object({
       sortOrder: z.number().int().min(0),

--- a/src/modules/adminContent/adminContentSchemas.ts
+++ b/src/modules/adminContent/adminContentSchemas.ts
@@ -299,8 +299,18 @@ export const moduleExportPayloadSchema = z.object({
   }),
 });
 
+// One learning section's payload — title + active-version markdown, both
+// localized. Assets (#483/F4) are not yet inlined; markdown-only for now (#512).
+export const sectionExportPayloadSchema = z.object({
+  title: localizedTextSchema,
+  bodyMarkdown: localizedTextSchema,
+  audit: exportAuditSchema.optional(),
+});
+
 // Course export inlines each module's full payload so the file is
-// self-contained (chosen 2026-05-19 over reference-only).
+// self-contained (chosen 2026-05-19 over reference-only). #512 adds an optional
+// `items` array carrying the full mixed module/section sequence; `modules` is
+// kept (now optional) so v1 importers that only understand modules still work.
 export const courseExportPayloadSchema = z.object({
   course: z.object({
     title: localizedTextSchema,
@@ -310,8 +320,15 @@ export const courseExportPayloadSchema = z.object({
     modules: z.array(z.object({
       sortOrder: z.number().int().min(0),
       module: moduleExportPayloadSchema,
-    })).min(1),
-  }),
+    })).optional(),
+    items: z.array(z.discriminatedUnion("type", [
+      z.object({ type: z.literal("MODULE"), sortOrder: z.number().int().min(0), module: moduleExportPayloadSchema }),
+      z.object({ type: z.literal("SECTION"), sortOrder: z.number().int().min(0), section: sectionExportPayloadSchema }),
+    ])).optional(),
+  }).refine(
+    (c) => (c.modules?.length ?? 0) > 0 || (c.items?.length ?? 0) > 0,
+    { message: "Course export must contain at least one module or item." },
+  ),
 });
 
 export const exportEnvelopeSchema = z.object({
@@ -332,6 +349,7 @@ export const exportEnvelopeSchema = z.object({
 
 export type ExportEnvelope = z.infer<typeof exportEnvelopeSchema>;
 export type ModuleExportPayload = z.infer<typeof moduleExportPayloadSchema>;
+export type SectionExportPayload = z.infer<typeof sectionExportPayloadSchema>;
 export type CourseExportPayload = z.infer<typeof courseExportPayloadSchema>;
 
 export const importBodySchema = z.object({

--- a/src/modules/adminContent/contentImportService.ts
+++ b/src/modules/adminContent/contentImportService.ts
@@ -23,7 +23,8 @@ import {
 } from "./adminContentCommands.js";
 import { adminContentRepository } from "./adminContentRepository.js";
 import { courseRepository } from "../course/courseRepository.js";
-import { createCourse, setCourseModules, publishCourse } from "../course/courseCommands.js";
+import { createCourse, setCourseModules, setCourseItems, publishCourse, type CourseItemInput } from "../course/courseCommands.js";
+import { createSection } from "../course/sectionCommands.js";
 import { localizedTextCodec, type LocalizedText } from "../../codecs/localizedTextCodec.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
@@ -205,23 +206,43 @@ export async function importCourseFromEnvelope(
 
   // Each inlined module payload is imported via createNew (a course import never
   // tries to replace existing modules — that would conflate two different
-  // collision questions). The resulting module IDs are attached to the course
-  // in the original sortOrder.
-  const importedModules: Array<{ moduleId: string; sortOrder: number }> = [];
-  for (const item of payload.course.modules) {
-    const imported = await importModulePayload(item.module, {
-      actorId: options.actorId,
-      mode: "createNew",
-    });
-    importedModules.push({ moduleId: imported.moduleId, sortOrder: item.sortOrder });
-  }
+  // collision questions). Sections are recreated likewise. #512: prefer the full
+  // mixed `items` sequence; fall back to the legacy modules-only list (v1 files).
+  const importedModuleIds: string[] = [];
+  let sectionCount = 0;
 
-  await setCourseModules(
-    courseId,
-    importedModules
-      .sort((a, b) => a.sortOrder - b.sortOrder)
-      .map((m) => ({ moduleId: m.moduleId, sortOrder: m.sortOrder })),
-  );
+  if (payload.course.items && payload.course.items.length > 0) {
+    const ordered = [...payload.course.items].sort((a, b) => a.sortOrder - b.sortOrder);
+    const courseItemInputs: CourseItemInput[] = [];
+    for (const entry of ordered) {
+      if (entry.type === "SECTION") {
+        const section = await createSection({
+          title: serializeRequired(entry.section.title),
+          bodyMarkdown: serializeRequired(entry.section.bodyMarkdown),
+          actorId: options.actorId,
+        });
+        courseItemInputs.push({ type: "SECTION", sectionId: section.id });
+        sectionCount += 1;
+      } else {
+        const imported = await importModulePayload(entry.module, { actorId: options.actorId, mode: "createNew" });
+        courseItemInputs.push({ type: "MODULE", moduleId: imported.moduleId });
+        importedModuleIds.push(imported.moduleId);
+      }
+    }
+    await setCourseItems(courseId, courseItemInputs);
+  } else {
+    const importedModules: Array<{ moduleId: string; sortOrder: number }> = [];
+    for (const item of payload.course.modules ?? []) {
+      const imported = await importModulePayload(item.module, { actorId: options.actorId, mode: "createNew" });
+      importedModules.push({ moduleId: imported.moduleId, sortOrder: item.sortOrder });
+    }
+    importedModules.sort((a, b) => a.sortOrder - b.sortOrder);
+    importedModuleIds.push(...importedModules.map((m) => m.moduleId));
+    await setCourseModules(
+      courseId,
+      importedModules.map((m) => ({ moduleId: m.moduleId, sortOrder: m.sortOrder })),
+    );
+  }
 
   // Same publish-state-preservation rule as for modules: if source course was
   // published (audit.publishedAt set), publish the destination course too.
@@ -238,10 +259,11 @@ export async function importCourseFromEnvelope(
     metadata: {
       courseId,
       mode: options.mode,
-      moduleCount: importedModules.length,
+      moduleCount: importedModuleIds.length,
+      sectionCount,
       sourcePublishedAt: payload.course.audit.publishedAt ?? null,
     },
   });
 
-  return { courseId, moduleIds: importedModules.map((m) => m.moduleId) };
+  return { courseId, moduleIds: importedModuleIds };
 }

--- a/test/m2-content-export-import.test.ts
+++ b/test/m2-content-export-import.test.ts
@@ -230,7 +230,7 @@ describe("#512 course export-import with learning sections", () => {
       .post("/api/admin/content/courses/import")
       .set(adminHeaders)
       .send({ payload: envelope, mode: "createNew" });
-    expect(importRes.status).toBe(201);
+    expect(importRes.status, JSON.stringify(importRes.body)).toBe(201);
     const newCourseId = importRes.body.courseId as string;
     expect(newCourseId).not.toBe(courseId);
 

--- a/test/m2-content-export-import.test.ts
+++ b/test/m2-content-export-import.test.ts
@@ -183,3 +183,65 @@ describe("#433 module export-import round-trip", () => {
     expect(importResponse.body.error).toBe("validation_error");
   });
 });
+
+describe("#512 course export-import with learning sections", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("round-trips a course containing an interleaved learning section", async () => {
+    const { moduleId } = await setupModule(`sec-${Date.now()}`);
+
+    const sectionRes = await request(app)
+      .post("/api/admin/content/sections")
+      .set(adminHeaders)
+      .send({
+        title: { "en-GB": "Intro section", nb: "Intro-seksjon", nn: "Intro-seksjon" },
+        bodyMarkdown: { "en-GB": "# Hello\n\nRead this first.", nb: "# Hei", nn: "# Hei" },
+      });
+    expect(sectionRes.status).toBe(201);
+    const sectionId = sectionRes.body.section.id as string;
+
+    const courseRes = await request(app)
+      .post("/api/admin/content/courses")
+      .set(adminHeaders)
+      .send({ title: { "en-GB": `Course ${Date.now()}`, nb: "Kurs", nn: "Kurs" } });
+    expect(courseRes.status).toBe(201);
+    const courseId = courseRes.body.course.id as string;
+
+    const itemsRes = await request(app)
+      .put(`/api/admin/content/courses/${courseId}/items`)
+      .set(adminHeaders)
+      .send({ items: [{ type: "SECTION", sectionId }, { type: "MODULE", moduleId }] });
+    expect(itemsRes.status).toBe(204);
+
+    // Export — envelope must carry the full mixed sequence incl. the section.
+    const exportRes = await request(app)
+      .get(`/api/admin/content/courses/${courseId}/export-package`)
+      .set(adminHeaders);
+    expect(exportRes.status).toBe(200);
+    const envelope = exportRes.body.envelope;
+    const items = envelope.course.course.items as Array<{ type: string; section?: { bodyMarkdown: unknown } }>;
+    expect(items.map((i) => i.type)).toEqual(["SECTION", "MODULE"]);
+    expect(items[0].section?.bodyMarkdown).toBeTruthy();
+
+    // Import as a new course — the section must be recreated in sequence.
+    const importRes = await request(app)
+      .post("/api/admin/content/courses/import")
+      .set(adminHeaders)
+      .send({ payload: envelope, mode: "createNew" });
+    expect(importRes.status).toBe(201);
+    const newCourseId = importRes.body.courseId as string;
+    expect(newCourseId).not.toBe(courseId);
+
+    const newItemsRes = await request(app)
+      .get(`/api/admin/content/courses/${newCourseId}/items`)
+      .set(adminHeaders);
+    expect(newItemsRes.status).toBe(200);
+    const newItems = newItemsRes.body.items as Array<{ type: string; sectionId?: string }>;
+    expect(newItems.map((i) => i.type)).toEqual(["SECTION", "MODULE"]);
+    const recreatedSection = newItems.find((i) => i.type === "SECTION");
+    expect(recreatedSection?.sectionId).toBeTruthy();
+    expect(recreatedSection?.sectionId).not.toBe(sectionId);
+  });
+});


### PR DESCRIPTION
Tetter datatap-gapet du fant: kurs-eksport/-import håndterte **kun moduler**, så seksjoner forsvant ved overføring mellom miljøer.

- **Envelope-format** (additivt, bakoverkompatibelt på `v1`): valgfri `items`-sekvens (diskriminert MODULE/SECTION) + ny `sectionExportPayloadSchema` (lokalisert title + bodyMarkdown). `modules` beholdt (nå valgfri) som subset for v1-importører.
- **Eksport:** bygger `items` fra `CourseItem` i rekkefølge, inliner hver seksjons aktive markdown; emitterer både `items` + `modules`-subset.
- **Import:** foretrekker `items` (gjenskaper seksjoner via `createSection` + bevarer rekkefølge via `setCourseItems`); faller tilbake til legacy `modules` for v1-filer.
- **Assets** (#483/F4) ennå ikke inlinet — markdown-only foreløpig (notert i #512).

Integrasjonstest: round-trip av kurs med interleaved seksjon. `tsc` + CI mot Postgres.

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)