### PR TITLE
feat(participant): FREETEXT_ONLY deltaker-flyt (v1.3.46, #578 slice 3)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,22 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.46 - 2026-06-21
+
+feat(participant): FREETEXT_ONLY deltaker-flyt (#578 slice 3)
+
+Deltaker kan nå fullføre en «Kun fritekst»-modul ende-til-ende.
+- Deltaker-visningen viser fritekst-felt + bekreftelse + oppgave-brief, og **skjuler MCQ-seksjonen**
+  for FREETEXT_ONLY.
+- **Vurdering uten MCQ-gate:** `deriveParticipantFlowGateState` tar nå `{ requiresMcq }` —
+  FREETEXT_ONLY låser opp vurdering så snart fritekst-innleveringen finnes. Etter innlevering startes
+  ikke et MCQ-forsøk (serveren ville 400); vurderingen kjøres direkte (auto, eller via «Start
+  vurdering»-knappen som nå er tilgjengelig).
+- **Tester:** ny participant-e2e (fritekst vist, MCQ skjult, vurdering kjøres uten MCQ-start) +
+  gate-unit-test for `requiresMcq:false`. tsc rent.
+- Med slice 1+2a+3 er FREETEXT_ONLY brukbar ende-til-ende (backend + samtale-authoring + deltaker).
+  Gjenstår: Avansert editor (3-veis), import/eksport, docs.
+
 ## 1.3.45 - 2026-06-21
 
 feat(author): «Kun fritekst» i samtale-flyten (#578 slice 2a)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.45",
+  "version": "1.3.46",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/participant-console-state.js
+++ b/public/participant-console-state.js
@@ -251,20 +251,23 @@ export function upsertModuleDraft(moduleDrafts, moduleId, draftData, nowMs = Dat
   return Object.fromEntries(ordered);
 }
 
-export function deriveParticipantFlowGateState(flowState) {
+export function deriveParticipantFlowGateState(flowState, options = {}) {
   const hasSubmission = flowState?.hasSubmission === true;
   const hasMcqSubmission = flowState?.hasMcqSubmission === true;
   const assessmentQueued = flowState?.assessmentQueued === true;
   const resultStatus = typeof flowState?.resultStatus === "string" ? flowState.resultStatus : null;
+  // #578: FREETEXT_ONLY modules have no MCQ, so the assessment unlocks as soon as the free-text
+  // submission exists — there is no MCQ gate.
+  const requiresMcq = options?.requiresMcq !== false;
 
-  const assessmentUnlocked = hasSubmission && hasMcqSubmission;
+  const assessmentUnlocked = hasSubmission && (!requiresMcq || hasMcqSubmission);
   const checkAssessmentUnlocked = assessmentUnlocked && assessmentQueued;
   const appealUnlocked = resultStatus === "COMPLETED";
 
   let assessmentHintKey = "flow.assessmentReady";
   if (!hasSubmission) {
     assessmentHintKey = "flow.assessmentLockedNeedsSubmission";
-  } else if (!hasMcqSubmission) {
+  } else if (requiresMcq && !hasMcqSubmission) {
     assessmentHintKey = "flow.assessmentLockedNeedsMcq";
   }
 

--- a/public/participant.js
+++ b/public/participant.js
@@ -509,6 +509,17 @@ function selectedModuleIsMcqOnly() {
   return moduleIsMcqOnly(resolveSelectedModule(loadedModules, selectedModuleId));
 }
 
+// #578: FREETEXT_ONLY — free-text + LLM assessment, no MCQ. The participant fills in the free-text
+// answer (like FREETEXT_PLUS_MCQ) but there is no MCQ section, and the assessment can run as soon
+// as the submission exists (no MCQ gate).
+function moduleIsFreetextOnly(module) {
+  return module?.assessmentMode === "FREETEXT_ONLY";
+}
+
+function selectedModuleIsFreetextOnly() {
+  return moduleIsFreetextOnly(resolveSelectedModule(loadedModules, selectedModuleId));
+}
+
 function getSubmissionFields(selectedModule) {
   // MCQ-only modules have no free-text deliverable — no submission fields to fill (#525).
   if (moduleIsMcqOnly(selectedModule)) {
@@ -1075,20 +1086,24 @@ function resetFlowStateForModuleContext() {
 }
 
 function renderFlowGating() {
-  const gate = deriveParticipantFlowGateState(flowState);
+  // #578: FREETEXT_ONLY has no MCQ — the assessment unlocks on the free-text submission alone.
+  const freetextOnly = selectedModuleIsFreetextOnly();
+  const gate = deriveParticipantFlowGateState(flowState, { requiresMcq: !freetextOnly });
   const hasAssessmentContext =
-    flowState.hasMcqSubmission || flowState.assessmentQueued || Boolean(flowState.resultStatus);
+    flowState.hasMcqSubmission || flowState.assessmentQueued || Boolean(flowState.resultStatus)
+    || (freetextOnly && flowState.hasSubmission);
   const autoAssessmentEnabled = getFlowSettings().autoStartAfterMcq;
   const hasSelectedModule = Boolean(resolveSelectedModule(loadedModules, selectedModuleId));
   const hasPreviewQuestions = currentQuestions.length > 0;
 
   assessmentSection.classList.toggle("hidden", !hasAssessmentContext);
-  mcqSection.classList.toggle("hidden", !hasSelectedModule || !flowState.hasSubmission);
+  // FREETEXT_ONLY has no MCQ section.
+  mcqSection.classList.toggle("hidden", !hasSelectedModule || !flowState.hasSubmission || freetextOnly);
   setSectionLocked(assessmentSection, !gate.assessmentUnlocked);
   setSectionLocked(appealSection, !gate.appealUnlocked);
   queueAssessmentButton.classList.toggle("hidden", autoAssessmentEnabled);
   createSubmissionButton.classList.toggle("hidden", flowState.hasSubmission);
-  submitMcqButton.classList.toggle("hidden", !flowState.hasSubmission || flowState.hasMcqSubmission);
+  submitMcqButton.classList.toggle("hidden", !flowState.hasSubmission || flowState.hasMcqSubmission || freetextOnly);
 
   const hasResultStatus = isAssessmentResultReady(flowState.resultStatus);
   resetSubmissionFlowButton.classList.toggle("hidden", !hasResultStatus);
@@ -2478,14 +2493,22 @@ createSubmissionButton.addEventListener("click", async () => {
       renderAssessmentProgress();
       renderAppealState();
       renderFlowGating();
-      const mcqStartBody = await startMcqForSubmission(moduleId, body.submission.id);
-      log({
-        submission: body.submission,
-        mcqStarted: {
-          attemptId: mcqStartBody.attemptId,
-          questionCount: Array.isArray(mcqStartBody.questions) ? mcqStartBody.questions.length : 0,
-        },
-      });
+      // #578: FREETEXT_ONLY has no MCQ — don't start an MCQ attempt (the server would 400). The
+      // assessment runs directly on the free-text submission (auto if enabled, otherwise via the
+      // now-unlocked "Start assessment" button).
+      if (selectedModuleIsFreetextOnly()) {
+        await startAutomaticAssessmentFlow(body.submission.id);
+        log({ submission: body.submission });
+      } else {
+        const mcqStartBody = await startMcqForSubmission(moduleId, body.submission.id);
+        log({
+          submission: body.submission,
+          mcqStarted: {
+            attemptId: mcqStartBody.attemptId,
+            questionCount: Array.isArray(mcqStartBody.questions) ? mcqStartBody.questions.length : 0,
+          },
+        });
+      }
     } catch (error) {
       log(error.message);
     }

--- a/test/e2e/participant-mcq-only.spec.ts
+++ b/test/e2e/participant-mcq-only.spec.ts
@@ -136,3 +136,63 @@ test("participant: MCQ-only auto-pass shows a discreet retry button", async ({ p
   await expect(retry).toBeVisible();
   await expect(retry).toHaveClass(/reset-flow-discreet/);
 });
+
+// #578: FREETEXT_ONLY — the participant fills in free text (no MCQ section) and the assessment runs
+// directly on the submission (no MCQ attempt is started; the server would 400 if one were).
+test("participant: FREETEXT_ONLY module shows free-text, hides MCQ, assesses without MCQ", async ({ page }) => {
+  await mockBase(page);
+  await page.addInitScript(() => {
+    try { localStorage.setItem("participant.locale", "nb"); } catch { /* ignore */ }
+  });
+
+  // Override the module list with a FREETEXT_ONLY module.
+  await page.route("**/api/modules**", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        modules: [
+          { id: "m-fto", title: "Essay Modul", description: null, assessmentMode: "FREETEXT_ONLY", submissionSchema: null, assessmentPolicy: null, taskText: "Skriv et essay", activeVersion: { versionNo: 1 }, participantStatus: null },
+        ],
+      }),
+    }),
+  );
+  await page.route("**/api/submissions", (route: Route) =>
+    route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ submission: { id: "s1" } }) }),
+  );
+  let mcqStartCalled = false;
+  await page.route("**/api/modules/*/mcq/start**", (route: Route) => {
+    mcqStartCalled = true;
+    return route.fulfill({ status: 400, contentType: "application/json", body: JSON.stringify({ error: "no_mcq" }) });
+  });
+  let runCalled = false;
+  await page.route("**/api/assessments/*/run", (route: Route) => {
+    runCalled = true;
+    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true }) });
+  });
+  await page.route("**/api/submissions/*/result", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ status: "PROCESSING" }) }),
+  );
+
+  await page.goto("/participant");
+  await page.locator("#loadModules").click();
+  await page.locator(".module-card", { hasText: "Essay Modul" }).click();
+
+  // Free-text fields + acknowledgement + task brief are shown; the MCQ section is hidden.
+  await expect(page.locator("#submissionFields textarea").first()).toBeVisible();
+  await expect(page.locator("#ack")).toBeVisible();
+  await expect(page.locator("#selectedModuleBrief")).toBeVisible();
+  await expect(page.locator("#mcqSection")).toBeHidden();
+
+  // Fill the free-text answer(s) + acknowledge, then create the submission.
+  for (const ta of await page.locator("#submissionFields textarea").all()) {
+    await ta.fill("This is a sufficiently long free-text answer for assessment.");
+  }
+  await page.locator("#ack").check();
+  await page.locator("#createSubmission").click();
+
+  // The assessment runs directly; no MCQ attempt is ever started, and the MCQ section stays hidden.
+  await expect.poll(() => runCalled).toBe(true);
+  expect(mcqStartCalled).toBe(false);
+  await expect(page.locator("#mcqSection")).toBeHidden();
+});

