### PR TITLE
fix(mcq-only): UX-batch fra staging-akseptanse + deterministisk MCQ-sensur (v1.3.27)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,28 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.27 - 2026-06-21
+
+fix(mcq-only): UX-batch fra staging-akseptanse + deterministisk MCQ-sensur (#525-oppfølging)
+
+Tilbakemeldinger fra forfatter-/deltaker-test av MCQ-only på staging:
+- **#4 Avrunding:** MCQ-resultat viser nå skår med 2 desimaler (66.67 % i stedet for 66.666…).
+- **#5 Toppmeny-rekkefølge:** content-area-nav er nå **Kurs, Moduler, Seksjoner, Kalibrering**
+  (4 admin-content-sider).
+- **#3 Layout:** «Kun MCQ-modul»-avkrysningen arvet full-bredde tekst-input-styling →
+  checkbox-reset i avansert editor.
+- **#7 MCQ direkte:** å velge en MCQ-only-modul oppretter nå besvarelsen + starter MCQ automatisk
+  (ingen «Opprett besvarelse»-klikk) — MCQ vises direkte.
+- **#8 Deterministisk sensur:** MCQ-only-innlevering behandles nå **synkront** i submit
+  (`processSubmissionJobNow`) — ingen LLM (var allerede skippet) og ingen async-jobb/poll-venting
+  → umiddelbart resultat, lavere kost.
+
+Design-saker logget for avklaring (ikke i denne): #554 (MCQ-only som førsteklasses opprettelses-
+valg), #555 (samtale-rekkefølge scenario/kilde).
+
+Test: oppdatert Playwright-e2e (auto-start ved MCQ-only-valg). tsc rent, 30 e2e + full vitest-suite
+grønn.
+
 ## 1.3.26 - 2026-06-21
 
 feat(author): MCQ-only forfatter-UI i avansert editor (#546, #525)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.26",
+  "version": "1.3.27",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-advanced.html
+++ b/public/admin-content-advanced.html
@@ -88,6 +88,8 @@
       .mcq-q-remove:hover, .mcq-opt-remove:hover, .prompt-ex-remove:hover, .ss-field-remove:hover { opacity: 1; }
       .mcq-option-row { display: grid; grid-template-columns: 20px 1fr 24px; gap: 6px; align-items: center; margin-bottom: 6px; }
       .mcq-option-row input[type="radio"] { margin: 0; }
+      /* #546 feedback: checkboxes must not inherit the full-width text-input styling. */
+      input[type="checkbox"] { width: auto; display: inline-block; vertical-align: middle; margin: 0 6px 0 0; }
       .prompt-example-row { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-1); margin-bottom: var(--space-1); }
       .prompt-example-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; font-size: 12px; font-weight: 700; color: var(--color-meta); text-transform: uppercase; letter-spacing: 0.05em; }
       .ss-field-row { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-1); margin-bottom: var(--space-1); }

--- a/public/admin-content-calibration.html
+++ b/public/admin-content-calibration.html
@@ -81,8 +81,8 @@
       </div>
 
       <nav id="contentAreaNav" class="content-area-nav" aria-label="Innholdsadministrasjon">
-        <a href="/admin-content" class="content-area-nav-link" id="navModuler">Moduler</a>
         <a href="/admin-content/courses" class="content-area-nav-link" id="navKurs">Kurs</a>
+        <a href="/admin-content" class="content-area-nav-link" id="navModuler">Moduler</a>
         <a href="/admin-content/sections" class="content-area-nav-link" id="navSeksjoner">Seksjoner</a>
         <a href="/admin-content/calibration" class="content-area-nav-link active" id="navKalibrering">Kalibrering</a>
       </nav>

--- a/public/admin-content-courses.html
+++ b/public/admin-content-courses.html
@@ -424,8 +424,8 @@
       </div>
 
       <nav id="contentAreaNav" class="content-area-nav" aria-label="Innholdsadministrasjon">
-        <a href="/admin-content" class="content-area-nav-link" id="navModuler">Moduler</a>
         <a href="/admin-content/courses" class="content-area-nav-link active" id="navKurs">Kurs</a>
