### PR TITLE
fix(assessment): utled rubrikk-maks fra kriterier, ikke scalingRule.max_total (v1.3.49, #578)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,24 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.49 - 2026-06-21
+
+fix(assessment): rubrikk-maks utledes fra kriterier, ikke (utdatert) scalingRule.max_total (#578)
+
+**Bug (funnet ved FREETEXT_ONLY-aksept):** en auto-generert rubrikk hadde 4 kriterier (maks 4×4=16),
+men `scalingRule.max_total = 24`. Vurderingen rekomputerer rubrikk-skåren ved å klampe hvert
+kriterium til [0,4] og summere — så et perfekt svar (16/16 ifølge LLM) ble regnet som 16/24 = 66,7 %.
+For **FREETEXT_ONLY** (ingen MCQ å kompensere med) ga det auto-stryk av et perfekt svar; for
+**FREETEXT_PLUS_MCQ** ble praktisk-skåren undervurdert (maskert av MCQ-bidraget).
+
+**Fix:** `buildAssessmentInputContext` utleder nå `rubricMaxTotal` fra **faktisk kriterie-antall × 4**
+(samme basis som rekomputeringen og som LLM-en bruker), og faller bare tilbake til
+`scalingRule.max_total` når rubrikken ikke har kriterier. Gjelder alle fritekst-modi og alle
+eksisterende rubrikker (ingen migrasjon nødvendig — skåringen er korrekt ved neste vurdering).
+
+- **Tester:** regresjonstest (4 kriterier + max_total 24 → maks 16) + fallback-test; oppdatert
+  eksisterende. 50/50 relevante unit grønne, tsc rent.
+
 ## 1.3.48 - 2026-06-21
 
 feat(content): FREETEXT_ONLY import/eksport + docs (#578 slice 4 — fullfører #578)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.48",
+  "version": "1.3.49",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/assessment/AssessmentInputFactory.ts
+++ b/src/modules/assessment/AssessmentInputFactory.ts
@@ -3,6 +3,10 @@ import { localizeContentText } from "../../i18n/content.js";
 import type { SupportedLocale } from "../../i18n/locale.js";
 import { assessmentPolicyCodec, type ModuleAssessmentPolicy } from "../../codecs/assessmentPolicyCodec.js";
 
+// Each rubric criterion is scored on a 0–4 scale (decisionService clamps every score to [0,4]).
+// The true rubric max is therefore (criteria count × 4) — see buildAssessmentInputContext (#578).
+const RUBRIC_MAX_SCORE_PER_CRITERION = 4;
+
 export type AssessmentInputContext = {
   /** Rubric criterion IDs extracted from the module rubric configuration. */
   rubricCriteriaIds: string[];
@@ -71,7 +75,15 @@ export function buildAssessmentInputContext(
   const assessmentPolicy = assessmentPolicyCodec.parse(submission.moduleVersion.assessmentPolicyJson);
 
   const rubricCriteriaIds = parseRubricCriteriaIds(rubricVersion.criteriaJson);
-  const rubricMaxTotal = parseRubricMaxTotal(rubricVersion.scalingRuleJson);
+  // #578 fix: the decision recomputes the rubric score by clamping each criterion to [0,4] and
+  // summing, so the TRUE max is (criteria count × 4). A stored scalingRule.max_total can be stale
+  // or wrong — e.g. a generated rubric with 4 criteria but max_total=24 made even a perfect answer
+  // score 16/24 = 66.7%. That under-scored every FREETEXT_PLUS_MCQ practical and was fatal for
+  // FREETEXT_ONLY (no MCQ to compensate → auto-fail of a perfect answer). Derive the max from the
+  // actual criteria; only fall back to scalingRule.max_total when there are no criteria.
+  const rubricMaxTotal = rubricCriteriaIds.length > 0
+    ? rubricCriteriaIds.length * RUBRIC_MAX_SCORE_PER_CRITERION
+    : parseRubricMaxTotal(rubricVersion.scalingRuleJson);
   const submissionFieldLabels = parseSubmissionFieldLabels(submission.moduleVersion.submissionSchemaJson, submissionLocale);
 
   const sensitiveDataPreprocess = preprocessSensitiveDataForLlm({

--- a/test/unit/assessment-input-factory.test.ts
+++ b/test/unit/assessment-input-factory.test.ts
@@ -145,7 +145,9 @@ describe("AssessmentInputFactory", () => {
       const context = buildAssessmentInputContext(submission, "nb");
 
       expect(context.rubricCriteriaIds).toEqual(["criterion_a", "criterion_b"]);
-      expect(context.rubricMaxTotal).toBe(20);
+      // #578: rubricMaxTotal is derived from the criteria count × 4 (2 × 4 = 8), NOT the stored
+      // scalingRule.max_total (20). The recompute clamps each criterion to [0,4], so this is the true max.
+      expect(context.rubricMaxTotal).toBe(8);
       expect(context.assessmentPolicy).toBeNull();
       expect(context.submissionLocale).toBe("nb");
       expect(context.sensitiveDataPreprocess.maskingEnabled).toBe(false);
@@ -175,6 +177,49 @@ describe("AssessmentInputFactory", () => {
 
       const context = buildAssessmentInputContext(submission, "en-GB");
       expect(context.assessmentPolicy).toEqual(policy);
+    });
+
+    // #578 regression: a generated rubric with 4 criteria but a stale scalingRule.max_total of 24
+    // must score on the real max (4 × 4 = 16), so a perfect answer is 100% — not 16/24 = 66.7%
+    // (which auto-failed FREETEXT_ONLY modules and under-scored FREETEXT_PLUS_MCQ practicals).
+    it("derives rubricMaxTotal from criteria count even when scalingRule.max_total is wrong", async () => {
+      const { buildAssessmentInputContext } = await import("../../src/modules/assessment/AssessmentInputFactory.js");
+      const submission = {
+        moduleId: "module-1",
+        responseJson: JSON.stringify({ answer: "response" }),
+        moduleVersion: {
+          assessmentPolicyJson: null,
+          submissionSchemaJson: null,
+          taskText: "Task",
+          assessorExpectedContent: null,
+          promptTemplateVersion: { systemPrompt: "", userPromptTemplate: "", examplesJson: "" },
+          rubricVersion: {
+            criteriaJson: JSON.stringify({ a: "0-4", b: "0-4", c: "0-4", d: "0-4" }),
+            scalingRuleJson: JSON.stringify({ max_total: 24, practical_weight: 70 }),
+          },
+        },
+      };
+      const context = buildAssessmentInputContext(submission, "nb");
+      expect(context.rubricCriteriaIds).toHaveLength(4);
+      expect(context.rubricMaxTotal).toBe(16);
+    });
+
+    it("falls back to scalingRule.max_total when the rubric has no criteria", async () => {
+      const { buildAssessmentInputContext } = await import("../../src/modules/assessment/AssessmentInputFactory.js");
+      const submission = {
+        moduleId: "module-1",
+        responseJson: JSON.stringify({ answer: "response" }),
+        moduleVersion: {
+          assessmentPolicyJson: null,
+          submissionSchemaJson: null,
+          taskText: "Task",
+          assessorExpectedContent: null,
+          promptTemplateVersion: { systemPrompt: "", userPromptTemplate: "", examplesJson: "" },
+          rubricVersion: { criteriaJson: "{}", scalingRuleJson: JSON.stringify({ max_total: 20 }) },
+        },
+      };
+      const context = buildAssessmentInputContext(submission, "nb");
+      expect(context.rubricMaxTotal).toBe(20);
     });
   });
 });


### PR DESCRIPTION
## Bug (funnet ved FREETEXT_ONLY-aksept på staging)

En «Kun fritekst»-modul med et **perfekt svar** (LLM: alle 4 kriterier 4/4, «veldig godt svar») fikk **Total 66,67 → auto-stryk**.

**Rotårsak (DB-verifisert):** rubrikken har **4 kriterier** (maks 4×4=16), men `scalingRule.max_total = 24`. Beslutningen rekomputerer rubrikk-skåren ved å klampe hvert kriterium til [0,4] og summere → maks er **kriterie-antall × 4 = 16**, ikke 24. `parseRubricMaxTotal` brukte den utdaterte `max_total=24` → 16/24 = 66,7 %.
- **FREETEXT_ONLY:** fatalt (ingen MCQ å kompensere) → perfekt svar stryker.
- **FREETEXT_PLUS_MCQ:** praktisk undervurdert (46,7/70), maskert av MCQ.

## Fix
`buildAssessmentInputContext` utleder `rubricMaxTotal` fra **faktisk kriterie-antall × 4** (samme basis som rekomputeringen og som LLM-en bruker for sin `practical_score_scaled`). Faller tilbake til `scalingRule.max_total` kun når rubrikken mangler kriterier. Fikser alle fritekst-modi + alle eksisterende rubrikker (ingen migrasjon — korrekt ved neste vurdering).

## Test
- Regresjonstest: 4 kriterier + `max_total:24` → `rubricMaxTotal=16`. Fallback-test (ingen kriterier → max_total). Oppdatert eksisterende. **50/50 relevante unit grønne**, tsc rent.

Del av #578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)