### PR TITLE
feat(module): FREETEXT_ONLY datamodell + vurderings-pipeline (v1.3.44, #578 slice 1)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,23 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.44 - 2026-06-21
+
+feat(module): FREETEXT_ONLY — datamodell + vurderings-pipeline (#578 slice 1)
+
+Fundamentet for «Kun Fritekst»-modultype (fritekst + LLM-vurdering, ingen MCQ). Kun backend —
+forfatter-/deltaker-UI kommer i senere skiver.
+- **Datamodell:** `AssessmentMode` += `FREETEXT_ONLY`; `ModuleVersion.mcqSetVersionId` (+ relasjon)
+  gjort nullable (migrasjon `20260621120000_freetext_only_modules`, expand-contract).
+- **Validering:** `moduleVersionBodySchema` — `mcqSetVersionId` valgfri + refine per modus
+  (FREETEXT_ONLY krever taskText+rubrikk+prompt, ingen mcqSet; FREETEXT_PLUS_MCQ krever begge).
+- **Pipeline:** `runAssessment` slipper MCQ-kravet for FREETEXT_ONLY og kjører LLM-stien;
+  `resolveAssessmentDecision` får `freetextOnly`-flagg → rubrikk skaleres til 0–100, ingen
+  MCQ-gate, rødflagg/manuell-vurdering beholdt. `createModuleVersion` validerer mcqSet kun for
+  modi som har det.
+- **Tester:** enhetstester for FREETEXT_ONLY-skåring (0–100, ingen MCQ-gate, manuell-vurdering
+  bevart) + schema-validering. tsc rent. (Ende-til-ende-integrasjon + UI i senere skiver.)
+
 ## 1.3.43 - 2026-06-21
 
 chore(process): `setHidden`-helper + «kartlegg full UI-flate»-stående ordre (retro)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.43",
+  "version": "1.3.44",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260621120000_freetext_only_modules/migration.sql
+++ b/prisma/migrations/20260621120000_freetext_only_modules/migration.sql
@@ -1,0 +1,7 @@
+-- AlterEnum: add the FREETEXT_ONLY assessment mode (#578) — free-text + LLM assessment, no MCQ.
+ALTER TYPE "AssessmentMode" ADD VALUE 'FREETEXT_ONLY';
+
+-- AlterTable: FREETEXT_ONLY module versions have no MCQ set, so mcqSetVersionId becomes nullable.
+-- Expand-contract: existing rows keep their value; FREETEXT_PLUS_MCQ/MCQ_ONLY still require it at
+-- the application layer (moduleVersionBodySchema refine).
+ALTER TABLE "ModuleVersion" ALTER COLUMN "mcqSetVersionId" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -170,6 +170,7 @@ model Module {
 enum AssessmentMode {
   FREETEXT_PLUS_MCQ
   MCQ_ONLY
+  FREETEXT_ONLY
 }
 
 model ModuleVersion {
@@ -177,14 +178,15 @@ model ModuleVersion {
   moduleId                  String
   versionNo                 Int
   // taskText / rubricVersionId / promptTemplateVersionId are free-text-assessment specific and
-  // are null for MCQ_ONLY modules (#525). They remain set for FREETEXT_PLUS_MCQ.
+  // are null for MCQ_ONLY modules (#525). They remain set for FREETEXT_PLUS_MCQ and FREETEXT_ONLY.
   taskText                  String?
   assessorExpectedContent   String?
   candidateTaskConstraints  String?
   assessmentBlueprint       String?
   rubricVersionId           String?
   promptTemplateVersionId   String?
-  mcqSetVersionId           String
+  // mcqSetVersionId is null for FREETEXT_ONLY modules (#578) — no multiple-choice component.
+  mcqSetVersionId           String?
   assessmentMode            AssessmentMode         @default(FREETEXT_PLUS_MCQ)
   submissionSchemaJson      String?
   assessmentPolicyJson      String?
@@ -196,7 +198,7 @@ model ModuleVersion {
   activeForModules          Module[]               @relation("ActiveModuleVersion")
   rubricVersion             RubricVersion?         @relation(fields: [rubricVersionId], references: [id], onDelete: Restrict)
   promptTemplateVersion     PromptTemplateVersion? @relation(fields: [promptTemplateVersionId], references: [id], onDelete: Restrict)
-  mcqSetVersion             MCQSetVersion          @relation(fields: [mcqSetVersionId], references: [id], onDelete: Restrict)
+  mcqSetVersion             MCQSetVersion?         @relation(fields: [mcqSetVersionId], references: [id], onDelete: Restrict)
   submissions               Submission[]
   assessmentDecisions       AssessmentDecision[]
   llmEvaluations            LLMEvaluation[]

--- a/src/modules/adminContent/adminContentCommands.ts
+++ b/src/modules/adminContent/adminContentCommands.ts
@@ -53,7 +53,8 @@ type CreateModuleVersionInput = {
   assessmentBlueprint?: string;
   rubricVersionId?: string | null;
   promptTemplateVersionId?: string | null;
-  mcqSetVersionId: string;
+  // #578: absent for FREETEXT_ONLY modules.
+  mcqSetVersionId?: string | null;
   submissionSchemaJson?: string;
   assessmentPolicyJson?: string;
 };
@@ -559,14 +560,21 @@ export async function createModuleVersion(input: CreateModuleVersionInput) {
   const versionNo = await getNextVersionNo("module", input.moduleId);
 
   const isMcqOnly = input.assessmentMode === "MCQ_ONLY";
+  const isFreetextOnly = input.assessmentMode === "FREETEXT_ONLY";
 
-  // MCQ set is always required and must belong to this module.
-  const mcqSet = await adminContentRepository.findMcqSetSummary(input.mcqSetVersionId);
-  if (!mcqSet || mcqSet.moduleId !== input.moduleId) {
-    throw new Error("MCQ set version is missing or belongs to another module.");
+  // MCQ set is required for every mode except FREETEXT_ONLY (#578), and must belong to this module.
+  if (!isFreetextOnly) {
+    if (!input.mcqSetVersionId) {
+      throw new Error("MCQ set version is required for this module type.");
+    }
+    const mcqSet = await adminContentRepository.findMcqSetSummary(input.mcqSetVersionId);
+    if (!mcqSet || mcqSet.moduleId !== input.moduleId) {
+      throw new Error("MCQ set version is missing or belongs to another module.");
+    }
   }
 
-  // Rubric + prompt are only validated for FREETEXT_PLUS_MCQ modules (#525).
+  // Rubric + prompt are validated for the free-text modes (FREETEXT_PLUS_MCQ + FREETEXT_ONLY),
+  // not for MCQ_ONLY (#525/#578).
   if (!isMcqOnly) {
     if (!input.rubricVersionId || !input.promptTemplateVersionId) {
       throw new Error("Rubric and prompt template are required for free-text modules.");
@@ -574,7 +582,8 @@ export async function createModuleVersion(input: CreateModuleVersionInput) {
     const [rubric, promptTemplate] = await adminContentRepository.findVersionDependencies({
       rubricVersionId: input.rubricVersionId,
       promptTemplateVersionId: input.promptTemplateVersionId,
-      mcqSetVersionId: input.mcqSetVersionId,
+      // mcqSet is validated above; "" yields a null 3rd result which we ignore here.
+      mcqSetVersionId: input.mcqSetVersionId ?? "",
     });
     if (!rubric || rubric.moduleId !== input.moduleId) {
       throw new Error("Rubric version is missing or belongs to another module.");
@@ -594,7 +603,7 @@ export async function createModuleVersion(input: CreateModuleVersionInput) {
     assessmentBlueprint: input.assessmentBlueprint,
     rubricVersionId: isMcqOnly ? null : input.rubricVersionId,
     promptTemplateVersionId: isMcqOnly ? null : input.promptTemplateVersionId,
-    mcqSetVersionId: input.mcqSetVersionId,
+    mcqSetVersionId: isFreetextOnly ? null : input.mcqSetVersionId,
     submissionSchemaJson: input.submissionSchemaJson,
     assessmentPolicyJson: input.assessmentPolicyJson,
   });

--- a/src/modules/adminContent/adminContentRepository.ts
+++ b/src/modules/adminContent/adminContentRepository.ts
@@ -480,7 +480,7 @@ export function createAdminContentRepository(client: AdminContentRepositoryClien
       assessmentBlueprint?: string | null;
       rubricVersionId?: string | null;
       promptTemplateVersionId?: string | null;
-      mcqSetVersionId: string;
+      mcqSetVersionId?: string | null;
       assessmentMode?: AssessmentMode;
       submissionSchemaJson?: string | null;
       assessmentPolicyJson?: string | null;

--- a/src/modules/adminContent/adminContentSchemas.ts
+++ b/src/modules/adminContent/adminContentSchemas.ts
@@ -129,7 +129,7 @@ export const assessmentPolicyBodySchema = z.object({
     .optional(),
 });
 
-export const assessmentModeSchema = z.enum(["FREETEXT_PLUS_MCQ", "MCQ_ONLY"]);
+export const assessmentModeSchema = z.enum(["FREETEXT_PLUS_MCQ", "MCQ_ONLY", "FREETEXT_ONLY"]);
 
 // #525: MCQ_ONLY modules have no free-text task, rubric or prompt — those fields become optional.
 // mcqSetVersionId is always required. FREETEXT_PLUS_MCQ (default) keeps the original requirements.
@@ -142,17 +142,27 @@ export const moduleVersionBodySchema = z
     assessmentBlueprint: z.string().trim().optional(),
     rubricVersionId: z.string().min(1).optional(),
     promptTemplateVersionId: z.string().min(1).optional(),
-    mcqSetVersionId: z.string().min(1),
+    // #578: optional — FREETEXT_ONLY modules have no MCQ set. Required for the other two modes
+    // via the refine below.
+    mcqSetVersionId: z.string().min(1).optional(),
     submissionSchema: submissionSchemaBodySchema.optional(),
     assessmentPolicy: assessmentPolicyBodySchema.optional(),
   })
   .refine(
-    (v) =>
-      v.assessmentMode === "MCQ_ONLY" ||
-      (Boolean(v.taskText) && Boolean(v.rubricVersionId) && Boolean(v.promptTemplateVersionId)),
+    (v) => {
+      const hasFreeText = Boolean(v.taskText) && Boolean(v.rubricVersionId) && Boolean(v.promptTemplateVersionId);
+      // FREETEXT_ONLY (#578): free-text fields required, no MCQ set.
+      if (v.assessmentMode === "FREETEXT_ONLY") return hasFreeText;
+      // MCQ_ONLY (#525): MCQ set required, no free-text fields.
+      if (v.assessmentMode === "MCQ_ONLY") return Boolean(v.mcqSetVersionId);
+      // FREETEXT_PLUS_MCQ (default): both free-text fields and an MCQ set required.
+      return hasFreeText && Boolean(v.mcqSetVersionId);
+    },
     {
       message:
-        "taskText, rubricVersionId and promptTemplateVersionId are required for FREETEXT_PLUS_MCQ modules.",
+        "FREETEXT_PLUS_MCQ requires taskText, rubricVersionId, promptTemplateVersionId and mcqSetVersionId; " +
+        "FREETEXT_ONLY requires taskText, rubricVersionId and promptTemplateVersionId (no mcqSet); " +
+        "MCQ_ONLY requires mcqSetVersionId.",
       path: ["assessmentMode"],
     },
   );

--- a/src/modules/assessment/AssessmentDecisionApplicationService.ts
+++ b/src/modules/assessment/AssessmentDecisionApplicationService.ts
@@ -24,6 +24,8 @@ type ApplyDecisionInput = {
   assessmentPolicy: ModuleAssessmentPolicy | null;
   rubricMaxTotal: number;
   rubricCriteriaIds: string[];
+  /** #578: FREETEXT_ONLY — practical/LLM-only scoring, no MCQ component. */
+  freetextOnly?: boolean;
   /** Localized module title text (may be a raw localization JSON string). */
   moduleTitle: string;
   submissionLocale: SupportedLocale;
@@ -55,6 +57,7 @@ export async function applyAssessmentDecision(input: ApplyDecisionInput): Promis
     assessmentPolicy: input.assessmentPolicy,
     rubricMaxTotal: input.rubricMaxTotal,
     rubricCriteriaIds: input.rubricCriteriaIds,
+    freetextOnly: input.freetextOnly,
   });
 
   if (!decisionResult.needsManualReview) {

--- a/src/modules/assessment/assessmentJobService.ts
+++ b/src/modules/assessment/assessmentJobService.ts
@@ -32,25 +32,35 @@ async function runAssessment(jobId: string) {
 
   const submission = job.submission;
   const submissionLocale = normalizeLocale(submission.locale) ?? "en-GB";
+  const assessmentMode = submission.moduleVersion.assessmentMode;
   const mcqAttempt = submission.mcqAttempts[0];
 
-  if (!mcqAttempt || mcqAttempt.scaledScore == null || mcqAttempt.percentScore == null) {
-    throw new Error("Cannot assess submission before MCQ completion.");
+  // FREETEXT_ONLY (#578) has no MCQ component, so there is no MCQ attempt to wait for. Every other
+  // mode must have a completed MCQ before assessment can run. Narrow the scores into locals so the
+  // rest of the function has plain numbers (0 for FREETEXT_ONLY).
+  let mcqScaledScore = 0;
+  let mcqPercentScore = 0;
+  if (assessmentMode !== "FREETEXT_ONLY") {
+    if (!mcqAttempt || mcqAttempt.scaledScore == null || mcqAttempt.percentScore == null) {
+      throw new Error("Cannot assess submission before MCQ completion.");
+    }
+    mcqScaledScore = mcqAttempt.scaledScore;
+    mcqPercentScore = mcqAttempt.percentScore;
   }
 
   await assessmentJobRepository.updateSubmissionStatus(submission.id, SubmissionStatus.PROCESSING);
 
   // MCQ_ONLY modules (#525): no free-text, no LLM evaluation. Decide pass/fail purely from the
   // MCQ score and finish — skip the rubric/prompt-based pipeline entirely.
-  if (submission.moduleVersion.assessmentMode === "MCQ_ONLY") {
+  if (assessmentMode === "MCQ_ONLY") {
     await applyMcqOnlyDecision({
       jobId,
       submissionId: submission.id,
       userId: submission.userId,
       moduleId: submission.moduleId,
       moduleVersionId: submission.moduleVersionId,
-      mcqScaledScore: mcqAttempt.scaledScore,
-      mcqPercentScore: mcqAttempt.percentScore,
+      mcqScaledScore,
+      mcqPercentScore,
       assessmentPolicy: assessmentPolicyCodec.parse(submission.moduleVersion.assessmentPolicyJson),
       moduleTitle: submission.moduleVersion.module.title,
       submissionLocale,
@@ -61,7 +71,7 @@ async function runAssessment(jobId: string) {
     return;
   }
 
-  // FREETEXT_PLUS_MCQ path: rubric + prompt are required here (MCQ_ONLY was gated out above).
+  // FREETEXT_PLUS_MCQ + FREETEXT_ONLY path: rubric + prompt are required (MCQ_ONLY gated out above).
   const { rubricVersionId, promptTemplateVersionId } = submission.moduleVersion;
   if (rubricVersionId == null || promptTemplateVersionId == null) {
     throw new Error("Free-text module version is missing rubric/prompt configuration.");
@@ -102,8 +112,11 @@ async function runAssessment(jobId: string) {
     moduleVersionId: submission.moduleVersionId,
     rubricVersionId,
     promptTemplateVersionId,
-    mcqScaledScore: mcqAttempt.scaledScore,
-    mcqPercentScore: mcqAttempt.percentScore,
+    // FREETEXT_ONLY has no MCQ attempt — scores are 0, and freetextOnly tells the decision logic to
+    // scale the rubric to the full 0–100 with no MCQ gate.
+    mcqScaledScore,
+    mcqPercentScore,
+    freetextOnly: assessmentMode === "FREETEXT_ONLY",
     llmResult: finalLlmResult,
     forceManualReviewReason,
     assessmentPolicy: inputContext.assessmentPolicy,

--- a/src/modules/assessment/decisionService.ts
+++ b/src/modules/assessment/decisionService.ts
@@ -29,6 +29,9 @@ type BuildDecisionInput = {
   assessmentPolicy?: ModuleAssessmentPolicy | null;
   rubricMaxTotal?: number;
   rubricCriteriaIds?: string[];
+  // #578: FREETEXT_ONLY — practical/LLM-only scoring, no MCQ component. The rubric score spans the
+  // full 0–100 and there is no MCQ gate.
+  freetextOnly?: boolean;
 };
 
 export type ResolvedAssessmentDecision = {
@@ -44,7 +47,7 @@ export type ResolvedAssessmentDecision = {
 
 type ResolveAssessmentDecisionInput = Pick<
   BuildDecisionInput,
-  "mcqScaledScore" | "mcqPercentScore" | "llmResult" | "forceManualReviewReason" | "assessmentPolicy" | "rubricMaxTotal" | "rubricCriteriaIds"
+  "mcqScaledScore" | "mcqPercentScore" | "llmResult" | "forceManualReviewReason" | "assessmentPolicy" | "rubricMaxTotal" | "rubricCriteriaIds" | "freetextOnly"
 >;
 
 export function resolveAssessmentDecision(input: ResolveAssessmentDecisionInput): ResolvedAssessmentDecision {
@@ -68,17 +71,23 @@ export function resolveAssessmentDecision(input: ResolveAssessmentDecisionInput)
   const recomputedRubricTotal = Object.values(validatedScores).reduce((sum, s) => sum + s, 0);
   const totalsInconsistent = recomputedRubricTotal !== input.llmResult.rubric_total;
 
+  // #578: FREETEXT_ONLY has no MCQ component, so the rubric/practical score spans the full 0–100
+  // (instead of the 0–70 practical band that leaves 30 for MCQ in FREETEXT_PLUS_MCQ).
+  const freetextOnly = input.freetextOnly === true;
+  const practicalScaleMax = freetextOnly ? 100 : 70;
   const recomputedPracticalScoreScaled =
-    rubricMaxTotal > 0 ? Number(((recomputedRubricTotal / rubricMaxTotal) * 70).toFixed(2)) : 0;
+    rubricMaxTotal > 0 ? Number(((recomputedRubricTotal / rubricMaxTotal) * practicalScaleMax).toFixed(2)) : 0;
 
   const effectivePracticalScaledScore =
-    input.assessmentPolicy?.scoring?.practicalWeight != null
+    !freetextOnly && input.assessmentPolicy?.scoring?.practicalWeight != null
       ? (recomputedPracticalScoreScaled / rules.weights.practicalMaxScore) * input.assessmentPolicy.scoring.practicalWeight
       : recomputedPracticalScoreScaled;
   const effectiveMcqScaledScore =
-    input.assessmentPolicy?.scoring?.mcqWeight != null
-      ? (input.mcqPercentScore / 100) * input.assessmentPolicy.scoring.mcqWeight
-      : input.mcqScaledScore;
+    freetextOnly
+      ? 0
+      : input.assessmentPolicy?.scoring?.mcqWeight != null
+        ? (input.mcqPercentScore / 100) * input.assessmentPolicy.scoring.mcqWeight
+        : input.mcqScaledScore;
   const totalScore = Number((effectivePracticalScaledScore + effectiveMcqScaledScore).toFixed(2));
   const practicalPercent = rubricMaxTotal > 0 ? (recomputedRubricTotal / rubricMaxTotal) * 100 : null;
 
@@ -88,7 +97,8 @@ export function resolveAssessmentDecision(input: ResolveAssessmentDecisionInput)
   const hasOpenRedFlag = hasForcingRedFlag(input.llmResult, rules.manualReview.redFlagSeverities);
   const hasOnlyInsufficientEvidenceFlags = hasOnlyInsufficientEvidenceRedFlags(input.llmResult);
 
-  const mcqGatePasses = mcqMinPercent === null || input.mcqPercentScore >= mcqMinPercent;
+  // FREETEXT_ONLY has no MCQ gate.
+  const mcqGatePasses = freetextOnly || mcqMinPercent === null || input.mcqPercentScore >= mcqMinPercent;
   const practicalGatePasses =
     practicalMinPercent === null ||
     (practicalPercent !== null && practicalPercent >= practicalMinPercent);

--- a/src/modules/assessment/mcqService.ts
+++ b/src/modules/assessment/mcqService.ts
@@ -41,9 +41,14 @@ export async function startMcqAttempt(
     if (submission.submissionStatus === SubmissionStatus.PROCESSING) {
       throw new Error("MCQ attempt cannot be started: submission has already been processed.");
     }
+    // #578: FREETEXT_ONLY modules have no MCQ set — they should never reach the MCQ flow.
+    const mcqSetVersionId = submission.moduleVersion.mcqSetVersionId;
+    if (mcqSetVersionId == null) {
+      throw new Error("This module has no multiple-choice component.");
+    }
     attempt = await mcqRepository.createAttempt({
       submissionId: submission.id,
-      mcqSetVersionId: submission.moduleVersion.mcqSetVersionId,
+      mcqSetVersionId,
       startedAt: new Date(),
     });
   }

--- a/test/m2-reporting.test.ts
+++ b/test/m2-reporting.test.ts
@@ -402,13 +402,13 @@ async function createPublishedModule(title: string) {
     data: {
       moduleId: module.id,
       versionNo: 1,
-      title: sourceModuleVersion!.mcqSetVersion.title,
+      title: sourceModuleVersion!.mcqSetVersion!.title,
     },
     select: { id: true },
   });
 
   await prisma.mCQQuestion.createMany({
-    data: sourceModuleVersion!.mcqSetVersion.questions.map((question) => ({
+    data: sourceModuleVersion!.mcqSetVersion!.questions.map((question) => ({
       mcqSetVersionId: mcqSetVersion.id,
       moduleId: module.id,
       stem: question.stem,

--- a/test/unit/decision-service.test.ts
+++ b/test/unit/decision-service.test.ts
@@ -936,3 +936,69 @@ describe("decision service", () => {
     expect(result.needsManualReview).toBe(false);
   });
 });
+
+// #578 — FREETEXT_ONLY: free-text + LLM assessment, no MCQ. The rubric spans the full 0–100
+// (vs the 0–70 practical band in FREETEXT_PLUS_MCQ) and there is no MCQ gate.
+describe("resolveAssessmentDecision — FREETEXT_ONLY (#578)", () => {
+  const criteriaIds = [
+    "relevance_for_case",
+    "quality_and_utility",
+    "iteration_and_improvement",
+    "human_quality_assurance",
+    "responsible_use",
+  ];
+
+  it("scales the rubric to 0–100 (no MCQ band) and ignores MCQ scores", async () => {
+    const { resolveAssessmentDecision } = await import("../../src/modules/assessment/decisionService.js");
+    const resolved = resolveAssessmentDecision({
+      mcqScaledScore: 0,
+      mcqPercentScore: 0,
+      llmResult: buildLlmResult(), // rubric_total 14 / max 20
+      rubricMaxTotal: 20,
+      rubricCriteriaIds: criteriaIds,
+      freetextOnly: true,
+    });
+    // (14/20)*100 = 70 — the whole score is practical; no +30 MCQ band.
+    expect(resolved.totalScore).toBe(70);
+    expect(resolved.passFailTotal).toBe(true);
+  });
+
+  it("has no MCQ gate — passes even with mcqMinPercent set and a 0 MCQ score", async () => {
+    const { resolveAssessmentDecision } = await import("../../src/modules/assessment/decisionService.js");
+    const policy = { passRules: { mcqMinPercent: 100 } } as never;
+    const freetext = resolveAssessmentDecision({
+      mcqScaledScore: 0,
+      mcqPercentScore: 0,
+      llmResult: buildLlmResult(),
+      rubricMaxTotal: 20,
+      rubricCriteriaIds: criteriaIds,
+      assessmentPolicy: policy,
+      freetextOnly: true,
+    });
+    expect(freetext.passFailTotal).toBe(true);
+
+    // Contrast: the same inputs WITHOUT freetextOnly fail the MCQ gate (0% < 100%).
+    const withMcqGate = resolveAssessmentDecision({
+      mcqScaledScore: 0,
+      mcqPercentScore: 0,
+      llmResult: buildLlmResult(),
+      rubricMaxTotal: 20,
+      rubricCriteriaIds: criteriaIds,
+      assessmentPolicy: policy,
+    });
+    expect(withMcqGate.passFailTotal).toBe(false);
+  });
+
+  it("still routes free-text submissions to manual review when the LLM recommends it", async () => {
+    const { resolveAssessmentDecision } = await import("../../src/modules/assessment/decisionService.js");
+    const resolved = resolveAssessmentDecision({
+      mcqScaledScore: 0,
+      mcqPercentScore: 0,
+      llmResult: buildLlmResult({ manual_review_recommended: true }),
+      rubricMaxTotal: 20,
+      rubricCriteriaIds: criteriaIds,
+      freetextOnly: true,
+    });
+    expect(resolved.needsManualReview).toBe(true);
+  });
+});

--- a/test/unit/mcq-only-modules.test.ts
+++ b/test/unit/mcq-only-modules.test.ts
@@ -66,4 +66,32 @@ describe("moduleVersionBodySchema (assessmentMode)", () => {
     });
     expect(parsed.success).toBe(true);
   });
+
+  // #578 — FREETEXT_ONLY: free-text fields required, no MCQ set.
+  it("accepts a FREETEXT_ONLY module with free-text fields and no MCQ set", () => {
+    const parsed = moduleVersionBodySchema.safeParse({
+      assessmentMode: "FREETEXT_ONLY",
+      taskText: "Do the task",
+      rubricVersionId: "rub-1",
+      promptTemplateVersionId: "prompt-1",
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects a FREETEXT_ONLY module missing taskText/rubric/prompt", () => {
+    const parsed = moduleVersionBodySchema.safeParse({
+      assessmentMode: "FREETEXT_ONLY",
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects a FREETEXT_PLUS_MCQ module missing the MCQ set", () => {
+    const parsed = moduleVersionBodySchema.safeParse({
+      assessmentMode: "FREETEXT_PLUS_MCQ",
+      taskText: "Do the task",
+      rubricVersionId: "rub-1",
+      promptTemplateVersionId: "prompt-1",
+    });
+    expect(parsed.success).toBe(false);
+  });
 });


### PR DESCRIPTION
## #578 slice 1 — «Kun Fritekst» fundament (backend)

Fritekst + LLM-vurdering, **ingen MCQ**. Tredje modultype ved siden av FREETEXT_PLUS_MCQ og MCQ_ONLY. Kun backend her — forfatter-/deltaker-UI + import/eksport kommer i senere skiver.

### Endringer
- **Datamodell:** `AssessmentMode` += `FREETEXT_ONLY`; `ModuleVersion.mcqSetVersionId` + relasjon nullable. Migrasjon `20260621120000_freetext_only_modules` (expand-contract: enum ADD VALUE + DROP NOT NULL).
- **Validering:** `moduleVersionBodySchema` — `mcqSetVersionId` valgfri + refine per modus (FREETEXT_ONLY: taskText+rubrikk+prompt, ingen mcqSet; FREETEXT_PLUS_MCQ: begge; MCQ_ONLY: mcqSet).
- **Pipeline:** `runAssessment` slipper MCQ-kravet for FREETEXT_ONLY og kjører LLM-stien; `resolveAssessmentDecision`/`applyAssessmentDecision` får `freetextOnly` → rubrikk skaleres til **0–100**, **ingen MCQ-gate**, rødflagg/manuell-vurdering **bevart**. `createModuleVersion` validerer mcqSet kun for modi som bruker det.

### Tester
- Enhetstester: FREETEXT_ONLY-skåring (total 0–100, MCQ-gate hoppes over, manuell-vurdering bevart) + schema-validering. **45/45 unit grønne**, `tsc` rent.
- Ende-til-ende-integrasjon (submission→run→decision) + UI dekkes i senere skiver (trenger DB/UI).

### Rollback
Additivt: ny enum-verdi + nullable kolonne. Ingen eksisterende rader endres; andre modi krever fortsatt mcqSet i app-laget. Revert av migrasjon: kolonnen kan ikke trygt gjøres NOT NULL igjen hvis FREETEXT_ONLY-rader finnes — men ingen lages før UI-skivene.

Del av #578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)