### PR TITLE
fix+feat(participant): MCQ-only-bugfikser + feiring ved bestått/fullført (v1.3.29, #549, #550)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,27 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.29 - 2026-06-21
+
+fix+feat(participant): MCQ-only-bugfikser + feiring ved bestått/fullført (#549, #550, +#1/#2-fiks)
+
+Andre runde med staging-tilbakemelding på MCQ-only:
+- **#1-fiks (auto-start):** «MCQ vises direkte» fungerte ikke via kurs-stien — auto-start-hooken lå
+  bare i modul-kort-klikket, ikke i `openCourseModule`. Flyttet inn i `activateParticipantModule`
+  så begge stier (kort + kurs) auto-oppretter besvarelse + starter MCQ.
+- **#2-fiks (layout):** seksjon 8 var visuelt entangled — MCQ-only-vekslingen + terskel grupperes
+  nå i et avgrenset «modultype»-delpanel, adskilt fra fritekst-feltene. (Full omlegging kommer i
+  #554 der modultype velges ved opprettelse.)
+- **#549 feiring bestått modul:** konfetti (lettvekts, dependency-fri, respekterer reduced-motion)
+  + «🎉 Gratulerer — du bestod!»-banner på resultatet (én gang per innlevering).
+- **#550 feiring fullført kurs:** konfetti + toast når et kurs blir fullført i økten (ikke for
+  allerede-fullførte kurs ved innlasting). E-post ved kurs-fullføring gjenstår (backend/ACS) —
+  sporet i #550; modul-bestått sender allerede resultat-e-post.
+
+Test: 30 e2e grønne (inkl. oppdatert MCQ-only-author-e2e), i18n-nøkkel-vakt dekker de nye nøklene,
+55 kontrakt-tester. tsc rent. (Feirings-banneret er dekorativt + i18n-vakt-dekket; visuell
+verifisering på staging.)
+
 ## 1.3.28 - 2026-06-21
 
 feat(content): MCQ-only import/eksport + bruker-doc (#547, #525)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.28",
+  "version": "1.3.29",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-advanced.html
+++ b/public/admin-content-advanced.html
@@ -90,6 +90,11 @@
       .mcq-option-row input[type="radio"] { margin: 0; }
       /* #546 feedback: checkboxes must not inherit the full-width text-input styling. */
       input[type="checkbox"] { width: auto; display: inline-block; vertical-align: middle; margin: 0 6px 0 0; }
+      /* #546 feedback: group the module-type (MCQ-only) control in a distinct sub-panel so it
+         reads as one choice, separate from the free-text fields. */
+      .module-type-panel { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-2); margin: var(--space-1) 0; background: var(--color-surface-muted, #f7f8fa); }
+      .module-type-toggle { display: flex; align-items: center; font-weight: 600; }
+      #moduleVersionMcqThresholdRow { margin-top: var(--space-1); }
       .prompt-example-row { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-1); margin-bottom: var(--space-1); }
       .prompt-example-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; font-size: 12px; font-weight: 700; color: var(--color-meta); text-transform: uppercase; letter-spacing: 0.05em; }
       .ss-field-row { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-1); margin-bottom: var(--space-1); }
@@ -553,10 +558,13 @@
     <section class="card" id="sectionModuleVersion">
       <h2 data-i18n="adminContent.moduleVersion.title">8) Participant-facing module version</h2>
       <div class="small" data-i18n="adminContent.help.moduleVersionOverview">Binds assignment text + scoring rules + evaluation instruction + test.</div>
