### PR TITLE
fix(course): bilde-max-størrelse i deltaker-leser + sticky seksjons-nav (v1.3.21)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,19 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.21 - 2026-06-19
+
+fix(course): begrens bilde-størrelse i deltaker-leser + sticky seksjons-nav (#483 follow-up)
+
+To funn fra staging-test:
+- **Bilde-størrelse:** deltaker-leseren manglet `max-width` på bilder → de viste i full
+  px-oppløsning og sprengte visningen. La til `#sectionReaderBody img { max-width:100%; height:auto }`
+  (editor-preview hadde det allerede).
+- **Toppmeny under redigering:** content-area-nav (Moduler/Kurs/Seksjoner) scrollet av toppen i
+  den lange editor-visningen. Gjort `position: sticky; top: 0` på seksjons-siden så den blir værende.
+
+Kun front-end (HTML/JS). `node --check` rent.
+
 ## 1.3.20 - 2026-06-19
 
 fix(course): asset-bilder rendres nå i preview + deltaker-visning (#483)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-sections.html
+++ b/public/admin-content-sections.html
@@ -13,6 +13,11 @@
         gap: 0;
         border-bottom: 2px solid var(--color-border-soft);
         margin-bottom: var(--space-3);
+        /* Stay visible while editing a (long) section so the workspace tabs don't scroll away. */
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        background: var(--color-bg, #f7f8fa);
       }
       .content-area-nav-link {
         padding: 10px var(--space-2);

--- a/public/participant.js
+++ b/public/participant.js
@@ -2839,6 +2839,10 @@ async function openSectionReader(courseId, sectionId) {
   overlay.setAttribute("aria-modal", "true");
   overlay.style.cssText = "position:fixed;inset:0;background:rgba(0,0,0,0.5);display:flex;justify-content:center;align-items:flex-start;overflow-y:auto;z-index:1000;padding:0;";
   overlay.innerHTML = `
+    <style>
+      #sectionReaderBody img { max-width: 100%; height: auto; display: block; margin: 8px 0; }
+      #sectionReaderBody iframe { max-width: 100%; }
+    </style>
     <div style="background:var(--color-surface,#fff);width:100%;max-width:760px;min-height:100%;margin:0 auto;padding:var(--space-3,16px);box-sizing:border-box;display:flex;flex-direction:column;">
       <h2 id="sectionReaderTitle" style="margin:0 0 var(--space-2,12px) 0;font-size:20px">…</h2>
       <div id="sectionReaderBody" class="section-reader-body">${escapeHtmlP(t("courses.section.loading"))}</div>


### PR DESCRIPTION
Fra staging-test av F4/U2:

- **Bilde-størrelse (skjermbilde 2):** deltaker-leseren manglet `max-width` → bilder viste i full px og sprengte visningen. La til `#sectionReaderBody img { max-width:100%; height:auto }`.
- **Toppmeny under redigering (skjermbilde 1):** content-area-nav scrollet av toppen i den lange editor-visningen → gjort `position: sticky; top: 0` på seksjons-siden så den følger med.

Kun front-end. `node --check` rent. (Merk: nav-en var alltid i shell-HTML-en; sticky løser at den forsvant ut av synet ved scrolling. Si fra hvis den var helt fraværende — da graver jeg videre.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)