### PR TITLE
feat(content): FREETEXT_ONLY import/eksport + docs (v1.3.48, #578 slice 4)

### DIFF
--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -127,7 +127,7 @@ All routes use the `courses` capability: PARTICIPANT, SUBJECT_MATTER_OWNER, ADMI
 | `POST` | `/api/admin/content/modules/:moduleId/module-versions` | ADMINISTRATOR, SUBJECT_MATTER_OWNER |
 | `POST` | `/api/admin/content/modules/:moduleId/module-versions/:moduleVersionId/publish` | ADMINISTRATOR, SUBJECT_MATTER_OWNER |
 
-#### Module assessment mode (`assessmentMode`) — #525
+#### Module assessment mode (`assessmentMode`) — #525/#578
 
 `POST .../module-versions` accepts an optional `assessmentMode`:
 
@@ -137,6 +137,11 @@ All routes use the `courses` capability: PARTICIPANT, SUBJECT_MATTER_OWNER, ADMI
   `promptTemplateVersionId` are omitted; only `mcqSetVersionId` is required. Pass/fail is decided
   purely by the MCQ score against a threshold (`assessmentPolicy.passRules.mcqMinPercent`,
   default **70%**).
+- `FREETEXT_ONLY` (#578) — free-text submission graded by the LLM, **no MCQ**. Requires `taskText`,
+  `rubricVersionId` and `promptTemplateVersionId`; `mcqSetVersionId` is omitted. The rubric/practical
+  score spans the full **0–100** (no MCQ band) and there is no MCQ gate. Red-flag / manual-review
+  routing applies as for FREETEXT_PLUS_MCQ. The assessment runs on the free-text submission directly
+  (no MCQ step). Export/import omit the MCQ set (`activeVersion.mcqSet` is `null`).
 
 **Certification invariant (#476/#525):** a course completion / certificate is issued only when a
 participant has **passed all modules** in the course **and read all learning sections**. This is

--- a/doc/MCQ_ONLY_MODULES_GUIDE.md
+++ b/doc/MCQ_ONLY_MODULES_GUIDE.md
@@ -1,12 +1,24 @@
-# MCQ-only modules — author guide
+# Module types — author guide
 
-A module can be **MCQ-only**: the participant answers multiple-choice questions only, with **no
-free-text answer and no LLM evaluation**. Pass/fail is decided purely by the MCQ score against a
-threshold. Use this for knowledge checks where a written deliverable isn't needed — it is faster
-and cheaper (deterministic grading, no LLM call).
+A module has one of **three assessment types**, chosen at creation (and changeable when you
+regenerate / re-save):
 
-The alternative (and default) mode is **free-text + MCQ**, where the participant submits a written
-answer that is graded by the LLM in addition to the MCQ.
+- **Free-text + MCQ** (default) — the participant submits a written answer graded by the LLM **and**
+  answers multiple-choice questions.
+- **Free-text only** (#578) — a written answer graded by the LLM, **no MCQ**. The score spans the
+  full 0–100 from the rubric; there is no MCQ component. Use it for essay/reflection modules.
+- **MCQ-only** — multiple-choice questions only, **no free-text and no LLM evaluation**. Pass/fail is
+  decided purely by the MCQ score against a threshold (default 70%). Fast and cheap (deterministic
+  grading, no LLM call) — use it for knowledge checks.
+
+You pick the type in the **conversation** («Hva slags modul er dette?» after the source step) or in
+the **advanced editor** (the *Module type* radio). The rest of this guide focuses on the two
+non-default types.
+
+## MCQ-only modules
+
+The participant answers multiple-choice questions only, with **no free-text answer and no LLM
+evaluation** — pass/fail is decided purely by the MCQ score against a threshold.
 
 ## Create an MCQ-only module (advanced editor)
 
@@ -43,7 +55,25 @@ assessment plan → questions).
 > asks the module-type question after the source step — so you can pick or switch to **“MCQ only”**
 > there too. Saving then writes a new MCQ-only version.
 
-## What the participant sees
+## Free-text-only modules (#578)
+
+A **free-text-only** module is like free-text + MCQ but **without the MCQ**: the participant writes
+an answer that the LLM assesses against the rubric, and that's it.
+
+- **Create (conversation):** choose **“Free-text only”** at the module-type question. The flow runs
+  scenario → certification level → assessment plan → draft, then goes straight to save (no MCQ
+  generation step). The saved version has `assessmentMode=FREETEXT_ONLY` and no MCQ set.
+- **Create (advanced editor):** pick **“Free-text only”** in the *Module type* radio. The free-text
+  fields + rubric + evaluation instruction stay; the MCQ card/section and pass-threshold disappear.
+- **Scoring:** the rubric score spans the full **0–100** (there is no MCQ band), and there is no MCQ
+  gate. Red flags and manual-review routing work exactly as for free-text + MCQ.
+
+### What the participant sees (free-text-only)
+
+- The free-text answer fields are shown (no MCQ section). After submitting, the assessment runs
+  directly on the written answer — there is no MCQ step.
+
+## What the participant sees (MCQ-only)
 
 - Selecting an MCQ-only module goes **straight to the questions** — there is no “create
   submission” / free-text step.

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,21 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.48 - 2026-06-21
+
+feat(content): FREETEXT_ONLY import/eksport + docs (#578 slice 4 — fullfører #578)
+
+- **Eksport:** `buildModuleExportEnvelope` krever ikke lenger MCQ-sett for FREETEXT_ONLY; emitter
+  `activeVersion.mcqSet = null`. **Import:** `moduleExportPayloadSchema.activeVersion.mcqSet` er
+  nullable; `contentImportService` hopper over MCQ-opprettelse for FREETEXT_ONLY og setter
+  `mcqSetVersionId = null`.
+- **Tester:** ny export-import-roundtrip for FREETEXT_ONLY (bevarer modus + mcqSet null; kjøres i CI
+  verify mot fersk Postgres). tsc rent.
+- **Docs:** `MCQ_ONLY_MODULES_GUIDE.md` generalisert til modultyper (3 typer) med egen Free-text-only-
+  seksjon; `API_REFERENCE.md` dokumenterer `FREETEXT_ONLY`.
+- **#578 «Kun Fritekst» er nå komplett** (backend + samtale + deltaker + Avansert + import/eksport +
+  docs). Klar for samlet deploy.
+
 ## 1.3.47 - 2026-06-21
 
 feat(author): 3-veis modultype-velger i Avansert editor (#578 slice 2b)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.47",
+  "version": "1.3.48",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/adminContentQueries.ts
+++ b/src/modules/adminContent/adminContentQueries.ts
@@ -289,9 +289,9 @@ export async function buildModuleExportEnvelope(
     throw new Error("Module has no versions to export.");
   }
 
-  // #525/#547: MCQ_ONLY modules have no rubric or prompt template — those are only required for
-  // free-text (FREETEXT_PLUS_MCQ) modules.
+  // #525/#547/#578: MCQ_ONLY modules have no rubric/prompt; FREETEXT_ONLY modules have no MCQ set.
   const isMcqOnly = moduleVersion.assessmentMode === "MCQ_ONLY";
+  const isFreetextOnly = moduleVersion.assessmentMode === "FREETEXT_ONLY";
 
   const rubricVersion =
     bundle.versions.rubricVersions.find((v) => v.id === moduleVersion.rubricVersionId)
@@ -313,7 +313,7 @@ export async function buildModuleExportEnvelope(
     bundle.versions.mcqSetVersions.find((v) => v.id === moduleVersion.mcqSetVersionId)
     ?? bundle.versions.mcqSetVersions[0]
     ?? null;
-  if (!mcqSetVersion) {
+  if (!mcqSetVersion && !isFreetextOnly) {
     throw new Error("Module has no MCQ-set versions to export.");
   }
 
@@ -352,19 +352,22 @@ export async function buildModuleExportEnvelope(
               active: true,
             }
           : (null as never),
-        mcqSet: {
-          title: mcqSetVersion.title as never,
-          // #557: omit rationale entirely when absent instead of emitting `rationale: null`
-          // (which the import schema rejected).
-          questions: (mcqSetVersion.questions as Array<Record<string, unknown>>).map((q) => {
-            if (q.rationale == null) {
-              const { rationale: _drop, ...rest } = q;
-              return rest;
+        // #578: FREETEXT_ONLY modules have no MCQ set — emit null.
+        mcqSet: mcqSetVersion
+          ? {
+              title: mcqSetVersion.title as never,
+              // #557: omit rationale entirely when absent instead of emitting `rationale: null`
+              // (which the import schema rejected).
+              questions: (mcqSetVersion.questions as Array<Record<string, unknown>>).map((q) => {
+                if (q.rationale == null) {
+                  const { rationale: _drop, ...rest } = q;
+                  return rest;
+                }
+                return q;
+              }) as never,
+              active: true,
             }
-            return q;
-          }) as never,
-          active: true,
-        },
+          : (null as never),
         audit: {
           publishedAt: moduleVersion.publishedAt ? new Date(moduleVersion.publishedAt).toISOString() : null,
           publishedBy: moduleVersion.publishedBy ?? null,

--- a/src/modules/adminContent/adminContentSchemas.ts
+++ b/src/modules/adminContent/adminContentSchemas.ts
@@ -324,7 +324,8 @@ export const moduleExportPayloadSchema = z.object({
     assessmentPolicy: assessmentPolicyBodySchema.nullable().optional(),
     rubric: rubricBodySchema.nullable().optional(),
     promptTemplate: promptTemplateBodySchema.nullable().optional(),
-    mcqSet: mcqSetBodySchema,
+    // #578: FREETEXT_ONLY exports have no MCQ set.
+    mcqSet: mcqSetBodySchema.nullable().optional(),
     audit: exportAuditSchema,
   }),
 });

--- a/src/modules/adminContent/contentImportService.ts
+++ b/src/modules/adminContent/contentImportService.ts
@@ -78,8 +78,9 @@ async function importModulePayload(
     moduleId = newModule.id;
   }
 
-  // #525/#547: MCQ_ONLY modules have no rubric or prompt template — skip them on import.
+  // #525/#547/#578: MCQ_ONLY has no rubric/prompt; FREETEXT_ONLY has no MCQ set — skip on import.
   const isMcqOnly = payload.activeVersion.assessmentMode === "MCQ_ONLY";
+  const isFreetextOnly = payload.activeVersion.assessmentMode === "FREETEXT_ONLY";
 
   const rubric =
     isMcqOnly || !payload.activeVersion.rubric
@@ -102,17 +103,20 @@ async function importModulePayload(
           active: true,
         });
 
-  const mcqSet = await createMcqSetVersion({
-    moduleId,
-    title: serializeRequired(payload.activeVersion.mcqSet.title),
-    active: true,
-    questions: payload.activeVersion.mcqSet.questions.map((question) => ({
-      stem: serializeRequired(question.stem),
-      options: question.options.map((option) => serializeRequired(option)),
-      correctAnswer: serializeRequired(question.correctAnswer),
-      rationale: question.rationale ? serializeRequired(question.rationale) : undefined,
-    })),
-  });
+  const mcqSet =
+    isFreetextOnly || !payload.activeVersion.mcqSet
+      ? null
+      : await createMcqSetVersion({
+          moduleId,
+          title: serializeRequired(payload.activeVersion.mcqSet.title),
+          active: true,
+          questions: payload.activeVersion.mcqSet.questions.map((question) => ({
+            stem: serializeRequired(question.stem),
+            options: question.options.map((option) => serializeRequired(option)),
+            correctAnswer: serializeRequired(question.correctAnswer),
+            rationale: question.rationale ? serializeRequired(question.rationale) : undefined,
+          })),
+        });
 
   const moduleVersion = await createModuleVersion({
     moduleId,
@@ -125,7 +129,7 @@ async function importModulePayload(
     assessmentBlueprint: payload.activeVersion.assessmentBlueprint ?? undefined,
     rubricVersionId: rubric?.id,
     promptTemplateVersionId: promptTemplate?.id,
-    mcqSetVersionId: mcqSet.id,
+    mcqSetVersionId: mcqSet?.id,
     submissionSchemaJson: payload.activeVersion.submissionSchema
       ? JSON.stringify(payload.activeVersion.submissionSchema)
       : undefined,

--- a/test/m2-content-export-import.test.ts
+++ b/test/m2-content-export-import.test.ts
@@ -329,3 +329,82 @@ describe("#547 MCQ-only module export-import round-trip", () => {
     expect(verifyResponse.body.envelope.module.activeVersion.mcqSet.questions).toHaveLength(1);
   });
 });
+
+// #578: FREETEXT_ONLY modules have taskText + rubric + prompt but NO MCQ set. Export must not
+// require the MCQ set, and the round-trip must preserve assessmentMode=FREETEXT_ONLY with mcqSet null.
+describe("#578 FREETEXT_ONLY module export-import round-trip", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  async function setupFreetextOnlyModule(suffix: string) {
+    const createResponse = await request(app)
+      .post("/api/admin/content/modules")
+      .set(adminHeaders)
+      .send({
+        title: { "en-GB": `Free-text-only source ${suffix}`, nb: `Kun-fritekst kilde ${suffix}`, nn: `Berre-fritekst kjelde ${suffix}` },
+        description: { "en-GB": "Free-text-only source", nb: "Kun fritekst", nn: "Berre fritekst" },
+        certificationLevel: "basic",
+      });
+    expect(createResponse.status).toBe(201);
+    const moduleId = createResponse.body.module.id as string;
+
+    const rubric = await request(app)
+      .post(`/api/admin/content/modules/${moduleId}/rubric-versions`)
+      .set(adminHeaders)
+      .send({ criteria: { relevance: "0-4", quality: "0-4" }, scalingRule: { practical_weight: 100, max_total: 20 } });
+    expect(rubric.status).toBe(201);
+    const rubricVersionId = rubric.body.rubricVersion.id as string;
+
+    const prompt = await request(app)
+      .post(`/api/admin/content/modules/${moduleId}/prompt-template-versions`)
+      .set(adminHeaders)
+      .send({ systemPrompt: { "en-GB": "Sys", nb: "Sys", nn: "Sys" }, userPromptTemplate: { "en-GB": "Eval", nb: "Eval", nn: "Eval" }, examples: [] });
+    expect(prompt.status).toBe(201);
+    const promptTemplateVersionId = prompt.body.promptTemplateVersion.id as string;
+
+    const moduleVersion = await request(app)
+      .post(`/api/admin/content/modules/${moduleId}/module-versions`)
+      .set(adminHeaders)
+      .send({
+        assessmentMode: "FREETEXT_ONLY",
+        taskText: { "en-GB": "Write an essay", nb: "Skriv et essay", nn: "Skriv eit essay" },
+        assessorExpectedContent: { "en-GB": "Depth", nb: "Dybde", nn: "Djupne" },
+        rubricVersionId,
+        promptTemplateVersionId,
+      });
+    expect(moduleVersion.status).toBe(201);
+    expect(moduleVersion.body.moduleVersion.assessmentMode).toBe("FREETEXT_ONLY");
+    return { moduleId };
+  }
+
+  it("exports a FREETEXT_ONLY module (no MCQ set) and re-imports it preserving the mode", async () => {
+    const { moduleId } = await setupFreetextOnlyModule("A");
+
+    const exportResponse = await request(app)
+      .get(`/api/admin/content/modules/${moduleId}/export-package`)
+      .set(adminHeaders);
+    expect(exportResponse.status).toBe(200);
+    const envelope = exportResponse.body.envelope;
+    expect(envelope.module.activeVersion.assessmentMode).toBe("FREETEXT_ONLY");
+    expect(envelope.module.activeVersion.mcqSet ?? null).toBeNull();
+    expect(envelope.module.activeVersion.taskText).toEqual(expect.objectContaining({ "en-GB": "Write an essay" }));
+    expect(envelope.module.activeVersion.rubric).not.toBeNull();
+
+    const importResponse = await request(app)
+      .post("/api/admin/content/modules/import")
+      .set(otherAdminHeaders)
+      .send({ mode: "createNew", payload: envelope });
+    expect(importResponse.status).toBe(201);
+    const newModuleId = importResponse.body.moduleId as string;
+    expect(newModuleId).not.toBe(moduleId);
+
+    const verifyResponse = await request(app)
+      .get(`/api/admin/content/modules/${newModuleId}/export-package`)
+      .set(adminHeaders);
+    expect(verifyResponse.status).toBe(200);
+    expect(verifyResponse.body.envelope.module.activeVersion.assessmentMode).toBe("FREETEXT_ONLY");
+    expect(verifyResponse.body.envelope.module.activeVersion.mcqSet ?? null).toBeNull();
+    expect(verifyResponse.body.envelope.module.activeVersion.taskText).toEqual(expect.objectContaining({ "en-GB": "Write an essay" }));
+  });
+});


### PR DESCRIPTION
## #578 slice 4 — import/eksport + docs (fullfører #578)

### Endringer
- **Eksport:** `buildModuleExportEnvelope` krever ikke MCQ-sett for FREETEXT_ONLY; emitter `activeVersion.mcqSet = null`.
- **Import:** `moduleExportPayloadSchema.activeVersion.mcqSet` nullable; `contentImportService` hopper over MCQ-opprettelse for FREETEXT_ONLY (`mcqSetVersionId = null`).
- **Docs:** `MCQ_ONLY_MODULES_GUIDE.md` → modultyper (3 typer) + Free-text-only-seksjon; `API_REFERENCE.md` dokumenterer `FREETEXT_ONLY`.

### Test
- Ny export-import-roundtrip for FREETEXT_ONLY (bevarer modus + mcqSet null) — kjøres i CI `verify` mot fersk Postgres. tsc rent.

### #578 komplett
Backend + samtale + deltaker + Avansert editor + import/eksport + docs. **Closes #578.** Klar for samlet deploy (staging → aksept → prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)