### PR TITLE
fix(participant): «Vis bevis»-lenke i Profil → Fullførte kurs (v1.3.40, #550)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,15 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.40 - 2026-06-21
+
+fix(participant): «Vis bevis»-lenke i Profil → Fullførte kurs (#550-oppfølging)
+
+- **Bugfiks (bruker-feedback):** Profil-sidens «Fullførte kurs»-tabell viste Bevis-ID som ren tekst
+  uten lenke. Bevis-ID-kolonnen lenker nå til `/certificate?id=<id>` (åpnes i ny fane), på linje med
+  bevis-banneret og «Mine kursbevis». i18n `profile.courses.view` i en-GB/nb/nn.
+- **Test:** ny Playwright-e2e (profil-tabell → bevis-lenke med riktig href + i18n-label).
+
 ## 1.3.39 - 2026-06-21
 
 fix(author): «Neste» deaktiveres mens kildemateriale hentes (#555-oppfølging)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.39",
+  "version": "1.3.40",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/i18n/profile-translations.js
+++ b/public/i18n/profile-translations.js
@@ -63,6 +63,7 @@ export const translations = {
     "profile.courses.table.completedAt": "Completed",
     "profile.courses.table.level": "Level",
     "profile.courses.table.certificateId": "Certificate ID",
+    "profile.courses.view": "View certificate",
 
     // GDPR rights
     "profile.section.rights": "Your rights",
@@ -149,6 +150,7 @@ export const translations = {
     "profile.courses.table.completedAt": "Fullført",
     "profile.courses.table.level": "Nivå",
     "profile.courses.table.certificateId": "Bevis-ID",
+    "profile.courses.view": "Vis bevis",
 
     "profile.section.rights": "Dine rettigheter",
     "profile.rights.view": "Se mine data",
@@ -232,6 +234,7 @@ export const translations = {
     "profile.courses.table.completedAt": "Fullført",
     "profile.courses.table.level": "Nivå",
     "profile.courses.table.certificateId": "Bevis-ID",
+    "profile.courses.view": "Vis bevis",
 
     "profile.section.rights": "Rettane dine",
     "profile.rights.view": "Sjå dataa mine",

--- a/public/profile.js
+++ b/public/profile.js
@@ -334,18 +334,38 @@ function renderCourses(body) {
 
   for (const course of courses) {
     const row = document.createElement("tr");
-    const cells = [
-      { text: localizeContentValue(course.courseTitle ?? course.courseId) },
-      { text: formatDateTime(course.completedAt) },
-      { text: localizeContentValue(course.certificationLevel) },
-      { text: course.certificateId ?? "â€”" },
-    ];
 
-    for (const { text } of cells) {
-      const td = document.createElement("td");
-      td.textContent = text;
-      row.appendChild(td);
+    const titleTd = document.createElement("td");
+    titleTd.textContent = localizeContentValue(course.courseTitle ?? course.courseId);
+    row.appendChild(titleTd);
+
+    const dateTd = document.createElement("td");
+    dateTd.textContent = formatDateTime(course.completedAt);
+    row.appendChild(dateTd);
+
+    const levelTd = document.createElement("td");
+    levelTd.textContent = localizeContentValue(course.certificationLevel);
+    row.appendChild(levelTd);
+
+    // #550: certificate ID + link to the printable certificate view (was ID text only).
+    const certTd = document.createElement("td");
+    if (course.certificateId) {
+      const idSpan = document.createElement("span");
+      idSpan.textContent = course.certificateId;
+      idSpan.style.cssText = "font-family:monospace;font-size:12px";
+      const link = document.createElement("a");
+      link.href = `/certificate?id=${encodeURIComponent(course.certificateId)}`;
+      link.target = "_blank";
+      link.rel = "noopener";
+      link.textContent = t("profile.courses.view");
+      link.style.cssText = "margin-left:8px";
+      certTd.appendChild(idSpan);
+      certTd.appendChild(link);
+    } else {
+      certTd.textContent = "—";
     }
+    row.appendChild(certTd);
+
     coursesBody.appendChild(row);
   }
 }

--- a/scripts/test/admin-content-static-server.mjs
+++ b/scripts/test/admin-content-static-server.mjs
@@ -47,6 +47,9 @@ function resolvePublicFile(requestPath) {
   if (requestPath === "/certificate") {
     return path.join(publicRoot, "certificate.html");
   }
+  if (requestPath === "/profile") {
+    return path.join(publicRoot, "profile.html");
+  }
   if (/^\/admin-content\/courses\/[^/]+$/.test(requestPath)) {
     return path.join(publicRoot, "admin-content-courses.html");
   }

--- a/test/e2e/profile-certificate-link.spec.ts
+++ b/test/e2e/profile-certificate-link.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+// #550 follow-up: the Profile page ("Fullførte kurs") lists course completions with a certificate
+// ID. It must link each row to the printable certificate view (/certificate?id=...). This e2e runs
+// the real profile.js and asserts the link renders with the resolved i18n label + correct href.
+
+async function mockProfile(page: Page) {
+  await page.route("**/participant/config", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        authMode: "mock",
+        navigation: { items: [], workspaceItems: [] },
+        identityDefaults: {
+          participant: { userId: "participant-1", email: "p@x.no", name: "P", department: "X", roles: ["PARTICIPANT"] },
+        },
+        calibrationWorkspace: { accessRoles: [] },
+        flow: {},
+        output: {},
+      }),
+    }),
+  );
+  await page.route("**/version", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "test" }) }),
+  );
+  await page.route("**/api/me", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: { id: "participant-1", name: "Kari", email: "p@x.no", roles: ["PARTICIPANT"] },
+        consent: { accepted: true, currentVersion: "1.0" },
+      }),
+    }),
+  );
+  await page.route("**/api/queue-counts", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ counts: {} }) }),
+  );
+  await page.route("**/api/modules/completed**", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ modules: [] }) }),
+  );
+}
+
+test("profile: completed courses link to the printable certificate", async ({ page }) => {
+  await mockProfile(page);
+  await page.addInitScript(() => {
+    try { localStorage.setItem("participant.locale", "en-GB"); } catch { /* ignore */ }
+  });
+
+  await page.route("**/api/courses/completions", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        completions: [
+          {
+            courseId: "c1",
+            certificateId: "cert-abc",
+            completedAt: "2026-06-20T10:00:00.000Z",
+            courseTitle: "Labour Law",
+            certificationLevel: "basic",
+          },
+        ],
+      }),
+    }),
+  );
+
+  await page.goto("/profile");
+
+  const link = page.locator('#coursesBody a[href="/certificate?id=cert-abc"]');
+  await expect(link).toBeVisible();
+  // i18n label resolved (not the raw key).
+  await expect(link).toHaveText("View certificate");
+  await expect(link).toHaveAttribute("target", "_blank");
+});


### PR DESCRIPTION
## Bugfiks (bruker-feedback under #550-aksept)

Profil-sidens **«Fullførte kurs»**-tabell (`/profile`) er hovedoversikten over deltakerens kursbevis, men Bevis-ID-kolonnen var **ren tekst uten lenke**. Den lenker nå til `/certificate?id=<id>` (ny fane) — konsistent med bevis-banneret i kursvisningen og «Mine kursbevis».

- i18n `profile.courses.view` i en-GB/nb/nn.
- Ny Playwright-e2e: profil-tabell → bevis-lenke (riktig href + resolvet i18n-label).
- Statisk e2e-server: la til `/profile`-mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)