### PR TITLE
feat(content): MCQ-only import/eksport + bruker-doc (v1.3.28, #547)

### DIFF
--- a/doc/MCQ_ONLY_MODULES_GUIDE.md
+++ b/doc/MCQ_ONLY_MODULES_GUIDE.md
@@ -1,0 +1,47 @@
+# MCQ-only modules — author guide
+
+A module can be **MCQ-only**: the participant answers multiple-choice questions only, with **no
+free-text answer and no LLM evaluation**. Pass/fail is decided purely by the MCQ score against a
+threshold. Use this for knowledge checks where a written deliverable isn't needed — it is faster
+and cheaper (deterministic grading, no LLM call).
+
+The alternative (and default) mode is **free-text + MCQ**, where the participant submits a written
+answer that is graded by the LLM in addition to the MCQ.
+
+## Create an MCQ-only module (advanced editor)
+
+1. Open the module in the **advanced editor** (`/admin-content/module/<id>/advanced`).
+2. Author the **MCQ set** as usual (step 7).
+3. In **step 8 — "Module version shown to participant"**, tick **“MCQ-only module (no free-text
+   answer or LLM assessment)”**.
+   - The free-text fields (assignment text, scoring rules, evaluation instruction) disappear —
+     you don't need them.
+   - A **“MCQ pass threshold (%)”** field appears (default **70**). Set the minimum percentage of
+     correct answers required to pass.
+4. Save the draft version (steps 5–8) and **publish** it. Rubric and evaluation instruction are
+   skipped automatically for MCQ-only modules.
+
+## What the participant sees
+
+- Selecting an MCQ-only module goes **straight to the questions** — there is no “create
+  submission” / free-text step.
+- On submit, the result is shown **immediately** (deterministic scoring, no waiting for LLM):
+  *Automatic pass* if the MCQ score ≥ threshold, otherwise *Automatic fail*.
+
+## Certification
+
+Course completion and certificates require the participant to **pass all modules** in the course
+**and read all learning sections**. An MCQ-only module counts as a module that must be passed,
+exactly like a free-text module.
+
+## Export / import
+
+MCQ-only modules export and import as normal module packages. The package records the
+`assessmentMode` and the MCQ pass threshold; rubric, evaluation instruction and assignment text are
+omitted for MCQ-only modules and restored as such on import.
+
+## Notes
+
+- Existing modules are unaffected — they remain free-text + MCQ unless you explicitly switch.
+- The MCQ pass threshold is stored per module version (in the assessment policy), so different
+  modules can use different thresholds.

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,27 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.28 - 2026-06-21
+
+feat(content): MCQ-only import/eksport + bruker-doc (#547, #525)
+
+Siste #525-skive. Modul-pakker støtter nå MCQ-only-moduler ende-til-ende:
+- **Eksport** (`buildModuleExportEnvelope`): kaster ikke lenger på manglende rubric/prompt for
+  MCQ-only; emitter `assessmentMode` + null rubric/prompt/taskText. Bundle-select + transform
+  bærer `assessmentMode`.
+- **Import** (`contentImportService`): MCQ-only-gren — hopper over rubric/prompt-opprettelse,
+  valgfri taskText, setter `assessmentMode`.
+- **Schema:** `moduleExportPayloadSchema.activeVersion` får `assessmentMode` + gjør
+  `taskText`/`rubric`/`promptTemplate` valgfrie/nullbare.
+- **Bonusfiks:** `assessmentPolicy.passRules.totalMin` gjort valgfri — MCQ-only-policy setter kun
+  `mcqMinPercent`, og decisionService defaulter `totalMin`. (Dette var også en latent #546-bug:
+  forfatter-lagring av MCQ-only sendte policy uten totalMin → ville blitt avvist.)
+- **Bruker-doc:** `doc/MCQ_ONLY_MODULES_GUIDE.md` (forfatter-guide: opprett, deltaker-opplevelse,
+  sertifisering, import/eksport).
+
+Test: ny integrasjons-roundtrip-test (MCQ-only eksport→import bevarer assessmentMode, ingen
+rubric/prompt). tsc rent. Logget separat: #557 (rationale:null eksport/import-bug, pre-eksisterende).
+
 ## 1.3.27 - 2026-06-21
 
 fix(mcq-only): UX-batch fra staging-akseptanse + deterministisk MCQ-sensur (#525-oppfølging)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.27",
+  "version": "1.3.28",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/adminContentQueries.ts
+++ b/src/modules/adminContent/adminContentQueries.ts
@@ -97,6 +97,7 @@ export async function getModuleContentBundle(moduleId: string) {
     rubricVersionId: version.rubricVersionId,
     promptTemplateVersionId: version.promptTemplateVersionId,
     mcqSetVersionId: version.mcqSetVersionId,
+    assessmentMode: version.assessmentMode,
     publishedBy: version.publishedBy,
     publishedAt: version.publishedAt,
     createdAt: version.createdAt,
@@ -288,11 +289,15 @@ export async function buildModuleExportEnvelope(
     throw new Error("Module has no versions to export.");
   }
 
+  // #525/#547: MCQ_ONLY modules have no rubric or prompt template — those are only required for
+  // free-text (FREETEXT_PLUS_MCQ) modules.
+  const isMcqOnly = moduleVersion.assessmentMode === "MCQ_ONLY";
+
   const rubricVersion =
     bundle.versions.rubricVersions.find((v) => v.id === moduleVersion.rubricVersionId)
     ?? bundle.versions.rubricVersions[0]
     ?? null;
-  if (!rubricVersion) {
+  if (!rubricVersion && !isMcqOnly) {
     throw new Error("Module has no rubric versions to export.");
   }
 
@@ -300,7 +305,7 @@ export async function buildModuleExportEnvelope(
     bundle.versions.promptTemplateVersions.find((v) => v.id === moduleVersion.promptTemplateVersionId)
     ?? bundle.versions.promptTemplateVersions[0]
     ?? null;
-  if (!promptTemplateVersion) {
+  if (!promptTemplateVersion && !isMcqOnly) {
     throw new Error("Module has no prompt-template versions to export.");
   }
 
@@ -325,23 +330,28 @@ export async function buildModuleExportEnvelope(
         certificationLevel: bundle.module.certificationLevel as never,
       },
       activeVersion: {
-        taskText: moduleVersion.taskText as never,
+        assessmentMode: moduleVersion.assessmentMode as never,
+        taskText: (moduleVersion.taskText ?? null) as never,
         assessorExpectedContent: (moduleVersion.assessorExpectedContent ?? null) as never,
         candidateTaskConstraints: (moduleVersion.candidateTaskConstraints ?? null) as never,
         assessmentBlueprint: null,
         submissionSchema: (moduleVersion.submissionSchema ?? null) as never,
         assessmentPolicy: (moduleVersion.assessmentPolicy ?? null) as never,
-        rubric: {
-          criteria: rubricVersion.criteria as Record<string, unknown>,
-          scalingRule: rubricVersion.scalingRule as Record<string, unknown>,
-          active: true,
-        },
-        promptTemplate: {
-          systemPrompt: promptTemplateVersion.systemPrompt as never,
-          userPromptTemplate: promptTemplateVersion.userPromptTemplate as never,
-          examples: (promptTemplateVersion.examples ?? []) as Array<Record<string, unknown>>,
-          active: true,
-        },
+        rubric: rubricVersion
+          ? {
+              criteria: rubricVersion.criteria as Record<string, unknown>,
+              scalingRule: rubricVersion.scalingRule as Record<string, unknown>,
+              active: true,
+            }
+          : (null as never),
+        promptTemplate: promptTemplateVersion
+          ? {
+              systemPrompt: promptTemplateVersion.systemPrompt as never,
+              userPromptTemplate: promptTemplateVersion.userPromptTemplate as never,
+              examples: (promptTemplateVersion.examples ?? []) as Array<Record<string, unknown>>,
+              active: true,
+            }
+          : (null as never),
         mcqSet: {
           title: mcqSetVersion.title as never,
           questions: mcqSetVersion.questions as never,

--- a/src/modules/adminContent/adminContentRepository.ts
+++ b/src/modules/adminContent/adminContentRepository.ts
@@ -228,6 +228,7 @@ export function createAdminContentRepository(client: AdminContentRepositoryClien
               assessmentBlueprint: true,
               submissionSchemaJson: true,
               assessmentPolicyJson: true,
+              assessmentMode: true,
               rubricVersionId: true,
               promptTemplateVersionId: true,
               mcqSetVersionId: true,

--- a/src/modules/adminContent/adminContentSchemas.ts
+++ b/src/modules/adminContent/adminContentSchemas.ts
@@ -114,7 +114,9 @@ export const assessmentPolicyBodySchema = z.object({
     .optional(),
   passRules: z
     .object({
-      totalMin: z.number().min(0).max(100),
+      // #547: optional — MCQ-only policies set only mcqMinPercent; decisionService defaults
+      // totalMin from assessmentRules when absent.
+      totalMin: z.number().min(0).max(100).optional(),
       mcqMinPercent: z.number().min(0).max(100).optional(),
       practicalMinPercent: z.number().min(0).max(100).optional(),
       borderlineWindow: z
@@ -302,14 +304,16 @@ export const moduleExportPayloadSchema = z.object({
     certificationLevel: certificationLevelInputSchema,
   }),
   activeVersion: z.object({
-    taskText: localizedTextSchema,
+    // #525/#547: MCQ_ONLY exports omit taskText/rubric/promptTemplate (no free-text assessment).
+    assessmentMode: assessmentModeSchema.optional(),
+    taskText: localizedTextSchema.nullable().optional(),
     assessorExpectedContent: localizedTextSchema.nullable().optional(),
     candidateTaskConstraints: localizedTextSchema.nullable().optional(),
     assessmentBlueprint: z.string().nullable().optional(),
     submissionSchema: submissionSchemaBodySchema.nullable().optional(),
     assessmentPolicy: assessmentPolicyBodySchema.nullable().optional(),
-    rubric: rubricBodySchema,
-    promptTemplate: promptTemplateBodySchema,
+    rubric: rubricBodySchema.nullable().optional(),
+    promptTemplate: promptTemplateBodySchema.nullable().optional(),
     mcqSet: mcqSetBodySchema,
     audit: exportAuditSchema,
   }),

--- a/src/modules/adminContent/contentImportService.ts
+++ b/src/modules/adminContent/contentImportService.ts
@@ -78,20 +78,29 @@ async function importModulePayload(
     moduleId = newModule.id;
   }
 
-  const rubric = await createRubricVersion({
-    moduleId,
-    criteria: payload.activeVersion.rubric.criteria,
-    scalingRule: payload.activeVersion.rubric.scalingRule,
-    active: true,
-  });
+  // #525/#547: MCQ_ONLY modules have no rubric or prompt template — skip them on import.
+  const isMcqOnly = payload.activeVersion.assessmentMode === "MCQ_ONLY";
 
-  const promptTemplate = await createPromptTemplateVersion({
-    moduleId,
-    systemPrompt: serializeRequired(payload.activeVersion.promptTemplate.systemPrompt),
-    userPromptTemplate: serializeRequired(payload.activeVersion.promptTemplate.userPromptTemplate),
-    examples: payload.activeVersion.promptTemplate.examples ?? [],
-    active: true,
-  });
+  const rubric =
+    isMcqOnly || !payload.activeVersion.rubric
+      ? null
+      : await createRubricVersion({
+          moduleId,
+          criteria: payload.activeVersion.rubric.criteria,
+          scalingRule: payload.activeVersion.rubric.scalingRule,
+          active: true,
+        });
+
+  const promptTemplate =
+    isMcqOnly || !payload.activeVersion.promptTemplate
+      ? null
+      : await createPromptTemplateVersion({
+          moduleId,
+          systemPrompt: serializeRequired(payload.activeVersion.promptTemplate.systemPrompt),
+          userPromptTemplate: serializeRequired(payload.activeVersion.promptTemplate.userPromptTemplate),
+          examples: payload.activeVersion.promptTemplate.examples ?? [],
+          active: true,
+        });
 
   const mcqSet = await createMcqSetVersion({
     moduleId,
@@ -107,12 +116,15 @@ async function importModulePayload(
 
   const moduleVersion = await createModuleVersion({
     moduleId,
-    taskText: serializeRequired(payload.activeVersion.taskText),
+    assessmentMode: payload.activeVersion.assessmentMode,
+    taskText: isMcqOnly || !payload.activeVersion.taskText
+      ? undefined
+      : serializeRequired(payload.activeVersion.taskText),
     assessorExpectedContent: serializeLocalized(payload.activeVersion.assessorExpectedContent),
     candidateTaskConstraints: serializeLocalized(payload.activeVersion.candidateTaskConstraints),
     assessmentBlueprint: payload.activeVersion.assessmentBlueprint ?? undefined,
-    rubricVersionId: rubric.id,
-    promptTemplateVersionId: promptTemplate.id,
+    rubricVersionId: rubric?.id,
+    promptTemplateVersionId: promptTemplate?.id,
     mcqSetVersionId: mcqSet.id,
     submissionSchemaJson: payload.activeVersion.submissionSchema
       ? JSON.stringify(payload.activeVersion.submissionSchema)

--- a/test/m2-content-export-import.test.ts
+++ b/test/m2-content-export-import.test.ts
@@ -247,3 +247,84 @@ describe("#512 course export-import with learning sections", () => {
     expect(recreatedSection?.sectionId).not.toBe(sectionId);
   });
 });
+
+// #525/#547: MCQ-only modules have no rubric/prompt/taskText. Export must not require them, and
+// the round-trip must preserve assessmentMode=MCQ_ONLY.
+describe("#547 MCQ-only module export-import round-trip", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  async function setupMcqOnlyModule(suffix: string) {
+    const createResponse = await request(app)
+      .post("/api/admin/content/modules")
+      .set(adminHeaders)
+      .send({
+        title: { "en-GB": `MCQ-only source ${suffix}`, nb: `Kun-MCQ kilde ${suffix}`, nn: `Kun-MCQ kjelde ${suffix}` },
+        description: { "en-GB": "MCQ-only source", nb: "Kun-MCQ", nn: "Kun-MCQ" },
+        certificationLevel: "basic",
+      });
+    expect(createResponse.status).toBe(201);
+    const moduleId = createResponse.body.module.id as string;
+
+    const mcq = await request(app)
+      .post(`/api/admin/content/modules/${moduleId}/mcq-set-versions`)
+      .set(adminHeaders)
+      .send({
+        title: { "en-GB": "MCQ", nb: "MCQ", nn: "MCQ" },
+        questions: [
+          {
+            stem: { "en-GB": "2+2?", nb: "2+2?", nn: "2+2?" },
+            options: [{ "en-GB": "4", nb: "4", nn: "4" }, { "en-GB": "5", nb: "5", nn: "5" }],
+            correctAnswer: { "en-GB": "4", nb: "4", nn: "4" },
+            rationale: { "en-GB": "Math", nb: "Matte", nn: "Matte" },
+          },
+        ],
+      });
+    expect(mcq.status).toBe(201);
+    const mcqSetVersionId = mcq.body.mcqSetVersion.id as string;
+
+    const moduleVersion = await request(app)
+      .post(`/api/admin/content/modules/${moduleId}/module-versions`)
+      .set(adminHeaders)
+      .send({
+        assessmentMode: "MCQ_ONLY",
+        mcqSetVersionId,
+        assessmentPolicy: { passRules: { mcqMinPercent: 70 } },
+      });
+    expect(moduleVersion.status).toBe(201);
+    expect(moduleVersion.body.moduleVersion.assessmentMode).toBe("MCQ_ONLY");
+    return { moduleId, mcqSetVersionId };
+  }
+
+  it("exports an MCQ-only module (no rubric/prompt/taskText) and re-imports it preserving the mode", async () => {
+    const { moduleId } = await setupMcqOnlyModule("A");
+
+    const exportResponse = await request(app)
+      .get(`/api/admin/content/modules/${moduleId}/export-package`)
+      .set(adminHeaders);
+    expect(exportResponse.status).toBe(200);
+    const envelope = exportResponse.body.envelope;
+    expect(envelope.module.activeVersion.assessmentMode).toBe("MCQ_ONLY");
+    expect(envelope.module.activeVersion.rubric ?? null).toBeNull();
+    expect(envelope.module.activeVersion.promptTemplate ?? null).toBeNull();
+    expect(envelope.module.activeVersion.taskText ?? null).toBeNull();
+    expect(envelope.module.activeVersion.mcqSet.questions).toHaveLength(1);
+
+    const importResponse = await request(app)
+      .post("/api/admin/content/modules/import")
+      .set(otherAdminHeaders)
+      .send({ mode: "createNew", payload: envelope });
+    expect(importResponse.status).toBe(201);
+    const newModuleId = importResponse.body.moduleId as string;
+    expect(newModuleId).not.toBe(moduleId);
+
+    const verifyResponse = await request(app)
+      .get(`/api/admin/content/modules/${newModuleId}/export-package`)
+      .set(adminHeaders);
+    expect(verifyResponse.status).toBe(200);
+    expect(verifyResponse.body.envelope.module.activeVersion.assessmentMode).toBe("MCQ_ONLY");
+    expect(verifyResponse.body.envelope.module.activeVersion.rubric ?? null).toBeNull();
+    expect(verifyResponse.body.envelope.module.activeVersion.mcqSet.questions).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Sammendrag
Siste #525-skive: modul-pakke **import/eksport** håndterer MCQ-only-moduler ende-til-ende + forfatter-dokumentasjon.

## Endringer
- **Eksport** (`buildModuleExportEnvelope`): kaster ikke lenger på manglende rubric/prompt for MCQ-only; emitter `assessmentMode` + null rubric/prompt/taskText. Bundle-select + transform bærer `assessmentMode`.
- **Import** (`contentImportService`): MCQ-only-gren — hopper over rubric/prompt-opprettelse, valgfri taskText, setter `assessmentMode`.
- **Schema**: `moduleExportPayloadSchema.activeVersion` får `assessmentMode` + valgfri/nullbar `taskText`/`rubric`/`promptTemplate`.
- **Bonusfiks**: `assessmentPolicy.passRules.totalMin` gjort valgfri — var en latent **#546-bug** (MCQ-only-forfatter-lagring sendte policy uten totalMin → ville blitt avvist i ekte bruk; mocket e2e fanget det ikke).
- **Bruker-doc**: `doc/MCQ_ONLY_MODULES_GUIDE.md`.

## Test
Ny integrasjons-roundtrip (MCQ-only eksport→import bevarer `assessmentMode`, ingen rubric/prompt). `tsc` rent. CI `verify` kjører full suite mot fersk DB.

## Funn logget separat
- #557 — MCQ-spørsmål uten rationale eksporteres som `rationale:null` → import avviser (pre-eksisterende, ikke MCQ-only-spesifikk).

## Rollback
Backend + schema (mer lempelig validering) + doc. Ingen migrasjoner. Trygg revert.

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)