### PR TITLE
fix(ingest): klient-filgrense 10 MB (v1.3.51, #479 Slice A)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,19 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.51 - 2026-06-22
+
+fix(ingest): klient-filgrense 2 → 10 MB (#479 Slice A oppfølging)
+
+Slice A (v1.3.50) hevet server-grensen, express-body-grensen og UI-tekstene til 10 MB, men
+**klient-vakten** `SOURCE_MATERIAL_MAX_BYTES` i `public/static/admin-content-shell.js` sto igjen
+på 2 MB. Resultat: en 2,6 MB-fil ble avvist i nettleseren med meldingen «… opptil 10 MB» (riktig
+tekst, feil grense) før opplasting i det hele tatt skjedde. Konstanten er nå 10 MB, med en
+kommentar som binder den til server-konstanten. Regresjons-e2e laster opp en ~3 MB-fil og krever
+at den aksepteres.
+
+Klassisk «riktig fiks, ufullstendig flate» — fanget av e2e-laget.
+
 ## 1.3.50 - 2026-06-22
 
 feat(ingest): kildemateriale-grense 2 → 10 MB (#479 Slice A) + skjul irrelevante skåre-rader (#591)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.50",
+  "version": "1.3.51",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -165,7 +165,10 @@ const srChanges = document.getElementById("srChanges");
 const srPreview = document.getElementById("srPreview");
 const srLang = document.getElementById("srLang");
 
-const SOURCE_MATERIAL_MAX_BYTES = 2 * 1024 * 1024;
+// #479 Slice A: must match SOURCE_MATERIAL_MAX_BYTES in
+// src/modules/adminContent/sourceMaterialExtractionService.ts (server). Keep both at 10 MB —
+// the client guard rejects oversize files before upload; the server enforces the real cap.
+const SOURCE_MATERIAL_MAX_BYTES = 10 * 1024 * 1024;
 // #454 Phase 3 (v1.2.3): 50K → 200K. v1.2.5: 200K → 1M. Begrunnelse: Phase 4 (auto-condense)
 // komprimerer enhver source > 50K til ~30K før LLM-pipeline, så reell LLM-kost er bundet
 // uavhengig av input-størrelse. 1M-cap'en eksisterer bare som sanity-grense for å unngå at

--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -1268,6 +1268,29 @@ test.describe("admin content browser coverage", () => {
     expect(mcqSetCreated).toBe(false);
   });
 
+  // #479 Slice A regression: the CLIENT file-size guard must allow files up to 10 MB. It was
+  // left at 2 MB while the toast message + server cap already said 10 MB, so a 2.6 MB upload was
+  // rejected client-side ("Filen er for stor … opptil 10 MB"). Upload a ~3 MB file and assert it
+  // is accepted (extracted into a source chip), not rejected as too large.
+  test("shell source step accepts a file between 2 and 10 MB", async ({ page }) => {
+    await mockCommonApis(page);
+
+    await page.goto("/admin-content");
+    await clickEnabledButton(page, "Create new module");
+    await submitActiveChatInput(page, "Big file module");
+
+    const threeMb = Buffer.alloc(3 * 1024 * 1024, 0x41);
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "big.pdf",
+      mimeType: "application/pdf",
+      buffer: threeMb,
+    });
+
+    // Accepted: a source chip with the filename appears and no "too large" toast is shown.
+    await expect(page.locator(".source-chip-label")).toContainText("big.pdf");
+    await expect(page.getByText(/too large/i)).toHaveCount(0);
+  });
+
   // #555: the conversation can author an MCQ-only module. After source material the author
   // picks "MCQ only", skips scenario/blueprint entirely, and the saved version sends
   // assessmentMode=MCQ_ONLY with the default 70% pass mark (no rubric/prompt/taskText).


### PR DESCRIPTION
## Bug
Slice A (v1.3.50) hevet kildemateriale-grensen til 10 MB på server, i express-body-grensen og i UI-tekstene — men **klient-vakten** `SOURCE_MATERIAL_MAX_BYTES` i `public/static/admin-content-shell.js` sto igjen på 2 MB.

**Symptom (bruker):** en 2,6 MB PDF ble avvist i nettleseren med «Filen er for stor. Bruk en støttet fil på opptil 10 MB.» (riktig tekst, men feil grense) — før opplasting i det hele tatt skjedde. 0,6 MB virket.

## Fiks
- Klient-konstanten satt til `10 * 1024 * 1024`, med kommentar som binder den til server-konstanten i `sourceMaterialExtractionService.ts`.
- Regresjons-e2e: laster opp en ~3 MB-fil og krever at den **aksepteres** (kilde-chip vises, ingen «too large»-toast). Passerer.

## Rollback
Én-linjes konstant + test. Revert; ingen migrasjoner, ingen infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)