### PR TITLE
docs(workflow): dokumentasjon som obligatorisk feature-steg (stående ordre)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,11 @@ These rules exist because their violation caused or worsened the May 2026 produc
 
 - **Always create a PR against `main`** — never push directly to `main`.
 - **Always bump `package.json` version and `doc/VERSIONS.md`** in the same commit as code changes.
+- **Documentation is a MANDATORY step (standing order):** a feature is not "done" until its
+  docs are updated. Any change to user-facing behavior or API/route surface MUST update **both**
+  technical docs (`doc/API_REFERENCE.md`, `doc/route-map.md`, arch notes) **and** user/author
+  docs under `doc/`. If they can't land in the same PR, open tracking doc issues (technical +
+  user) in the same milestone before the feature is complete.
 - **For infra changes**, include in the PR description:
   - Which environments are affected
   - Behavior on first deploy (fresh environment) vs normal deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,20 @@ A2 Assessment Platform — Next.js + Prisma + PostgreSQL on Azure App Service.
 - Create GitHub issue → specify/plan → implement → test → document, in that order.
 - Deploy cadence: staging and production both require manual `workflow_dispatch`. Push to `main` does NOT auto-deploy.
 
+### Documentation is a MANDATORY step — not optional (standing order)
+
+A feature is **not "done" until its documentation is updated**. Any change that adds or alters
+user-facing behavior or API/route surface MUST, within the same feature arc, update **both**:
+
+1. **Technical docs** — `doc/API_REFERENCE.md` (new/changed endpoints), `doc/route-map.md`
+   (new pages/routes), and a short architecture note when a new data model or invariant is added.
+2. **User / author docs** — how a SMO/author uses the feature, and what the participant sees;
+   new user-facing capabilities get a guide (or a section in one) under `doc/`.
+
+If docs cannot land in the same PR, open tracking doc issues (technical + user) in the **same
+milestone** as the feature before it is considered complete. The "document" step must never
+lapse silently — it is part of the definition of done.
+
 ### Which deploy workflow to use
 
 | Type of change | Use workflow | Why |


### PR DESCRIPTION
Gjør teknisk **og** bruker-dokumentasjon til et obligatorisk steg i hver feature — en feature er ikke «ferdig» før docs er oppdatert (eller sporet i samme milestone). Kodifisert i `CLAUDE.md` + `AGENTS.md` (synket).

Utløst av at hele #476-seksjons-LMS-arbeidet ble levert + staging-validert uten dok-oppdatering; #521 (teknisk) + #522 (bruker) opprettet i etterkant.

Instruksjons-/konvensjonsendring — ingen kode/runtime-påvirkning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)