-      <div><label><input type="checkbox" id="moduleVersionMcqOnly" class="inline" /> <span data-i18n="adminContent.moduleVersion.mcqOnly">MCQ-only module (no free-text answer or LLM assessment)</span></label></div>
-      <div class="small" data-i18n="adminContent.help.mcqOnly">When enabled, participants only answer multiple-choice questions. No assignment text, scoring rules or evaluation instruction are needed — pass/fail is decided purely by the MCQ score.</div>
-      <div class="row" id="moduleVersionMcqThresholdRow" hidden>
-        <div><label for="moduleVersionMcqMinPercent" data-i18n="adminContent.moduleVersion.mcqMinPercent">MCQ pass threshold (%)</label><input id="moduleVersionMcqMinPercent" type="number" min="0" max="100" value="70" /></div>
+      <div class="module-type-panel">
+        <label class="module-type-toggle"><input type="checkbox" id="moduleVersionMcqOnly" /> <span data-i18n="adminContent.moduleVersion.mcqOnly">MCQ-only module (no free-text answer or LLM assessment)</span></label>
+        <div class="small" data-i18n="adminContent.help.mcqOnly">When enabled, participants only answer multiple-choice questions. No assignment text, scoring rules or evaluation instruction are needed — pass/fail is decided purely by the MCQ score.</div>
+        <div id="moduleVersionMcqThresholdRow" hidden>
+          <label for="moduleVersionMcqMinPercent" data-i18n="adminContent.moduleVersion.mcqMinPercent">MCQ pass threshold (%)</label>
+          <input id="moduleVersionMcqMinPercent" type="number" min="0" max="100" value="70" style="max-width:120px" />
+        </div>
       </div>
       <div id="moduleVersionFreetextFields">
       <details class="json-fallback-panel">

