### PR TITLE
fix(course): rendre asset-bilder i preview + deltaker-visning (v1.3.20, #483)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,22 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.20 - 2026-06-19
+
+fix(course): asset-bilder rendres nå i preview + deltaker-visning (#483)
+
+Etter at opplastings-500-en (1.3.19) var løst, ble bildet satt inn men vist brutt: resolver-en
+lager `<img src="/api/content-assets/<id>">`, men et plain `<img>` kan ikke bære Bearer/console-
+auth-headerne — serve-endepunktet svarte 401 → brutt bilde. (CSP-en manglet også `blob:`.)
+
+- Ny `hydrateContentAssetImages(root, getHeaders)` i `api-client.js`: henter hvert
+  `/api/content-assets/`-bilde via autentisert `fetch` og bytter til en lokal `blob:`-URL.
+  Kalles etter render i seksjons-editorens preview + deltaker-leseren.
+- CSP `img-src` utvidet med `blob:` (lokalt generert av vår egen JS; ingen ekstern last-vektor).
+
+Klient + én CSP-direktiv. Regresjonsvakt i `security-headers.test.ts` (img-src blob:). `tsc` +
+`node --check` rene. App-only deploy.
+
 ## 1.3.19 - 2026-06-19
 
 fix(course): bilde-opplasting 500 — apiFetch sendte FormData med JSON Content-Type (#483)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/api-client.js
+++ b/public/api-client.js
@@ -167,6 +167,37 @@ export async function apiFetch(url, getHeadersOrOptions = {}, maybeOptions = {})
   return body;
 }
 
+// Loads private course-asset images (#483/F4). A plain <img src="/api/content-assets/<id>">
+// can't carry the Bearer/console auth headers, so the server returns 401 and the image breaks.
+// This fetches each such image WITH the authenticated headers and swaps in an object URL.
+// Call after injecting rendered section HTML (editor preview + participant reader).
+export async function hydrateContentAssetImages(root, getHeadersOrFn) {
+  if (!root || typeof root.querySelectorAll !== "function") return;
+  const images = Array.from(root.querySelectorAll('img[src^="/api/content-assets/"]'));
+  if (images.length === 0) return;
+
+  const baseHeaders = typeof getHeadersOrFn === "function" ? { ...getHeadersOrFn() } : { ...(getHeadersOrFn ?? {}) };
+  delete baseHeaders["Content-Type"];
+  delete baseHeaders["content-type"];
+  const token = await getAccessToken();
+  if (token) baseHeaders["Authorization"] = `Bearer ${token}`;
+
+  await Promise.all(
+    images.map(async (img) => {
+      const src = img.getAttribute("src");
+      if (!src) return;
+      try {
+        const response = await fetch(src, { headers: baseHeaders });
+        if (!response.ok) return;
+        const blob = await response.blob();
+        img.src = URL.createObjectURL(blob);
+      } catch {
+        /* leave the broken image; non-fatal */
+      }
+    }),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Queue counts — nav badge helper
 // ---------------------------------------------------------------------------

--- a/public/participant.js
+++ b/public/participant.js
@@ -1,5 +1,5 @@
 import { localeLabels, supportedLocales, translations } from "/static/i18n/participant-translations.js";
-import { apiFetch, buildConsoleHeaders, getConsoleConfig, fetchQueueCounts, applyNavReviewBadge } from "/static/api-client.js";
+import { apiFetch, buildConsoleHeaders, getConsoleConfig, fetchQueueCounts, applyNavReviewBadge, hydrateContentAssetImages } from "/static/api-client.js";
 import { initConsentGuard } from "/static/consent-guard.js";
 import { hideLoading, showEmpty, showLoading } from "/static/loading.js";
 import { showToast } from "/static/toast.js";
@@ -2881,7 +2881,11 @@ async function openSectionReader(courseId, sectionId) {
     const bodyEl = overlay.querySelector("#sectionReaderBody");
     if (titleEl) titleEl.textContent = body.title ?? "";
     // body.html is already sanitised server-side with the F3/X1 policy.
-    if (bodyEl) bodyEl.innerHTML = body.html ?? "";
+    if (bodyEl) {
+      bodyEl.innerHTML = body.html ?? "";
+      // Private asset images can't carry auth headers as a plain <img>; hydrate them.
+      await hydrateContentAssetImages(bodyEl, headers);
+    }
   } catch (error) {
     const bodyEl = overlay.querySelector("#sectionReaderBody");
     if (bodyEl) bodyEl.textContent = error instanceof Error ? error.message : t("courses.loadError");

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -3,7 +3,7 @@ import {
   localeLabels,
   translations as adminContentTranslations,
 } from "/static/i18n/admin-content-translations.js";
-import { apiFetch, buildConsoleHeaders, getConsoleConfig } from "/static/api-client.js";
+import { apiFetch, buildConsoleHeaders, getConsoleConfig, hydrateContentAssetImages } from "/static/api-client.js";
 import { resolveWorkspaceNavigationItems } from "/static/participant-console-state.js";
 import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
 import { showToast } from "/static/toast.js";
@@ -284,6 +284,7 @@ async function refreshPreview() {
       body: JSON.stringify({ markdown: editing.body[editing.editLocale] ?? "" }),
     });
     pane.innerHTML = data.html ?? "";
+    await hydrateContentAssetImages(pane, getHeaders);
   } catch {
     /* leave previous preview on transient error */
   }

--- a/src/middleware/securityHeaders.ts
+++ b/src/middleware/securityHeaders.ts
@@ -10,13 +10,15 @@ import type { NextFunction, Request, Response } from "express";
 //   style="..." attributes. Style injection is far lower risk than script injection.
 // - connect-src / frame-src / form-action allow the Entra (Microsoft) login origin so
 //   MSAL's silent-token iframe, token fetches, and redirect login keep working.
-// - blob: is intentionally NOT listed: the only blob: usage is <a download> CSV/JSON
-//   exports, which are downloads (not CSP-governed resource loads).
+// - img-src allows blob: so course-section asset images (#483/F4) can render: a plain
+//   <img src="/api/content-assets/<id>"> can't carry the auth headers the endpoint requires,
+//   so the client fetches each image with auth and swaps in a locally-created blob: URL.
+//   blob: is same-origin and only constructable by our own JS — no external load vector.
 const CONTENT_SECURITY_POLICY = [
   "default-src 'self'",
   "script-src 'self'",
   "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' data:",
+  "img-src 'self' data: blob:",
   "font-src 'self'",
   "connect-src 'self' https://login.microsoftonline.com https://*.microsoftonline.com",
   "frame-src https://login.microsoftonline.com https://*.microsoftonline.com",

--- a/test/unit/security-headers.test.ts
+++ b/test/unit/security-headers.test.ts
@@ -20,6 +20,8 @@ describe("securityHeadersMiddleware", () => {
     expect(csp).toBeDefined();
     expect(csp).toContain("default-src 'self'");
     expect(csp).toContain("script-src 'self'");
+    // blob: is required so authenticated course-asset images can render (#483/F4).
+    expect(csp).toContain("img-src 'self' data: blob:");
     expect(csp).toContain("object-src 'none'");
     expect(csp).toContain("frame-ancestors 'none'");
   });


### PR DESCRIPTION
Andre del av bilde-fiksen (1.3.19 løste opplastings-500; dette fikser at bildet vises **brutt**).

**Rotårsak:** resolver lager `<img src="/api/content-assets/<id>">`, men et plain `<img>` kan ikke bære Bearer/console-auth-headerne apiFetch legger på → serve-endepunktet svarer 401 → brutt bilde. CSP-en manglet også `blob:`.

**Fiks:**
- `hydrateContentAssetImages(root, getHeaders)` (api-client.js): henter hvert `/api/content-assets/`-bilde via autentisert `fetch` → lokal `blob:`-URL. Kalles etter render i seksjons-editorens preview + deltaker-leseren.
- CSP `img-src` += `blob:` (lokalt generert av vår JS; ingen ekstern last-vektor). Regresjonsvakt i `security-headers.test.ts`.

Klient + én CSP-direktiv. App-only. `tsc` + `node --check` rene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)