### PR TITLE
fix(security): block SSRF via redirect chains in URL source fetch endpoint

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,14 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.2.1 - 2026-05-23
+
+fix(security): block SSRF through redirect chains in URL source-material fetch
+
+- URL fetcher now uses manual redirect handling and validates each `Location` hop with the same SSRF policy as the initial URL.
+- Redirects to private/internal addresses are rejected before any follow-up request is sent.
+- Added a unit test covering redirect-to-loopback blocking.
+
 ## 1.2.0 - 2026-05-23
 
 feat(admin): server-side URL-fetching for kildemateriale (#454 Phase 1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.1.98",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a2-assessment-platform",
-      "version": "1.1.98",
+      "version": "1.2.1",
       "dependencies": {
         "@azure/communication-email": "^1.1.0",
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/urlFetchService.ts
+++ b/src/modules/adminContent/urlFetchService.ts
@@ -11,6 +11,7 @@ import { SOURCE_MATERIAL_MAX_BYTES } from "./sourceMaterialExtractionService.js"
 const FETCH_TIMEOUT_MS = 10_000;
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
 const ALLOWED_CONTENT_TYPES = ["text/html", "application/xhtml+xml", "text/plain"];
+const MAX_REDIRECTS = 5;
 
 export class UrlFetchError extends Error {
   constructor(public readonly code: string, message: string) {
@@ -126,17 +127,41 @@ async function assertSafeUrl(rawUrl: string): Promise<URL> {
 }
 
 // Fetches the URL with a strict byte cap. Streams response into a buffer; aborts if cap exceeded.
-async function fetchWithLimit(parsedUrl: URL, signal: AbortSignal): Promise<{ buffer: Buffer; contentType: string }> {
-  const response = await fetch(parsedUrl.toString(), {
-    method: "GET",
-    redirect: "follow",
-    signal,
-    headers: {
-      // Be polite: identify ourselves
-      "user-agent": "A2AssessmentPlatform/url-fetch (+https://github.com/jkosmo/a2-assessment-platform)",
-      accept: "text/html, application/xhtml+xml, text/plain;q=0.9, */*;q=0.5",
-    },
-  });
+async function fetchWithLimit(parsedUrl: URL, signal: AbortSignal): Promise<{ buffer: Buffer; contentType: string; finalUrl: string }> {
+  let currentUrl = parsedUrl;
+  let response: Response | undefined;
+
+  for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount += 1) {
+    response = await fetch(currentUrl.toString(), {
+      method: "GET",
+      redirect: "manual",
+      signal,
+      headers: {
+        // Be polite: identify ourselves
+        "user-agent": "A2AssessmentPlatform/url-fetch (+https://github.com/jkosmo/a2-assessment-platform)",
+        accept: "text/html, application/xhtml+xml, text/plain;q=0.9, */*;q=0.5",
+      },
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      if (redirectCount === MAX_REDIRECTS) {
+        throw new UrlFetchError("too_many_redirects", `Too many redirects (>${MAX_REDIRECTS}).`);
+      }
+      const location = response.headers.get("location");
+      if (!location) {
+        throw new UrlFetchError("invalid_redirect", "Redirect response missing Location header.");
+      }
+      const nextUrl = new URL(location, currentUrl);
+      currentUrl = await assertSafeUrl(nextUrl.toString());
+      continue;
+    }
+
+    break;
+  }
+
+  if (!response) {
+    throw new UrlFetchError("fetch_failed", "Fetch failed before receiving a response.");
+  }
   if (!response.ok) {
     throw new UrlFetchError("http_error", `Upstream returned ${response.status}.`);
   }
@@ -161,7 +186,7 @@ async function fetchWithLimit(parsedUrl: URL, signal: AbortSignal): Promise<{ bu
     }
     chunks.push(value);
   }
-  return { buffer: Buffer.concat(chunks.map((c) => Buffer.from(c))), contentType: baseType };
+  return { buffer: Buffer.concat(chunks.map((c) => Buffer.from(c))), contentType: baseType, finalUrl: currentUrl.toString() };
 }
 
 async function extractMainText(buffer: Buffer, contentType: string, sourceUrl: string): Promise<string> {
@@ -192,8 +217,8 @@ export async function fetchUrlAsSourceMaterial(rawUrl: string): Promise<UrlFetch
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
-    const { buffer, contentType } = await fetchWithLimit(parsedUrl, controller.signal);
-    const extractedText = await extractMainText(buffer, contentType, parsedUrl.toString());
+    const { buffer, contentType, finalUrl } = await fetchWithLimit(parsedUrl, controller.signal);
+    const extractedText = await extractMainText(buffer, contentType, finalUrl);
     const trimmed = extractedText.trim();
     if (!trimmed) {
       throw new UrlFetchError("empty_extracted_text", "Extracted text is empty.");

--- a/test/unit/url-fetch-service.test.ts
+++ b/test/unit/url-fetch-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { fetchUrlAsSourceMaterial, UrlFetchError, checkAndConsumeRateLimit } from "../../src/modules/adminContent/urlFetchService.js";
 
 // #454 Phase 1: SSRF-guard tests. These are the critical security tests — they validate
@@ -71,6 +71,28 @@ describe("urlFetchService SSRF protection", () => {
     await expect(fetchUrlAsSourceMaterial("http://prod.internal/")).rejects.toMatchObject({
       code: "private_address",
     });
+  });
+
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("blocks redirects to private addresses", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: "http://127.0.0.1/internal" },
+        })
+      );
+
+    await expect(fetchUrlAsSourceMaterial("http://1.1.1.1/source")).rejects.toMatchObject({
+      code: "private_address",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
### Motivation
- The URL fetcher followed HTTP redirects automatically, allowing an attacker-controlled public host to redirect the server to private/internal addresses and exfiltrate content. 
- The goal is to close this SSRF redirect bypass while preserving safe public-URL behavior and existing extraction logic.

### Description
- Replace automatic redirect following with manual redirect handling in `fetchWithLimit` and introduce `MAX_REDIRECTS = 5` to cap hops. 
- Re-validate every redirect `Location` by calling `assertSafeUrl` before following, and reject missing/invalid `Location` headers or redirect loops with clear `UrlFetchError` codes. 
- Return the validated `finalUrl` from `fetchWithLimit` and pass it to `extractMainText` so extraction uses the resolved, validated URL. 
- Add a unit test that simulates a `302` redirect to `127.0.0.1` and asserts the request is blocked with `private_address`. 
- Bump package version to `1.2.1` and add an entry to `doc/VERSIONS.md` documenting the security fix.

### Testing
- Ran the focused unit suite with `npx vitest run test/unit/url-fetch-service.test.ts` which passed (8/8). 
- Attempted full `npm test` but it failed in this environment due to the repository `pretest` requiring Docker for local PostgreSQL bootstrap, which is unavailable here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a114fb9b1fc832db3198cccb7508d3a)