+        <a href="/admin-content" class="content-area-nav-link" id="navModuler">Moduler</a>
         <a href="/admin-content/sections" class="content-area-nav-link" id="navSeksjoner">Seksjoner</a>
         <a href="/admin-content/calibration" class="content-area-nav-link" id="navKalibrering" hidden>Kalibrering</a>
       </nav>

--- a/public/admin-content-library.html
+++ b/public/admin-content-library.html
@@ -259,8 +259,8 @@
       </div>
 
       <nav id="contentAreaNav" class="content-area-nav" aria-label="Innholdsadministrasjon">
-        <a href="/admin-content" class="content-area-nav-link active" id="navModuler">Moduler</a>
         <a href="/admin-content/courses" class="content-area-nav-link" id="navKurs">Kurs</a>
+        <a href="/admin-content" class="content-area-nav-link active" id="navModuler">Moduler</a>
         <a href="/admin-content/sections" class="content-area-nav-link" id="navSeksjoner">Seksjoner</a>
         <a href="/admin-content/calibration" class="content-area-nav-link" id="navKalibrering" hidden>Kalibrering</a>
       </nav>

--- a/public/admin-content-sections.html
+++ b/public/admin-content-sections.html
@@ -88,8 +88,8 @@
       </div>
 
       <nav id="contentAreaNav" class="content-area-nav" aria-label="Innholdsadministrasjon">
-        <a href="/admin-content" class="content-area-nav-link" id="navModuler">Moduler</a>
         <a href="/admin-content/courses" class="content-area-nav-link" id="navKurs">Kurs</a>
+        <a href="/admin-content" class="content-area-nav-link" id="navModuler">Moduler</a>
         <a href="/admin-content/sections" class="content-area-nav-link active" id="navSeksjoner">Seksjoner</a>
       </nav>
 

--- a/public/participant.js
+++ b/public/participant.js
@@ -845,6 +845,12 @@ function renderModules() {
     button.setAttribute("aria-pressed", module.selected ? "true" : "false");
     button.addEventListener("click", () => {
       activateParticipantModule(module.id);
+      // #546 feedback: MCQ-only modules have no free-text step — go straight to the questions by
+      // creating the (empty) submission + starting the MCQ immediately, instead of requiring the
+      // participant to click "Create submission" first.
+      if (moduleIsMcqOnly(module) && !previewModeEnabled && !flowState.hasSubmission && !createSubmissionButton.disabled) {
+        createSubmissionButton.click();
+      }
     });
 
     const title = document.createElement("div");

--- a/src/modules/assessment/decisionService.ts
+++ b/src/modules/assessment/decisionService.ts
@@ -180,9 +180,11 @@ export function resolveMcqOnlyDecision(
   mcqMinPercent: number,
 ): { passFailTotal: boolean; decisionReason: string } {
   const passFailTotal = mcqPercentScore >= mcqMinPercent;
+  // Round the displayed score to 2 decimals (raw can be e.g. 66.6666… ) — #546 feedback.
+  const shownScore = Math.round(mcqPercentScore * 100) / 100;
   const decisionReason = passFailTotal
-    ? `Automatic pass: MCQ score ${mcqPercentScore}% meets the required minimum of ${mcqMinPercent}%.`
-    : `Automatic fail: MCQ score ${mcqPercentScore}% is below the required minimum of ${mcqMinPercent}%.`;
+    ? `Automatic pass: MCQ score ${shownScore}% meets the required minimum of ${mcqMinPercent}%.`
+    : `Automatic fail: MCQ score ${shownScore}% is below the required minimum of ${mcqMinPercent}%.`;
   return { passFailTotal, decisionReason };
 }
 

--- a/src/modules/assessment/mcqService.ts
+++ b/src/modules/assessment/mcqService.ts
@@ -2,7 +2,7 @@ import { SubmissionStatus } from "../../db/prismaRuntime.js";
 import { getAssessmentRules } from "../../config/assessmentRules.js";
 import { assessmentJobRepository } from "./assessmentJobRepository.js";
 import { mcqRepository } from "./mcqRepository.js";
-import { enqueueAssessmentJob } from "./assessmentJobService.js";
+import { enqueueAssessmentJob, processSubmissionJobNow } from "./assessmentJobService.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
 import type { SupportedLocale } from "../../i18n/locale.js";
@@ -135,6 +135,17 @@ export async function submitMcqAttempt(input: {
   await assessmentJobRepository.updateSubmissionStatus(submission.id, SubmissionStatus.PROCESSING);
 
   await enqueueAssessmentJob(submission.id);
+
+  // #546 feedback: MCQ-only modules are graded deterministically (no LLM). Process the assessment
+  // synchronously so the participant gets the result immediately, instead of waiting for the async
+  // worker + poll cycle. Falls back to the enqueued job if synchronous processing fails.
+  if (submission.moduleVersion?.assessmentMode === "MCQ_ONLY") {
+    try {
+      await processSubmissionJobNow(submission.id);
+    } catch (error) {
+      console.warn("Synchronous MCQ-only assessment failed; leaving job for async worker.", error);
+    }
+  }
 
   await recordAuditEvent({
     entityType: auditEntityTypes.mcqAttempt,

--- a/test/e2e/participant-mcq-only.spec.ts
+++ b/test/e2e/participant-mcq-only.spec.ts
@@ -54,6 +54,17 @@ test("participant: MCQ-only module hides the free-text step; free-text module ke
     try { localStorage.setItem("participant.locale", "nb"); } catch { /* ignore */ }
   });
 
+  // #546: selecting an MCQ-only module auto-creates the (empty) submission + starts the MCQ — no
+  // manual "create submission" click. Capture the auto-creation.
+  let submissionCreated = false;
+  await page.route("**/api/submissions", (route: Route) => {
+    submissionCreated = true;
+    return route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ submission: { id: "s1" } }) });
+  });
+  await page.route("**/api/modules/*/mcq/start**", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ attemptId: "a1", questions: [] }) }),
+  );
+
   await page.goto("/participant");
   await page.locator("#loadModules").click();
 
