### PR TITLE
fix(security): normalize generated rubric scoring scale

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,14 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.1.66 - 2026-05-20
+
+fix(security): lock generated rubric scoring scale to assessor contract
+
+- Normalize generated module rubric criteria to `maxScore: 4` and set `scalingRule.max_total` to `criteria_count * 4` when auto-saving generated rubrics.
+- Tighten rubric generation schema/prompt so generated criteria must use `maxScore: 4` and keep the 3-6 criteria contract.
+- This preserves existing assessor behavior (`rubric_scores` 0..4 per criterion) and prevents LLM-controlled denominator drift.
+
 ## 1.1.65 - 2026-05-20
 
 feat(admin): module-specific rubric generation (#378, closes #368)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.1.65",
+  "version": "1.1.66",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -1071,15 +1071,19 @@ function resolveCurrentRubricPayload() {
 
 function moduleSpecificRubricToStoragePayload(generated) {
   const criteria = Array.isArray(generated?.criteria) ? generated.criteria : [];
-  const totalMax = criteria.reduce((sum, c) => sum + (Number(c?.maxScore) || 0), 0) || 1;
+  const normalizedCriteria = criteria.map((c) => ({
+    ...c,
+    maxScore: 4,
+  }));
+  const totalMax = normalizedCriteria.length * 4 || 1;
   const criteriaRecord = Object.fromEntries(
-    criteria.map((c) => [
+    normalizedCriteria.map((c) => [
       String(c?.id ?? "criterion"),
       {
         label: c?.label ?? "",
         description: c?.description ?? "",
-        maxScore: Number(c?.maxScore) || 0,
-        weight: Number(((Number(c?.maxScore) || 0) / totalMax).toFixed(2)),
+        maxScore: 4,
+        weight: normalizedCriteria.length > 0 ? Number((1 / normalizedCriteria.length).toFixed(2)) : 0,
         candidateVisible: Boolean(c?.candidateVisible),
       },
     ]),

--- a/src/modules/adminContent/llmContentGenerationService.ts
+++ b/src/modules/adminContent/llmContentGenerationService.ts
@@ -227,12 +227,12 @@ const moduleRubricResponseCodec = z.object({
         id: z.string().min(1),
         label: z.string().min(1),
         description: z.string().min(1),
-        maxScore: z.number().int().min(1).max(10),
+        maxScore: z.literal(4),
         candidateVisible: z.boolean().default(true),
       }),
     )
-    .min(2)
-    .max(8),
+    .min(3)
+    .max(6),
   generatedFromTask: z.boolean().default(true),
   assessorNotes: z.string().default(""),
 });
@@ -1065,7 +1065,7 @@ ${blueprintSection}## Authoring rules
 
 - Produce 3-6 criteria. Each must name a specific dimension the task actually tests (e.g. "Trade-off between privacy and audit obligation", not "Quality of reasoning").
 - Each \`description\` must reference concrete content from the task or assessor expectations so a human assessor can apply it without guessing.
-- \`maxScore\` per criterion is an integer 1-10. Sum across all criteria should land in the range 10-30.
+- \`maxScore\` per criterion must be exactly 4 to match assessor scoring (0-4 per criterion).
 - \`id\` is short snake_case (e.g. "scenario_application", "priority_reasoning"). Stable across runs.
 - \`candidateVisible: true\` means the criterion text is appropriate to show the candidate before they submit. Set false only for criteria that would leak the expected answer.
 - \`assessorNotes\` is a short paragraph with one or two judgement calls the assessor should make consistently across submissions (e.g. don't penalise for missing X unless the task asked for it). Keep it under 60 words.
@@ -1080,7 +1080,7 @@ Return a single JSON object:
       "id": "snake_case_id",
       "label": "Short label in ${LOCALE_DISPLAY[input.locale]}",
       "description": "1-2 sentences that name what the assessor checks for, grounded in the task.",
-      "maxScore": integer 1-10,
+      "maxScore": 4,
       "candidateVisible": boolean
     }
   ],


### PR DESCRIPTION
### Motivation
- The new module-specific rubric generator persisted LLM-controlled `maxScore` values (1–10) and `scalingRule.max_total`, which is incompatible with the assessor contract that always scores each criterion 0..4 and allowed LLM output to inflate or suppress final practical scores.

### Description
- Constrain the generated rubric schema to require `maxScore: 4` and a 3–6 criteria contract in `src/modules/adminContent/llmContentGenerationService.ts` by switching to `z.literal(4)` and tightening min/max counts.
- Normalize auto-generated rubrics in the frontend `moduleSpecificRubricToStoragePayload` in `public/static/admin-content-shell.js` so each criterion is persisted with `maxScore: 4`, equal weights, and `scalingRule.max_total = criteria_count * 4` to eliminate LLM-controlled denominators.
- Bump package version to `1.1.66` in `package.json` and add a release note entry in `doc/VERSIONS.md` documenting the security fix.
- Changes touch `src/modules/adminContent/llmContentGenerationService.ts`, `public/static/admin-content-shell.js`, `package.json`, and `doc/VERSIONS.md`.

### Testing
- Ran `npm run lint` (TypeScript `tsc --noEmit`) which completed successfully.
- Ran `npm run test:admin-content:dom` which passed (`test/dom/admin-content-workspaces.dom.test.js` all tests passed).
- Attempted `npm run test:unit -- src/modules/adminContent/llmContentGenerationService.ts` but Vitest exited with code 1 because no unit test files matched that path filter.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0e20191054832d9a7fe6e79c690543)