### PR TITLE
docs(course): API + route-map + brukerguide for læringsseksjoner (#521, #522)

### DIFF
--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -49,6 +49,20 @@ See [DOMAIN_LIFECYCLE.md](DOMAIN_LIFECYCLE.md) for the full ownership model.
 
 ---
 
+## Courses (participant)
+
+All routes use the `courses` capability: PARTICIPANT, SUBJECT_MATTER_OWNER, ADMINISTRATOR, APPEAL_HANDLER, REPORT_READER, REVIEWER.
+
+| Method | Route | Description |
+|---|---|---|
+| `GET` | `/api/courses` | Published courses with progress. `progress.total` counts **all elements** (modules + learning sections); `completed` = passed modules + read sections. |
+| `GET` | `/api/courses/completions` | The user's course completions / certificates |
+| `GET` | `/api/courses/:courseId` | Course detail. Returns `modules[]` (legacy) and `items[]` — the ordered mixed module/section sequence; SECTION items carry a `read` flag (#491/#492). |
+| `GET` | `/api/courses/:courseId/sections/:sectionId` | Sanitised HTML + title of a learning section in the participant's locale. Validates the section belongs to the published course (#491). |
+| `POST` | `/api/courses/:courseId/sections/:sectionId/read` | Mark a section as read (idempotent). `204` on success (#492). |
+
+---
+
 ## Manual Review
 
 | Method | Route | Role(s) |
@@ -118,6 +132,44 @@ See [DOMAIN_LIFECYCLE.md](DOMAIN_LIFECYCLE.md) for the full ownership model.
 
 ---
 
+## Admin - Courses & Learning Sections
+
+All routes use the `admin_content` capability: ADMINISTRATOR, SUBJECT_MATTER_OWNER. Localized
+fields (`title`, `bodyMarkdown`) accept a string or a partial `{en-GB,nb,nn}` object.
+
+### Courses
+
+| Method | Route | Description |
+|---|---|---|
+| `GET` | `/api/admin/content/courses` | List courses (with module count) |
+| `POST` | `/api/admin/content/courses` | Create a course |
+| `GET` | `/api/admin/content/courses/:courseId` | Course detail (modules) |
+| `PUT` | `/api/admin/content/courses/:courseId` | Update course metadata |
+| `PUT` | `/api/admin/content/courses/:courseId/modules` | Set module list (legacy; dual-writes CourseItem) |
+| `GET` | `/api/admin/content/courses/:courseId/items` | Read the ordered mixed module/section sequence (#486/B2) |
+| `PUT` | `/api/admin/content/courses/:courseId/items` | Set the ordered sequence — body `{ items: [{type:"MODULE",moduleId} \| {type:"SECTION",sectionId}] }`. Re-syncs CourseModule (#486). |
+| `POST` | `/api/admin/content/courses/:courseId/publish` | Publish course |
+| `POST` | `/api/admin/content/courses/:courseId/archive` | Archive course |
+| `POST` | `/api/admin/content/courses/:courseId/localize-copy` | LLM-translate course title/description |
+| `GET` | `/api/admin/content/courses/:courseId/export-package` | Export envelope (inlines modules **and** sections in order, #512) |
+| `POST` | `/api/admin/content/courses/import` | Import a course envelope (recreates sections via `items`, falls back to modules-only v1) |
+| `DELETE` | `/api/admin/content/courses/:courseId` | Delete course |
+
+### Learning sections (#476)
+
+| Method | Route | Description |
+|---|---|---|
+| `POST` | `/api/admin/content/sections` | Create a section (`title` + `bodyMarkdown`) → section + version 1 |
+| `GET` | `/api/admin/content/sections` | List sections |
+| `GET` | `/api/admin/content/sections/:sectionId` | Section detail (active version's `bodyMarkdown`) |
+| `PATCH` | `/api/admin/content/sections/:sectionId/title` | Update title |
+| `PUT` | `/api/admin/content/sections/:sectionId/content` | Publish a new immutable content version (latest-wins) |
+| `DELETE` | `/api/admin/content/sections/:sectionId` | Delete (blocked `400` if the section is used in a course) |
+| `POST` | `/api/admin/content/sections/preview` | Render markdown → sanitised HTML (same F3/X1 policy as participant view) |
+| `POST` | `/api/admin/content/sections/localize` | LLM-translate title + bodyMarkdown to another locale (markdown-preserving). Rate-limited. |
+
+---
+
 ## Admin - Modules
 
 | Method | Route | Role(s) |
@@ -156,6 +208,8 @@ These URLs are not role-gated by Express itself; access is enforced by the authe
 | `/review` | REVIEWER, APPEAL_HANDLER, ADMINISTRATOR |
 | `/calibration` | Runtime-configurable via `calibrationWorkspace.accessRoles` (default SUBJECT_MATTER_OWNER, ADMINISTRATOR) |
 | `/admin-content` | SUBJECT_MATTER_OWNER, ADMINISTRATOR |
+| `/admin-content/courses` (+ `/courses/new`, `/courses/:id`) | SUBJECT_MATTER_OWNER, ADMINISTRATOR |
+| `/admin-content/sections` | SUBJECT_MATTER_OWNER, ADMINISTRATOR |
 | `/results` | SUBJECT_MATTER_OWNER, ADMINISTRATOR, REPORT_READER |
 | `/profile` | any authenticated |
 | `/admin-platform` | ADMINISTRATOR |

--- a/doc/LEARNING_SECTIONS_GUIDE.md
+++ b/doc/LEARNING_SECTIONS_GUIDE.md
@@ -1,0 +1,77 @@
+# Læringsseksjoner — brukerguide
+
+> Bruker- og forfatterveiledning for læringsseksjoner i kurs (#476). Teknisk referanse:
+> [API_REFERENCE.md](API_REFERENCE.md); design/IA: [DESIGN_476_LMS_SECTIONS_IA.md](DESIGN_476_LMS_SECTIONS_IA.md).
+
+## Hva er en læringsseksjon?
+
+En **læringsseksjon** er lesestoff (markdown med tekst, bilder, lenker og evt. embedded video)
+som kan legges **mellom moduler i et kurs**. Der en modul tester og vurderer deltakeren, er en
+seksjon innhold deltakeren leser før hen går videre. Seksjoner er **gjenbrukbare** — samme
+seksjon kan brukes i flere kurs (et bibliotek, slik moduler fungerer).
+
+Et kurs blir dermed et **forløp** av elementer: moduler (vurdert) og seksjoner (lest), i den
+rekkefølgen forfatteren bestemmer.
+
+---
+
+## For forfattere (SMO/administrator)
+
+### 1. Opprett eller rediger en seksjon
+
+1. Gå til **Innholdsforvaltning → Seksjoner**.
+2. **«+ Ny seksjon»** (eller **«Rediger»** på en eksisterende).
+3. Skriv en **tittel** og innholdet i **Markdown**-feltet. **Forhåndsvisningen** til høyre
+   viser hvordan deltakeren ser det (samme sanitisering som i deltaker-visningen).
+4. Klikk **«Lagre ny versjon»**. Hver lagring oppretter en ny, immutabel versjon — historiske
+   visninger påvirkes ikke (siste versjon vises til nye lesere).
+
+> **Tips — markdown:** overskrifter (`#`), lister, **fet**/_kursiv_, lenker `[tekst](url)`,
+> bilder og kodeblokker støttes. Skript og utrygge elementer fjernes automatisk.
+
+### 2. Flere språk (nb / nn / en-GB)
+
+- Bruk **språk-fanene** øverst i editoren til å skrive hvert språk manuelt.
+- **«Oversett fra dette språket»** bruker KI til å oversette tittel + innhold til de andre
+  språkene (markdown bevares). **Se alltid over** resultatet før du lagrer — du eier teksten;
+  oversettelse er et utgangspunkt, ikke en automatisk sannhet.
+- En deltaker ser seksjonen på sitt profilspråk; mangler et språk, faller visningen tilbake til
+  et utfylt språk (aldri tomt).
+
+### 3. Embedded video
+
+Du kan lime inn en `<iframe>` mot **betrodde video-verter** (YouTube, youtube-nocookie, Vimeo).
+Andre iframes fjernes av sikkerhetshensyn.
+
+### 4. Legg seksjonen inn i et kurs
+
+1. **Innholdsforvaltning → Kurs** → åpne kurset.
+2. Under **«Innhold i kurset»**: bruk nedtrekkslista nederst og **«Legg til seksjon»** (velg fra
+   biblioteket). Seksjoner vises med **blått [SEKSJON]-merke**, moduler med [MODUL].
+3. Bruk **↑/↓** for å plassere seksjonen i ønsket rekkefølge mellom modulene.
+4. **«Lagre kurs»**, deretter **«Publiser kurs»**.
+
+### 5. Eksport / import
+
+Kurs-eksport (**«Eksporter»** på et kurs) tar med seksjonene og rekkefølgen i pakkefila, og
+**«Importer kurs-pakke»** gjenskaper dem i målmiljøet. (Eldre pakker uten seksjoner importeres
+fortsatt.)
+
+---
+
+## For deltakere
+
+- I et kurs vises seksjoner i forløpet med **«Les»** og et **«Ikke lest»/«Lest»**-merke.
+- Klikk en seksjon → innholdet åpnes i en lesevisning (mobilvennlig).
+- Klikk **«Marker som lest»** når du er ferdig → seksjonen telles som fullført.
+- **Fremdrift** teller **alle elementer**: en seksjon som er lest og en modul som er bestått
+  teller likt mot «X/Y fullført».
+
+---
+
+## Begrensninger / på vei
+
+- **Bilde-opplasting** (`{{asset:...}}`) i seksjoner er under arbeid (#483/#489) — foreløpig
+  refereres bilder via URL.
+- **Versjons-pinning per deltaker** (at en deltaker midt i kurset beholder en bestemt versjon)
+  kommer senere; nå vises siste versjon.

--- a/doc/route-map.md
+++ b/doc/route-map.md
@@ -11,7 +11,9 @@ This map covers all admin-content entry points and their status for pilot. Use i
 | `/admin-content/module/:moduleId/advanced` | Module — advanced editor | `admin-content-advanced.html` | **Canonical** |
 | `/admin-content/courses` | Course list | `admin-content-courses.html` | **Canonical** |
 | `/admin-content/courses/new` | New course (conversational flow) | `admin-content-courses.html` | **Canonical** |
-| `/admin-content/courses/:courseId` | Course detail | `admin-content-courses.html` | **Canonical** |
+| `/admin-content/courses/:courseId` | Course detail (builder: mixed modules + sections) | `admin-content-courses.html` | **Canonical** |
+| `/admin-content/sections` | Learning sections library + editor (#476) | `admin-content-sections.html` | **Canonical** |
+| `/admin-content/sections?id=<id>` or `?new` | Section editor (open existing / new) | `admin-content-sections.html` | **Canonical** |
 | `/admin-content/calibration` | Calibration workspace | `admin-content-calibration.html` | **Canonical** |
 
 ### Legacy routes (present during pilot, not primary)
@@ -44,11 +46,11 @@ The conversational and advanced editors are two modes of the same module workspa
 | `/api/submissions` | Participant | Submit work, view results, file appeals |
 | `/api/assessments` | Participant | Trigger assessment, poll job status |
 | `/api/modules` | Participant | Browse available modules, run MCQ |
-| `/api/courses` | Participant | Browse enrolled courses |
+| `/api/courses` | Participant | Browse courses; read learning sections + mark read (#476) |
 | `/api/me` | All | Current user identity and roles |
 | `/api/reviews` | Reviewer / Admin | Manual review queue and override |
 | `/api/appeals` | Appeal Handler / Admin | Appeal queue and resolution |
-| `/api/admin/content` | SMO / Admin | Module and course content management |
+| `/api/admin/content` | SMO / Admin | Module, course, and learning-section content management |
 | `/api/admin/platform` | Admin | Platform administration |
 | `/participant/config` | Public (rate-limited) | Participant console bootstrap config |
 | `/healthz` | Public | Health check (no version info) |


### PR DESCRIPTION
Lukker dokumentasjons-gapet for seksjons-funksjonaliteten (per den nye stående ordren om obligatorisk dok).

**Teknisk (#521):**
- `API_REFERENCE.md`: ny **Courses (participant)**-seksjon (kurs-endepunktene var udokumentert fra før) inkl. seksjon-innhold + mark-read; ny **Admin - Courses & Learning Sections**-gruppe (seksjon-CRUD, `/items`, preview, localize, export/import); seksjons-sider i Workspace UIs.
- `route-map.md`: `/admin-content/sections`-sidene + oppdaterte base-paths.

**Bruker (#522):**
- Ny `doc/LEARNING_SECTIONS_GUIDE.md`: forfatter (opprett/rediger, språk + KI-oversettelse, video, legg i kurs, eksport/import) + deltaker (les, marker som lest, fremdrift) + begrensninger.

Ren dokumentasjon — ingen kode/runtime-endring.

Closes #521
Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)