### PR TITLE
docs(workflow): test-sammen-med-feature + lokal-kjøring-før-deploy (stående ordre)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,13 @@ These rules exist because their violation caused or worsened the May 2026 produc
   technical docs (`doc/API_REFERENCE.md`, `doc/route-map.md`, arch notes) **and** user/author
   docs under `doc/`. If they can't land in the same PR, open tracking doc issues (technical +
   user) in the same milestone before the feature is complete.
+- **Tests are written WITH the feature, run locally BEFORE deploy (standing order):** retroactive
+  tests are only regression guards. A user-facing change MUST ship a Playwright browser e2e
+  (`test/e2e/`) of its primary flow in the same PR — the client layer (i18n keys, fetch/header
+  behavior incl. multipart, CSP, `<img>`/auth, rendering, CSS) is invisible to supertest and is
+  where the costly bugs hide. Exercise the real client→server flow locally (`npm run dev`, local
+  Postgres + `AUTH_MODE=mock`) before deploying; staging is an acceptance gate, not a debugger.
+  Not "done" until the e2e passes locally + in CI.
 - **For infra changes**, include in the PR description:
   - Which environments are affected
   - Behavior on first deploy (fresh environment) vs normal deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,25 @@ If docs cannot land in the same PR, open tracking doc issues (technical + user) 
 milestone** as the feature before it is considered complete. The "document" step must never
 lapse silently — it is part of the definition of done.
 
+### Tests are written WITH the feature, and run locally BEFORE deploy (standing order)
+
+Retroactive tests are only regression guards — they do not prevent the first occurrence of a
+bug. To actually shrink the deploy→manual-test→fix loop, the test must exist **when the feature
+is built**, and must be runnable **without a staging deploy**:
+
+1. **User-facing change ⇒ a browser e2e of the primary flow ships in the same PR.** Server/logic
+   gets unit/integration tests as usual; anything in the **client layer** (i18n key resolution,
+   `fetch`/header behavior incl. multipart, CSP, `<img>`/auth, rendering, CSS/layout) MUST be
+   exercised by a Playwright e2e (`test/e2e/`) written alongside the feature — not afterwards.
+   The class of bugs that cost us 3–4 manual rounds (FormData sent as JSON → 500, raw i18n keys,
+   `<img>` 401, CSP `blob:`) all live in this layer and are invisible to supertest.
+2. **Run the real client→server flow locally before deploying.** A staging deploy is an
+   acceptance gate, not a debugging tool. Use `npm run dev` (local Postgres + `AUTH_MODE=mock`)
+   to exercise the actual browser flow in seconds; deploy only once it passes locally.
+3. A user-facing feature is **not "done"** until its e2e passes locally + in CI. Writing the test
+   first (or at least alongside) forces you to run the real path early, which is where these
+   integration bugs surface.
+
 ### Which deploy workflow to use
 
 | Type of change | Use workflow | Why |


### PR DESCRIPTION
Kodifiserer innsikten: tester skrevet i etterkant er kun regresjonsvakter — for å hindre feilene må e2e-en skrives **sammen med** featuren og kjøres **lokalt før** deploy.

Definition-of-done for brukervendte endringer: Playwright-e2e av primærflyten i samme PR + kjør ekte klient→server-flyt lokalt (`npm run dev`, mock-auth) før deploy. Staging = akseptanse-port, ikke feilsøkingsverktøy. Kodifisert i `CLAUDE.md` + `AGENTS.md`.

Instruksjons-/konvensjonsendring — ingen runtime-påvirkning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)