### PR TITLE
fix(author): deaktiver «Neste» mens kildemateriale hentes (v1.3.39, #555)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,15 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.39 - 2026-06-21
+
+fix(author): «Neste» deaktiveres mens kildemateriale hentes (#555-oppfølging)
+
+- **Bugfiks (forfatter-feedback):** ved URL-henting (og fil-opplasting) var det meste av UI passivt,
+  men **«Neste»-knappen var fortsatt klikkbar** — uklart hva som skjedde ved klikk midt i hentingen.
+  «Neste» deaktiveres nå mens kilde hentes/ekstraheres og re-aktiveres når det er ferdig (begge
+  stier: URL-fetch + fil-opplasting).
+
 ## 1.3.38 - 2026-06-21
 
 feat(participant): utskrivbart kursbevis ved kursfullføring (#550)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.38",
+  "version": "1.3.39",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -504,6 +504,9 @@ function _domFormFields(entry) {
       const originalLabel = urlBtn.textContent;
       urlBtn.disabled = true;
       uploadBtn.disabled = true;
+      // #555-oppfølging (forfatter-feedback): «Neste» var fortsatt klikkbar mens URL-en ble hentet
+      // — uklart hva som skjedde. Deaktiver den til hentingen er ferdig.
+      btn.disabled = true;
       urlBtn.textContent = t("shell.source.fetching");
       try {
         const result = await apiFetch(
@@ -526,6 +529,7 @@ function _domFormFields(entry) {
       } finally {
         urlBtn.disabled = false;
         uploadBtn.disabled = false;
+        btn.disabled = false;
         urlBtn.textContent = originalLabel;
       }
     });
@@ -605,6 +609,8 @@ function _domFormFields(entry) {
       const originalLabel = uploadBtn.textContent;
       uploadBtn.disabled = true;
       urlBtn.disabled = true;
+      // #555-oppfølging: hold «Neste» deaktivert mens filer ekstraheres (samme grunn som URL).
+      btn.disabled = true;
 
       // v1.2.3: ekstrahérer filene sekvensielt. Sekvensielt er trygt for parser-worker
       // (én job om gangen, ingen pool-uttømming) og gir tydelig progress-status til bruker.
@@ -660,6 +666,7 @@ function _domFormFields(entry) {
       }
       uploadBtn.disabled = false;
       urlBtn.disabled = false;
+      btn.disabled = false;
       uploadBtn.textContent = originalLabel;
       fileInput.value = "";
       inputEl.focus();


### PR DESCRIPTION
## Bugfiks (forfatter-feedback under #555-aksept)

Ved **URL-henting** (og fil-opplasting) var det meste av UI passivt, men **«Neste»-knappen var fortsatt klikkbar** — uklart hva som skjedde ved klikk midt i hentingen.

«Neste» (`btn`) deaktiveres nå mens kilde hentes/ekstraheres og re-aktiveres i `finally` — begge stier (URL-fetch + fil-opplasting). Ren frontend-endring.

### Test
4/4 kilde-skjema-e2e grønne (create new module, MCQ-only-samtale, regen, source-material upload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)