### PR TITLE
feat(course): auto-oversettelse-assist i seksjons-editor (v1.3.13, #514)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,21 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.13 - 2026-06-16
+
+feat(course): auto-oversettelse-assist i seksjons-editor (#514)
+
+Eksplisitt LLM-oversettelse av seksjoner (tittel + bodyMarkdown), på linje med kurs/moduler.
+Per teacher-locale-prinsippet: eksplisitt handling, forfatter ser over resultatet før lagring.
+
+- `localizeSectionContent` + `buildSectionLocalizationPrompts` i llmContentGenerationService —
+  markdown-bevarende prompt (bevarer #-overskrifter, lister, lenker, kode, {{asset:...}};
+  oversetter kun lesbar tekst)
+- `POST /api/admin/content/sections/localize` (rate-limited, validerer source≠target)
+- Editor: «Oversett fra dette språket»-knapp fyller de andre språk-fanene fra aktivt språk;
+  forfatter reviewer/redigerer før lagring
+- Unit-tester for prompt-byggeren (markdown/placeholder-bevaring + felt-utelatelse)
+
 ## 1.3.12 - 2026-06-16
 
 feat(course): export/import tar med læringsseksjoner (#512)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -24,6 +24,7 @@ const LABELS = {
     save: "Save new version", saved: "Section saved.", deleted: "Section deleted.",
     confirmDelete: "Delete this section?", loadError: "Could not load sections.",
     needContent: "Add a title and content in at least one language.",
+    translate: "Translate from this language", translating: "Translating…", translated: "Translated — review before saving.",
   },
   nb: {
     heading: "Seksjoner", newSection: "+ Ny seksjon", colTitle: "Tittel", colVersion: "Versjon",
@@ -32,6 +33,7 @@ const LABELS = {
     save: "Lagre ny versjon", saved: "Seksjon lagret.", deleted: "Seksjon slettet.",
     confirmDelete: "Slette denne seksjonen?", loadError: "Kunne ikke laste seksjoner.",
     needContent: "Fyll inn tittel og innhold på minst ett språk.",
+    translate: "Oversett fra dette språket", translating: "Oversetter…", translated: "Oversatt — se over før du lagrer.",
   },
   nn: {
     heading: "Seksjonar", newSection: "+ Ny seksjon", colTitle: "Tittel", colVersion: "Versjon",
@@ -40,6 +42,7 @@ const LABELS = {
     save: "Lagre ny versjon", saved: "Seksjon lagra.", deleted: "Seksjon sletta.",
     confirmDelete: "Slette denne seksjonen?", loadError: "Kunne ikkje laste seksjonar.",
     needContent: "Fyll inn tittel og innhald på minst eitt språk.",
+    translate: "Omset frå dette språket", translating: "Omset…", translated: "Omsett — sjå over før du lagrar.",
   },
 };
 
@@ -214,11 +217,13 @@ async function renderEditorView(sectionId) {
       </div>
       <div class="editor-actions">
         <button type="button" id="saveBtn" class="btn btn-primary">${escapeHtml(L("save"))}</button>
+        <button type="button" id="translateBtn" class="btn btn-secondary" style="width:auto">${escapeHtml(L("translate"))}</button>
         <span class="editor-status" id="editorStatus"></span>
       </div>
     </div>`;
 
   document.getElementById("backLink")?.addEventListener("click", (e) => { e.preventDefault(); goTo("list"); });
+  document.getElementById("translateBtn")?.addEventListener("click", translateFromCurrent);
   document.getElementById("langTabs")?.addEventListener("click", (event) => {
     const tab = event.target.closest("[data-locale]");
     if (!tab) return;
@@ -309,6 +314,37 @@ async function saveSection() {
     if (status) status.textContent = L("saved");
   } catch (err) {
     showToast(err?.message ?? "Error", "error");
+  }
+}
+
+// Explicit LLM translation (#514): translate the active language's content into
+// the other locales, which the author reviews/edits before saving.
+async function translateFromCurrent() {
+  captureInputs();
+  const src = editing.editLocale;
+  const title = (editing.title[src] ?? "").trim();
+  const body = (editing.body[src] ?? "").trim();
+  if (!title && !body) {
+    showToast(L("needContent"), "error");
+    return;
+  }
+  const btn = document.getElementById("translateBtn");
+  if (btn) { btn.disabled = true; btn.textContent = L("translating"); }
+  try {
+    for (const target of EDITOR_LOCALES.filter((l) => l !== src)) {
+      const res = await apiFetch("/api/admin/content/sections/localize", getHeaders, {
+        method: "POST",
+        body: JSON.stringify({ title: title || undefined, bodyMarkdown: body || undefined, sourceLocale: src, targetLocale: target }),
+      });
+      if (res.title) editing.title[target] = res.title;
+      if (res.bodyMarkdown) editing.body[target] = res.bodyMarkdown;
+    }
+    showToast(L("translated"));
+    renderEditorFields();
+  } catch (err) {
+    showToast(err?.message ?? "Error", "error");
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = L("translate"); }
   }
 }
 

--- a/src/modules/adminContent/llmContentGenerationService.ts
+++ b/src/modules/adminContent/llmContentGenerationService.ts
@@ -126,6 +126,18 @@ export type CourseCopyLocalizationResult = {
   description?: string;
 };
 
+export type SectionLocalizationInput = {
+  title?: string;
+  bodyMarkdown?: string;
+  sourceLocale: GenerationLocale;
+  targetLocale: GenerationLocale;
+};
+
+export type SectionLocalizationResult = {
+  title?: string;
+  bodyMarkdown?: string;
+};
+
 export type BlueprintInput = {
   sourceMaterial: string;
   certificationLevel: CertificationLevel;
@@ -208,6 +220,13 @@ const courseCopyLocalizationResponseCodec = z.object({
   title: z.string().min(1).optional(),
   description: z.string().optional(),
 }).refine((value) => Boolean(value.title || value.description), {
+  message: "At least one localized field is required.",
+});
+
+const sectionLocalizationResponseCodec = z.object({
+  title: z.string().min(1).optional(),
+  bodyMarkdown: z.string().optional(),
+}).refine((value) => Boolean(value.title || value.bodyMarkdown), {
   message: "At least one localized field is required.",
 });
 
@@ -1567,6 +1586,62 @@ export async function localizeCourseCopy(input: CourseCopyLocalizationInput): Pr
   const parsed = courseCopyLocalizationResponseCodec.safeParse(raw);
   if (!parsed.success) {
     throw new Error(`Course copy localization failed validation: ${JSON.stringify(parsed.error.issues)}`);
+  }
+  return parsed.data;
+}
+
+// Markdown-preserving translation of a learning section (#514). Unlike course
+// copy, bodyMarkdown must keep its markdown structure and {{asset:...}}
+// placeholders intact — only human-readable text is translated.
+export function buildSectionLocalizationPrompts(input: SectionLocalizationInput): {
+  systemPrompt: string;
+  userPrompt: string;
+} {
+  const systemPrompt =
+    "You are a professional translator for a certification platform. Translate the provided learning-section content faithfully and return strict JSON only - no commentary.";
+
+  const titleSection = typeof input.title === "string" && input.title.trim().length > 0
+    ? `\ntitle:\n${input.title.trim()}\n`
+    : "";
+  const bodySection = typeof input.bodyMarkdown === "string" && input.bodyMarkdown.trim().length > 0
+    ? `\nbodyMarkdown:\n${input.bodyMarkdown.trim()}\n`
+    : "";
+
+  const returnFields: string[] = [];
+  if (titleSection) returnFields.push(`  "title": "translated title in ${LOCALE_DISPLAY[input.targetLocale]}"`);
+  if (bodySection) returnFields.push(`  "bodyMarkdown": "translated markdown body in ${LOCALE_DISPLAY[input.targetLocale]}"`);
+
+  const userPrompt = `Translate the following learning-section content from ${LOCALE_DISPLAY[input.sourceLocale]} to ${LOCALE_DISPLAY[input.targetLocale]}.
+
+${buildLanguageEnforcementDirective(input.targetLocale)}
+
+## Translation rules
+
+- Translate ONLY human-readable text. Preserve meaning, tone and intended audience.
+- Keep ALL markdown formatting exactly: headings (#), lists, links, emphasis, code blocks, tables, images.
+- Do NOT translate or alter URLs, code, or {{asset:...}} placeholders.
+- Do not add or remove content, fields, or markdown structure.
+
+## Source content
+${titleSection}
+${bodySection}
+## Return format
+
+Return a single JSON object (bodyMarkdown value must be a JSON string with escaped newlines):
+{
+${returnFields.join(",\n")}
+}`;
+
+  return { systemPrompt, userPrompt };
+}
+
+export async function localizeSectionContent(input: SectionLocalizationInput): Promise<SectionLocalizationResult> {
+  const { systemPrompt, userPrompt } = buildSectionLocalizationPrompts(input);
+
+  const raw = await callLlm(systemPrompt, userPrompt);
+  const parsed = sectionLocalizationResponseCodec.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(`Section localization failed validation: ${JSON.stringify(parsed.error.issues)}`);
   }
   return parsed.data;
 }

--- a/src/routes/adminSections.ts
+++ b/src/routes/adminSections.ts
@@ -8,10 +8,12 @@ import {
   listSections,
   deleteSection,
 } from "../modules/course/index.js";
-import { localizedTextPatchSchema } from "../modules/adminContent/adminContentSchemas.js";
+import { localizedTextPatchSchema, generationLocaleSchema } from "../modules/adminContent/adminContentSchemas.js";
 import { localizedTextCodec } from "../codecs/localizedTextCodec.js";
 import { NotFoundError } from "../errors/AppError.js";
 import { renderSectionMarkdown } from "../modules/course/sectionContent.js";
+import { localizeSectionContent } from "../modules/adminContent/llmContentGenerationService.js";
+import { generateLimiter } from "../middleware/rateLimiting.js";
 
 const adminSectionsRouter = Router();
 
@@ -22,6 +24,12 @@ const createSectionSchema = z.object({
 const titleSchema = z.object({ title: localizedTextPatchSchema });
 const contentSchema = z.object({ bodyMarkdown: localizedTextPatchSchema });
 const previewSchema = z.object({ markdown: z.string() });
+const localizeSchema = z.object({
+  title: z.string().trim().min(1).optional(),
+  bodyMarkdown: z.string().trim().min(1).optional(),
+  sourceLocale: generationLocaleSchema,
+  targetLocale: generationLocaleSchema,
+}).refine((v) => Boolean(v.title || v.bodyMarkdown), { message: "At least one field is required." });
 
 type SectionWithActiveVersion = {
   id: string;
@@ -72,6 +80,26 @@ adminSectionsRouter.post("/preview", async (request, response, next) => {
   }
   try {
     response.json({ html: renderSectionMarkdown(parsed.data.markdown) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Explicit LLM translation assist (#514) — translate title + bodyMarkdown from
+// one locale to another; the author reviews/edits the result before saving.
+adminSectionsRouter.post("/localize", generateLimiter, async (request, response, next) => {
+  const parsed = localizeSchema.safeParse(request.body);
+  if (!parsed.success) {
+    response.status(400).json({ error: "validation_error", issues: parsed.error.issues });
+    return;
+  }
+  try {
+    if (parsed.data.sourceLocale === parsed.data.targetLocale) {
+      response.json({ title: parsed.data.title, bodyMarkdown: parsed.data.bodyMarkdown });
+      return;
+    }
+    const result = await localizeSectionContent(parsed.data);
+    response.json(result);
   } catch (error) {
     next(error);
   }

--- a/test/unit/llm-content-generation-service.test.ts
+++ b/test/unit/llm-content-generation-service.test.ts
@@ -6,6 +6,7 @@ import {
   buildModuleDraftPrompts,
   buildModuleDraftLocalizationPrompts,
   buildModuleDraftRevisionPrompts,
+  buildSectionLocalizationPrompts,
   detectDominantLanguage,
   extractMcqRevisionTargets,
   hasMeaningfulMcqRevision,
@@ -477,6 +478,34 @@ describe("llm content generation prompts", () => {
 
       expect(userPrompt).not.toContain("Assessment blueprint");
     });
+  });
+});
+
+describe("section localization prompts (#514)", () => {
+  it("instructs markdown + placeholder preservation and targets the right locale", () => {
+    const { systemPrompt, userPrompt } = buildSectionLocalizationPrompts({
+      title: "Intro",
+      bodyMarkdown: "# Heading\n\nSee {{asset:fig1}} and [link](https://a-2.no).",
+      sourceLocale: "nb",
+      targetLocale: "en-GB",
+    });
+    expect(systemPrompt.toLowerCase()).toContain("translator");
+    expect(userPrompt).toContain("{{asset:...}}");
+    expect(userPrompt.toLowerCase()).toContain("markdown");
+    expect(userPrompt).toContain('"bodyMarkdown"');
+    expect(userPrompt).toContain('"title"');
+    // The actual content to translate is embedded.
+    expect(userPrompt).toContain("{{asset:fig1}}");
+  });
+
+  it("omits a field that was not provided", () => {
+    const { userPrompt } = buildSectionLocalizationPrompts({
+      title: "Bare tittel",
+      sourceLocale: "nb",
+      targetLocale: "nn",
+    });
+    expect(userPrompt).toContain('"title"');
+    expect(userPrompt).not.toContain('"bodyMarkdown"');
   });
 });
 


### PR DESCRIPTION
Eksplisitt LLM-oversettelse av seksjoner (tittel + bodyMarkdown), på linje med kurs/moduler. Per teacher-locale-prinsippet: **eksplisitt handling**, forfatter ser over resultatet før lagring.

- `localizeSectionContent` + `buildSectionLocalizationPrompts` — **markdown-bevarende** prompt (bevarer #-overskrifter, lister, lenker, kode, `{{asset:...}}`; oversetter kun lesbar tekst)
- `POST /api/admin/content/sections/localize` (rate-limited, validerer source≠target)
- Editor: «Oversett fra dette språket»-knapp fyller de andre språk-fanene; forfatter reviewer/redigerer før lagring
- Unit-tester for prompt-byggeren (markdown/placeholder-bevaring + felt-utelatelse)

`tsc` + unit-tester rene. Rebaset på main etter #512.

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)