### PR TITLE
fix(course): rett LMS-flyt avdekket ved lokal mock-testing + UX/dev-tooling (v1.3.22, #540, #542)

### DIFF
--- a/doc/LOCAL_DEV_NO_DOCKER.md
+++ b/doc/LOCAL_DEV_NO_DOCKER.md
@@ -35,8 +35,21 @@ Connection (matches `.env.postgres.local`): `127.0.0.1:54329`, user `a2_app`, db
 2. **Run the app:** `npm run dev:local` (app on `http://127.0.0.1:3000`, `AUTH_MODE=mock`).
 3. **Stop Postgres** when done: `C:\Users\<you>\a2-pg-local\stop-pg.cmd`.
 
+### Consent on a fresh database
+
+In mock mode each console page sends a different mock identity (e.g. the section editor uses
+`content-owner-1`, the participant view uses the default `dev-user-1`). Privacy consent is
+stored **per user**, so on a fresh DB every identity hits a `403 consent_required` until it
+accepts the notice. To pre-accept the current consent version for all mock identities at once:
+
+```
+npm run dev:seed:consent
+```
+
+Run it once after a fresh setup or a DB reset. Idempotent.
+
 To reset the local DB: `dotenv -e .env.postgres.local -- npx prisma migrate reset` (then it
-re-applies migrations + seeds).
+re-applies migrations + seeds), followed by `npm run dev:seed:consent`.
 
 ## Notes
 

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,30 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.22 - 2026-06-20
+
+fix(course): rett opp LMS-flyt avdekket ved lokal mock-testing (#540, #542) + UX/dev-tooling
+
+Første økt med lokal full-stack-kjøring (portable Postgres + `AUTH_MODE=mock`) avdekket to ekte
+feil som var usynlige på staging fordi Entra-Bearer-token skjulte dem:
+
+- **#542 (ekte produktfeil):** `participant.js` sendte header-*objektet* (`headers()`) til
+  `apiFetch`, som forventer en *funksjon*. Objektet ble tolket som `options` og alle `x-user-*`-
+  headere droppet. På Entra bærer Bearer-token identiteten, så det virket; i mock-modus forsvant
+  identiteten → fallback til rolleløs `dev-user-1` → 403 på `/api/courses`, `/api/modules`,
+  seksjons-lesing. Fikset alle 6 kall-steder (`headers()` → `headers`).
+- **#540:** seksjons-/kurs-/bibliotek-konsollene manglet `initConsentGuard` → viste rå
+  `403 consent_required` i innholdsområdet i stedet for samtykke-dialogen. Lagt til på alle tre.
+- **UX:** bilde-opplasting krevde manuell lagring først. Ulagret seksjon auto-lagres nå stille
+  før opplasting (`persistSection({ silent })`).
+- **Dev-tooling:** `localizeSectionContent` returnerer nå deterministisk stub-output i
+  `LLM_MODE=stub` (lokal/CI) i stedet for å kaste, så oversett-*flyten* kan testes uten LLM.
+  Nytt `npm run dev:seed:consent` forhåndsgodkjenner samtykke for alle mock-identiteter på fersk DB.
+
+Tester (skrevet med fiksene, kjørt lokalt): Playwright-e2e for samtykke-dialog (#540) og at
+deltaker-flyten sender `x-user-*` i mock-modus (#542). Static-test-serveren serverer nå
+`/participant`. `tsc` rent, alle 27 e2e grønne. (Dev-konsoll-race #541 logget separat, lav prio.)
+
 ## 1.3.21 - 2026-06-19
 
 fix(course): begrens bilde-størrelse i deltaker-leser + sticky seksjons-nav (#483 follow-up)

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.21",
+  "version": "1.3.22",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",
   "scripts": {
     "dev": "npm run postgres:setup && dotenv -e .env.postgres.local -- tsx watch src/index.ts",
     "dev:local": "dotenv -e .env.postgres.local -- tsx watch src/index.ts",
+    "dev:seed:consent": "dotenv -e .env.postgres.local -- tsx scripts/dev/seed-mock-consent.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node scripts/runtime/startup.mjs",
     "postgres:setup": "node scripts/postgres/localSetup.mjs setup",

--- a/public/participant.js
+++ b/public/participant.js
@@ -978,7 +978,7 @@ async function ensureParticipantModuleAvailable(moduleId) {
     return loadedModules.some((module) => module?.id === moduleId);
   }
 
-  const body = await apiFetch("/api/modules?includeCompleted=true", headers());
+  const body = await apiFetch("/api/modules?includeCompleted=true", headers);
   loadedModules = Array.isArray(body.modules) ? body.modules : [];
   hasLoadedModules = true;
   syncParticipantModuleWorkspace();
@@ -2670,8 +2670,8 @@ document.getElementById("loadCoursesBtn")?.addEventListener("click", async () =>
 
 async function loadParticipantCourses() {
   const [coursesBody, completionsBody] = await Promise.all([
-    apiFetch("/api/courses", headers()),
-    apiFetch("/api/courses/completions", headers()),
+    apiFetch("/api/courses", headers),
+    apiFetch("/api/courses/completions", headers),
   ]);
   participantCourses = Array.isArray(coursesBody.courses) ? coursesBody.courses : [];
   participantCompletions = {};
@@ -2755,7 +2755,7 @@ function buildCourseAccordionItem(course) {
 async function loadCourseDetail(courseId) {
   const container = document.getElementById(`courseDetail_${courseId}`);
   try {
-    const body = await apiFetch(`/api/courses/${encodeURIComponent(courseId)}`, headers());
+    const body = await apiFetch(`/api/courses/${encodeURIComponent(courseId)}`, headers);
     courseDetailCache[courseId] = body.course;
     renderCourseDetailModules(courseId, body.course);
   } catch (error) {
@@ -2870,7 +2870,7 @@ async function openSectionReader(courseId, sectionId) {
   markReadBtn?.addEventListener("click", async () => {
     markReadBtn.disabled = true;
     try {
-      await apiFetch(`/api/courses/${encodeURIComponent(courseId)}/sections/${encodeURIComponent(sectionId)}/read`, headers(), { method: "POST" });
+      await apiFetch(`/api/courses/${encodeURIComponent(courseId)}/sections/${encodeURIComponent(sectionId)}/read`, headers, { method: "POST" });
       markedRead = true;
       markReadBtn.textContent = t("courses.section.doneBadge");
     } catch (error) {
@@ -2880,7 +2880,7 @@ async function openSectionReader(courseId, sectionId) {
   });
 
   try {
-    const body = await apiFetch(`/api/courses/${encodeURIComponent(courseId)}/sections/${encodeURIComponent(sectionId)}`, headers());
+    const body = await apiFetch(`/api/courses/${encodeURIComponent(courseId)}/sections/${encodeURIComponent(sectionId)}`, headers);
     const titleEl = overlay.querySelector("#sectionReaderTitle");
     const bodyEl = overlay.querySelector("#sectionReaderBody");
     if (titleEl) titleEl.textContent = body.title ?? "";

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -10,6 +10,7 @@ import {
   fetchQueueCounts,
   applyNavReviewBadge,
 } from "/static/api-client.js";
+import { initConsentGuard } from "/static/consent-guard.js";
 import {
   resolveWorkspaceNavigationItems,
 } from "/static/participant-console-state.js";
@@ -1562,6 +1563,8 @@ async function init() {
   buildLocaleSelector();
   renderWorkspaceNavigation();
   renderContentAreaNav();
+
+  await initConsentGuard(getHeaders, currentLocale);
 
   try {
     const body = await apiFetch("/version", { headers: {} });

--- a/public/static/admin-content-library.js
+++ b/public/static/admin-content-library.js
@@ -10,6 +10,7 @@ import {
   fetchQueueCounts,
   applyNavReviewBadge,
 } from "/static/api-client.js";
+import { initConsentGuard } from "/static/consent-guard.js";
 import {
   resolveRoleSwitchState,
   resolveWorkspaceNavigationItems,
@@ -697,7 +698,7 @@ async function init() {
   }
 
   try {
-    const me = await apiFetch("/api/me", getHeaders);
+    const me = await initConsentGuard(getHeaders, currentLocale);
     activeUserRoles = Array.isArray(me?.user?.roles) ? me.user.roles : [];
   } catch {
     activeUserRoles = [];

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -4,6 +4,7 @@ import {
   translations as adminContentTranslations,
 } from "/static/i18n/admin-content-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, hydrateContentAssetImages } from "/static/api-client.js";
+import { initConsentGuard } from "/static/consent-guard.js";
 import { resolveWorkspaceNavigationItems } from "/static/participant-console-state.js";
 import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
 import { showToast } from "/static/toast.js";
@@ -242,7 +243,6 @@ async function renderEditorView(sectionId) {
   document.getElementById("markdownInput")?.addEventListener("input", () => { captureInputs(); schedulePreview(); });
   document.getElementById("saveBtn")?.addEventListener("click", saveSection);
   document.getElementById("uploadImageBtn")?.addEventListener("click", () => {
-    if (!editing.id) { showToast(L("saveFirst"), "error"); return; }
     document.getElementById("imageFileInput")?.click();
   });
   document.getElementById("imageFileInput")?.addEventListener("change", (event) => {
@@ -300,14 +300,17 @@ function nonEmptyLocales(obj) {
   return out;
 }
 
-async function saveSection() {
+// Persist the section (create on first save, otherwise update title + content).
+// Returns true on success. `silent` suppresses the success toast so callers like
+// the image upload can auto-save transparently without a confusing extra toast.
+async function persistSection({ silent } = {}) {
   captureInputs();
   const status = document.getElementById("editorStatus");
   const title = nonEmptyLocales(editing.title);
   const bodyMarkdown = nonEmptyLocales(editing.body);
   if (Object.keys(title).length === 0 || Object.keys(bodyMarkdown).length === 0) {
     showToast(L("needContent"), "error");
-    return;
+    return false;
   }
   try {
     if (!editing.id) {
@@ -327,11 +330,19 @@ async function saveSection() {
         body: JSON.stringify({ bodyMarkdown }),
       });
     }
-    showToast(L("saved"));
-    if (status) status.textContent = L("saved");
+    if (!silent) {
+      showToast(L("saved"));
+      if (status) status.textContent = L("saved");
+    }
+    return true;
   } catch (err) {
     showToast(err?.message ?? "Error", "error");
+    return false;
   }
+}
+
+async function saveSection() {
+  await persistSection();
 }
 
 // Explicit LLM translation (#514): translate the active language's content into
@@ -377,8 +388,9 @@ async function translateFromCurrent() {
 }
 
 // Image upload (#489/U2): upload to the section's blob storage, then insert a markdown
-// image referencing the asset (![alt](asset:<id>)) at the cursor. Requires the section to
-// be saved first (assets attach to a section id). Alt text is mandatory (a11y).
+// image referencing the asset (![alt](asset:<id>)) at the cursor. Assets attach to a
+// section id, so an unsaved section is auto-saved first (transparent to the author).
+// Alt text is mandatory (a11y).
 function insertAtCursor(text) {
   const ta = document.getElementById("markdownInput");
   if (!ta) return;
@@ -391,7 +403,12 @@ function insertAtCursor(text) {
 }
 
 async function uploadImage(file) {
-  if (!editing.id) { showToast(L("saveFirst"), "error"); return; }
+  // Assets need a section id — auto-save first (silently) if this is a new section.
+  // persistSection shows the needContent toast if there's nothing to save yet.
+  if (!editing.id) {
+    const saved = await persistSection({ silent: true });
+    if (!saved || !editing.id) return;
+  }
   const alt = window.prompt(L("altPrompt"), "");
   if (alt === null) return; // cancelled
   const btn = document.getElementById("uploadImageBtn");
@@ -464,6 +481,8 @@ async function init() {
 
   buildLocaleSelector();
   renderWorkspaceNavigation();
+
+  await initConsentGuard(getHeaders, currentLocale);
 
   try {
     const body = await apiFetch("/version", { headers: {} });

--- a/scripts/dev/seed-mock-consent.ts
+++ b/scripts/dev/seed-mock-consent.ts
@@ -1,0 +1,55 @@
+/**
+ * Dev-only helper: record privacy-consent for every mock identity used by the
+ * local consoles (AUTH_MODE=mock).
+ *
+ * Why: each console page sends a different mock identity (see
+ * participant-console identityDefaults + the MOCK_DEFAULT_USER_ID "dev-user-1").
+ * Consent is stored per user, so on a fresh database every one of these
+ * identities would otherwise hit the 403 consent_required gate until it accepts
+ * the notice individually. This pre-accepts the current consent version for all
+ * of them so local testing flows straight through.
+ *
+ * Safe to run anywhere: it only touches these fixed mock externalIds, which do
+ * not correspond to real Entra users. Idempotent.
+ *
+ *   npm run dev:seed:consent
+ */
+import { PrismaClient } from "@prisma/client";
+import { upsertUserFromPrincipal } from "../../src/repositories/userRepository.js";
+import { getActiveConsentVersion } from "../../src/modules/platformConfig/consentConfigService.js";
+
+const prisma = new PrismaClient();
+
+// externalId + email for each mock identity (roles are irrelevant for consent).
+const MOCK_IDENTITIES: Array<{ externalId: string; email: string; name: string }> = [
+  { externalId: "dev-user-1", email: "dev.user@company.com", name: "Dev User" },
+  { externalId: "participant-1", email: "participant@company.com", name: "Platform Participant" },
+  { externalId: "content-owner-1", email: "content.owner@company.com", name: "Platform Content Owner" },
+  { externalId: "smo-1", email: "smo@company.com", name: "Platform Subject Matter Owner" },
+  { externalId: "reviewer-user-1", email: "reviewer1@company.com", name: "Platform Reviewer" },
+  { externalId: "handler-1", email: "appeal.handler@company.com", name: "Platform Appeal Handler" },
+  { externalId: "admin-1", email: "admin@company.com", name: "Platform Admin" },
+];
+
+async function main() {
+  const consentVersion = await getActiveConsentVersion();
+  for (const identity of MOCK_IDENTITIES) {
+    const user = await upsertUserFromPrincipal({ ...identity, tokenRoles: [], groupIds: [] });
+    await prisma.userConsent.upsert({
+      where: { userId_consentVersion: { userId: user.id, consentVersion } },
+      update: {},
+      create: { userId: user.id, consentVersion },
+    });
+    console.log(`✓ consent ${consentVersion} for ${identity.externalId}`);
+  }
+  console.log(`Done — ${MOCK_IDENTITIES.length} mock identities consented to version ${consentVersion}.`);
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/test/admin-content-static-server.mjs
+++ b/scripts/test/admin-content-static-server.mjs
@@ -38,6 +38,9 @@ function resolvePublicFile(requestPath) {
   if (requestPath === "/admin-content/sections") {
     return path.join(publicRoot, "admin-content-sections.html");
   }
+  if (requestPath === "/participant") {
+    return path.join(publicRoot, "participant.html");
+  }
   if (/^\/admin-content\/courses\/[^/]+$/.test(requestPath)) {
     return path.join(publicRoot, "admin-content-courses.html");
   }

--- a/src/modules/adminContent/llmContentGenerationService.ts
+++ b/src/modules/adminContent/llmContentGenerationService.ts
@@ -1645,6 +1645,17 @@ export function normaliseLiteralNewlines(value: string | undefined): string | un
 }
 
 export async function localizeSectionContent(input: SectionLocalizationInput): Promise<SectionLocalizationResult> {
+  // Stub mode (local dev / CI): return a deterministic, clearly-tagged localisation
+  // so the translate client→server flow is exercisable without a live LLM. Real
+  // translation quality is validated against azure_openai on staging.
+  if (env.LLM_MODE !== "azure_openai") {
+    const tag = `[${input.targetLocale}]`;
+    return {
+      title: input.title ? `${tag} ${input.title}` : undefined,
+      bodyMarkdown: input.bodyMarkdown ? `${tag} ${input.bodyMarkdown}` : undefined,
+    };
+  }
+
   const { systemPrompt, userPrompt } = buildSectionLocalizationPrompts(input);
 
   const raw = await callLlm(systemPrompt, userPrompt);

--- a/test/e2e/section-editor.spec.ts
+++ b/test/e2e/section-editor.spec.ts
@@ -26,7 +26,12 @@ async function mockBaseApis(page: Page) {
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "test" }) }),
   );
   await page.route("**/api/me", (route: Route) =>
-    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ user: { roles: ["SUBJECT_MATTER_OWNER"] } }) }),
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      // The consent guard (#540) reads consent.accepted; without it init throws.
+      body: JSON.stringify({ user: { roles: ["SUBJECT_MATTER_OWNER"] }, consent: { accepted: true, currentVersion: "1.0" } }),
+    }),
   );
 }
 
@@ -83,4 +88,97 @@ test("section editor: no raw i18n keys, and image upload is sent as multipart", 
 
   // The asset reference is inserted into the markdown.
   await expect(page.locator("#markdownInput")).toHaveValue(/asset:a1/);
+});
+
+// #540: the section editor must show the blocking consent dialog when consent is not yet
+// accepted — not dump the raw "403 consent_required" JSON into the content area.
+test("section editor: shows consent dialog (not raw 403) when consent not accepted", async ({ page }) => {
+  await mockBaseApis(page);
+  // Override /api/me to report consent NOT accepted.
+  await page.route("**/api/me", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ user: { roles: ["SUBJECT_MATTER_OWNER"] }, consent: { accepted: false, currentVersion: "1.0" } }),
+    }),
+  );
+  // The consent text endpoint (GET) the guard fetches to render the modal.
+  await page.route("**/api/me/consent", (route: Route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ version: "1.0", body: "Personvern", platformName: "A2" }),
+      });
+    }
+    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true }) });
+  });
+  await page.route("**/api/admin/content/sections", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ sections: [] }) }),
+  );
+
+  await page.goto("/admin-content/sections");
+
+  // The blocking consent modal must appear …
+  await expect(page.locator("#consent-modal-overlay")).toBeVisible();
+  // … and the raw error must NOT be shown anywhere.
+  await expect(page.locator("#main-content")).not.toContainText("consent_required");
+});
+
+// #542: in mock mode the participant console must send the x-user-* identity headers when
+// loading courses. The bug passed the header OBJECT to apiFetch (which expects a function),
+// so apiFetch silently dropped the headers → backend fell back to a roleless default user → 403.
+// On Entra the Bearer token hid this; only mock mode (local) exposes it.
+test("participant: course load sends x-user-* identity headers in mock mode", async ({ page }) => {
+  await page.route("**/participant/config", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        authMode: "mock",
+        navigation: { items: [], workspaceItems: [] },
+        identityDefaults: {
+          participant: { userId: "participant-1", email: "p@x.no", name: "P", department: "X", roles: ["PARTICIPANT"] },
+        },
+        calibrationWorkspace: { accessRoles: [] },
+        flow: {},
+        output: {},
+      }),
+    }),
+  );
+  await page.route("**/version", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "test" }) }),
+  );
+  await page.route("**/api/me", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ user: { roles: ["PARTICIPANT"] }, consent: { accepted: true, currentVersion: "1.0" } }),
+    }),
+  );
+  await page.route("**/api/queue-counts", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ counts: {} }) }),
+  );
+
+  let coursesUserId: string | undefined;
+  let coursesRoles: string | undefined;
+  await page.route("**/api/courses", (route: Route) => {
+    const h = route.request().headers();
+    coursesUserId = h["x-user-id"];
+    coursesRoles = h["x-user-roles"];
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ courses: [{ id: "c1", title: "Kurs", description: null, moduleCount: 1, progress: { completed: 0, total: 1, courseStatus: "NOT_STARTED" } }] }),
+    });
+  });
+  await page.route("**/api/courses/completions", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ completions: [] }) }),
+  );
+
+  await page.goto("/participant");
+  await page.locator("#loadCoursesBtn").click();
+
+  await expect.poll(() => coursesUserId).toBe("participant-1");
+  expect(coursesRoles).toContain("PARTICIPANT");
 });


