### PR TITLE
fix(course): retest-funn — liste, delvis-locale-import, oversettelse-\n + GUI-lås (v1.3.14)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,26 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.14 - 2026-06-17
+
+fix(course): retest-funn — liste-overflow, import av delvise locales, oversettelse-\n + GUI-lås
+
+Fire funn fra manuell retest:
+1. **Seksjons-liste horisontal scroll:** `row-action-btn` arvet shared.css `button{width:100%}`
+   → full-bredde knapper sprengte tabellen. Satt `width:auto` + flex-actions-celle.
+2. **Import av kurs med seksjon feilet (#512):** seksjons-payloaden brukte `localizedTextSchema`
+   (krever alle tre locales), men seksjoner har ofte delvise locales (kun nb) → union-valideringsfeil
+   ved import. Byttet til `localizedTextPatchSchema` (delvis objekt OK). Round-trip-testen bruker nå
+   en kun-nb-seksjon for å dekke dette.
+3. **Oversettelse la inn literal `\n` (nynorsk):** prompt-instruksjonen om «escaped newlines» fikk
+   modellen til å skrive backslash-n. Forenklet prompten + la til `normaliseLiteralNewlines`-
+   defensiv normalisering. Engelsk var allerede OK.
+4. **GUI ikke låst under oversettelse:** editor-kontroller (input/faner/lagre/tilbake/oversett)
+   deaktiveres nå mens LLM-kallet pågår.
+
+`tsc` + unit-tester (44) rene. Mark-som-lest-404: ruten er bekreftet live (401 uautentisert) — bes
+retestet; kunne ikke reproduseres fra koden.
+
 ## 1.3.13 - 2026-06-16
 
 feat(course): auto-oversettelse-assist i seksjons-editor (#514)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-sections.html
+++ b/public/admin-content-sections.html
@@ -46,7 +46,8 @@
       .sections-table th, .sections-table td { text-align: left; padding: 10px var(--space-2); border-bottom: 1px solid var(--color-border-soft); }
       .sections-table th { font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-meta); }
       .sections-table .col-actions { text-align: right; white-space: nowrap; }
-      .row-action-btn { background: none; border: 1px solid var(--color-border-soft); border-radius: var(--radius-btn); padding: 4px 8px; font-size: 13px; cursor: pointer; color: var(--color-text); }
+      .row-action-btn { width: auto; background: none; border: 1px solid var(--color-border-soft); border-radius: var(--radius-btn); padding: 4px 8px; font-size: 13px; cursor: pointer; color: var(--color-text); white-space: nowrap; }
+      .sections-table .col-actions { display: flex; gap: 6px; justify-content: flex-end; }
       .row-action-btn:hover { background: var(--color-row-hover); }
       .row-action-btn.destructive { color: var(--color-error); border-color: #f5c0bb; }
 

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -328,8 +328,18 @@ async function translateFromCurrent() {
     showToast(L("needContent"), "error");
     return;
   }
+  // Lock the editor while translating so the author can't edit/navigate mid-call.
+  const controls = ["translateBtn", "saveBtn", "titleInput", "markdownInput", "backLink"]
+    .map((id) => document.getElementById(id))
+    .filter(Boolean);
+  const tabs = Array.from(document.querySelectorAll(".lang-tab"));
+  const setLocked = (locked) => {
+    controls.forEach((el) => { el.disabled = locked; el.style.pointerEvents = locked ? "none" : ""; el.style.opacity = locked ? "0.6" : ""; });
+    tabs.forEach((el) => { el.disabled = locked; el.style.pointerEvents = locked ? "none" : ""; });
+  };
   const btn = document.getElementById("translateBtn");
-  if (btn) { btn.disabled = true; btn.textContent = L("translating"); }
+  setLocked(true);
+  if (btn) btn.textContent = L("translating");
   try {
     for (const target of EDITOR_LOCALES.filter((l) => l !== src)) {
       const res = await apiFetch("/api/admin/content/sections/localize", getHeaders, {
@@ -344,7 +354,8 @@ async function translateFromCurrent() {
   } catch (err) {
     showToast(err?.message ?? "Error", "error");
   } finally {
-    if (btn) { btn.disabled = false; btn.textContent = L("translate"); }
+    setLocked(false);
+    if (btn) btn.textContent = L("translate");
   }
 }
 

--- a/src/modules/adminContent/adminContentSchemas.ts
+++ b/src/modules/adminContent/adminContentSchemas.ts
@@ -301,9 +301,12 @@ export const moduleExportPayloadSchema = z.object({
 
 // One learning section's payload — title + active-version markdown, both
 // localized. Assets (#483/F4) are not yet inlined; markdown-only for now (#512).
+// Sections legitimately have partial locales (an author may fill only nb), so
+// the export uses the patch schema (string OR partial object), not the strict
+// all-three-locale localizedTextSchema (#512 follow-up).
 export const sectionExportPayloadSchema = z.object({
-  title: localizedTextSchema,
-  bodyMarkdown: localizedTextSchema,
+  title: localizedTextPatchSchema,
+  bodyMarkdown: localizedTextPatchSchema,
   audit: exportAuditSchema.optional(),
 });
 

--- a/src/modules/adminContent/llmContentGenerationService.ts
+++ b/src/modules/adminContent/llmContentGenerationService.ts
@@ -1627,12 +1627,21 @@ ${titleSection}
 ${bodySection}
 ## Return format
 
-Return a single JSON object (bodyMarkdown value must be a JSON string with escaped newlines):
+Return a single valid JSON object. Keep real line breaks inside the markdown (do NOT write the
+two characters backslash + n; use actual newlines, which JSON encodes automatically):
 {
 ${returnFields.join(",\n")}
 }`;
 
   return { systemPrompt, userPrompt };
+}
+
+// Defensive: some models emit literal "\n" (backslash + n) instead of real
+// newlines despite instructions (observed for nn but not en-GB). Normalise them
+// back to newlines so markdown renders. Only touches backslash-n sequences.
+export function normaliseLiteralNewlines(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return value;
+  return value.includes("\\n") ? value.replace(/\\r\\n|\\n/g, "\n") : value;
 }
 
 export async function localizeSectionContent(input: SectionLocalizationInput): Promise<SectionLocalizationResult> {
@@ -1643,7 +1652,10 @@ export async function localizeSectionContent(input: SectionLocalizationInput): P
   if (!parsed.success) {
     throw new Error(`Section localization failed validation: ${JSON.stringify(parsed.error.issues)}`);
   }
-  return parsed.data;
+  return {
+    title: parsed.data.title,
+    bodyMarkdown: normaliseLiteralNewlines(parsed.data.bodyMarkdown),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/test/m2-content-export-import.test.ts
+++ b/test/m2-content-export-import.test.ts
@@ -195,9 +195,11 @@ describe("#512 course export-import with learning sections", () => {
     const sectionRes = await request(app)
       .post("/api/admin/content/sections")
       .set(adminHeaders)
+      // Partial locales on purpose (only nb) — sections need not have all three;
+      // this exercises the patch-schema export/import path (#512 follow-up).
       .send({
-        title: { "en-GB": "Intro section", nb: "Intro-seksjon", nn: "Intro-seksjon" },
-        bodyMarkdown: { "en-GB": "# Hello\n\nRead this first.", nb: "# Hei", nn: "# Hei" },
+        title: { nb: "Intro-seksjon" },
+        bodyMarkdown: { nb: "# Hei\n\nLes dette først." },
       });
     expect(sectionRes.status).toBe(201);
     const sectionId = sectionRes.body.section.id as string;

--- a/test/unit/llm-content-generation-service.test.ts
+++ b/test/unit/llm-content-generation-service.test.ts
@@ -7,6 +7,7 @@ import {
   buildModuleDraftLocalizationPrompts,
   buildModuleDraftRevisionPrompts,
   buildSectionLocalizationPrompts,
+  normaliseLiteralNewlines,
   detectDominantLanguage,
   extractMcqRevisionTargets,
   hasMeaningfulMcqRevision,
@@ -506,6 +507,13 @@ describe("section localization prompts (#514)", () => {
     });
     expect(userPrompt).toContain('"title"');
     expect(userPrompt).not.toContain('"bodyMarkdown"');
+  });
+
+  it("normalises literal backslash-n back to real newlines", () => {
+    expect(normaliseLiteralNewlines("# Hei\\n\\nLes dette")).toBe("# Hei\n\nLes dette");
+    // Real newlines are left untouched.
+    expect(normaliseLiteralNewlines("# Hei\n\nLes dette")).toBe("# Hei\n\nLes dette");
+    expect(normaliseLiteralNewlines(undefined)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Fire funn fra manuell retest:

1. **Seksjons-liste horisontal scroll:** `row-action-btn` arvet shared.css `button{width:100%}` → full-bredde knapper sprengte tabellen. `width:auto` + flex-actions-celle.
2. **Import av kurs med seksjon feilet (#512):** seksjons-payload brukte `localizedTextSchema` (krever 3 locales), men seksjoner har ofte delvise (kun nb) → byttet til `localizedTextPatchSchema`. Round-trip-test bruker nå kun-nb-seksjon.
3. **Oversettelse la inn literal `\n` (nn):** forenklet prompt + `normaliseLiteralNewlines`-normalisering.
4. **GUI låses under oversettelse** (editor-kontroller deaktiveres).

`tsc` + 44 unit-tester rene. **Mark-som-lest-404:** ruten er bekreftet live (401 uautentisert) — bes retestet; kunne ikke reproduseres fra kode/test (integrasjonstest grønn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)