### PR TITLE
feat+fix(author): MCQ length-cue-deteksjon (#551) + kurs-pakke-guard i modul-import (v1.3.35)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,22 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.35 - 2026-06-21
+
+feat+fix(author): MCQ length-cue-deteksjon (#551) + kurs-pakke-guard i modul-import
+
+- **#551 MCQ-lengde-cue:** ny deterministisk `detectCorrectAnswerLengthBias` flagger sett der
+  fasiten er lengst i ≥70 % av spørsmålene. Koblet inn i `generateMcqQuestions` (legges i
+  `validationWarnings`), generate-MCQ-ruten returnerer det i `validation.issues`, og samtale-shellen
+  viser nå MCQ-kvalitets-advarsler i «MCQ klar»-boblen (tidligere ble validation-issues ikke vist).
+  Prompten hadde allerede en grundig «Option parity»-regel — den deterministiske sjekken fanger når
+  LLM-en likevel bryter den.
+- **Import-guard:** å importere en **kurs**-pakke via «Importer modul-pakke» ga rå
+  `scope_mismatch`-400. Modul-importen sjekker nå `scope` klient-side og gir en handlingsbar
+  melding («Dette er en kurs-pakke. Importer den fra Kurs-siden …»).
+
+Test: 5 nye unit-tester (lengde-bias-heuristikk), eksisterende llm-gen (44) uendret, 30 e2e, tsc rent.
+
 ## 1.3.34 - 2026-06-21
 
 fix(content): eksport utelater rationale:null → MCQ-spørsmål uten rationale kan re-importeres (#557)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.34",
+  "version": "1.3.35",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-library.js
+++ b/public/static/admin-content-library.js
@@ -784,6 +784,11 @@ async function init() {
       } catch (parseError) {
         throw new Error(`Filen er ikke gyldig JSON: ${parseError instanceof Error ? parseError.message : "ukjent feil"}`);
       }
+      // Friendly guard: a course package can't be imported here — point the author to the Kurs page
+      // instead of surfacing the raw scope_mismatch 400 (#563-relatert UX-funn).
+      if (payload?.scope === "course") {
+        throw new Error("Dette er en kurs-pakke. Importer den fra Kurs-siden med «Importer kurs-pakke».");
+      }
       const result = await apiFetch("/api/admin/content/modules/import", getHeaders, {
         method: "POST",
         body: JSON.stringify({ payload, mode: "createNew" }),

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -1617,10 +1617,15 @@ async function generateMcqInBackground(sourceMaterial, certLevel, locale, genera
   sessionDraft = buildPreviewCandidate({ mcqQuestions: localizedQuestions });
   clearPreviewCandidate();
   scrollPreviewToBottom();
+  // #551: surface MCQ quality warnings (incl. the length-cue check) so the author can review.
+  const mcqWarnings = Array.isArray(result?.validation?.issues) ? result.validation.issues : [];
+  const mcqWarningsHtml = mcqWarnings.length > 0
+    ? `<p style="margin:8px 0 0;font-size:13px;color:var(--color-warning,#b45309)">⚠ ${mcqWarnings.map(escapeHtml).join("<br>")}</p>`
+    : "";
   logResolveSlot(
     slot,
     () => `<strong>${escapeHtml(tf("shell.generating.mcqReady", { count: questions.length }))}</strong>
-      <p style="margin:8px 0 0;font-size:13px;color:var(--color-meta)">${escapeHtml(t("shell.generating.reviewPreviewHint"))}</p>`,
+      <p style="margin:8px 0 0;font-size:13px;color:var(--color-meta)">${escapeHtml(t("shell.generating.reviewPreviewHint"))}</p>${mcqWarningsHtml}`,
   );
   onAccept?.(questions);
 }

--- a/src/modules/adminContent/llmContentGenerationService.ts
+++ b/src/modules/adminContent/llmContentGenerationService.ts
@@ -1364,6 +1364,47 @@ export async function generateModuleDraft(input: ModuleDraftInput): Promise<Modu
 // MCQ generation (#246)
 // ---------------------------------------------------------------------------
 
+// #551: deterministic guard against the "correct answer is almost always the longest" length cue.
+// The generation prompt already mandates option parity, but the LLM doesn't always comply — this
+// flags sets where the correct option is the longest in a high proportion of questions so the
+// author is prompted to review/regenerate. Exported for unit testing.
+export function detectCorrectAnswerLengthBias(
+  questions: Array<{ options: string[]; correctAnswer: string }>,
+  { minQuestions = 3, ratioThreshold = 0.7 }: { minQuestions?: number; ratioThreshold?: number } = {},
+): { biased: boolean; longestCorrectRatio: number; consideredCount: number } {
+  const considered = questions.filter(
+    (q) => Array.isArray(q.options) && q.options.length >= 2 && typeof q.correctAnswer === "string",
+  );
+  if (considered.length < minQuestions) {
+    return { biased: false, longestCorrectRatio: 0, consideredCount: considered.length };
+  }
+  let longestCorrect = 0;
+  for (const q of considered) {
+    const correct = q.correctAnswer.trim();
+    const correctLen = correct.length;
+    const distractorLengths = q.options
+      .map((o) => o.trim())
+      .filter((o) => o !== correct)
+      .map((o) => o.length);
+    const maxDistractor = distractorLengths.length > 0 ? Math.max(...distractorLengths) : 0;
+    if (correctLen > maxDistractor) longestCorrect++;
+  }
+  const longestCorrectRatio = longestCorrect / considered.length;
+  return {
+    biased: longestCorrectRatio >= ratioThreshold,
+    longestCorrectRatio,
+    consideredCount: considered.length,
+  };
+}
+
+function appendLengthBiasWarning(result: McqGenerationResult): McqGenerationResult {
+  const { biased, longestCorrectRatio } = detectCorrectAnswerLengthBias(result.questions);
+  if (!biased) return result;
+  const pct = Math.round(longestCorrectRatio * 100);
+  const warning = `Length cue: the correct answer is the longest option in ${pct}% of questions — review option parity so the answer isn't guessable by length (#551).`;
+  return { ...result, validationWarnings: [...(result.validationWarnings ?? []), warning] };
+}
+
 export async function generateMcqQuestions(input: McqGenerationInput): Promise<McqGenerationResult> {
   const { systemPrompt, userPrompt } = buildMcqGenerationPrompts(input);
 
@@ -1396,7 +1437,7 @@ export async function generateMcqQuestions(input: McqGenerationInput): Promise<M
   const first = await attempt(null);
   const sampleText = mcqSampleForLanguageCheck(first);
   if (!isLikelyWrongLocale(sampleText, input.locale)) {
-    return first;
+    return appendLengthBiasWarning(first);
   }
   console.warn(
     `[#444] generateMcqQuestions language mismatch: expected ${input.locale}, detected ${detectDominantLanguage(sampleText)}. Retrying with stronger directive.`,
@@ -1408,7 +1449,7 @@ export async function generateMcqQuestions(input: McqGenerationInput): Promise<M
       `[#444] generateMcqQuestions language retry also produced wrong language (expected ${input.locale}). Returning result anyway — operator must verify.`,
     );
   }
-  return second;
+  return appendLengthBiasWarning(second);
 }
 
 function mcqSampleForLanguageCheck(result: McqGenerationResult): string {

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -985,7 +985,8 @@ adminContentRouter.post("/generate/mcq", generateLimiter, async (request, respon
       questions: result.questions,
       validation: {
         valid: validation.valid,
-        issues: validation.issues,
+        // #551: include the deterministic length-cue warning alongside distractor-quality issues.
+        issues: [...validation.issues, ...(result.validationWarnings ?? [])],
       },
     });
   } catch (err) {

--- a/test/unit/mcq-length-cue.test.ts
+++ b/test/unit/mcq-length-cue.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { detectCorrectAnswerLengthBias } from "../../src/modules/adminContent/llmContentGenerationService.js";
+
+// #551: deterministic guard — flag MCQ sets where the correct answer is the longest option in a
+// high proportion of questions (a classic "length cue" that lets candidates guess).
+
+function q(correct: string, ...distractors: string[]) {
+  return { options: [correct, ...distractors], correctAnswer: correct };
+}
+
+describe("detectCorrectAnswerLengthBias (#551)", () => {
+  it("flags a set where the correct answer is consistently the longest", () => {
+    const questions = [
+      q("A long, carefully-qualified correct answer", "Short", "Tiny", "Brief"),
+      q("Another notably longer correct option here", "No", "Maybe", "Yes"),
+      q("The detailed and precise correct choice text", "A", "B", "C"),
+    ];
+    const result = detectCorrectAnswerLengthBias(questions);
+    expect(result.biased).toBe(true);
+    expect(result.longestCorrectRatio).toBe(1);
+  });
+
+  it("does not flag a balanced set (similar option lengths)", () => {
+    const questions = [
+      q("Option alpha here", "Option beta here", "Option gamma now", "Option delta xx"),
+      q("Choice one is fine", "Choice two is fine", "Choice three okk", "Choice four okkk"),
+      q("Pick aaaa bbbb cc", "Pick dddd eeee ff", "Pick gggg hhhh ii", "Pick jjjj kkkk ll"),
+    ];
+    expect(detectCorrectAnswerLengthBias(questions).biased).toBe(false);
+  });
+
+  it("does not flag below the ratio threshold (only some questions biased)", () => {
+    const questions = [
+      q("A very long correct answer that stands out clearly", "Short", "Tiny", "Brief"),
+      q("Even", "Even text", "Even longer text", "Even longest text here"), // correct shortest
+      q("Same size A", "Same size B", "Same size C", "Same size D"),
+      q("Same len 1", "Same len 2", "Same len 3", "Same len 4"),
+    ];
+    expect(detectCorrectAnswerLengthBias(questions).biased).toBe(false);
+  });
+
+  it("does not flag short sets (below minQuestions)", () => {
+    const questions = [q("A long correct answer that stands out", "x", "y")];
+    expect(detectCorrectAnswerLengthBias(questions).biased).toBe(false);
+  });
+
+  it("respects a custom threshold", () => {
+    const questions = [
+      q("Long correct answer one here", "a", "b"),
+      q("Long correct answer two here", "c", "d"),
+      q("Short", "A longer distractor wins", "b"), // correct not longest
+    ];
+    // 2/3 ≈ 0.67 — below default 0.7, above a 0.6 threshold.
+    expect(detectCorrectAnswerLengthBias(questions).biased).toBe(false);
+    expect(detectCorrectAnswerLengthBias(questions, { ratioThreshold: 0.6 }).biased).toBe(true);
+  });
+});


### PR DESCRIPTION
## #551 — MCQ length-cue
Ny deterministisk `detectCorrectAnswerLengthBias`: flagger sett der fasiten er lengst i ≥70 % av spørsmålene (klassisk «length cue»). Koblet inn i `generateMcqQuestions` → `validationWarnings`; generate-MCQ-ruten returnerer det i `validation.issues`; samtale-shellen viser nå MCQ-kvalitets-advarsler i «MCQ klar»-boblen (validation-issues ble tidligere ikke vist i det hele tatt). Prompten hadde allerede en grundig «Option parity»-regel — den deterministiske sjekken fanger når LLM-en likevel bryter den.

## Import-guard (retest-funn)
Å importere en **kurs**-pakke via «Importer modul-pakke» ga rå `scope_mismatch`-400. Modul-importen sjekker nå `scope` klient-side og gir en handlingsbar melding («Dette er en kurs-pakke. Importer den fra Kurs-siden …»).

## Test
5 nye unit-tester (lengde-bias-heuristikk inkl. terskel/balansert/kort sett), eksisterende llm-gen (44) uendret, 30 e2e, `tsc` rent.

## Rollback
Backend (deteksjon + rute) + frontend (shell + import-guard). Ingen migrasjoner. Trygg revert.

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)