### PR TITLE
fix(course): bilde-opplasting 500 — apiFetch FormData Content-Type (v1.3.19, #483)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,21 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.19 - 2026-06-19
+
+fix(course): bilde-opplasting 500 — apiFetch sendte FormData med JSON Content-Type (#483)
+
+Bilde-opplasting feilet med 500 fordi `buildConsoleHeaders` setter `Content-Type:
+application/json`, og `apiFetch` slo den inn i FormData-opplastingen. Nettleseren satte da ikke
+multipart-boundary, og server-ens `express.json()` prøvde å parse multipart-kroppen som JSON →
+`SyntaxError: Unexpected token '-', "------WebK"...` → 500 (før requesten nådde multer/blob).
+
+Fiks: `apiFetch` stripper nå `Content-Type` når `body` er `FormData`, så nettleseren setter
+`multipart/form-data` med boundary selv. Klient-only.
+
+CI fanget det ikke fordi integrasjonstesten bruker supertest `.attach` (korrekt multipart) i
+stedet for `apiFetch` — nettopp UI-opplastings-gapet sporet i #524.
+
 ## 1.3.18 - 2026-06-17
 
 feat(course): bilde-opplasting i seksjons-editor — U2 fase 3 (#489)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/api-client.js
+++ b/public/api-client.js
@@ -145,9 +145,18 @@ export async function apiFetch(url, getHeadersOrOptions = {}, maybeOptions = {})
     baseHeaders["Authorization"] = `Bearer ${token}`;
   }
 
+  const headers = { ...baseHeaders, ...(options.headers ?? {}) };
+  // For multipart/FormData uploads the browser must set Content-Type (with the
+  // boundary) itself. buildConsoleHeaders injects "application/json", which would
+  // otherwise make the server parse the multipart body as JSON and 500 (#483/F4).
+  if (typeof FormData !== "undefined" && options.body instanceof FormData) {
+    delete headers["Content-Type"];
+    delete headers["content-type"];
+  }
+
   const response = await fetch(url, {
     ...options,
-    headers: { ...baseHeaders, ...(options.headers ?? {}) },
+    headers,
   });
 
   const body = await parseResponseBody(response);


### PR DESCRIPTION
**Rotårsak:** `buildConsoleHeaders` setter `Content-Type: application/json`, og `apiFetch` slo den inn i FormData-bilde-opplastingen. Nettleseren satte da ikke multipart-boundary → server-ens `express.json()` parset multipart-kroppen som JSON → `SyntaxError: Unexpected token '-', "------WebK"…` → 500 (før requesten nådde multer/blob).

**Fiks:** `apiFetch` stripper `Content-Type` når `body instanceof FormData`, så nettleseren setter `multipart/form-data` med boundary selv. Klient-only.

**Hvorfor CI ikke fanget det:** integrasjonstesten (`m2-section-assets`) bruker supertest `.attach` (korrekt multipart) i stedet for `apiFetch` — nettopp UI-opplastings-gapet sporet i #524. Diagnostisert fra staging-loggen (unhandled_error-stack).

Funnet under staging-test av F4/U2; ingen prod-påvirkning (prod på v1.2.38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)