--- a/public/admin-content.js
+++ b/public/admin-content.js
@@ -3750,10 +3750,10 @@ deleteModuleButton.addEventListener("click", async () => {
 // #525/#546: toggle the free-text authoring fields + MCQ threshold based on the MCQ-only switch.
 function applyMcqOnlyAuthoringVisibility() {
   const mcqOnly = moduleVersionMcqOnlyInput?.checked === true;
-  // Use style.display: the threshold row carries the `.row` class whose CSS display overrides the
-  // [hidden] attribute (same gotcha as participant ack), so toggle display directly (#525/#546).
-  if (moduleVersionFreetextFields) moduleVersionFreetextFields.style.display = mcqOnly ? "none" : "";
-  if (moduleVersionMcqThresholdRow) moduleVersionMcqThresholdRow.style.display = mcqOnly ? "" : "none";
+  // Both are plain <div>s (no class overriding the [hidden] attribute after the #546 layout
+  // cleanup), so the hidden property works directly (#525/#546).
+  if (moduleVersionFreetextFields) moduleVersionFreetextFields.hidden = mcqOnly;
+  if (moduleVersionMcqThresholdRow) moduleVersionMcqThresholdRow.hidden = !mcqOnly;
 }
 moduleVersionMcqOnlyInput?.addEventListener("change", applyMcqOnlyAuthoringVisibility);
 applyMcqOnlyAuthoringVisibility();

--- a/public/i18n/participant-translations.js
+++ b/public/i18n/participant-translations.js
@@ -268,6 +268,8 @@ export const translations = {
     "result.rationaleValue.responsible_use":
       "Responsible-use checks are described in the submission.",
     "result.none": "No result loaded.",
+    "result.celebratePass": "🎉 Congratulations — you passed!",
+    "courses.celebrateComplete": "🎉 Course completed — well done!",
     "history.empty": "No submissions found.",
     "history.entry": "Submission",
     "history.module": "Module",
@@ -561,6 +563,8 @@ export const translations = {
     "result.rationaleValue.responsible_use":
       "Kontroller for ansvarlig bruk er beskrevet i innleveringen.",
     "result.none": "Ingen resultat lastet.",
+    "result.celebratePass": "🎉 Gratulerer — du bestod!",
+    "courses.celebrateComplete": "🎉 Kurs fullført — godt jobbet!",
     "history.empty": "Ingen innleveringer funnet.",
     "history.entry": "Innlevering",
     "history.module": "Modul",
@@ -855,6 +859,8 @@ export const translations = {
     "result.rationaleValue.responsible_use":
       "Kontrollar for ansvarleg bruk er skildra i innleveringa.",
     "result.none": "Ingen resultat lasta.",
+    "result.celebratePass": "🎉 Gratulerer — du bestod!",
+    "courses.celebrateComplete": "🎉 Kurs fullført — godt jobba!",
     "history.empty": "Ingen innleveringar funne.",
     "history.entry": "Innlevering",
     "history.module": "Modul",

--- a/public/participant.html
+++ b/public/participant.html
@@ -86,6 +86,8 @@
       .course-module-button.selected { background: var(--color-blue-light); }
       .course-module-button[disabled] { cursor: wait; opacity: 0.8; }
       .course-certificate-banner { padding: 8px 12px; background: #f4fbf7; border: 1px solid #b8d9c6; border-radius: var(--radius-card); font-size: 13px; color: #1f7a4d; font-weight: 600; }
+      /* #549/#550: celebratory pass / course-completion banner. */
+      .celebrate-banner { padding: 12px 16px; margin-bottom: var(--space-2, 12px); background: linear-gradient(90deg, #e8f7ee, #eef4ff); border: 1px solid #b8d9c6; border-radius: var(--radius-card); font-size: 16px; font-weight: 700; color: #16703f; text-align: center; }
     </style>
   </head>
   <body>

--- a/public/participant.js
+++ b/public/participant.js
@@ -88,6 +88,9 @@ const COMPLETED_MODULE_STATUSES = new Set(["COMPLETED"]);
 let currentQuestions = [];
 let currentLocale = resolveInitialLocale();
 let latestResult = null;
+// #549: ensures the pass celebration (confetti + banner) fires once per submission, not on every
+// result poll. Reset when the module context changes / a new submission starts.
+let celebrationShown = false;
 let latestHistory = null;
 let participantRuntimeConfig = {
   authMode: "mock",
@@ -845,12 +848,6 @@ function renderModules() {
     button.setAttribute("aria-pressed", module.selected ? "true" : "false");
     button.addEventListener("click", () => {
       activateParticipantModule(module.id);
-      // #546 feedback: MCQ-only modules have no free-text step — go straight to the questions by
-      // creating the (empty) submission + starting the MCQ immediately, instead of requiring the
-      // participant to click "Create submission" first.
-      if (moduleIsMcqOnly(module) && !previewModeEnabled && !flowState.hasSubmission && !createSubmissionButton.disabled) {
-        createSubmissionButton.click();
-      }
     });
 
     const title = document.createElement("div");
@@ -993,6 +990,13 @@ function activateParticipantModule(moduleId, options = {}) {
   restoreDraftForSelectedModule(true);
   updateCreateSubmissionAvailability();
 
+  // #546 feedback: MCQ-only modules have no free-text step — go straight to the questions by
+  // creating the (empty) submission + starting the MCQ immediately, so the participant never sees
+  // a "create submission" step. Covers both entry points (module card + course → openCourseModule).
+  if (moduleIsMcqOnly(nextModule) && !previewModeEnabled && !flowState.hasSubmission && !createSubmissionButton.disabled) {
+    createSubmissionButton.click();
+  }
+
   // v1.2.22 (#465): kollaps modullisten så modul-innholdet får mer plass. Bruker kan
   // ekspandere igjen ved å klikke «Last moduler»-knappen.
   document.getElementById("moduleListSection")?.classList.add("module-list-collapsed");
@@ -1051,6 +1055,7 @@ function resetFlowStateForModuleContext() {
     assessmentQueued: false,
     resultStatus: null,
   };
+  celebrationShown = false;
   latestAppeal = null;
   assessmentProgressKey = "assessment.progress.idle";
   setAssessmentProgressDetail();
@@ -2078,6 +2083,52 @@ function formatHistoryModuleValue(module) {
   return `${moduleTitle} (${t("modules.debugId")}: ${moduleId})`;
 }
 
+// #549/#550: lightweight, dependency-free confetti for celebrating a pass / course completion.
+// Decorative only — wrapped so it can never throw into the calling flow.
+function launchConfetti() {
+  try {
+    if (window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const canvas = document.createElement("canvas");
+    canvas.style.cssText = "position:fixed;inset:0;pointer-events:none;z-index:9998";
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    document.body.appendChild(canvas);
+    const ctx = canvas.getContext("2d");
+    const colors = ["#2563eb", "#16a34a", "#f59e0b", "#db2777", "#7c3aed"];
+    const pieces = Array.from({ length: 140 }, () => ({
+      x: Math.random() * canvas.width,
+      y: -20 - Math.random() * canvas.height * 0.3,
+      r: 4 + Math.random() * 6,
+      c: colors[Math.floor(Math.random() * colors.length)],
+      vy: 2 + Math.random() * 3.5,
+      vx: -1.5 + Math.random() * 3,
+      rot: Math.random() * Math.PI,
+      vr: -0.12 + Math.random() * 0.24,
+    }));
+    const start = performance.now();
+    function frame(now) {
+      const elapsed = now - start;
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      for (const p of pieces) {
+        p.x += p.vx;
+        p.y += p.vy;
+        p.rot += p.vr;
+        ctx.save();
+        ctx.translate(p.x, p.y);
+        ctx.rotate(p.rot);
+        ctx.fillStyle = p.c;
+        ctx.fillRect(-p.r / 2, -p.r / 2, p.r, p.r);
+        ctx.restore();
+      }
+      if (elapsed < 2600) requestAnimationFrame(frame);
+      else canvas.remove();
+    }
+    requestAnimationFrame(frame);
+  } catch {
+    /* confetti is decorative; never block the result flow on it */
+  }
+}
+
 function renderResultSummary(body) {
   latestResult = body;
   latestAppeal = body?.latestAppeal ?? latestAppeal;
@@ -2140,6 +2191,18 @@ function renderResultSummary(body) {
 
     rationaleCard.appendChild(rationaleList);
     resultSummary.appendChild(rationaleCard);
+  }
+
+  // #549: celebrate an automatic/confirmed pass — confetti + a clear "passed" banner, shown once
+  // per result (the result view re-renders on each poll). De-emphasising retry is handled in
+  // renderFlowGating.
+  if (body.decision?.passFailTotal === true && !celebrationShown) {
+    celebrationShown = true;
+    const banner = document.createElement("div");
+    banner.className = "celebrate-banner";
+    banner.textContent = t("result.celebratePass");
+    resultSummary.prepend(banner);
+    launchConfetti();
   }
 
   resultSummary.dataset.hasResult = "true";
@@ -2705,6 +2768,11 @@ if (previewModeEnabled) {
 
 let participantCourses = [];
 let participantCompletions = {};   // courseId -> completion
+// #550: celebrate a course completion only when it happens during the session (e.g. the
+// participant just passed the last module / read the last section), not for already-completed
+// courses on first load.
+const celebratedCompletedCourses = new Set();
+let courseAccordionInitialized = false;
 let courseDetailCache = {};        // courseId -> CourseDetail
 
 function escapeHtmlP(str) {
@@ -2748,6 +2816,23 @@ function renderParticipantCourseAccordion() {
   for (const course of participantCourses) {
     container.appendChild(buildCourseAccordionItem(course));
   }
+
+  // #550: confetti when a course becomes completed during this session.
+  let newlyCompleted = false;
+  for (const course of participantCourses) {
+    const isCompleted = Boolean(participantCompletions[course.id]) || course.progress?.courseStatus === "COMPLETED";
+    if (!isCompleted) continue;
+    if (!celebratedCompletedCourses.has(course.id)) {
+      celebratedCompletedCourses.add(course.id);
+      if (courseAccordionInitialized) newlyCompleted = true;
+    }
+  }
+  if (newlyCompleted) {
+    launchConfetti();
+    showToast(t("courses.celebrateComplete"), "success");
+  }
+  courseAccordionInitialized = true;
+
   // Deep link: ?courseId=xxx opens that course
   const linkedCourseId = new URLSearchParams(window.location.search).get("courseId");
   if (linkedCourseId) {


### PR DESCRIPTION
## Sammendrag
Andre runde med din staging-tilbakemelding på MCQ-only + feiring.

## Bugfikser (fra din retest)
- **#1** «MCQ vises direkte» fungerte ikke via **kurs-stien** — auto-start-hooken lå kun i modul-kort-klikket, ikke i `openCourseModule`. Flyttet inn i `activateParticipantModule` → begge stier auto-oppretter besvarelse + starter MCQ.
- **#2** Seksjon 8-layout: MCQ-only-veksling + terskel grupperes nå i et avgrenset **«modultype»-delpanel**, adskilt fra fritekst-feltene. (Full omlegging kommer i #554.)

## Feiring
- **#549** Konfetti (dependency-fri, respekterer `prefers-reduced-motion`) + «🎉 Gratulerer — du bestod!»-banner på bestått resultat (én gang per innlevering).
- **#550** Konfetti + toast når et kurs fullføres **i økten** (ikke for allerede-fullførte ved innlasting).

## Gjenstår
- **#550 e-post** ved kurs-fullføring (backend/ACS — trenger mal + verifisering; modul-bestått sender allerede resultat-e-post). Sporet i #550.

## Test
30 e2e grønne (inkl. oppdatert MCQ-only-author-e2e), i18n-nøkkel-vakt dekker nye nøkler, 55 kontrakt-tester, `tsc` rent. Feirings-banneret er dekorativt — visuell verifisering på staging.

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)