### PR DESCRIPTION
## Sammendrag
Første økt med **lokal full-stack-kjøring** (portable Postgres + `AUTH_MODE=mock`) avdekket to
ekte feil som var usynlige på staging fordi Entra-Bearer-token skjulte dem — akkurat klient-lag-
bug-klassen den lokale løkka skulle fange.

## Feil rettet
- **#542 (ekte produktfeil):** `participant.js` sendte header-*objektet* (`headers()`) til
  `apiFetch`, som forventer en *funksjon*. Objektet ble tolket som `options`, og alle `x-user-*`-
  headere ble droppet. På Entra bærer Bearer-token identiteten (virket); i mock-modus forsvant
  identiteten → fallback til rolleløs `dev-user-1` → 403 på `/api/courses`, `/api/modules` og
  seksjons-lesing. Fikset alle 6 kall-steder (`headers()` → `headers`).
- **#540:** seksjons-/kurs-/bibliotek-konsollene manglet `initConsentGuard` → viste rå
  `403 consent_required` i innholdsområdet i stedet for samtykke-dialogen. Lagt til på alle tre.

## UX + dev-tooling
- **Auto-lagre ved bildeopplasting:** ulagret seksjon auto-lagres nå stille før opplasting
  (`persistSection({ silent })`) — ingen manuell «lagre først».
- **Stub-lokalisering:** `localizeSectionContent` returnerer deterministisk stub-output i
  `LLM_MODE=stub` (lokal/CI) i stedet for å kaste, så oversett-*flyten* kan testes uten LLM.
- **`npm run dev:seed:consent`:** forhåndsgodkjenner samtykke for alle mock-identiteter på fersk DB.

## Tester (skrevet med fiksene, kjørt lokalt + CI)
- Playwright-e2e: samtykke-dialog vises (ikke rå 403) på seksjons-siden (#540).
- Playwright-e2e: deltaker-flyten sender `x-user-*` i mock-modus (#542).
- Static-test-serveren serverer nå `/participant`.
- `tsc` rent · 523 unit · 27 e2e grønne.

## Rollback
Ren front-end + én server-stub + dev-script/tester. Ingen infra, ingen migrasjoner, ingen API-
kontrakt-endring. Revert av commit-en er trygt.

## Restanse
- #541 (dev-konsoll-race: «Last kurs» klikkbar før identitet satt) — logget, lav prio, ikke i denne PR-en.

Closes #540
Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)
