### PR TITLE
sec(ingest): re-valider redirect-mål mot SSRF-policy ved URL-henting (v1.3.15, #504)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,21 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.15 - 2026-06-17
+
+sec(ingest): re-valider redirect-mål mot SSRF-policy ved URL-henting (#504)
+
+Tetter en aktiv SSRF-bypass i `fetchUrlAsSourceMaterial`: kun den opprinnelige URL-en ble
+validert, men `redirect: "follow"` fulgte automatisk redirects — en angriper kunne sende inn en
+public URL som redirecter til `127.0.0.1`/intern adresse, som vi så hentet + parset (med `jsdom`
+i prod). Erstattet med `redirect: "manual"` + manuell løkke som re-validerer HVERT redirect-mål
+med `assertSafeUrl` før det følges, capet på `MAX_REDIRECTS = 5` (`invalid_redirect` /
+`too_many_redirects`). Ny unit-test: public start-URL som 302-redirecter til loopback blokkeres
+(`private_address`). 8/8 url-fetch-tester grønne.
+
+Portering av codex-PR #504 (var basert på v1.2.2, konfliktende) rent inn på main. Restrisiko
+DNS-rebinding (fetch re-resolver etter sjekken) spores som eget oppfølger-issue.
+
 ## 1.3.14 - 2026-06-17
 
 fix(course): retest-funn — liste-overflow, import av delvise locales, oversettelse-\n + GUI-lås

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/urlFetchService.ts
+++ b/src/modules/adminContent/urlFetchService.ts
@@ -126,42 +126,67 @@ async function assertSafeUrl(rawUrl: string): Promise<URL> {
 }
 
 // Fetches the URL with a strict byte cap. Streams response into a buffer; aborts if cap exceeded.
+// Redirects are followed MANUALLY so each hop is re-validated against the SSRF policy
+// (assertSafeUrl) — automatic redirect-following would let an attacker-controlled redirect
+// reach a private/internal address despite the initial host being public (#504).
+const MAX_REDIRECTS = 5;
+
 async function fetchWithLimit(parsedUrl: URL, signal: AbortSignal): Promise<{ buffer: Buffer; contentType: string }> {
-  const response = await fetch(parsedUrl.toString(), {
-    method: "GET",
-    redirect: "follow",
-    signal,
-    headers: {
-      // Be polite: identify ourselves
-      "user-agent": "A2AssessmentPlatform/url-fetch (+https://github.com/jkosmo/a2-assessment-platform)",
-      accept: "text/html, application/xhtml+xml, text/plain;q=0.9, */*;q=0.5",
-    },
-  });
-  if (!response.ok) {
-    throw new UrlFetchError("http_error", `Upstream returned ${response.status}.`);
-  }
-  const contentType = (response.headers.get("content-type") ?? "").toLowerCase();
-  const baseType = contentType.split(";")[0].trim();
-  if (!ALLOWED_CONTENT_TYPES.includes(baseType)) {
-    throw new UrlFetchError("unsupported_content_type", `Content-Type ${baseType || "(missing)"} is not supported.`);
-  }
-  if (!response.body) {
-    throw new UrlFetchError("empty_response", "Upstream returned no body.");
-  }
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    total += value.byteLength;
-    if (total > SOURCE_MATERIAL_MAX_BYTES) {
-      try { await reader.cancel(); } catch {}
-      throw new UrlFetchError("too_large", `Response exceeds ${SOURCE_MATERIAL_MAX_BYTES} bytes.`);
+  let currentUrl = parsedUrl;
+  for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
+    const response = await fetch(currentUrl.toString(), {
+      method: "GET",
+      redirect: "manual",
+      signal,
+      headers: {
+        // Be polite: identify ourselves
+        "user-agent": "A2AssessmentPlatform/url-fetch (+https://github.com/jkosmo/a2-assessment-platform)",
+        accept: "text/html, application/xhtml+xml, text/plain;q=0.9, */*;q=0.5",
+      },
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      if (!location) {
+        throw new UrlFetchError("invalid_redirect", "Upstream redirect response missing Location header.");
+      }
+      if (redirectCount === MAX_REDIRECTS) {
+        throw new UrlFetchError("too_many_redirects", `Too many redirects (max ${MAX_REDIRECTS}).`);
+      }
+      const redirectedUrl = new URL(location, currentUrl);
+      // Re-validate the redirect target against the full SSRF policy before following.
+      currentUrl = await assertSafeUrl(redirectedUrl.toString());
+      continue;
     }
-    chunks.push(value);
+
+    if (!response.ok) {
+      throw new UrlFetchError("http_error", `Upstream returned ${response.status}.`);
+    }
+    const contentType = (response.headers.get("content-type") ?? "").toLowerCase();
+    const baseType = contentType.split(";")[0].trim();
+    if (!ALLOWED_CONTENT_TYPES.includes(baseType)) {
+      throw new UrlFetchError("unsupported_content_type", `Content-Type ${baseType || "(missing)"} is not supported.`);
+    }
+    if (!response.body) {
+      throw new UrlFetchError("empty_response", "Upstream returned no body.");
+    }
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > SOURCE_MATERIAL_MAX_BYTES) {
+        try { await reader.cancel(); } catch {}
+        throw new UrlFetchError("too_large", `Response exceeds ${SOURCE_MATERIAL_MAX_BYTES} bytes.`);
+      }
+      chunks.push(value);
+    }
+    return { buffer: Buffer.concat(chunks.map((c) => Buffer.from(c))), contentType: baseType };
   }
-  return { buffer: Buffer.concat(chunks.map((c) => Buffer.from(c))), contentType: baseType };
+
+  throw new UrlFetchError("too_many_redirects", `Too many redirects (max ${MAX_REDIRECTS}).`);
 }
 
 async function extractMainText(buffer: Buffer, contentType: string, sourceUrl: string): Promise<string> {

--- a/test/unit/url-fetch-service.test.ts
+++ b/test/unit/url-fetch-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { fetchUrlAsSourceMaterial, UrlFetchError, checkAndConsumeRateLimit } from "../../src/modules/adminContent/urlFetchService.js";
 
 // #454 Phase 1: SSRF-guard tests. These are the critical security tests — they validate
@@ -71,6 +71,26 @@ describe("urlFetchService SSRF protection", () => {
     await expect(fetchUrlAsSourceMaterial("http://prod.internal/")).rejects.toMatchObject({
       code: "private_address",
     });
+  });
+
+  // #504: redirects are re-validated. A public start URL that 302-redirects to a
+  // loopback/internal address must be blocked at the redirect hop, not followed.
+  it("re-validates redirects and blocks redirect to a private/internal address", async () => {
+    const originalFetch = global.fetch;
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(null, { status: 302, headers: { location: "http://127.0.0.1/internal" } }),
+    );
+    global.fetch = fetchMock as typeof fetch;
+    try {
+      // 93.184.216.34 is a public IP literal → passes the initial SSRF check, so the
+      // mocked fetch runs and returns the malicious redirect.
+      await expect(fetchUrlAsSourceMaterial("https://93.184.216.34/start")).rejects.toMatchObject({
+        code: "private_address",
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      global.fetch = originalFetch;
+    }
   });
 });
 


### PR DESCRIPTION
Lander codex-PR #504 rent på main (originalen var v1.2.2-basert og konfliktende).

## Hva
Tetter aktiv SSRF-bypass i `fetchUrlAsSourceMaterial`: kun opprinnelig URL ble validert, men `redirect: "follow"` fulgte redirects automatisk → angriper kunne sende public URL som redirecter til `127.0.0.1`/intern adresse, som vi hentet + parset (`jsdom` i prod gjør det utnyttbart).

## Fiks
- `redirect: "manual"` + manuell løkke som **re-validerer hvert redirect-mål med `assertSafeUrl`** før det følges.
- Cap `MAX_REDIRECTS = 5` (`invalid_redirect` / `too_many_redirects`).
- Ny unit-test: public start-URL som 302-redirecter til loopback blokkeres (`private_address`). 8/8 url-fetch-tester grønne.

## Verifisering
- `tsc` + `vitest` (8/8) rene lokalt. CI kjører full suite.

## Restrisiko (eget oppfølger-issue)
DNS-rebinding/TOCTOU: `fetch()` re-resolver DNS etter `assertSafeUrl`-sjekken. Utenfor denne PR-ens scope.

Erstatter #504 (lukkes ved merge av denne).

🤖 Generated with [Claude Code](https://claude.com/claude-code)