### PR TITLE
feat(author): modultype-valg i regenerer-flyten (v1.3.41, #579)

### DIFF
--- a/doc/MCQ_ONLY_MODULES_GUIDE.md
+++ b/doc/MCQ_ONLY_MODULES_GUIDE.md
@@ -38,6 +38,11 @@ Since v1.3.36 (#555) the conversation follows the same order as the advanced edi
 Picking **“Free-text + MCQ”** instead keeps the full flow (scenario → certification level →
 assessment plan → questions).
 
+> Since v1.3.41 (#579) the **“Generate new content from source material”** flow (used when you
+> create a module from the library and land in the conversation, or reopen an existing module) also
+> asks the module-type question after the source step — so you can pick or switch to **“MCQ only”**
+> there too. Saving then writes a new MCQ-only version.
+
 ## What the participant sees
 
 - Selecting an MCQ-only module goes **straight to the questions** — there is no “create

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,21 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.41 - 2026-06-21
+
+feat(author): modultype-valg i regenerer-flyten (#579)
+
+- **Bugfiks/feature (forfatter-feedback):** Den anbefalte opprett-veien (biblioteks-dialogen, #348)
+  oppretter modulen og lander i samtalens **«Generer nytt innhold»**-flyt — som *ikke* hadde
+  modultype-steget fra #555. Forfatter så derfor aldri modultype i praksis. Regen-flyten spør nå
+  modultype etter kilde, før scenario — samme som ny-modul-flyten.
+- **Typebytte:** «Fritekst + flervalg» → uendret regen (scenario → vurderingsplan → MCQ).
+  «Kun flervalg» → MCQ-only-generering, lagres som ny `MCQ_ONLY`-versjon (ingen scenario/rubrikk/
+  prompt). Cert-nivå gjenbrukes fra modulen.
+- «Kun Fritekst» kommer når #578 lander (tredje valg).
+- **Test:** to nye e2e (regen: kilde → modultype → scenario; regen → «Kun flervalg» → MCQ-count
+  uten scenario). 37/37 admin-content e2e grønne.
+
 ## 1.3.40 - 2026-06-21
 
 fix(participant): «Vis bevis»-lenke i Profil → Fullførte kurs (#550-oppfølging)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.40",
+  "version": "1.3.41",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -3861,6 +3861,38 @@ function continueRegenAfterScenario(existingModuleId, sourceMaterial, knownCertL
   }
 }
 
+// #579: modultype-valg i regen-flyten. Den anbefalte opprett-veien (biblioteks-dialogen, #348)
+// oppretter modulen og lander her, så dette er stedet forfatter faktisk velger type. Etter kilde,
+// før scenario. Tillater typebytte: lagring skriver en ny versjon i valgt modus.
+//   - «Fritekst + flervalg» → uendret regen (scenario → cert/vurderingsplan → MCQ)
+//   - «Kun flervalg» → MCQ-only-generering, lagres som MCQ_ONLY (ingen scenario/rubrikk/prompt)
+function askForModuleTypeRegen(existingModuleId, sourceMaterial, knownCertLevel) {
+  logBot(
+    () =>
+      `<strong>${escapeHtml(t("shell.moduleType.prompt"))}</strong>`
+      + `<br><span style="font-size:13px;color:var(--color-meta)">${escapeHtml(t("shell.moduleType.hint"))}</span>`,
+    [
+      { labelKey: "shell.moduleType.freetext", action: () => askForScenarioModeRegen(existingModuleId, sourceMaterial, knownCertLevel) },
+      { labelKey: "shell.moduleType.mcqOnly", action: () => startMcqOnlyRegen(sourceMaterial, knownCertLevel) },
+    ],
+  );
+}
+
+function startMcqOnlyRegen(sourceMaterial, knownCertLevel) {
+  // Flag the in-progress draft as MCQ_ONLY so saveDraftBundleInBackground emits the MCQ_ONLY
+  // module version (no rubric/prompt/taskText). Cert level is reused from the existing module.
+  sessionDraft = {
+    ...(sessionDraft ?? {}),
+    title: sessionDraft?.title ?? bundle?.module?.title,
+    assessmentMode: "MCQ_ONLY",
+    mcqMinPercent: SHELL_MCQ_ONLY_MIN_PERCENT,
+    mcqQuestions: [],
+  };
+  renderPreview();
+  const certLevel = knownCertLevel ?? bundle?.module?.certificationLevel ?? "intermediate";
+  askForMcqQuestionCount(sourceMaterial, certLevel, currentLocale, "thorough", () => showDraftReadyActions());
+}
+
 function askForSourceMaterial(moduleTitle, existingModuleId, knownCertLevel, scenarioMode = "auto") {
   logForm(
     "source-material",
@@ -3875,7 +3907,8 @@ function askForSourceMaterial(moduleTitle, existingModuleId, knownCertLevel, sce
         askForModuleType(moduleTitle, sourceMaterial);
         return;
       }
-      askForScenarioModeRegen(existingModuleId, sourceMaterial, knownCertLevel);
+      // #579: regen spør også modultype etter kilde (forfatter kan bytte type ved regenerering).
+      askForModuleTypeRegen(existingModuleId, sourceMaterial, knownCertLevel);
     },
     "",
     {},

--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -1514,7 +1514,7 @@ test.describe("admin content browser coverage", () => {
 
   // #555: regen on an existing module follows the unified order too — source material BEFORE
   // scenario (forfatter-feedback 2026-06-21: scenario-first felt wrong here as well).
-  test("shell regen flow asks for source material before scenario", async ({ page }) => {
+  test("shell regen flow asks for source, then module type, then scenario", async ({ page }) => {
     await mockCommonApis(page, {
       modules: [{ id: "module-1", title: "Trade unions" }],
       moduleExports: {
@@ -1529,13 +1529,43 @@ test.describe("admin content browser coverage", () => {
     await page.goto("/admin-content/module/module-1/conversation");
     await clickEnabledButton(page, "Generate new content from source material");
 
-    // Source material is asked first; the scenario prompt must NOT be shown yet.
+    // Source material is asked first; neither module-type nor scenario shown yet.
     await expect(page.getByText("Paste source material")).toBeVisible();
+    await expect(page.getByText("What kind of module is this?")).toHaveCount(0);
     await expect(page.getByText("Should the task use a scenario?")).toHaveCount(0);
 
-    // After submitting source, the scenario prompt appears.
+    // #579: after source, the module-type question appears in regen too (not scenario directly).
     await submitActiveChatInput(page, "Updated source notes about labour rights and organising.");
+    await expect(page.getByText("What kind of module is this?")).toBeVisible();
+    await expect(page.getByText("Should the task use a scenario?")).toHaveCount(0);
+
+    // Free-text branch then leads to the scenario question.
+    await clickEnabledButton(page, "Free-text + MCQ");
     await expect(page.getByText("Should the task use a scenario?")).toBeVisible();
+  });
+
+  // #579: choosing "MCQ only" when regenerating skips scenario and goes straight to MCQ count.
+  test("shell regen flow can switch the module to MCQ-only", async ({ page }) => {
+    await mockCommonApis(page, {
+      modules: [{ id: "module-1", title: "Trade unions" }],
+      moduleExports: {
+        "module-1": buildMockModuleExport({
+          id: "module-1",
+          title: "Trade unions",
+          moduleVersionId: "module-1-version-1",
+        }),
+      },
+    });
+
+    await page.goto("/admin-content/module/module-1/conversation");
+    await clickEnabledButton(page, "Generate new content from source material");
+    await submitActiveChatInput(page, "Source notes for an MCQ-only quiz.");
+    await expect(page.getByText("What kind of module is this?")).toBeVisible();
+    await clickEnabledButton(page, "MCQ only");
+
+    // No scenario on the MCQ-only branch — straight to the question-count question.
+    await expect(page.getByText("Should the task use a scenario?")).toHaveCount(0);
+    await expect(page.getByText(/How many MCQ questions/i)).toBeVisible();
   });
 
   test("shell source-material upload keeps extracted content out of the input and sends it to generation", async ({ page }) => {


### PR DESCRIPTION
## #579 — modultype i regen-flyten (fikser #555s reelle gap)

**Rotårsak (forfatter-test):** Den anbefalte opprett-veien (biblioteks-dialogen, #348) oppretter modulen og lander i samtalens **«Generer nytt innhold»**-flyt — som *ikke* hadde modultype-steget fra #555. Derfor så forfatter aldri modultype, uansett.

Regen-flyten spør nå **modultype etter kilde, før scenario** — samme som ny-modul-flyten.

### Endringer
- `askForModuleTypeRegen` + `startMcqOnlyRegen` i regen-stien.
- «Fritekst + flervalg» → uendret regen. «Kun flervalg» → MCQ-only-generering, lagres som ny `MCQ_ONLY`-versjon (typebytte). Cert-nivå gjenbrukes.
- «Kun Fritekst» kommer med #578.

### Test
- 2 nye e2e (regen: kilde → modultype → scenario; regen → «Kun flervalg» → MCQ-count uten scenario).
- **37/37 admin-content e2e grønne** lokalt. Ren frontend.

### Docs
VERSIONS + MCQ_ONLY_MODULES_GUIDE oppdatert.

Closes #579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)