### PR TITLE
fix(authoring): retry Azure OpenAI 429/5xx i innholds-generering (v1.3.54, #479)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,20 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.54 - 2026-06-22
+
+fix(authoring): retry Azure OpenAI 429/5xx i innholds-genereringen (#479)
+
+Utløst av Slice B (crawl): crawl kan produsere mye større kildemateriale, som fanner ut i flere
+store LLM-kall (komprimer → vurderingsplan → utkast → MCQ) på sekunder og sprenger Azure OpenAI sin
+tokens-per-minutt-kvote → `429 too_many_requests`. `callLlm` gjorde **ett** kall og kastet umiddelbart,
+så en transient 429 stoppet hele pipelinen — og komprimerings-fallbacken sendte da det **fulle**
+(for store) materialet nedstrøms, som garanterte flere 429.
+
+`callLlm` retryer nå 429/500/502/503/504 med opptil 4 forsøk: ærer serverens `Retry-After`-header,
+ellers eksponentiell backoff (1→2→4→8 s, cap 20 s) med jitter. Eksporterte `parseRetryAfterMs` +
+`computeLlmBackoffMs` er unit-testet. Samme mangel i assessment-LLM-klienten spores i #603.
+
 ## 1.3.53 - 2026-06-22
 
 feat(ingest): same-domain crawl av kildemateriale (#479 Slice B)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.53",
+  "version": "1.3.54",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/llmContentGenerationService.ts
+++ b/src/modules/adminContent/llmContentGenerationService.ts
@@ -1264,6 +1264,37 @@ Return a single JSON object:
   return { systemPrompt, userPrompt };
 }
 
+// #479: Azure OpenAI returns 429 ("too_many_requests") when the deployment's tokens-per-minute
+// quota is exceeded — easy to hit now that crawl can produce large source material fanning into
+// several big calls (condense → blueprint → draft → MCQ) within seconds. A single un-retried 429
+// aborted the whole pipeline (and the condense fallback then sent the FULL oversized material
+// downstream, guaranteeing more 429s). These calls are now retried with backoff that honours the
+// server's Retry-After. 5xx are transient gateway errors and are retried too.
+const LLM_MAX_ATTEMPTS = 4;
+const LLM_RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+const LLM_BACKOFF_BASE_MS = 1_000;
+const LLM_BACKOFF_MAX_MS = 20_000;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Parses a Retry-After header (delta-seconds or HTTP-date). Returns null when absent/unparseable.
+export function parseRetryAfterMs(header: string | null | undefined): number | null {
+  if (!header) return null;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.round(seconds * 1000);
+  const dateMs = Date.parse(header);
+  if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
+  return null;
+}
+
+// Backoff for attempt N (0-based): honour Retry-After if the server sent one, otherwise exponential
+// (1s, 2s, 4s, …) capped, with jitter to avoid thundering-herd retries across concurrent calls.
+export function computeLlmBackoffMs(attempt: number, retryAfterMs: number | null): number {
+  if (retryAfterMs !== null) return Math.min(retryAfterMs, LLM_BACKOFF_MAX_MS);
+  const exponential = Math.min(LLM_BACKOFF_BASE_MS * 2 ** attempt, LLM_BACKOFF_MAX_MS);
+  return Math.round(exponential * (0.5 + Math.random() * 0.5));
+}
+
 async function callLlm(systemPrompt: string, userPrompt: string, maxTokens = 4000): Promise<unknown> {
   if (env.LLM_MODE !== "azure_openai") {
     throw new Error("LLM content generation requires LLM_MODE=azure_openai.");
@@ -1285,18 +1316,33 @@ async function callLlm(systemPrompt: string, userPrompt: string, maxTokens = 400
     [tokenParam]: maxTokens,
   };
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "api-key": env.AZURE_OPENAI_API_KEY ?? "",
-    },
-    body: JSON.stringify(body),
-  });
+  let response: Response | null = null;
+  for (let attempt = 0; attempt < LLM_MAX_ATTEMPTS; attempt++) {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "api-key": env.AZURE_OPENAI_API_KEY ?? "",
+      },
+      body: JSON.stringify(body),
+    });
 
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    throw new Error(`Azure OpenAI generation failed (${response.status}): ${text.slice(0, 200)}`);
+    if (response.ok || !LLM_RETRYABLE_STATUSES.has(response.status)) break;
+
+    // Retryable (429/5xx). Back off and retry unless this was the last attempt.
+    if (attempt < LLM_MAX_ATTEMPTS - 1) {
+      const waitMs = computeLlmBackoffMs(attempt, parseRetryAfterMs(response.headers.get("retry-after")));
+      console.warn(
+        `[#479] Azure OpenAI ${response.status} — retrying in ${waitMs}ms (attempt ${attempt + 1}/${LLM_MAX_ATTEMPTS}).`,
+      );
+      await sleep(waitMs);
+    }
+  }
+
+  if (!response || !response.ok) {
+    const status = response?.status ?? 0;
+    const text = response ? await response.text().catch(() => "") : "";
+    throw new Error(`Azure OpenAI generation failed (${status}): ${text.slice(0, 200)}`);
   }
 
   const payload = (await response.json()) as {

--- a/test/unit/llm-content-generation-service.test.ts
+++ b/test/unit/llm-content-generation-service.test.ts
@@ -12,7 +12,49 @@ import {
   extractMcqRevisionTargets,
   hasMeaningfulMcqRevision,
   isLikelyWrongLocale,
+  parseRetryAfterMs,
+  computeLlmBackoffMs,
 } from "../../src/modules/adminContent/llmContentGenerationService.js";
+
+// #479: Azure OpenAI 429/5xx retry helpers. A single un-retried 429 used to abort the whole
+// authoring pipeline (condense → blueprint → draft), which crawl made easy to trigger via large
+// source material. These pin the Retry-After parsing + backoff bounds.
+describe("LLM retry backoff", () => {
+  it("parses Retry-After as delta-seconds", () => {
+    expect(parseRetryAfterMs("2")).toBe(2000);
+    expect(parseRetryAfterMs("0")).toBe(0);
+  });
+
+  it("parses Retry-After as an HTTP-date (future → positive ms)", () => {
+    const future = new Date(Date.now() + 5000).toUTCString();
+    const ms = parseRetryAfterMs(future);
+    expect(ms).not.toBeNull();
+    expect(ms as number).toBeGreaterThanOrEqual(0);
+    expect(ms as number).toBeLessThanOrEqual(5000);
+  });
+
+  it("returns null for missing/garbage Retry-After", () => {
+    expect(parseRetryAfterMs(null)).toBeNull();
+    expect(parseRetryAfterMs(undefined)).toBeNull();
+    expect(parseRetryAfterMs("not-a-date")).toBeNull();
+  });
+
+  it("honours Retry-After when present (capped)", () => {
+    expect(computeLlmBackoffMs(0, 3000)).toBe(3000);
+    // Capped at the 20s ceiling even if the server asks for more.
+    expect(computeLlmBackoffMs(0, 999_999)).toBe(20_000);
+  });
+
+  it("falls back to exponential backoff with jitter, bounded", () => {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const ms = computeLlmBackoffMs(attempt, null);
+      expect(ms).toBeGreaterThan(0);
+      expect(ms).toBeLessThanOrEqual(20_000);
+    }
+    // Later attempts trend larger (jitter floor of attempt 3 ≥ attempt 0 ceiling here).
+    expect(computeLlmBackoffMs(3, null)).toBeGreaterThanOrEqual(computeLlmBackoffMs(0, null));
+  });
+});
 
 describe("llm content generation prompts", () => {
   it("treats source material as hidden author background for module drafts", () => {


### PR DESCRIPTION
## Bug (bruker-rapportert, staging 1.3.53)
Etter en **crawl** (Slice B) feilet modul-genereringen i en kaskade:
1. «Kunne ikke komprimere — fortsetter med fullt kildemateriale.»
2. «Generering av vurderingsplan feilet — fortsetter uten.»
3. «Generering feilet: 500: Azure OpenAI generation failed (**429**): Too Many Requests».

## Rotårsak
`callLlm` ([llmContentGenerationService.ts](src/modules/adminContent/llmContentGenerationService.ts)) gjorde **ett** fetch-kall og kastet umiddelbart ved ikke-ok. Crawl kan nå produsere mye større kildemateriale, som fanner ut i flere store LLM-kall (komprimer → vurderingsplan → utkast → MCQ) på sekunder og sprenger Azure OpenAI sin **tokens-per-minutt-kvote** → `429 too_many_requests`. En transient 429 stoppet hele pipelinen. Verre: komprimerings-fallbacken sendte da det **fulle** (for store) materialet nedstrøms — som garanterte flere 429.

## Fiks
`callLlm` retryer nå transiente svar (**429/500/502/503/504**, opptil 4 forsøk):
- ærer serverens **`Retry-After`**-header (Azure sender den på 429),
- ellers eksponentiell backoff (1→2→4→8 s, cap 20 s) med jitter (unngår thundering-herd på tvers av samtidige kall).

Med retry rekker komprimeringen å lykkes (etter kort venting), krymper materialet, og nedstrøms-kallene blir mindre — kaskaden brytes ved roten.

## Test
- `parseRetryAfterMs` + `computeLlmBackoffMs` eksportert og unit-testet (delta-sekunder, HTTP-date, manglende/søppel, cap, jitter-grenser). 49/49 i `llm-content-generation-service.test.ts`.
- `tsc` rent.

## Oppfølging
Samme manglende retry i `llmAssessmentService` (deltaker-vurdering) spores i **#603**.

## Rollback
Revert; ingen migrasjoner, ingen infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)