### PR TITLE
chore(process): setHidden-helper + «map full UI surface» standing order (v1.3.43)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,17 @@ These rules exist because their violation caused or worsened the May 2026 produc
   where the costly bugs hide. Exercise the real client→server flow locally (`npm run dev`, local
   Postgres + `AUTH_MODE=mock`) before deploying; staging is an acceptance gate, not a debugger.
   Not "done" until the e2e passes locally + in CI.
+- **Map the full UI surface before building/fixing (standing order):** most of our deploy→bug→deploy
+  churn is *"correct fix, incomplete surface"* — fixing the one path in the screenshot while sibling
+  paths break next. Before coding a UI feature/fix: (1) `grep` the feature/i18n label across **all**
+  pages and enumerate every entry point + surface (e.g. module creation has two entries; a
+  certificate shows in three places), fixing them in the same PR; (2) write the e2e for the
+  **documented/recommended user journey**, not the code path you built; (3) for "move/reorder a step"
+  changes, grep where else that sequence occurs; (4) for conditional visibility use
+  `setHidden(el, on)` (`public/static/dom-visibility.js`) / inline `style.display` — **never** the
+  `.hidden` class or `[hidden]` on an element with a `display`-setting class
+  (`.row`/`.card`/`.content-card`/`.module-brief`/grid…), since `.hidden` (no `!important`) loses the
+  cascade and the element never hides. Recurring trap.
 - **For infra changes**, include in the PR description:
   - Which environments are affected
   - Behavior on first deploy (fresh environment) vs normal deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,30 @@ is built**, and must be runnable **without a staging deploy**:
    first (or at least alongside) forces you to run the real path early, which is where these
    integration bugs surface.
 