--- a/test/participant-console-state.test.js
+++ b/test/participant-console-state.test.js
@@ -156,6 +156,26 @@ describe("participant console state helpers", () => {
     expect(completed.appealHintKey).toBe("flow.appealReady");
   });
 
+  it("unlocks assessment without MCQ for FREETEXT_ONLY modules (#578)", () => {
+    // requiresMcq:false → assessment unlocks on the free-text submission alone (no MCQ gate).
+    const freetextOnly = deriveParticipantFlowGateState(
+      { hasSubmission: true, hasMcqSubmission: false, assessmentQueued: false, resultStatus: null },
+      { requiresMcq: false },
+    );
+    expect(freetextOnly.assessmentUnlocked).toBe(true);
+    expect(freetextOnly.assessmentHintKey).toBe("flow.assessmentReady");
+
+    // The default (requiresMcq) still gates on MCQ.
+    const requiresMcq = deriveParticipantFlowGateState({
+      hasSubmission: true,
+      hasMcqSubmission: false,
+      assessmentQueued: false,
+      resultStatus: null,
+    });
+    expect(requiresMcq.assessmentUnlocked).toBe(false);
+    expect(requiresMcq.assessmentHintKey).toBe("flow.assessmentLockedNeedsMcq");
+  });
+
   it("sanitizes configured appeal workspace statuses", () => {
     const statuses = sanitizeAppealStatuses(["open", "IN_REVIEW", "INVALID", "OPEN"], [
       "OPEN",


### PR DESCRIPTION
## #578 slice 3 — FREETEXT_ONLY deltaker-flyt

Med slice 1 (backend) + 2a (samtale-authoring) + denne er **FREETEXT_ONLY brukbar ende-til-ende**.

### Endringer
- Deltaker-visningen viser fritekst-felt + bekreftelse + oppgave-brief, og **skjuler MCQ-seksjonen** for FREETEXT_ONLY.
- `deriveParticipantFlowGateState(flowState, { requiresMcq })`: FREETEXT_ONLY låser opp vurdering så snart fritekst-innleveringen finnes (ingen MCQ-gate).
- Etter innlevering startes **ikke** et MCQ-forsøk for FREETEXT_ONLY (serveren ville 400); vurderingen kjøres direkte (auto, eller via «Start vurdering»).

### Test
- Ny participant-e2e: fritekst vist, MCQ skjult, vurdering kjøres uten MCQ-start. Gate-unit-test for `requiresMcq:false`. **7/7 participant-e2e + 13 gate-tester grønne**, tsc rent.

### Gjenstår i #578
Avansert editor (3-veis modultype), import/eksport, docs. Deploy av hele FREETEXT_ONLY samlet når disse er på plass.

Del av #578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)