### PR TITLE
chore(dev): dev:local + portable-Postgres lokal-dev-guide (no Docker/WSL/admin)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,13 @@ These rules exist because their violation caused or worsened the May 2026 produc
   technical docs (`doc/API_REFERENCE.md`, `doc/route-map.md`, arch notes) **and** user/author
   docs under `doc/`. If they can't land in the same PR, open tracking doc issues (technical +
   user) in the same milestone before the feature is complete.
+- **Tests are written WITH the feature, run locally BEFORE deploy (standing order):** retroactive
+  tests are only regression guards. A user-facing change MUST ship a Playwright browser e2e
+  (`test/e2e/`) of its primary flow in the same PR — the client layer (i18n keys, fetch/header
+  behavior incl. multipart, CSP, `<img>`/auth, rendering, CSS) is invisible to supertest and is
+  where the costly bugs hide. Exercise the real client→server flow locally (`npm run dev`, local
+  Postgres + `AUTH_MODE=mock`) before deploying; staging is an acceptance gate, not a debugger.
+  Not "done" until the e2e passes locally + in CI.
 - **For infra changes**, include in the PR description:
   - Which environments are affected
   - Behavior on first deploy (fresh environment) vs normal deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,25 @@ If docs cannot land in the same PR, open tracking doc issues (technical + user) 
 milestone** as the feature before it is considered complete. The "document" step must never
 lapse silently — it is part of the definition of done.
 
+### Tests are written WITH the feature, and run locally BEFORE deploy (standing order)
+
+Retroactive tests are only regression guards — they do not prevent the first occurrence of a
+bug. To actually shrink the deploy→manual-test→fix loop, the test must exist **when the feature
+is built**, and must be runnable **without a staging deploy**:
+
+1. **User-facing change ⇒ a browser e2e of the primary flow ships in the same PR.** Server/logic
+   gets unit/integration tests as usual; anything in the **client layer** (i18n key resolution,
+   `fetch`/header behavior incl. multipart, CSP, `<img>`/auth, rendering, CSS/layout) MUST be
+   exercised by a Playwright e2e (`test/e2e/`) written alongside the feature — not afterwards.
+   The class of bugs that cost us 3–4 manual rounds (FormData sent as JSON → 500, raw i18n keys,
+   `<img>` 401, CSP `blob:`) all live in this layer and are invisible to supertest.
+2. **Run the real client→server flow locally before deploying.** A staging deploy is an
+   acceptance gate, not a debugging tool. Use `npm run dev` (local Postgres + `AUTH_MODE=mock`)
+   to exercise the actual browser flow in seconds; deploy only once it passes locally.
+3. A user-facing feature is **not "done"** until its e2e passes locally + in CI. Writing the test
+   first (or at least alongside) forces you to run the real path early, which is where these
+   integration bugs surface.
+
 ### Which deploy workflow to use
 
 | Type of change | Use workflow | Why |

--- a/doc/LOCAL_DEV_NO_DOCKER.md
+++ b/doc/LOCAL_DEV_NO_DOCKER.md
@@ -1,0 +1,46 @@
+# Local dev without Docker / WSL / admin
+
+This machine can't run Docker Desktop or WSL2 (enabling the "Virtual Machine Platform"
+Windows feature requires admin, which we don't have). The standard `npm run dev` /
+`npm run postgres:*` flow uses Docker and therefore won't work here. This is the admin-free
+substitute: a **portable PostgreSQL** (zip binaries, runs in a user folder) + a `dev:local`
+script that skips the Docker step.
+
+## Two loops
+
+- **Fast client loop (no DB needed):** the Playwright client e2e runs the real front-end in
+  Chromium against mocked APIs — this is what catches the client-layer bug class (i18n keys,
+  fetch/Content-Type, CSP, rendering). No Postgres required:
+  ```
+  npx playwright test --config playwright.admin-content.config.ts
+  ```
+- **Full-stack loop (real app + DB):** portable Postgres + `npm run dev:local` (below).
+
+## Portable PostgreSQL (one-time setup)
+
+Already set up on this machine under `C:\Users\<you>\a2-pg-local\`:
+- `pgsql\` — PostgreSQL 16 binaries (from the EnterpriseDB Windows zip; **extract with Windows
+  `tar.exe`, not Git Bash tar or PowerShell Expand-Archive** — the former is GNU tar that can't
+  read zip, the latter is unreliably slow on a 300 MB archive).
+- `data\` — the data directory, `initdb`'d with superuser `a2_app` and **trust auth on
+  localhost** (so the password in `DATABASE_URL` is ignored locally).
+- Databases `a2_assessment_dev` + `a2_assessment_test` created; migrations applied; dev seeded.
+
+Connection (matches `.env.postgres.local`): `127.0.0.1:54329`, user `a2_app`, db `a2_assessment_dev`.
+
+## Daily use
+
+1. **Start Postgres** (once per reboot): run `C:\Users\<you>\a2-pg-local\start-pg.cmd`
+   (or `pg_ctl -D <data> -o "-p 54329" -l <log> start`).
+2. **Run the app:** `npm run dev:local` (app on `http://127.0.0.1:3000`, `AUTH_MODE=mock`).
+3. **Stop Postgres** when done: `C:\Users\<you>\a2-pg-local\stop-pg.cmd`.
+
+To reset the local DB: `dotenv -e .env.postgres.local -- npx prisma migrate reset` (then it
+re-applies migrations + seeds).
+
+## Notes
+
+- Integration tests (`npm test`) still need Postgres; they run in **CI** — you don't need them
+  locally. The two loops above cover local development.
+- Definition of done for user-facing changes (see CLAUDE.md): a Playwright e2e of the primary
+  flow, written with the feature and run locally before deploy.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "npm run postgres:setup && dotenv -e .env.postgres.local -- tsx watch src/index.ts",
+    "dev:local": "dotenv -e .env.postgres.local -- tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node scripts/runtime/startup.mjs",
     "postgres:setup": "node scripts/postgres/localSetup.mjs setup",


### PR DESCRIPTION
Admin-fri lokal dev-løkke (Docker/WSL er blokkert uten admin på dev-maskinen).

- `dev:local`-script: kjører appen mot `.env.postgres.local` uten docker `postgres:setup`.
- `doc/LOCAL_DEV_NO_DOCKER.md`: portabel-Postgres-oppsett (admin-fritt) + de to loopene — klient-e2e (uten DB, fanger klient-bug-klassen) og full-stack (`dev:local` + portabel Postgres).

Verifisert lokalt: full stack booter mot portabel Postgres (/healthz, /version, /admin-content/sections = 200); klient-e2e grønn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)