+### Map the full UI surface before building/fixing (standing order)
+
+Established 2026-06-21 after a retrospective: a wave of authoring/MCQ-only work produced **6 bugs
+across 5 deploys (v1.3.37→1.3.42)**, almost all of the form *"correct fix, incomplete surface"* —
+the fix landed in the one code path in the screenshot, while sibling paths produced the next bug.
+
+1. **Enumerate every entry point and every surface before coding.** A behaviour usually appears in
+   more than one place. Module creation has **two** entries (the library "create module" dialog
+   `#348` → conversation regen, AND the conversation idle "new module"); a course certificate shows
+   in **three** places (result banner, `/participant/completed`, `/profile`). `grep` the feature
+   name / i18n label across **all** pages first, list the paths, and fix them in the same PR.
+2. **E2e must follow the documented/recommended user journey — not the code path you happened to
+   build.** A green e2e that exercises the convenient path gives false confidence when users take a
+   different one. (We shipped a module-type step into a flow users don't use; the e2e passed.)
+3. **For "move/reorder a step" changes, grep where else that sequence occurs** before editing
+   (scenario/source ordering lived in new-module + regen + external-LLM handoff — only one was
+   fixed at first).
+4. **Conditional visibility: use `setHidden(el, on)` (`public/static/dom-visibility.js`), never the
+   `.hidden` class or `[hidden]` attribute on an element that has a `display`-setting class**
+   (`.row`/`.inline`/`.card`/`.content-card`/`.module-brief`/`.summary-grid`…). `.hidden` is
+   `display:none` without `!important` and loses the cascade to those class rules, so the element
+   never hides. This is a **recurring** trap — assume any `.row`/`.card`/grid element needs
+   `setHidden` / inline `style.display`, and assert it actually hides in the e2e.
+
 ### Which deploy workflow to use
 
 | Type of change | Use workflow | Why |

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,19 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.43 - 2026-06-21
+
+chore(process): `setHidden`-helper + «kartlegg full UI-flate»-stående ordre (retro)
+
+Etter retrospektiv på 6 bugger/5 deploys (1.3.37→1.3.42), de fleste «riktig fiks, ufullstendig flate»:
+- **Ny `public/static/dom-visibility.js` med `setHidden(el, hidden)`** — bruker `style.display`, robust
+  mot den tilbakevendende `.hidden`/display-klasse-cascade-fellen. `participant.js` bruker den nå for
+  oppgave-brief (adferds-identisk; e2e uendret grønn).
+- **Ny stående ordre i CLAUDE.md + AGENTS.md:** «Map the full UI surface before building/fixing» —
+  enumerér alle innganger/flater (grep label på tvers), e2e følger anbefalt brukerreise ikke kode-sti,
+  grep søsken-sekvenser ved «flytt et steg», og bruk `setHidden` for betinget synlighet.
+- Ingen brukerendring (refaktor + docs).
+
 ## 1.3.42 - 2026-06-21
 
 fix(participant): MCQ-only resultat-visning — skjul tom oppgave-brief + diskret retry (#525-oppfølging)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.42",
+  "version": "1.3.43",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/participant.js
+++ b/public/participant.js
@@ -3,6 +3,7 @@ import { apiFetch, buildConsoleHeaders, getConsoleConfig, fetchQueueCounts, appl
 import { initConsentGuard } from "/static/consent-guard.js";
 import { hideLoading, showEmpty, showLoading } from "/static/loading.js";
 import { showToast } from "/static/toast.js";
+import { setHidden } from "/static/dom-visibility.js";
 import {
   buildModuleCardViewModels,
   deriveParticipantFlowGateState,
@@ -662,9 +663,9 @@ function renderSelectedModuleSummary() {
   // class (defined earlier in the cascade, no !important). Gate via inline style.display so an
   // MCQ-only module (taskText == null) doesn't show an empty OPPGAVE/VEILEDNING brief (#525 follow-up).
   if (selectedModuleCandidateConstraintsSection) {
-    selectedModuleCandidateConstraintsSection.style.display = constraints ? "" : "none";
+    setHidden(selectedModuleCandidateConstraintsSection, !constraints);
   }
-  selectedModuleBrief.style.display = selectedModule && selectedModule.taskText ? "" : "none";
+  setHidden(selectedModuleBrief, !(selectedModule && selectedModule.taskText));
   renderSubmissionFields(getSubmissionFields(selectedModule));
   updateModuleSelectionVisibility(Boolean(selectedModule));
 }

--- a/public/static/dom-visibility.js
+++ b/public/static/dom-visibility.js
@@ -1,0 +1,18 @@
+// Robust visibility toggling for the vanilla-JS frontend.
+//
+// WHY THIS EXISTS: the `.hidden` utility class is `display: none` WITHOUT `!important`, and several
+// layout classes set `display` (`.row`, `.inline`, `.card`, `.content-card`, `.module-brief`,
+// `.summary-grid`, …). Those rules are defined later in the cascade, so for an element carrying
+// such a class the `.hidden` class (and the `[hidden]` attribute, which the UA sheet expresses the
+// same way) is OVERRIDDEN — `el.classList.toggle("hidden", true)` / `el.hidden = true` then does
+// nothing and the element stays visible. This has caused the same bug repeatedly
+// (empty MCQ-only brief, content cards, threshold rows, ack labels — see CLAUDE.md).
+//
+// Inline `style.display` beats class rules, so toggling it is always correct. Use `setHidden` for
+// ANY element that has (or might gain) a display-setting class. For plain elements the `.hidden`
+// class is fine, but `setHidden` is safe everywhere, so prefer it for conditional UI.
+
+export function setHidden(el, hidden) {
+  if (!el) return;
+  el.style.display = hidden ? "none" : "";
+}


### PR DESCRIPTION
Retrospektiv-tiltak etter 6 bugger/5 deploys (1.3.37→1.3.42), de fleste «riktig fiks, ufullstendig flate».

## Endringer
- **`public/static/dom-visibility.js`** — `setHidden(el, hidden)` (bruker `style.display`), robust mot den tilbakevendende `.hidden`/display-klasse-cascade-fellen. `participant.js` bruker den for oppgave-brief (**adferds-identisk** — e2e uendret grønn).
- **Stående ordre i CLAUDE.md + AGENTS.md:** «Map the full UI surface before building/fixing» — (1) grep label på tvers, enumerér alle innganger/flater, fiks i samme PR; (2) e2e følger anbefalt brukerreise ikke kode-sti; (3) grep søsken-sekvenser ved «flytt et steg»; (4) `setHidden` for betinget synlighet.

## Hvorfor en presis CI-grep ikke ble lagt til
156 `.hidden`-bruk over 15 filer; de fleste ufarlige. En hard gate ville krevd migrering av alt / stor allowlist = churn + falsk trygghet. Cascade-fellen kan ikke detekteres statisk (krever JS-element→CSS-klasse-korrelasjon). Ekte guard = sanksjonert helper + stående ordre + journey/visibility-e2e.

Ingen brukerendring. Trenger ikke egen deploy — rir med neste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)