### PR TITLE
test(ingest): karakteriserings-e2e fetch-url + FREETEXT_ONLY skåre (#599)

### DIFF
--- a/doc/design/TEST_COVERAGE_BASELINE_599.md
+++ b/doc/design/TEST_COVERAGE_BASELINE_599.md
@@ -1,0 +1,79 @@
+# Testdekning-baseline (#599) — utkast
+
+> Discovery-artefakt for EPIC #595. Formål: fastslå hva som er vernet **før** refactoring
+> (#596 single source of truth, #598 frontend-oppdeling) starter, og peke ut hullene som må
+> tettes med karakteriserings-tester først. Måler dagens tilstand — ikke ønsket fremtid.
+
+## 1. Testinventar per lag
+
+| Lag | Antall | Harness | Krever DB | Vurdering |
+|-----|--------|---------|-----------|-----------|
+| **unit** (`test/unit/`) | 58 filer | vitest | nei | Sterk på server-logikk + rene funksjoner |
+| **integration** (`test/*.test.*`) | 58 filer | vitest + Postgres | **ja** (pretest) | Sterk på server-flyt (m1/m2-suiter) |
+| **dom** (`test/dom/`) | 2 filer | vitest + jsdom | nei | Kun statisk HTML-/a11y-kontrakt, ikke atferd |
+| **e2e** (`test/e2e/`) | 6 specs / 44 tester | Playwright + statisk server | nei | Eneste atferds-vern for klient-laget |
+
+## 2. Hvor dekningen er sterk vs. tynn
+
+**Sterk:** server-laget. `src/modules/*` har bred unit + integration-dekning (assessment-pipeline,
+admin-content-publisering, calibration, appeals, source-material-extract, SSRF/crawl-logikk).
+
+**Tynn — og det er her buggene bor:** klient-laget. Tre monolitter utgjør ~16 000 linjer:
+
+| Fil | Linjer | Direkte test-hjem i dag |
+|-----|--------|--------------------------|
+| `public/admin-content.js` (avansert editor) | 5 176 | kun e2e |
+| `public/static/admin-content-shell.js` (Samtale) | 4 672 | kun e2e |
+| `public/participant.js` | 3 107 | kun e2e |
+
+**Strukturell rotårsak:** klient-funksjonene (`renderResultSummary`, `deriveParticipantFlowGateState`,
+`selectedModuleIsFreetextOnly`, modultype-synlighet …) er ikke eksportert/importerbare. De kan
+derfor **ikke** unit-testes — eneste vern er full e2e. Dette er både hvorfor karakterisering nå må
+skje i e2e, **og** et selvstendig argument for #598 (ekstraher rene funksjoner → billig unit-test).
+
+## 3. Flate → test-mapping (høyrisiko-flater for refactoring)
+
+| Flate | e2e/dom-dekning | Status |
+|-------|-----------------|--------|
+| Filgrense/opplasting | `admin-content-workspaces`, `section-editor` | ✅ (regresjons-e2e lagt til 1.3.51) |
+| Modul-opprettelse (Samtale) | `admin-content-workspaces` | ✅ (men kun «Samtale»-inngang; biblioteks-dialog #348?) |
+| Modultype-velger (3-veis) | `admin-content-workspaces` | ✅ |
+| MCQ_ONLY (forfatter + deltaker) | `admin-content-workspaces`, `participant-mcq-only` | ✅ |
+| FREETEXT_ONLY (forfatter + deltaker) | `admin-content-workspaces`, `participant-mcq-only` | ⚠️ delvis (resultat-rad revertert som ikke-deterministisk) |
+| Skåre-visning per modus (#591) | `participant-mcq-only` | ⚠️ kun MCQ-grenen deterministisk; fritekst-grenen udekket |
+| Kursbevis (3 visninger) | `participant-certificate`, `profile-certificate-link` | ✅ (resultat-banner-visningen?) |
+| Læringsseksjon | `participant-section-reader`, `section-editor`, m.fl. | ✅ |
+| **Enkelt-URL-henting (fetch-url, #454)** | **INGEN** | ❌ klient fetch-lag uten e2e |
+| **Crawl (Slice B, #479)** | (i #593-branch, ikke på main ennå) | 🔜 lander med #593 |
+| **Participant flow-gating** | indirekte via `participant-mcq-only` | ⚠️ ingen direkte test av gate-state-logikken |
+
+## 4. Konkrete hull å tette før refactoring
+
+1. ✅ **`fetch-url` (enkelt-URL-henting):** TETTET — karakteriserings-e2e lagt til
+   (`admin-content-workspaces`: «fetches a single URL and adds a source chip»).
+2. ✅ **Skåre-visning, FREETEXT_ONLY-grenen:** TETTET — deterministisk e2e via `#checkResult` med
+   `autoStartAfterMcq=false` (`participant-mcq-only`: «FREETEXT_ONLY result hides the MCQ score
+   row»). Begge grener av `renderResultSummary` er nå pinnet.
+3. **Participant flow-gating:** karakteriser gate-state for hver modus (FREETEXT_PLUS_MCQ / MCQ_ONLY
+   / FREETEXT_ONLY) — i dag kun indirekte. *(gjenstår)*
+4. **Modul-opprettelse, biblioteks-inngangen (#348):** verifiser at e2e dekker *begge* innganger
+   (Samtale-idle + biblioteks-dialog), ikke bare Samtale. *(gjenstår)*
+5. **Kvantitativ server-baseline:** installer `@vitest/coverage-v8` og fest et tall på `src/modules/*`
+   som `verify` håndhever (gate: «ikke under baseline» på berørte moduler). *(gjenstår)*
+6. ✅ **Synk-vakt for opplastings-body-grense:** TETTET — `source-material-extraction-service`-testen
+   asserterer at `SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES` alltid rommer en maks-fil base64 (mønster
+   for #596).
+
+## 5. Anbefalt rekkefølge for #599
+
+1. Legg til coverage-provider → kvantitativ server-baseline + rapport.
+2. Skriv karakteriserings-e2e for hullene i §4 (1–4) — pinner *dagens* oppførsel.
+3. Innfør dekningsgate i `verify` på modulene #596/#598 vil røre.
+4. Først da: løft blokkeringen på #596 og #598.
+
+## 6. Notater
+
+- Integration-suiten krever Docker/Postgres lokalt (pretest). For rask iterasjon under #599 er
+  unit + dom + e2e (alle DB-frie) det effektive arbeidssettet; integration verifiseres i CI (`verify`,
+  fersk DB).
+- Crawl-e2e og enkelt-URL-e2e bør samles når #593 merges, så `fetch-url`-hullet tettes samtidig.

--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -1291,6 +1291,39 @@ test.describe("admin content browser coverage", () => {
     await expect(page.getByText(/too large/i)).toHaveCount(0);
   });
 
+  // #454/#599 characterization: the source step can fetch a single URL. Clicking "Fetch from URL"
+  // prompts for a URL, POSTs to /source-material/fetch-url, and adds a source chip labelled with
+  // the returned hostname. This client fetch-layer flow had no e2e (baseline gap §4.1); pins
+  // current behaviour before the #596/#598 refactors touch the shell.
+  test("shell source step fetches a single URL and adds a source chip", async ({ page }) => {
+    await mockCommonApis(page);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let fetchBody: any = null;
+    await page.route("**/api/admin/content/source-material/fetch-url", async (route: Route) => {
+      fetchBody = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          extractedText: "Main article text extracted from the page.",
+          sourceHostname: "example.org",
+          fetchedBytes: 1234,
+        }),
+      });
+    });
+
+    await page.goto("/admin-content");
+    await clickEnabledButton(page, "Create new module");
+    await submitActiveChatInput(page, "URL module");
+
+    page.once("dialog", (dialog) => dialog.accept("https://example.org/article"));
+    await clickEnabledButton(page, "Fetch from URL");
+
+    await expect(page.locator(".source-chip-label")).toContainText("example.org");
+    expect(fetchBody?.url).toBe("https://example.org/article");
+  });
+
   // #555: the conversation can author an MCQ-only module. After source material the author
   // picks "MCQ only", skips scenario/blueprint entirely, and the saved version sends
   // assessmentMode=MCQ_ONLY with the default 70% pass mark (no rubric/prompt/taskText).

--- a/test/e2e/participant-mcq-only.spec.ts
+++ b/test/e2e/participant-mcq-only.spec.ts
@@ -200,6 +200,77 @@ test("participant: FREETEXT_ONLY module shows free-text, hides MCQ, assesses wit
   await expect.poll(() => runCalled).toBe(true);
   expect(mcqStartCalled).toBe(false);
   await expect(page.locator("#mcqSection")).toBeHidden();
-  // (#591 result-row hiding is covered deterministically by the MCQ-only test above; the symmetric
-  // free-text-only branch hides the MCQ row via the same renderResultSummary gate.)
+});
+
+// #591/#599 characterization: the FREETEXT_ONLY branch of renderResultSummary must show the
+// practical score but HIDE the (always-0) MCQ score — the mirror of the MCQ-only case above. Made
+// deterministic by disabling auto-assessment (config autoStartAfterMcq=false) so the "View result"
+// button is enabled and we render a mocked COMPLETED result directly, instead of racing the poll.
+test("participant: FREETEXT_ONLY result hides the MCQ score row, shows the practical score", async ({ page }) => {
+  await mockBase(page);
+  await page.addInitScript(() => {
+    try { localStorage.setItem("participant.locale", "nb"); } catch { /* ignore */ }
+  });
+
+  // Override config: disable auto-assessment so #checkResult is clickable (not gated by the loop).
+  await page.route("**/participant/config", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        authMode: "mock",
+        navigation: { items: [], workspaceItems: [] },
+        identityDefaults: {
+          participant: { userId: "participant-1", email: "p@x.no", name: "P", department: "X", roles: ["PARTICIPANT"] },
+        },
+        calibrationWorkspace: { accessRoles: [] },
+        flow: { autoStartAfterMcq: false },
+        output: {},
+      }),
+    }),
+  );
+  await page.route("**/api/modules**", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        modules: [
+          { id: "m-fto", title: "Essay Modul", description: null, assessmentMode: "FREETEXT_ONLY", submissionSchema: null, assessmentPolicy: null, taskText: "Skriv et essay", activeVersion: { versionNo: 1 }, participantStatus: null },
+        ],
+      }),
+    }),
+  );
+  await page.route("**/api/submissions", (route: Route) =>
+    route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ submission: { id: "s1" } }) }),
+  );
+  // Completed result with a 0 MCQ component (as FREETEXT_ONLY always has).
+  await page.route("**/api/submissions/*/result", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "COMPLETED",
+        decision: { passFailTotal: true, decisionType: "AUTOMATIC" },
+        scoreComponents: { totalScore: 85, mcqScaledScore: 0, practicalScaledScore: 85 },
+        participantGuidance: {},
+      }),
+    }),
+  );
+
+  await page.goto("/participant");
+  await page.locator("#loadModules").click();
+  await page.locator(".module-card", { hasText: "Essay Modul" }).click();
+
+  // Submit the free-text answer (no auto-assessment now), then view the result.
+  for (const ta of await page.locator("#submissionFields textarea").all()) {
+    await ta.fill("This is a sufficiently long free-text answer for assessment.");
+  }
+  await page.locator("#ack").check();
+  await page.locator("#createSubmission").click();
+  await page.locator("#checkResult").click();
+
+  // The practical score row is shown; the (always-0) MCQ score row is hidden.
+  const result = page.locator("#resultSummary");
+  await expect(result).toContainText("Praktisk poeng");
+  await expect(result).not.toContainText("MCQ-poeng");
 });


