### PR TITLE
fix(ingest): del opplastings-body-grense app + parser-worker (v1.3.52, #479)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,21 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.52 - 2026-06-22
+
+fix(ingest): parser-worker body-grense delt med hoved-app (#479 Slice A oppfølging)
+
+Tredje «ufullstendig flate» i samme kjede: parser-workeren (`src/parserApp.ts`) er en **egen
+tjeneste** med sin egen `express.json`-grense som sto hardkodet på 4 MB. En 5,6 MB PPTX (base64
+~7,5 MB) ble derfor avvist med `413 Payload Too Large` fra parser-workeren, selv om klient + hoved-
+app + fil-cap var hevet til 10 MB.
+
+**Strukturell fiks (såer #596):** ny delt konstant `SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES`,
+**utledet** fra `SOURCE_MATERIAL_MAX_BYTES` (base64 4/3 + JSON-envelope-headroom), konsumert av
+**både** hoved-appens extract-rute (`app.ts`) og parser-workeren (`parserApp.ts`). De tre tallene
+kan ikke lenger drifte fra hverandre. En **synk-vakt-test** asserterer at grensen alltid rommer en
+maks-fil sin base64.
+
 ## 1.3.51 - 2026-06-22
 
 fix(ingest): klient-filgrense 2 → 10 MB (#479 Slice A oppfølging)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.51",
+  "version": "1.3.52",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import express from "express";
 import path from "node:path";
 import { appName, appVersion } from "./config/appMetadata.js";
 import { getParticipantConsoleRuntimeConfig } from "./config/participantConsole.js";
+import { SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES } from "./modules/adminContent/sourceMaterialExtractionService.js";
 import { rolesFor } from "./config/capabilities.js";
 import { authenticate } from "./auth/authenticate.js";
 import { requireAnyRole } from "./auth/authorization.js";
@@ -36,9 +37,14 @@ app.use(attachCorrelationId);
 app.use(requestLoggingMiddleware);
 app.use(securityHeadersMiddleware);
 // #479 (Slice A): source-material upload sends files as base64 in JSON (10 MB max → ~13.3 MB
-// encoded). Give just that route a larger body limit; registered before the global parser so it
-// parses first (express.json skips once req._body is set), keeping every other endpoint at 5 MB.
-app.use("/api/admin/content/source-material/extract", express.json({ limit: "16mb" }));
+// encoded). Give just that route a larger body limit, derived from the shared single-source-of-
+// truth constant so it can never be smaller than a max-size file's base64. Registered before the
+// global parser so it parses first (express.json skips once req._body is set), keeping every other
+// endpoint at 5 MB. The parser worker (parserApp.ts) uses the SAME constant.
+app.use(
+  "/api/admin/content/source-material/extract",
+  express.json({ limit: SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES }),
+);
 app.use(express.json({ limit: "5mb" }));
 app.use("/static", express.static(publicStaticPath));
 app.use("/static", express.static(publicRootPath));

--- a/src/modules/adminContent/sourceMaterialExtractionService.ts
+++ b/src/modules/adminContent/sourceMaterialExtractionService.ts
@@ -60,9 +60,19 @@ async function loadPptParser() {
 }
 
 // #479 (Slice A): raised from 2 MB → 10 MB per file. Sent as base64 in JSON, so the upload route
-// gets a larger express.json body limit (see app.ts). Files above this should use a future
-// multipart path rather than base64-in-JSON.
+// gets a larger express.json body limit (see SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES). Files above
+// this should use a future multipart path rather than base64-in-JSON.
 export const SOURCE_MATERIAL_MAX_BYTES = 10 * 1024 * 1024;
+
+// #479: SINGLE SOURCE OF TRUTH for the upload-request body limit. The file is sent base64-encoded
+// inside a JSON envelope, which inflates the payload by 4/3, plus headroom for the JSON keys
+// (fileName, mimeType) and whitespace. BOTH express services that receive the upload must use this
+// — the main app's /source-material/extract route (app.ts) AND the parser worker (parserApp.ts).
+// Deriving it from SOURCE_MATERIAL_MAX_BYTES is what stops these limits from silently drifting
+// apart again (the parser worker's hardcoded 4 MB caused a 413 on a 5.6 MB file after the file cap
+// was raised to 10 MB). A sync-guard test asserts this can hold a max-size file's base64.
+export const SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES =
+  Math.ceil((SOURCE_MATERIAL_MAX_BYTES * 4) / 3) + 2 * 1024 * 1024;
 
 export const SUPPORTED_SOURCE_MATERIAL_EXTENSIONS = [
   ".txt",

--- a/src/parserApp.ts
+++ b/src/parserApp.ts
@@ -10,6 +10,7 @@ import {
   SourceMaterialTooLargeError,
   SourceMaterialPolicyError,
   SourceMaterialTimeoutError,
+  SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES,
 } from "./modules/adminContent/sourceMaterialExtractionService.js";
 
 const parserEnvSchema = z.object({
@@ -107,7 +108,12 @@ const parseRequestSchema = z.object({
 });
 
 const parserApp = express();
-parserApp.use(express.json({ limit: "4mb" }));
+// #479: the parser worker receives the SAME base64-in-JSON upload as the main app, so it must use
+// the SAME shared body limit. A hardcoded 4 MB here caused a 413 ("Payload Too Large") on a 5.6 MB
+// file after the per-file cap was raised to 10 MB (#479 Slice A) — the cap was raised in the
+// extraction service and main app, but this separate service's limit was missed. Deriving from the
+// shared constant prevents that drift.
+parserApp.use(express.json({ limit: SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES }));
 
 // Health endpoint — no auth (used by Azure App Service probes)
 parserApp.get("/health", (_req, res) => {

--- a/test/unit/source-material-extraction-service.test.ts
+++ b/test/unit/source-material-extraction-service.test.ts
@@ -4,6 +4,7 @@ import {
   extractSourceMaterialText,
   SourceMaterialExtractionError,
   SOURCE_MATERIAL_MAX_BYTES,
+  SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES,
   SourceMaterialTooLargeError,
   UnsupportedSourceMaterialFormatError,
 } from "../../src/modules/adminContent/sourceMaterialExtractionService.js";
@@ -33,6 +34,19 @@ function fakeOoxmlBuffer() {
     0x00, 0x00,
   ]);
 }
+
+// #479/#596 sync-guard: the upload body limit shared by the main app (app.ts) and the parser
+// worker (parserApp.ts) MUST be able to hold a max-size file's base64 envelope. A hardcoded parser
+// limit (4 MB) that was smaller than this caused a 413 on a 5.6 MB file after the cap rose to 10 MB.
+// Deriving the limit from SOURCE_MATERIAL_MAX_BYTES makes this an invariant; this test pins it.
+describe("source material upload body limit (sync guard)", () => {
+  it("can hold a max-size file's base64 payload plus JSON envelope headroom", () => {
+    const base64Bytes = Math.ceil((SOURCE_MATERIAL_MAX_BYTES * 4) / 3);
+    expect(SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES).toBeGreaterThan(base64Bytes);
+    // Headroom is bounded too — not absurdly large.
+    expect(SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES).toBeLessThan(base64Bytes + 8 * 1024 * 1024);
+  });
+});
 
 describe("source material extraction service", () => {
   it("detects the expanded minimum file-type set", () => {


### PR DESCRIPTION
## Bug (bruker-rapportert)
Etter at klient-grensen ble fikset (1.3.51): en 2,3 MB PDF gikk gjennom, en 18 MB PPT ble korrekt stoppet, men en **5,6 MB PPTX** ga:

> `Parser worker error: 413 ... Payload Too Large`

## Rotårsak — tredje «ufullstendig flate»
Parser-workeren (`src/parserApp.ts`) er en **egen tjeneste** (eget App Service) med sin egen `express.json({ limit: "4mb" })`. Slice A hevet fil-cap (extraction-service), express-body (hoved-app) og UI-tekst til 10 MB — men denne separate tjenestens grense ble glemt. 5,6 MB → base64 ~7,5 MB > 4 MB → 413 før handleren.

## Fiks (strukturell — såer #596)
- Ny delt konstant `SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES`, **utledet** fra `SOURCE_MATERIAL_MAX_BYTES` (base64 × 4/3 + JSON-envelope-headroom).
- Konsumert av **både** `app.ts` (extract-rute) og `parserApp.ts`. De tre tallene (fil-cap, app-body, parser-body) kan ikke lenger drifte fra hverandre.
- **Synk-vakt-test**: asserterer at body-grensen alltid rommer en maks-fil sin base64 (mønster for #596).

Den dekodede byte-cap-en (`SourceMaterialTooLargeError`) er allerede 10 MB — 18 MB stoppes fortsatt korrekt.

## Test
- `tsc` rent.
- `source-material-extraction-service` unit: 9/9 (inkl. ny sync-guard).

## Deploy
Kode-only (ingen infra/bicep/workflow) → `deploy-app.yml`. Deploy-scriptet deployer web + worker + **parser** fra samme pakke, så parser-workeren får ny grense.

## Rollback
Revert; ingen migrasjoner, ingen infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)