### PR TITLE
fix(content): eksport utelater rationale:null → MCQ uten rationale re-importerbart (v1.3.34, #557)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,19 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.34 - 2026-06-21
+
+fix(content): eksport utelater rationale:null → MCQ-spørsmål uten rationale kan re-importeres (#557)
+
+Et MCQ-spørsmål uten `rationale` ble eksportert som `rationale: null`, men import-schemaet godtok
+`string|object|undefined` (ikke null) → `validation_error` ved re-import. Eksporten utelater nå
+`rationale`-nøkkelen når den mangler (i stedet for null), så import (optional) godtar fraværet.
+(Valgte eksport-fiks framfor å nullbar-gjøre det delte `mcqQuestionSchema`, som ville kaskadert til
+MCQ-revisjons-endepunktet.)
+
+Test: export/import-roundtrip-testen bruker nå et spørsmål **uten** rationale (regresjonsvakt).
+6 roundtrip-tester grønne, tsc rent.
+
 ## 1.3.33 - 2026-06-21
 
 fix(author+participant): MCQ-only kort-gating + kurs-cache (staging-tilbakemelding runde 4)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.33",
+  "version": "1.3.34",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/adminContentQueries.ts
+++ b/src/modules/adminContent/adminContentQueries.ts
@@ -354,7 +354,15 @@ export async function buildModuleExportEnvelope(
           : (null as never),
         mcqSet: {
           title: mcqSetVersion.title as never,
-          questions: mcqSetVersion.questions as never,
+          // #557: omit rationale entirely when absent instead of emitting `rationale: null`
+          // (which the import schema rejected).
+          questions: (mcqSetVersion.questions as Array<Record<string, unknown>>).map((q) => {
+            if (q.rationale == null) {
+              const { rationale: _drop, ...rest } = q;
+              return rest;
+            }
+            return q;
+          }) as never,
           active: true,
         },
         audit: {

--- a/test/m2-content-export-import.test.ts
+++ b/test/m2-content-export-import.test.ts
@@ -274,10 +274,11 @@ describe("#547 MCQ-only module export-import round-trip", () => {
         title: { "en-GB": "MCQ", nb: "MCQ", nn: "MCQ" },
         questions: [
           {
+            // #557: deliberately NO rationale — export must not emit rationale:null and import
+            // must accept its absence (this round-trip previously failed).
             stem: { "en-GB": "2+2?", nb: "2+2?", nn: "2+2?" },
             options: [{ "en-GB": "4", nb: "4", nn: "4" }, { "en-GB": "5", nb: "5", nn: "5" }],
             correctAnswer: { "en-GB": "4", nb: "4", nn: "4" },
-            rationale: { "en-GB": "Math", nb: "Matte", nn: "Matte" },
           },
         ],
       });


### PR DESCRIPTION
## Sammendrag
Lukker #557 (fant under #547). Et MCQ-spørsmål uten `rationale` ble eksportert som `rationale: null`, men import-schemaet godtok `string|object|undefined` (ikke null) → `validation_error` ved re-import.

## Fiks
- Eksporten (`buildModuleExportEnvelope`) **utelater** `rationale`-nøkkelen når den mangler, i stedet for `null`. Import (optional) godtar fraværet.
- Valgte eksport-fiks framfor å `.nullable()`-gjøre det delte `mcqQuestionSchema` (det kaskaderte til MCQ-revisjons-endepunktets `McqRevisionInput`).

## Test
Roundtrip-testen bruker nå et MCQ-spørsmål **uten** rationale (regresjonsvakt). 6 roundtrip-tester grønne, `tsc` rent.

## Rollback
Backend (eksport-serialisering). Ingen migrasjoner. Trygg revert.

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)