### PR DESCRIPTION
Første nedbetaling på #599 (EPIC #595) — **testdekning-baseline før refactoring**. Tester er additive; ingen runtime-endring, ingen version-bump.

## Hva
Pinner *dagens* klient-oppførsel på to dokumenterte hull fra baseline-rapporten:

1. **`fetch-url` (enkelt-URL-henting)** — `admin-content-workspaces.spec.ts`: klikker «Fetch from URL», svarer på URL-prompt, verifiserer at kilde-chip med vertsnavn legges til. Var helt udekket e2e (#454 klient-fetch-lag).
2. **FREETEXT_ONLY skåre-visning** — `participant-mcq-only.spec.ts`: deterministisk via `#checkResult` med `autoStartAfterMcq=false` (unngår auto-poll-race). Verifiserer at praktisk poeng vises men MCQ-poeng skjules — speilet av MCQ-only-grenen (#591). Begge grener av `renderResultSummary` er nå pinnet.

## Også med
- `doc/design/TEST_COVERAGE_BASELINE_599.md` — baseline-rapporten (inventar, flate→test-mapping, gjenstående hull §4.3–4.5).

## Status mot #599
Tettet: fetch-url, FREETEXT_ONLY-skåre, body-grense-synk-vakt (i #600). Gjenstår: participant flow-gating, biblioteks-inngang for modul-opprettelse (#348), kvantitativ server-baseline (`@vitest/coverage-v8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)