### PR TITLE
feat(course): asset-opplasting backend — F4 fase 2 (v1.3.17, #483)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ doc/pentest/PENTEST-*.md
 .claude/worktrees/
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+
+# Local course-asset storage fallback (dev/test)
+.course-assets-local/

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,26 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.17 - 2026-06-17
+
+feat(course): asset-opplasting backend — F4 fase 2 (#483)
+
+Backend for bilde-/asset-opplasting til læringsseksjoner. Bygger på fase 1-infra (#483, 1.3.16).
+
+- Ny `SectionAsset`-modell (sectionId, filename, mimeType, blobPath, sizeBytes) + migrering.
+- `assetStorage.ts`: blob-backend via web-app-MSI (`DefaultAzureCredential`, ingen nøkkel) når
+  `COURSE_ASSETS_BLOB_ENDPOINT` er satt; ellers **filsystem-fallback** for lokal/CI.
+- `POST /api/admin/content/sections/:id/assets` (multipart via multer; mime-allowlist **uten SVG**
+  pga XSS; 5 MB cap; feil → 400) + `GET .../assets` (liste).
+- Privat servering: `GET /api/content-assets/:id` (ny `content_assets`-kapabilitet — alle
+  autentiserte innholds-lesere) streamer blob via appen; aldri public blob-tilgang.
+- Resolver: `![alt](asset:<id>)` i markdown → `<img src="/api/content-assets/<id>">` ved render
+  (før sanitisering; portabelt for export/import-remapping).
+
+`@azure/storage-blob` + `@azure/identity` + `multer` i `dependencies`. Integrasjonstest
+(opplasting→liste→servering + mime-avvisning + 404) + resolver-unit-tester. `tsc` rent.
+Deployes app-only etter at fase 1-infra er oppe på staging. U2-UI = fase 3.
+
 ## 1.3.16 - 2026-06-17
 
 feat(infra): course-asset blob storage — F4 fase 1 (#483)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.2.38",
+  "version": "1.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a2-assessment-platform",
-      "version": "1.2.38",
+      "version": "1.3.16",
       "dependencies": {
         "@azure/communication-email": "^1.1.0",
+        "@azure/identity": "^4.13.1",
+        "@azure/storage-blob": "^12.32.0",
         "@mozilla/readability": "^0.6.0",
         "@prisma/client": "6.5.0",
         "dompurify": "^3.4.10",
@@ -19,6 +21,7 @@
         "jsdom": "^29.1.1",
         "mammoth": "^1.11.0",
         "marked": "^18.0.5",
+        "multer": "^2.2.0",
         "officeparser": "^6.1.0",
         "pdf-parse": "^2.4.5",
         "ppt": "^0.0.2",
@@ -34,6 +37,7 @@
         "@types/dompurify": "^3.0.5",
         "@types/express": "^5.0.1",
         "@types/jsdom": "^28.0.3",
+        "@types/multer": "^2.1.0",
         "@types/node": "^22.13.10",
         "@types/supertest": "^6.0.3",
         "dotenv-cli": "^8.0.0",
@@ -205,6 +209,22 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
+      "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@azure/core-client": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0"
+      }
+    },
     "node_modules/@azure/core-lro": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
@@ -214,6 +234,18 @@
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-util": "^1.2.0",
         "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "license": "MIT",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -264,6 +296,41 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@azure/core-xml": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.1.tgz",
+      "integrity": "sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.9",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@azure/logger": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
@@ -272,6 +339,85 @@
       "dependencies": {
         "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.14.0.tgz",
+      "integrity": "sha512-Dfl7hPZe9/JJwRhFFXHq2z1oHYBuGubmff3kWXOsd1AGgyXlqjNYAWuN/1JL/ZrcZBs8TKMjGSil6Rcc7E8VPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.9.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.9.0.tgz",
+      "integrity": "sha512-1MWGjqgUCRAYgLmVFZKp7fs3Rg1TFvIMgywY8ze2olNVvLlJoRThuoziWSDJuwwyJI5L4rnLb9Tyt5D9GvSLPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.5.tgz",
+      "integrity": "sha512-RUuewWk9JvWJS5Yiy8/74Lm1rQAWlrU/qg/Bgtk1jIauVRtnb9XKwS5Xg0J+Whwjesq9EVrBIFgQEP8vHxgezA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.9.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@azure/storage-blob": {
+      "version": "12.32.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.32.0.tgz",
+      "integrity": "sha512-80LzSNnFQye2LCCBFghAJS6jJQJ7N4bfgZ6qDMgVGRtugZ7TLDKQZ2hczMigmZH3jAcMRdma/IygsC5+0gT7Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.3",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.5",
+        "@azure/logger": "^1.1.4",
+        "@azure/storage-common": "^12.4.0",
+        "events": "^3.0.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-common": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.4.0.tgz",
+      "integrity": "sha512-kNhJKMxQb374KOVt63CZnGIpDcrKNzJeyANLJymxE9mCJSdRGzb+Iv9oSIiCj6tNMLypr530b9ObOiA/5OvwOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.1.4",
+        "events": "^3.3.0",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1134,6 +1280,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -1778,6 +1936,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
@@ -2065,6 +2233,24 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2198,11 +2384,43 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2532,6 +2750,46 @@
         "node": ">=6"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2663,6 +2921,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -2932,6 +3199,45 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.2.tgz",
+      "integrity": "sha512-DYPkXnVSJHAGAkSBeVYhEo/seIpz2SLr9OQcX7m6lXaX3gvoB+DCKzFdZIEhZGI3I1DUhObBAUOT/v2xfoXz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^1.0.1",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.4.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
@@ -3325,10 +3631,55 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-unsafe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/is-url": {
@@ -3336,6 +3687,21 @@
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -3453,6 +3819,34 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -3463,6 +3857,27 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jwt-decode": {
@@ -3482,6 +3897,48 @@
       "dependencies": {
         "immediate": "~3.0.5"
       }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/lop": {
       "version": "0.4.2",
@@ -3656,6 +4113,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -4020,6 +4496,24 @@
         "wrappy": "1"
       }
     },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/opencollective-postinstall": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
@@ -4060,6 +4554,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -4443,6 +4952,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4476,6 +4997,18 @@
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -4678,6 +5211,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -4692,6 +5233,21 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/strtok3": {
       "version": "10.3.5",
@@ -5804,6 +6360,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -5811,6 +6382,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",
@@ -56,6 +56,8 @@
   },
   "dependencies": {
     "@azure/communication-email": "^1.1.0",
+    "@azure/identity": "^4.13.1",
+    "@azure/storage-blob": "^12.32.0",
     "@mozilla/readability": "^0.6.0",
     "@prisma/client": "6.5.0",
     "dompurify": "^3.4.10",
@@ -66,6 +68,7 @@
     "jsdom": "^29.1.1",
     "mammoth": "^1.11.0",
     "marked": "^18.0.5",
+    "multer": "^2.2.0",
     "officeparser": "^6.1.0",
     "pdf-parse": "^2.4.5",
     "ppt": "^0.0.2",
@@ -81,6 +84,7 @@
     "@types/dompurify": "^3.0.5",
     "@types/express": "^5.0.1",
     "@types/jsdom": "^28.0.3",
+    "@types/multer": "^2.1.0",
     "@types/node": "^22.13.10",
     "@types/supertest": "^6.0.3",
     "dotenv-cli": "^8.0.0",

--- a/prisma/migrations/20260617000001_add_section_asset/migration.sql
+++ b/prisma/migrations/20260617000001_add_section_asset/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "SectionAsset" (
+    "id" TEXT NOT NULL,
+    "sectionId" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "blobPath" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SectionAsset_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SectionAsset_sectionId_idx" ON "SectionAsset"("sectionId");
+
+-- AddForeignKey
+ALTER TABLE "SectionAsset" ADD CONSTRAINT "SectionAsset_sectionId_fkey" FOREIGN KEY ("sectionId") REFERENCES "CourseSection"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -505,6 +505,24 @@ model CourseSection {
   activeVersion   CourseSectionVersion?  @relation("ActiveCourseSectionVersion", fields: [activeVersionId], references: [id], onDelete: SetNull)
   courseItems     CourseItem[]
   reads           CourseSectionRead[]
+  assets          SectionAsset[]
+}
+
+// Media-asset (bilde) for en læringsseksjon (#483/F4). Binæren ligger i Azure Blob
+// (privat container); denne raden er metadata + blob-sti. Refereres fra markdown via
+// `asset:<id>`-URL i et vanlig bilde (`![alt](asset:<id>)`), som resolves til serve-
+// endepunktet ved render.
+model SectionAsset {
+  id        String        @id @default(cuid())
+  sectionId String
+  filename  String
+  mimeType  String
+  blobPath  String
+  sizeBytes Int
+  createdAt DateTime      @default(now())
+  section   CourseSection @relation(fields: [sectionId], references: [id], onDelete: Cascade)
+
+  @@index([sectionId])
 }
 
 // Per-deltaker lese-markering av en læringsseksjon i et kurs (#487/#492). Moduler

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import { errorHandlingMiddleware } from "./middleware/errorHandling.js";
 import { requireConsent } from "./middleware/consentMiddleware.js";
 import { meRouter } from "./routes/me.js";
 import { coursesRouter } from "./routes/courses.js";
+import { contentAssetsRouter } from "./routes/contentAssets.js";
 import { modulesRouter } from "./routes/modules.js";
 import { submissionsRouter } from "./routes/submissions.js";
 import { assessmentsRouter } from "./routes/assessments.js";
@@ -141,6 +142,7 @@ app.use("/api", authenticate, generalApiLimiter, requireConsent);
 
 app.use("/api/me", meRouter);
 app.use("/api/courses", requireAnyRole(rolesFor("courses")), coursesRouter);
+app.use("/api/content-assets", requireAnyRole(rolesFor("content_assets")), contentAssetsRouter);
 app.use("/api/modules", requireAnyRole(rolesFor("modules")), modulesRouter);
 app.use("/api/submissions", requireAnyRole(rolesFor("submissions")), submissionsRouter);
 app.use("/api/assessments", requireAnyRole(rolesFor("assessments")), assessmentsRouter);

--- a/src/config/capabilities.ts
+++ b/src/config/capabilities.ts
@@ -46,6 +46,20 @@ export const API_ROUTE_CAPABILITIES = [
     ],
   },
   {
+    // Serve learning-section media assets (#483/F4) to any authenticated content viewer —
+    // participants (in published-course sections) and authors (editor preview).
+    id: "content_assets",
+    prefix: "/api/content-assets",
+    roles: [
+      AppRole.PARTICIPANT,
+      AppRole.SUBJECT_MATTER_OWNER,
+      AppRole.ADMINISTRATOR,
+      AppRole.APPEAL_HANDLER,
+      AppRole.REPORT_READER,
+      AppRole.REVIEWER,
+    ],
+  },
+  {
     id: "submissions",
     prefix: "/api/submissions",
     roles: [AppRole.PARTICIPANT, AppRole.ADMINISTRATOR, AppRole.REVIEWER],

--- a/src/modules/course/assetCommands.ts
+++ b/src/modules/course/assetCommands.ts
@@ -1,0 +1,64 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "../../db/prisma.js";
+import { NotFoundError, ValidationError } from "../../errors/AppError.js";
+import { putAsset, getAsset } from "./assetStorage.js";
+
+// SVG is intentionally excluded — it can carry scripts (XSS). Raster images only (#483/F4).
+export const ALLOWED_ASSET_MIME_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+export const MAX_ASSET_BYTES = 5 * 1024 * 1024; // 5 MB
+
+export async function createSectionAsset(input: {
+  sectionId: string;
+  filename: string;
+  mimeType: string;
+  buffer: Buffer;
+}) {
+  const section = await prisma.courseSection.findUnique({
+    where: { id: input.sectionId },
+    select: { id: true },
+  });
+  if (!section) {
+    throw new NotFoundError("CourseSection", "section_not_found", "Course section not found.");
+  }
+  if (!ALLOWED_ASSET_MIME_TYPES.includes(input.mimeType)) {
+    throw new ValidationError(`Unsupported image type (${input.mimeType || "unknown"}). Allowed: PNG, JPEG, GIF, WebP.`);
+  }
+  if (input.buffer.byteLength > MAX_ASSET_BYTES) {
+    throw new ValidationError(`Image too large (${input.buffer.byteLength} bytes, max ${MAX_ASSET_BYTES}).`);
+  }
+
+  const safeName = (input.filename || "file").replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 100) || "file";
+  const blobPath = `sections/${input.sectionId}/${randomUUID()}-${safeName}`;
+
+  // Upload binary first; only persist metadata once the blob is stored. A failed upload
+  // leaves no row; a failed row-insert leaves an orphan blob (rare, tolerable for v1).
+  await putAsset(blobPath, input.buffer, input.mimeType);
+
+  return prisma.sectionAsset.create({
+    data: {
+      sectionId: input.sectionId,
+      filename: safeName,
+      mimeType: input.mimeType,
+      blobPath,
+      sizeBytes: input.buffer.byteLength,
+    },
+    select: { id: true, sectionId: true, filename: true, mimeType: true, sizeBytes: true },
+  });
+}
+
+export async function listSectionAssets(sectionId: string) {
+  return prisma.sectionAsset.findMany({
+    where: { sectionId },
+    orderBy: { createdAt: "asc" },
+    select: { id: true, filename: true, mimeType: true, sizeBytes: true },
+  });
+}
+
+export async function getSectionAssetContent(assetId: string): Promise<{ mimeType: string; filename: string; buffer: Buffer }> {
+  const asset = await prisma.sectionAsset.findUnique({ where: { id: assetId } });
+  if (!asset) {
+    throw new NotFoundError("SectionAsset", "asset_not_found", "Asset not found.");
+  }
+  const buffer = await getAsset(asset.blobPath);
+  return { mimeType: asset.mimeType, filename: asset.filename, buffer };
+}

--- a/src/modules/course/assetStorage.ts
+++ b/src/modules/course/assetStorage.ts
@@ -1,0 +1,42 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { BlobServiceClient, type ContainerClient } from "@azure/storage-blob";
+import { DefaultAzureCredential } from "@azure/identity";
+
+// Storage backend for course learning-section assets (#483/F4).
+// - In Azure (COURSE_ASSETS_BLOB_ENDPOINT set): private blob storage, authenticated via the
+//   web app's managed identity (DefaultAzureCredential) — no account key/SAS exists.
+// - Locally / in CI (no endpoint): filesystem fallback, so dev + tests work without Azure.
+
+const blobEndpoint = process.env.COURSE_ASSETS_BLOB_ENDPOINT;
+const containerName = process.env.COURSE_ASSETS_CONTAINER ?? "course-assets";
+const localDir = process.env.COURSE_ASSETS_LOCAL_DIR ?? path.resolve(process.cwd(), ".course-assets-local");
+
+export const assetStorageMode: "blob" | "local" = blobEndpoint ? "blob" : "local";
+
+let containerClient: ContainerClient | null = null;
+function getContainerClient(): ContainerClient {
+  if (!containerClient) {
+    const service = new BlobServiceClient(blobEndpoint as string, new DefaultAzureCredential());
+    containerClient = service.getContainerClient(containerName);
+  }
+  return containerClient;
+}
+
+export async function putAsset(blobPath: string, buffer: Buffer, contentType: string): Promise<void> {
+  if (assetStorageMode === "blob") {
+    const block = getContainerClient().getBlockBlobClient(blobPath);
+    await block.uploadData(buffer, { blobHTTPHeaders: { blobContentType: contentType } });
+    return;
+  }
+  const full = path.join(localDir, blobPath);
+  await fs.mkdir(path.dirname(full), { recursive: true });
+  await fs.writeFile(full, buffer);
+}
+
+export async function getAsset(blobPath: string): Promise<Buffer> {
+  if (assetStorageMode === "blob") {
+    return getContainerClient().getBlockBlobClient(blobPath).downloadToBuffer();
+  }
+  return fs.readFile(path.join(localDir, blobPath));
+}

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -10,6 +10,13 @@ export {
   listSections,
   deleteSection,
 } from "./sectionCommands.js";
+export {
+  createSectionAsset,
+  listSectionAssets,
+  getSectionAssetContent,
+  ALLOWED_ASSET_MIME_TYPES,
+  MAX_ASSET_BYTES,
+} from "./assetCommands.js";
 export { courseRepository, createCourseRepository } from "./courseRepository.js";
 export { computeCourseStatus } from "./courseQueries.js";
 export type {

--- a/src/modules/course/sectionContent.ts
+++ b/src/modules/course/sectionContent.ts
@@ -73,6 +73,14 @@ export function sanitizeSectionHtml(html: string): string {
   });
 }
 
+// Rewrites `asset:<id>` image sources (authored as `![alt](asset:<id>)`, #483/F4) to the
+// authenticated serve endpoint. Runs BEFORE sanitisation so DOMPurify sees a normal relative
+// URL (the `asset:` scheme would otherwise be stripped as an unknown protocol). The indirection
+// keeps references portable for cross-environment export/import (ids can be remapped).
+function resolveAssetUrls(html: string): string {
+  return html.replace(/(<img\b[^>]*\bsrc=")asset:([a-zA-Z0-9]+)(")/gi, "$1/api/content-assets/$2$3");
+}
+
 /**
  * Renders SMO-authored markdown to sanitised HTML safe to inject into the
  * participant view. Returns an empty string for empty / non-string input.
@@ -80,5 +88,5 @@ export function sanitizeSectionHtml(html: string): string {
 export function renderSectionMarkdown(markdownInput: string): string {
   if (typeof markdownInput !== "string" || markdownInput.length === 0) return "";
   const rawHtml = marked.parse(markdownInput, { async: false }) as string;
-  return sanitizeSectionHtml(rawHtml);
+  return sanitizeSectionHtml(resolveAssetUrls(rawHtml));
 }

--- a/src/routes/adminSections.ts
+++ b/src/routes/adminSections.ts
@@ -1,4 +1,5 @@
-import { Router } from "express";
+import { Router, type Request, type RequestHandler } from "express";
+import multer from "multer";
 import { z } from "zod";
 import {
   createSection,
@@ -7,6 +8,9 @@ import {
   getSection,
   listSections,
   deleteSection,
+  createSectionAsset,
+  listSectionAssets,
+  MAX_ASSET_BYTES,
 } from "../modules/course/index.js";
 import { localizedTextPatchSchema, generationLocaleSchema } from "../modules/adminContent/adminContentSchemas.js";
 import { localizedTextCodec } from "../codecs/localizedTextCodec.js";
@@ -16,6 +20,21 @@ import { localizeSectionContent } from "../modules/adminContent/llmContentGenera
 import { generateLimiter } from "../middleware/rateLimiting.js";
 
 const adminSectionsRouter = Router();
+
+// In-memory upload (buffer streamed to blob). Multer errors (incl. file-too-large) → 400.
+const uploadAssetMiddleware = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_ASSET_BYTES, files: 1 },
+}).single("file");
+const uploadAsset: RequestHandler = (request, response, next) => {
+  uploadAssetMiddleware(request, response, (err: unknown) => {
+    if (err) {
+      response.status(400).json({ error: "upload_error", message: err instanceof Error ? err.message : "Upload failed." });
+      return;
+    }
+    next();
+  });
+};
 
 const createSectionSchema = z.object({
   title: localizedTextPatchSchema,
@@ -164,6 +183,35 @@ adminSectionsRouter.put("/:sectionId/content", async (request, response, next) =
       request.context?.userId,
     );
     response.json({ section: toDetail(section) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Asset upload (#483/F4) — multipart image upload to a section's blob storage.
+adminSectionsRouter.post("/:sectionId/assets", uploadAsset, async (request: Request<{ sectionId: string }>, response, next) => {
+  const file = request.file;
+  if (!file) {
+    response.status(400).json({ error: "validation_error", message: "Missing file (field name 'file')." });
+    return;
+  }
+  try {
+    const asset = await createSectionAsset({
+      sectionId: request.params.sectionId,
+      filename: file.originalname,
+      mimeType: file.mimetype,
+      buffer: file.buffer,
+    });
+    // The author references the asset in markdown as ![alt](asset:<id>).
+    response.status(201).json({ asset: { ...asset, ref: `asset:${asset.id}` } });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminSectionsRouter.get("/:sectionId/assets", async (request, response, next) => {
+  try {
+    response.json({ assets: await listSectionAssets(request.params.sectionId) });
   } catch (error) {
     next(error);
   }

--- a/src/routes/contentAssets.ts
+++ b/src/routes/contentAssets.ts
@@ -1,0 +1,24 @@
+import { Router } from "express";
+import { getSectionAssetContent } from "../modules/course/index.js";
+
+const contentAssetsRouter = Router();
+
+// Serve a learning-section media asset (#483/F4). The web app streams the blob from private
+// storage via its managed identity — assets are never publicly accessible. Referenced from
+// section markdown as `asset:<id>`, resolved to `/api/content-assets/<id>` at render time.
+contentAssetsRouter.get("/:assetId", async (request, response, next) => {
+  if (!request.context?.userId) {
+    response.status(401).json({ error: "unauthorized" });
+    return;
+  }
+  try {
+    const { mimeType, buffer } = await getSectionAssetContent(request.params.assetId);
+    response.setHeader("Content-Type", mimeType);
+    response.setHeader("Cache-Control", "private, max-age=3600");
+    response.send(buffer);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export { contentAssetsRouter };

--- a/test/m2-section-assets.test.ts
+++ b/test/m2-section-assets.test.ts
@@ -36,6 +36,14 @@ describe("Section asset upload + serve", () => {
     return res.body.section.id as string;
   }
 
+  // Sections can't be deleted while their version FK (Restrict) holds; detach + drop versions
+  // first. Assets cascade with the section.
+  async function deleteSectionFully(sectionId: string): Promise<void> {
+    await prisma.courseSection.update({ where: { id: sectionId }, data: { activeVersionId: null } });
+    await prisma.courseSectionVersion.deleteMany({ where: { sectionId } });
+    await prisma.courseSection.delete({ where: { id: sectionId } });
+  }
+
   it("uploads an image, lists it, and serves it back to a participant", async () => {
     const sectionId = await createSection();
 
@@ -61,7 +69,7 @@ describe("Section asset upload + serve", () => {
     expect(served.headers["content-type"]).toContain("image/png");
     expect(served.body.length).toBe(PNG_1PX.length);
 
-    await prisma.courseSection.delete({ where: { id: sectionId } });
+    await deleteSectionFully(sectionId);
   });
 
   it("rejects a disallowed mime type", async () => {
@@ -71,7 +79,7 @@ describe("Section asset upload + serve", () => {
       .set(adminHeaders)
       .attach("file", Buffer.from("hello"), { filename: "x.txt", contentType: "text/plain" });
     expect(res.status).toBe(400);
-    await prisma.courseSection.delete({ where: { id: sectionId } });
+    await deleteSectionFully(sectionId);
   });
 
   it("returns 404 for an unknown asset id", async () => {

--- a/test/m2-section-assets.test.ts
+++ b/test/m2-section-assets.test.ts
@@ -1,0 +1,81 @@
+import request from "supertest";
+import { afterAll, describe, expect, it } from "vitest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+
+const adminHeaders = {
+  "x-user-id": "admin-1",
+  "x-user-email": "admin@company.com",
+  "x-user-name": "Platform Admin",
+};
+const participantHeaders = {
+  "x-user-id": "participant-1",
+  "x-user-email": "participant@company.com",
+  "x-user-name": "Platform Participant",
+  "x-user-roles": "PARTICIPANT",
+};
+
+// 1x1 transparent PNG.
+const PNG_1PX = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+// #483/F4 — section asset upload + serve (filesystem fallback in CI; no Azure storage).
+describe("Section asset upload + serve", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  async function createSection(): Promise<string> {
+    const res = await request(app)
+      .post("/api/admin/content/sections")
+      .set(adminHeaders)
+      .send({ title: { nb: `Asset-seksjon ${Date.now()}` }, bodyMarkdown: { nb: "# Hei" } });
+    expect(res.status).toBe(201);
+    return res.body.section.id as string;
+  }
+
+  it("uploads an image, lists it, and serves it back to a participant", async () => {
+    const sectionId = await createSection();
+
+    const upload = await request(app)
+      .post(`/api/admin/content/sections/${sectionId}/assets`)
+      .set(adminHeaders)
+      .attach("file", PNG_1PX, { filename: "pixel.png", contentType: "image/png" });
+    expect(upload.status).toBe(201);
+    const assetId = upload.body.asset.id as string;
+    expect(upload.body.asset.ref).toBe(`asset:${assetId}`);
+
+    const list = await request(app)
+      .get(`/api/admin/content/sections/${sectionId}/assets`)
+      .set(adminHeaders);
+    expect(list.status).toBe(200);
+    expect((list.body.assets as Array<{ id: string }>).some((a) => a.id === assetId)).toBe(true);
+
+    // Served back (any authenticated content viewer, e.g. a participant).
+    const served = await request(app)
+      .get(`/api/content-assets/${assetId}`)
+      .set(participantHeaders);
+    expect(served.status).toBe(200);
+    expect(served.headers["content-type"]).toContain("image/png");
+    expect(served.body.length).toBe(PNG_1PX.length);
+
+    await prisma.courseSection.delete({ where: { id: sectionId } });
+  });
+
+  it("rejects a disallowed mime type", async () => {
+    const sectionId = await createSection();
+    const res = await request(app)
+      .post(`/api/admin/content/sections/${sectionId}/assets`)
+      .set(adminHeaders)
+      .attach("file", Buffer.from("hello"), { filename: "x.txt", contentType: "text/plain" });
+    expect(res.status).toBe(400);
+    await prisma.courseSection.delete({ where: { id: sectionId } });
+  });
+
+  it("returns 404 for an unknown asset id", async () => {
+    const res = await request(app).get("/api/content-assets/does-not-exist").set(participantHeaders);
+    expect(res.status).toBe(404);
+  });
+});

--- a/test/unit/section-content-markdown.test.ts
+++ b/test/unit/section-content-markdown.test.ts
@@ -92,3 +92,17 @@ describe("embedded video iframe allowlist (X1, #493)", () => {
     expect(ALLOWED_VIDEO_IFRAME_HOSTS).toContain("player.vimeo.com");
   });
 });
+
+describe("asset URL resolution (#483/F4)", () => {
+  it("rewrites asset:<id> image sources to the serve endpoint and keeps alt text", () => {
+    const html = renderSectionMarkdown("![Et bilde](asset:abc123XYZ)");
+    expect(html).toContain('src="/api/content-assets/abc123XYZ"');
+    expect(html).toContain('alt="Et bilde"');
+    expect(html).not.toContain("asset:abc123XYZ");
+  });
+
+  it("leaves normal https image URLs untouched", () => {
+    const html = renderSectionMarkdown("![x](https://a-2.no/f.png)");
+    expect(html).toContain('src="https://a-2.no/f.png"');
+  });
+});


### PR DESCRIPTION
Fase 2 (backend) av bilde-opplasting til læringsseksjoner. Bygger på fase 1-infra (#530, 1.3.16). **App-only** — deployes etter at fase 1-infra er oppe på staging.

- `SectionAsset`-modell + migrering.
- `assetStorage`: blob via web-app-MSI (`DefaultAzureCredential`, ingen nøkkel) når `COURSE_ASSETS_BLOB_ENDPOINT` er satt; ellers **filsystem-fallback** (lokal/CI).
- `POST /api/admin/content/sections/:id/assets` (multer multipart, mime-allowlist **uten SVG**, 5 MB cap, feil→400) + `GET .../assets`.
- **Privat servering** `GET /api/content-assets/:id` (ny `content_assets`-kapabilitet) — appen streamer blob via MSI, aldri public.
- Resolver: `![alt](asset:<id>)` → `<img src="/api/content-assets/<id>">` ved render (før sanitisering; portabelt for export/import).

`tsc` rent. Integrasjonstest (opplasting→liste→servering + mime-avvisning + 404, filsystem-fallback i CI) + resolver-unit-tester.

Del av #483 / #476 / #478. U2-UI = fase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)