### PR TITLE
fix(participant): MCQ-only 409 ved innlevering + fullførings-flyt (v1.3.30)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,25 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.30 - 2026-06-21
+
+fix(participant): MCQ-only 409 ved innlevering + fullførings-flyt (staging-tilbakemelding runde 3)
+
+- **#2 (409 «already completed and passed»):** rotårsak — #8 sync-sensur fullfører MCQ-only-
+  innleveringen ved mcq/submit, men UI kjørte likevel auto-assessment (`/assessments/:id/run`) →
+  409 mot recert-vernet. `mcq/submit` returnerer nå `assessmentComplete`; UI hopper over auto-run
+  og henter resultatet direkte. Auto-start (#7) fyrer heller ikke for en allerede bestått modul.
+- **#3 seksjonsleser lukkes ikke:** «Marker som lest» lukker nå leseren (forventet) + re-laster
+  kurs-oversikten.
+- **#3 modul-status + kurs-konfetti:** kurs-lista re-lastes nå etter bestått modul og etter
+  seksjons-lesing, så status oppdateres i kursoversikten og #550-konfettien fyrer ved fullført kurs.
+
+Test: 30 e2e grønne (oppdatert section-reader-e2e: mark-read lukker leseren), mcq-service unit +
+i18n/contract grønne, tsc rent.
+
+Note: helhetlig forfatter-IA (#554/#555) — omforent design (felles rekkefølge Samtale+Avansert,
+uten nummerering, modultype på topp) er festet på issuene; implementeres som egen runde.
+
 ## 1.3.29 - 2026-06-21
 
 fix+feat(participant): MCQ-only-bugfikser + feiring ved bestått/fullført (#549, #550, +#1/#2-fiks)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.29",
+  "version": "1.3.30",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/participant.js
+++ b/public/participant.js
@@ -993,7 +993,9 @@ function activateParticipantModule(moduleId, options = {}) {
   // #546 feedback: MCQ-only modules have no free-text step — go straight to the questions by
   // creating the (empty) submission + starting the MCQ immediately, so the participant never sees
   // a "create submission" step. Covers both entry points (module card + course → openCourseModule).
-  if (moduleIsMcqOnly(nextModule) && !previewModeEnabled && !flowState.hasSubmission && !createSubmissionButton.disabled) {
+  // #2 fix: don't auto-start for an already-passed module (avoids a needless retake / 409).
+  const alreadyPassed = nextModule.participantStatus?.latestDecision?.passFailTotal === true;
+  if (moduleIsMcqOnly(nextModule) && !alreadyPassed && !previewModeEnabled && !flowState.hasSubmission && !createSubmissionButton.disabled) {
     createSubmissionButton.click();
   }
 
@@ -2203,6 +2205,11 @@ function renderResultSummary(body) {
     banner.textContent = t("result.celebratePass");
     resultSummary.prepend(banner);
     launchConfetti();
+    // #550 feedback: passing a module can complete a course — refresh the (possibly off-screen)
+    // course list so its status updates and the course-completion confetti can fire.
+    if (participantCourses.length > 0) {
+      loadParticipantCourses().catch(() => {});
+    }
   }
 
   resultSummary.dataset.hasResult = "true";
@@ -2534,10 +2541,14 @@ submitMcqButton.addEventListener("click", async () => {
       });
       currentQuestions = [];
       renderQuestions();
+      // #2 fix: MCQ-only submissions are finalised synchronously (assessmentComplete) — the
+      // assessment is already done, so we must NOT auto-run it (that 409s against the recert
+      // re-run guard). Just fetch + show the ready result.
+      const alreadyAssessed = body.assessmentComplete === true;
       flowState = {
         ...flowState,
         hasMcqSubmission: true,
-        assessmentQueued: getFlowSettings().autoStartAfterMcq,
+        assessmentQueued: !alreadyAssessed && getFlowSettings().autoStartAfterMcq,
         resultStatus: null,
       };
       assessmentProgressKey = "assessment.progress.idle";
@@ -2545,7 +2556,10 @@ submitMcqButton.addEventListener("click", async () => {
       renderAssessmentProgress();
       renderFlowGating();
       persistCurrentModuleDraft(true);
-      if (getFlowSettings().autoStartAfterMcq) {
+      if (alreadyAssessed) {
+        const resultBody = await apiFetch(`/api/submissions/${submissionId}/result`, headers);
+        renderResultSummary(resultBody);
+      } else if (getFlowSettings().autoStartAfterMcq) {
         await startAutomaticAssessmentFlow(submissionId);
       }
       log(body);
@@ -2995,8 +3009,12 @@ async function openSectionReader(courseId, sectionId) {
   let markedRead = false;
   const close = () => {
     overlay.remove();
-    // Refresh the course detail so the "read" badge + progress update.
-    if (markedRead) loadCourseDetail(courseId);
+    // Refresh both the course detail (read badge) AND the course list (course-level progress +
+    // completion), so status updates and the #550 course-completion confetti can fire (#549/#550).
+    if (markedRead) {
+      loadCourseDetail(courseId);
+      loadParticipantCourses().catch(() => {});
+    }
   };
   overlay.querySelector("#sectionReaderClose")?.addEventListener("click", close);
   overlay.addEventListener("click", (e) => { if (e.target === overlay) close(); });
@@ -3004,14 +3022,15 @@ async function openSectionReader(courseId, sectionId) {
     if (e.key === "Escape") { close(); document.removeEventListener("keydown", onKey); }
   });
 
-  // Explicit "mark as read" (#492 feedback) — clearer than auto-marking on open.
+  // Explicit "mark as read" (#492 feedback). #550 feedback: marking read should also close the
+  // reader (the participant expected it to close) and refresh course status.
   const markReadBtn = overlay.querySelector("#sectionReaderMarkRead");
   markReadBtn?.addEventListener("click", async () => {
     markReadBtn.disabled = true;
     try {
       await apiFetch(`/api/courses/${encodeURIComponent(courseId)}/sections/${encodeURIComponent(sectionId)}/read`, headers, { method: "POST" });
       markedRead = true;
-      markReadBtn.textContent = t("courses.section.doneBadge");
+      close();
     } catch (error) {
       markReadBtn.disabled = false;
       showToast(error instanceof Error ? error.message : t("courses.loadError"), "error");

--- a/src/modules/assessment/mcqService.ts
+++ b/src/modules/assessment/mcqService.ts
@@ -139,9 +139,11 @@ export async function submitMcqAttempt(input: {
   // #546 feedback: MCQ-only modules are graded deterministically (no LLM). Process the assessment
   // synchronously so the participant gets the result immediately, instead of waiting for the async
   // worker + poll cycle. Falls back to the enqueued job if synchronous processing fails.
+  let assessmentComplete = false;
   if (submission.moduleVersion?.assessmentMode === "MCQ_ONLY") {
     try {
       await processSubmissionJobNow(submission.id);
+      assessmentComplete = true;
     } catch (error) {
       console.warn("Synchronous MCQ-only assessment failed; leaving job for async worker.", error);
     }
@@ -166,6 +168,9 @@ export async function submitMcqAttempt(input: {
     percentScore,
     scaledScore,
     passFailMcq,
+    // #546/#2: when true the assessment was already finalised synchronously (MCQ-only) — the client
+    // must NOT auto-run the assessment again (that would 409 against the recert re-run guard).
+    assessmentComplete,
   };
 }
 

--- a/test/e2e/participant-section-reader.spec.ts
+++ b/test/e2e/participant-section-reader.spec.ts
@@ -110,8 +110,8 @@ test("participant: open a course section, render its image, and mark it read", a
   await expect(img).toHaveCount(1);
   await expect.poll(async () => (await img.getAttribute("src")) ?? "").toMatch(/^blob:/);
 
-  // Mark as read fires the POST and updates the button.
+  // Mark as read fires the POST and closes the reader (#550 feedback).
   await page.locator("#sectionReaderMarkRead").click();
   await expect.poll(() => markReadCalled).toBe(true);
-  await expect(page.locator("#sectionReaderMarkRead")).not.toBeEnabled();
+  await expect(page.locator("#sectionReaderOverlay")).toHaveCount(0);
 });


### PR DESCRIPTION
## Staging-tilbakemelding runde 3
- **#2 (409 «already completed and passed»):** rotårsak — #8 sync-sensur fullfører MCQ-only ved `mcq/submit`, men UI kjørte likevel auto-assessment (`/assessments/:id/run`) → 409 mot recert-vernet. `mcq/submit` returnerer nå `assessmentComplete`; UI hopper over auto-run + henter resultatet direkte. Auto-start fyrer heller ikke for en allerede bestått modul.
- **#3 seksjonsleser lukkes ikke:** «Marker som lest» lukker nå leseren + re-laster kurs-oversikten.
- **#3 status + kurs-konfetti:** kurs-lista re-lastes etter bestått modul og etter lesing → status oppdateres + #550-konfetti fyrer ved fullført kurs.

## Test
30 e2e grønne (oppdatert section-reader-e2e: mark-read lukker leseren), mcq-service unit + i18n/contract grønne, `tsc` rent.

## Rollback
Frontend + én mcqService-retur-utvidelse. Ingen migrasjoner. Trygg revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)