@@ -62,6 +73,8 @@ test("participant: MCQ-only module hides the free-text step; free-text module ke
   await expect(page.locator("#submissionFields textarea")).toHaveCount(0);
   await expect(page.locator("#submissionFields")).toContainText("flervalgsspørsmål");
   await expect(page.locator("#ack")).toBeHidden();
+  // #546: submission auto-created on select (MCQ shown directly, no extra click).
+  await expect.poll(() => submissionCreated).toBe(true);
 
   // Switch to the free-text module → the answer textarea + acknowledgement come back.
   // (Selecting a module collapses the list, so re-expand it first.)


### PR DESCRIPTION
## Sammendrag
UX-fikser fra din staging-akseptanse av MCQ-only (1.3.26) + deterministisk MCQ-sensur.

- **#4** MCQ-resultat: skår avrundes til 2 desimaler.
- **#5** Toppmeny: **Kurs, Moduler, Seksjoner, Kalibrering** (4 admin-content-sider).
- **#3** «Kun MCQ-modul»-checkbox arvet full-bredde input-styling → checkbox-reset.
- **#7** Valg av MCQ-only-modul auto-oppretter besvarelse + starter MCQ → **MCQ vises direkte** (ingen «Opprett besvarelse»-klikk).
- **#8** MCQ-only sensureres **synkront/deterministisk** i submit (`processSubmissionJobNow`) — ingen LLM, ingen async-jobb/poll → umiddelbart resultat, lavere kost.

## Ikke i denne (logget for design-avklaring)
- #554 — MCQ-only som førsteklasses valg ved opprettelse (ikke skjul-veksling)
- #555 — samtale-rekkefølge (scenario før kilde)

## Test
Oppdatert Playwright-e2e (auto-start ved MCQ-only-valg). `tsc` rent · 30 e2e · **full vitest-suite (116 filer, 797 tester) grønn**.

## Rollback
Front-end + 2 backend-funksjoner (rounding, synkron MCQ-only-prosessering). Ingen migrasjoner. Trygg revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)