### PR TITLE
fix(participant): MCQ-only resultat — skjul tom brief + diskret retry (v1.3.42, #525)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,23 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.42 - 2026-06-21
+
+fix(participant): MCQ-only resultat-visning — skjul tom oppgave-brief + diskret retry (#525-oppfølging)
+
+To funn ved forfatter-test av MCQ-only-modul:
+- **Tom OPPGAVE/VEILEDNING vist:** `selectedModuleBrief` (`.module-brief{display:grid}`) ble skjult
+  via `.hidden`-klassen, men grid-regelen (definert senere i cascaden, ingen `!important`) overstyrte
+  → en tom oppgave-brief vistes for MCQ-only (som ikke har `taskText`). Skjules nå via
+  `style.display` (samme klasse-overstyrings-felle som tidligere). Gjelder også VEILEDNING-seksjonen.
+- **Retry-knapp «helt borte»:** i MCQ-only-stien ble `flowState.resultStatus` satt til `null` og
+  aldri synket etter at resultatet ble hentet → `hasResultStatus` forble false → «Slett innlevering
+  og start på nytt» ble alltid skjult (også ved **stryk**). Nå synkes status + gating re-rendres, så
+  knappen finnes igjen. Ved **bestått** nedtones den til en diskret sekundær-handling
+  (`.reset-flow-discreet`) i stedet for prominent rød knapp.
+- **Test:** utvidet `participant-mcq-only.spec.ts` (brief skjult for MCQ-only / synlig for fritekst;
+  MCQ-only auto-bestått → diskret retry-knapp). 6/6 participant-e2e grønne.
+
 ## 1.3.41 - 2026-06-21
 
 feat(author): modultype-valg i regenerer-flyten (#579)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.41",
+  "version": "1.3.42",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/participant.html
+++ b/public/participant.html
@@ -88,6 +88,10 @@
       .course-certificate-banner { padding: 8px 12px; background: #f4fbf7; border: 1px solid #b8d9c6; border-radius: var(--radius-card); font-size: 13px; color: #1f7a4d; font-weight: 600; }
       /* #549/#550: celebratory pass / course-completion banner. */
       .celebrate-banner { padding: 12px 16px; margin-bottom: var(--space-2, 12px); background: linear-gradient(90deg, #e8f7ee, #eef4ff); border: 1px solid #b8d9c6; border-radius: var(--radius-card); font-size: 16px; font-weight: 700; color: #16703f; text-align: center; }
+      /* #549/feedback: once passed, the retry/"delete & start over" button is de-emphasised to a
+         discreet secondary action (overrides .btn-danger) so it doesn't compete with the pass state. */
+      .reset-flow-discreet { background: transparent; border: none; box-shadow: none; color: var(--color-meta, #64748b); font-size: 13px; font-weight: 400; padding: 4px 8px; text-decoration: underline; }
+      .reset-flow-discreet:hover { color: var(--color-text, #1e293b); background: transparent; }
     </style>
   </head>
   <body>

--- a/public/participant.js
+++ b/public/participant.js
@@ -132,6 +132,7 @@ let flowState = {
   hasMcqSubmission: false,
   assessmentQueued: false,
   resultStatus: null,
+  resultPassFail: null,
 };
 let latestAppeal = null;
 let assessmentProgressKey = "assessment.progress.idle";
@@ -657,11 +658,13 @@ function renderSelectedModuleSummary() {
   selectedModuleTaskText.textContent = selectedModule?.taskText ?? "";
   const constraints = selectedModule?.candidateTaskConstraints ?? "";
   if (selectedModuleCandidateTaskConstraints) selectedModuleCandidateTaskConstraints.textContent = constraints;
-  if (selectedModuleCandidateConstraintsSection) selectedModuleCandidateConstraintsSection.classList.toggle("hidden", !constraints);
-  selectedModuleBrief.classList.toggle(
-    "hidden",
-    !(selectedModule && selectedModule.taskText),
-  );
+  // .module-brief / .module-brief-section set `display: grid`, which overrides the `.hidden`
+  // class (defined earlier in the cascade, no !important). Gate via inline style.display so an
+  // MCQ-only module (taskText == null) doesn't show an empty OPPGAVE/VEILEDNING brief (#525 follow-up).
+  if (selectedModuleCandidateConstraintsSection) {
+    selectedModuleCandidateConstraintsSection.style.display = constraints ? "" : "none";
+  }
+  selectedModuleBrief.style.display = selectedModule && selectedModule.taskText ? "" : "none";
   renderSubmissionFields(getSubmissionFields(selectedModule));
   updateModuleSelectionVisibility(Boolean(selectedModule));
 }
@@ -1088,6 +1091,10 @@ function renderFlowGating() {
 
   const hasResultStatus = isAssessmentResultReady(flowState.resultStatus);
   resetSubmissionFlowButton.classList.toggle("hidden", !hasResultStatus);
+  // Feedback (#549): once the participant has passed, retry/«delete & start over» should be a
+  // discreet secondary action — not compete with the pass celebration. A failed result keeps it
+  // at normal prominence so a retake is easy.
+  resetSubmissionFlowButton.classList.toggle("reset-flow-discreet", hasResultStatus && flowState.resultPassFail === true);
 
   const createSubmissionBusy = createSubmissionButton.dataset.busy === "true";
   const submitMcqBusy = submitMcqButton.dataset.busy === "true";
@@ -2149,6 +2156,9 @@ function renderResultSummary(body) {
   );
   renderAssessmentProgress();
 
+  // Track the outcome so renderFlowGating can de-emphasise the retry button once passed.
+  flowState.resultPassFail = body?.decision?.passFailTotal ?? null;
+
   clearSummaryContainer(resultSummary);
   const summaryCard = createSummaryCard("");
   const summaryGrid = document.createElement("div");
@@ -2558,7 +2568,14 @@ submitMcqButton.addEventListener("click", async () => {
       persistCurrentModuleDraft(true);
       if (alreadyAssessed) {
         const resultBody = await apiFetch(`/api/submissions/${submissionId}/result`, headers);
+        // Sync resultStatus from the fetched result so the flow knows the assessment is ready —
+        // otherwise hasResultStatus stays false and the retry button never appears (also on fail).
+        flowState = {
+          ...flowState,
+          resultStatus: typeof resultBody.status === "string" ? resultBody.status : "COMPLETED",
+        };
         renderResultSummary(resultBody);
+        renderFlowGating();
       } else if (getFlowSettings().autoStartAfterMcq) {
         await startAutomaticAssessmentFlow(submissionId);
       }

--- a/test/e2e/participant-mcq-only.spec.ts
+++ b/test/e2e/participant-mcq-only.spec.ts
@@ -73,13 +73,66 @@ test("participant: MCQ-only module hides the free-text step; free-text module ke
   await expect(page.locator("#submissionFields textarea")).toHaveCount(0);
   await expect(page.locator("#submissionFields")).toContainText("flervalgsspørsmål");
   await expect(page.locator("#ack")).toBeHidden();
+  // #525 follow-up: MCQ-only has no taskText, so the OPPGAVE/VEILEDNING brief must be hidden
+  // (regression guard for the .module-brief display:grid vs .hidden cascade bug).
+  await expect(page.locator("#selectedModuleBrief")).toBeHidden();
   // #546: submission auto-created on select (MCQ shown directly, no extra click).
   await expect.poll(() => submissionCreated).toBe(true);
 
-  // Switch to the free-text module → the answer textarea + acknowledgement come back.
+  // Switch to the free-text module → the answer textarea + acknowledgement + brief come back.
   // (Selecting a module collapses the list, so re-expand it first.)
   await page.locator("#loadModules").click();
   await page.locator(".module-card", { hasText: "Fritekst Modul" }).click();
   await expect(page.locator("#submissionFields textarea")).not.toHaveCount(0);
   await expect(page.locator("#ack")).toBeVisible();
+  await expect(page.locator("#selectedModuleBrief")).toBeVisible();
+});
+
+// Feedback (#549/#525): after an MCQ-only auto-pass the result is ready, so the retry button must
+// be present (not "completely gone") and de-emphasised (discreet) rather than a prominent danger
+// button. Regression guard for the resultStatus-never-synced bug.
+test("participant: MCQ-only auto-pass shows a discreet retry button", async ({ page }) => {
+  await mockBase(page);
+  await page.addInitScript(() => {
+    try { localStorage.setItem("participant.locale", "nb"); } catch { /* ignore */ }
+  });
+
+  await page.route("**/api/submissions", (route: Route) =>
+    route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ submission: { id: "s1" } }) }),
+  );
+  await page.route("**/api/modules/*/mcq/start**", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ attemptId: "a1", questions: [{ id: "q1", stem: "Spørsmål 1", options: ["A", "B"] }] }),
+    }),
+  );
+  await page.route("**/api/modules/*/mcq/submit", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ assessmentComplete: true }) }),
+  );
+  await page.route("**/api/submissions/*/result", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "COMPLETED",
+        decision: { passFailTotal: true, decisionType: "AUTOMATIC" },
+        scoreComponents: { totalScore: 100, mcqScaledScore: 100, practicalScaledScore: 0 },
+        participantGuidance: {},
+      }),
+    }),
+  );
+
+  await page.goto("/participant");
+  await page.locator("#loadModules").click();
+  await page.locator(".module-card", { hasText: "MCQ Modul" }).click();
+
+  // Answer the question and submit the MCQ.
+  await page.locator("input[name='q_q1']").first().check();
+  await page.locator("#submitMcq").click();
+
+  // The retry button is visible (result is ready) and discreet (passed) — not the prominent danger button.
+  const retry = page.locator("#resetSubmissionFlow");
+  await expect(retry).toBeVisible();
+  await expect(retry).toHaveClass(/reset-flow-discreet/);
 });


### PR DESCRIPTION
## To funn ved forfatter-test av MCQ-only-modul

**1. Tom OPPGAVE/VEILEDNING vist.** `selectedModuleBrief` (`.module-brief{display:grid}`) ble skjult via `.hidden`-klassen, men grid-regelen (senere i cascaden, ingen `!important`) overstyrte → tom oppgave-brief for MCQ-only (ingen `taskText`). Skjules nå via `style.display` (samme klasse-overstyrings-felle som før). Gjelder også VEILEDNING-seksjonen.

**2. Retry-knapp «helt borte».** I MCQ-only-stien ble `flowState.resultStatus = null` aldri synket etter result-fetch → `hasResultStatus` forble false → «Slett innlevering og start på nytt» alltid skjult (også ved **stryk**, så man kunne ikke ta testen på nytt). Nå synkes status + gating re-rendres. Ved **bestått** nedtones knappen til diskret sekundær-handling (`.reset-flow-discreet`) i stedet for prominent rød.

## Test
- Utvidet `participant-mcq-only.spec.ts`: brief skjult for MCQ-only / synlig for fritekst; MCQ-only auto-bestått → diskret retry-knapp synlig.
- **6/6 participant-e2e grønne.** Ren frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)