### PR TITLE
sec(ingest): lukk DNS-rebinding/TOCTOU i URL-henting (v1.3.32, #520)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,24 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.32 - 2026-06-21
+
+sec(ingest): lukk DNS-rebinding/TOCTOU i URL-henting (#520)
+
+`assertSafeUrl` validerte hostnavnets IP-er på forhånd, men `fetch` gjorde sitt eget DNS-oppslag —
+en angriper med kort-TTL-record kunne returnere public IP ved sjekken og privat IP ved selve
+tilkoblingen (DNS-rebinding) → SSRF-bypass.
+
+- Ny `createValidatingLookup` brukes som `connect.lookup` i en undici `Agent` (dispatcher). Det er
+  oppslaget fetch faktisk kobler til med, og det re-validerer hver resolved IP (avviser private/
+  metadata/loopback) ved tilkoblingstidspunktet → rebinding-vinduet lukket.
+- Global `fetch` beholdes (test-mockbar) med `dispatcher`-opsjon; `assertSafeUrl` (forhånds-sjekk)
+  beholdt som første lag (defense-in-depth).
+- `undici` lagt eksplisitt i `dependencies` (var transitiv).
+
+Test: 8 nye unit-tester (rebinding/metadata/IPv6/mixed/fail-closed). Eksisterende url-fetch-tester
+uendret (16 grønne totalt). tsc rent.
+
 ## 1.3.31 - 2026-06-21
 
 feat(author): avansert-editor IA — fjern nummerering + modultype på topp (#554, del 1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.16",
+  "version": "1.3.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a2-assessment-platform",
-      "version": "1.3.16",
+      "version": "1.3.32",
       "dependencies": {
         "@azure/communication-email": "^1.1.0",
         "@azure/identity": "^4.13.1",
@@ -26,6 +26,7 @@
         "pdf-parse": "^2.4.5",
         "ppt": "^0.0.2",
         "prisma": "^6.5.0",
+        "undici": "^7.25.0",
         "word-extractor": "^1.0.4",
         "zod": "^3.24.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.31",
+  "version": "1.3.32",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",
@@ -75,6 +75,7 @@
     "pdf-parse": "^2.4.5",
     "ppt": "^0.0.2",
     "prisma": "^6.5.0",
+    "undici": "^7.25.0",
     "word-extractor": "^1.0.4",
     "zod": "^3.24.2"
   },

--- a/src/modules/adminContent/urlFetchService.ts
+++ b/src/modules/adminContent/urlFetchService.ts
@@ -4,7 +4,9 @@
 // LLM kun for å fetche URL-er.
 
 import { lookup as dnsLookup } from "node:dns/promises";
+import { lookup as dnsLookupCallback } from "node:dns";
 import { isIPv4, isIPv6 } from "node:net";
+import { Agent } from "undici";
 
 import { SOURCE_MATERIAL_MAX_BYTES } from "./sourceMaterialExtractionService.js";
 
@@ -20,10 +22,9 @@ export class UrlFetchError extends Error {
 }
 
 // SSRF: block requests against private IP ranges, loopback, link-local, and cloud
-// metadata endpoints. Resolves hostname via DNS and checks the resulting IP. There's a
-// known TOCTOU window between resolve and fetch where DNS could change (DNS rebinding) —
-// for v1 we accept that risk; mitigation (resolve-once-then-connect-to-IP-with-Host-header)
-// can be added in Phase 1.1 if needed.
+// metadata endpoints. Two layers: (1) assertSafeUrl validates the hostname's resolved IPs up
+// front; (2) the fetch uses ssrfSafeDispatcher whose connect-time lookup re-validates the IP it
+// actually connects to — closing the DNS-rebinding / TOCTOU window (#520).
 const PRIVATE_IPV4_RANGES: Array<[number, number, number]> = [
   // [first-octet, second-octet-min, second-octet-max]
   // RFC 1918 + loopback + link-local + CGNAT
@@ -71,6 +72,58 @@ function isPrivateIp(ip: string): boolean {
   if (isIPv6(ip)) return isPrivateIpv6(ip);
   return false;
 }
+
+// #520: close the DNS-rebinding / TOCTOU window. assertSafeUrl validates the hostname's resolved
+// IPs up front, but a low-TTL attacker record could return a public IP then (the check) and a
+// private IP at connect time (the fetch's own resolve). This custom lookup is the resolution the
+// fetch actually uses to connect, and it re-validates every resolved address — so the IP we connect
+// to is guaranteed public. Exported for unit testing.
+export function createValidatingLookup(
+  resolver: typeof dnsLookupCallback = dnsLookupCallback,
+) {
+  return function validatingLookup(
+    hostname: string,
+    options: Parameters<typeof dnsLookupCallback>[1],
+    callback: (err: NodeJS.ErrnoException | null, address: unknown, family?: number) => void,
+  ): void {
+    const opts = typeof options === "object" && options !== null ? options : {};
+    resolver(hostname, { ...opts, all: true, verbatim: true }, (err, addresses) => {
+      if (err) {
+        callback(err, "", 0);
+        return;
+      }
+      const list = Array.isArray(addresses) ? addresses : [];
+      if (list.length === 0) {
+        callback(new UrlFetchError("dns_failed", `Could not resolve hostname (${hostname}).`), "", 0);
+        return;
+      }
+      for (const entry of list) {
+        if (isPrivateIp(entry.address)) {
+          callback(
+            new UrlFetchError(
+              "private_address",
+              `URL hostname (${hostname}) resolved to a private address (${entry.address}) at connect time.`,
+            ),
+            "",
+            0,
+          );
+          return;
+        }
+      }
+      // All resolved addresses validated as public — hand them to undici (pinned).
+      if ((opts as { all?: boolean }).all) {
+        callback(null, list);
+      } else {
+        callback(null, list[0].address, list[0].family);
+      }
+    });
+  };
+}
+
+// Shared dispatcher whose connect step re-validates the resolved IP (#520).
+const ssrfSafeDispatcher = new Agent({
+  connect: { lookup: createValidatingLookup() as never },
+});
 
 export interface UrlFetchResult {
   extractedText: string;
@@ -134,16 +187,20 @@ const MAX_REDIRECTS = 5;
 async function fetchWithLimit(parsedUrl: URL, signal: AbortSignal): Promise<{ buffer: Buffer; contentType: string }> {
   let currentUrl = parsedUrl;
   for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
+    // Node's global fetch is undici under the hood and honors a `dispatcher` option (not in the
+    // TS RequestInit type), so we keep using global fetch (test-mockable) while routing through the
+    // SSRF-safe dispatcher for connect-time IP re-validation (#520).
     const response = await fetch(currentUrl.toString(), {
       method: "GET",
       redirect: "manual",
       signal,
+      dispatcher: ssrfSafeDispatcher,
       headers: {
         // Be polite: identify ourselves
         "user-agent": "A2AssessmentPlatform/url-fetch (+https://github.com/jkosmo/a2-assessment-platform)",
         accept: "text/html, application/xhtml+xml, text/plain;q=0.9, */*;q=0.5",
       },
-    });
+    } as RequestInit & { dispatcher: unknown });
 
     if (response.status >= 300 && response.status < 400) {
       const location = response.headers.get("location");

--- a/test/unit/url-fetch-ssrf-pinning.test.ts
+++ b/test/unit/url-fetch-ssrf-pinning.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { createValidatingLookup } from "../../src/modules/adminContent/urlFetchService.js";
+
+// #520: the connect-time lookup must re-validate the resolved IP so a DNS-rebinding attacker
+// (public IP at the up-front check, private IP at connect time) cannot reach internal addresses.
+
+type Addr = { address: string; family: number };
+
+// Build a fake dns.lookup-style resolver that returns a fixed address list.
+function resolverReturning(addresses: Addr[] | Error) {
+  return (
+    _hostname: string,
+    _options: unknown,
+    cb: (err: NodeJS.ErrnoException | null, addresses: Addr[]) => void,
+  ) => {
+    if (addresses instanceof Error) cb(addresses as NodeJS.ErrnoException, []);
+    else cb(null, addresses);
+  };
+}
+
+function runLookup(addresses: Addr[] | Error, options: Record<string, unknown> = {}) {
+  const lookup = createValidatingLookup(resolverReturning(addresses) as never);
+  return new Promise<{ err: unknown; address: unknown; family?: number }>((resolve) => {
+    lookup("example.test", options as never, (err, address, family) => resolve({ err, address, family }));
+  });
+}
+
+describe("createValidatingLookup (SSRF connect-time pinning, #520)", () => {
+  it("rejects when the resolved address is private (rebinding to internal)", async () => {
+    const { err } = await runLookup([{ address: "10.0.0.5", family: 4 }]);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as { code?: string }).code).toBe("private_address");
+  });
+
+  it("rejects the cloud metadata endpoint", async () => {
+    const { err } = await runLookup([{ address: "169.254.169.254", family: 4 }]);
+    expect((err as { code?: string }).code).toBe("private_address");
+  });
+
+  it("rejects when ANY resolved address is private (mixed public+private)", async () => {
+    const { err } = await runLookup([
+      { address: "93.184.216.34", family: 4 },
+      { address: "127.0.0.1", family: 4 },
+    ]);
+    expect((err as { code?: string }).code).toBe("private_address");
+  });
+
+  it("passes a public address through (single)", async () => {
+    const { err, address, family } = await runLookup([{ address: "93.184.216.34", family: 4 }]);
+    expect(err).toBeNull();
+    expect(address).toBe("93.184.216.34");
+    expect(family).toBe(4);
+  });
+
+  it("returns the full validated list when options.all is set", async () => {
+    const { err, address } = await runLookup([{ address: "93.184.216.34", family: 4 }], { all: true });
+    expect(err).toBeNull();
+    expect(Array.isArray(address)).toBe(true);
+    expect((address as Addr[])[0].address).toBe("93.184.216.34");
+  });
+
+  it("rejects a private IPv6 (unique-local)", async () => {
+    const { err } = await runLookup([{ address: "fc00::1", family: 6 }]);
+    expect((err as { code?: string }).code).toBe("private_address");
+  });
+
+  it("propagates resolver errors", async () => {
+    const { err } = await runLookup(new Error("dns boom"));
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("fails closed when nothing resolves", async () => {
+    const { err } = await runLookup([]);
+    expect((err as { code?: string }).code).toBe("dns_failed");
+  });
+});


### PR DESCRIPTION
## Sammendrag
Lukker DNS-rebinding/TOCTOU-SSRF i URL-henting (#520). `assertSafeUrl` validerte IP-ene på forhånd, men `fetch` re-resolved selv — en kort-TTL-angriper kunne rebinde til intern IP ved tilkobling.

## Fiks
- `createValidatingLookup` som `connect.lookup` i en undici `Agent` (dispatcher) — re-validerer den faktiske IP-en ved tilkobling (avviser private/metadata/loopback/IPv6-ULA). Rebinding-vinduet lukket.
- Global `fetch` beholdt (test-mockbar) med `dispatcher`-opsjon; `assertSafeUrl` beholdt som første lag (defense-in-depth).
- `undici` eksplisitt i `dependencies` (var transitiv) + package-lock synket.

## Test
8 nye unit-tester (rebinding/metadata/mixed public+private/IPv6-ULA/fail-closed). Eksisterende url-fetch-tester uendret (16 grønne totalt). `tsc` rent.

## Rollback
Backend + dep. Ingen migrasjoner. Trygg revert.

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)