### PR TITLE
fix(author+participant): MCQ-only kort-gating + kurs-cache (v1.3.33)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,22 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.33 - 2026-06-21
+
+fix(author+participant): MCQ-only kort-gating + kurs-cache (staging-tilbakemelding runde 4)
+
+- **#554 kort-gating:** «Vurderingskriterier»/«LLM-prompt»/«Innleveringsskjema»-kortene + rubric/
+  prompt-seksjonene vistes fortsatt ved Kun MCQ — `.content-card`/`.card`-CSS overstyrer
+  `[hidden]`-attributtet. Bruker nå `style.display` (samme gotcha som `.row`/`.inline` tidligere),
+  + re-applyer gatingen etter innholds-refresh. e2e utvidet til å sjekke at kort faktisk skjules.
+- **Kurs-cache (D):** etter bestått modul re-lastet kurs-lista accordion med ferske «Laster…»-
+  containere, men `courseDetailCache` beholdt gammel oppføring → expand hoppet over ny-henting →
+  placeholder hang. `loadParticipantCourses` tømmer nå cachen.
+
+Logget: #563 (konsistens — kurs publiseres ikke vs modul krever publisering).
+
+Test: 30 e2e (utvidet MCQ-only-author + section-reader), 49 kontrakt/i18n, tsc rent.
+
 ## 1.3.32 - 2026-06-21
 
 sec(ingest): lukk DNS-rebinding/TOCTOU i URL-henting (#520)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.32",
+  "version": "1.3.33",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content.js
+++ b/public/admin-content.js
@@ -2589,6 +2589,8 @@ function renderContentCards() {
 
   updateStateRail();
   renderAdvancedPreview();
+  // #554: keep MCQ-only gating applied after any content refresh.
+  applyMcqOnlyAuthoringVisibility();
 }
 
 // ── Assessment policy helper ───────────────────────────────────────────────────
@@ -3760,13 +3762,14 @@ const MCQ_ONLY_HIDDEN_ELEMENT_IDS = [
 
 function applyMcqOnlyAuthoringVisibility() {
   const mcqOnly = moduleVersionMcqOnlyInput?.checked === true;
-  // Plain elements (no class overriding the [hidden] attribute after the #546 layout cleanup),
-  // so the hidden property works directly (#525/#546/#554).
   if (moduleVersionFreetextFields) moduleVersionFreetextFields.hidden = mcqOnly;
   if (moduleVersionMcqThresholdRow) moduleVersionMcqThresholdRow.hidden = !mcqOnly;
+  // The sections/cards carry classes (.card, .content-card) whose CSS display overrides the
+  // [hidden] attribute, so toggle style.display directly (#554 follow-up — the [hidden] approach
+  // left the cards visible on staging).
   for (const id of MCQ_ONLY_HIDDEN_ELEMENT_IDS) {
     const el = document.getElementById(id);
-    if (el) el.hidden = mcqOnly;
+    if (el) el.style.display = mcqOnly ? "none" : "";
   }
 }
 moduleVersionMcqOnlyInput?.addEventListener("change", applyMcqOnlyAuthoringVisibility);

--- a/public/participant.js
+++ b/public/participant.js
@@ -2816,6 +2816,10 @@ async function loadParticipantCourses() {
       participantCompletions[c.courseId] = c;
     }
   }
+  // Reloading the course list rebuilds the accordion with fresh "loading…" detail containers;
+  // invalidate the per-course detail cache so expanding re-fetches into the new container instead
+  // of skipping the fetch and leaving the placeholder stuck (#550 follow-up).
+  courseDetailCache = {};
   renderParticipantCourseAccordion();
 }
 

--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -1045,14 +1045,18 @@ test.describe("admin content browser coverage", () => {
     await page.goto("/admin-content/module/module-1/advanced");
     await expect(page.locator("#moduleStatusTitle")).toContainText("Trade unions");
 
-    // Free-text fields visible, threshold hidden by default.
+    // Free-text fields + content cards visible, threshold hidden by default.
     await expect(page.locator("#moduleVersionFreetextFields")).toBeVisible();
     await expect(page.locator("#moduleVersionMcqThresholdRow")).toBeHidden();
+    await expect(page.locator("#contentCard_rubric")).toBeVisible();
 
-    // Enable MCQ-only → free-text fields hidden, threshold shown.
+    // Enable MCQ-only → free-text fields + free-text content cards hidden, threshold shown.
+    // (#554 follow-up: .content-card CSS overrides [hidden], so gating uses style.display.)
     await page.locator("#moduleVersionMcqOnly").check();
     await expect(page.locator("#moduleVersionFreetextFields")).toBeHidden();
     await expect(page.locator("#moduleVersionMcqThresholdRow")).toBeVisible();
+    await expect(page.locator("#contentCard_rubric")).toBeHidden();
+    await expect(page.locator("#contentCard_prompt")).toBeHidden();
     await page.locator("#moduleVersionMcqMinPercent").fill("80");
 
     await page.locator("#saveContentBundle").click();


### PR DESCRIPTION
## Staging-tilbakemelding runde 4
- **#554 kort-gating:** «Vurderingskriterier»/«LLM-prompt»/«Innleveringsskjema»-kortene + rubric/prompt-seksjonene vistes fortsatt ved Kun MCQ — `.content-card`/`.card`-CSS overstyrer `[hidden]`. Bruker nå `style.display` + re-applyer gatingen etter innholds-refresh. e2e utvidet til å sjekke at kort faktisk skjules.
- **Kurs-cache (D):** etter bestått modul hang kurs-detaljen på «Laster moduler…» — `courseDetailCache` beholdt gammel oppføring etter reload. `loadParticipantCourses` tømmer nå cachen.

## Logget (ikke fikset)
- #563 — kurs publiseres ikke (kun lagres) vs modul krever publisering (livssyklus-konsistens).

## Test
30 e2e (utvidet MCQ-only-author + section-reader), 49 kontrakt/i18n, `tsc` rent.

## Rollback
Frontend. Ingen migrasjoner. Trygg revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)