### PR TITLE
fix(security): enforce ownership on replaceExisting module import

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,15 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.1.64 - 2026-05-20
+
+fix(security): enforce module ownership on replaceExisting imports
+
+- Added an ownership check in `POST /api/admin/content/modules/import` before
+  `replaceExisting` imports proceed.
+- Prevents users from importing a new version into modules they do not own,
+  closing an authorization gap that could be combined with auto-publish.
+
 ## 1.1.63 - 2026-05-20
 
 fix(admin): imported modules/courses auto-publish if source was published + import button styling (#433 follow-up)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.1.63",
+  "version": "1.1.64",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -241,6 +241,9 @@ adminContentRouter.post("/modules/import", async (request, response) => {
     return;
   }
   try {
+    if ((data.mode ?? "createNew") === "replaceExisting" && data.targetId) {
+      await assertModuleOwnership(data.targetId, actorId, request.context?.roles ?? []);
+    }
     // Cast through unknown: zod-inferred OUTPUT types from the import side and the
     // schema-builder side are structurally identical but nominally unrelated when
     // they cross module boundaries via different re-export chains. Runtime payload


### PR DESCRIPTION
### Motivation
- Close an authorization gap where `replaceExisting` imports could attach imported versions to arbitrary `targetId` values and, combined with auto-publish, let non-owners make live changes to another user's module. 
- Ensure imported content cannot bypass the normal publish path ownership and pre-publish validation gates by enforcing the same ownership constraints as the explicit publish endpoint.

### Description
- Added an ownership assertion in the import route: when `(data.mode ?? "createNew") === "replaceExisting" && data.targetId` the route calls `assertModuleOwnership(data.targetId, actorId, request.context?.roles ?? [])` before proceeding with `importModuleFromEnvelope` in `src/routes/adminContent.ts`.
- Bumped the application version from `1.1.63` to `1.1.64` in `package.json` per repository policy. 
- Added a `1.1.64` entry to `doc/VERSIONS.md` documenting the security fix. 
- Files changed: `src/routes/adminContent.ts`, `package.json`, and `doc/VERSIONS.md`.

### Testing
- Attempted to run the focused integration test `npm test -- test/m2-content-export-import.test.ts`, but the test preflight requires Docker for a local Postgres instance and the run failed in this environment with an error stating Docker is required, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0de718c1ec832db02a1101a036aaff)