### PR TITLE
fix(authoring): chunket komprimering under TPM-kvoten (v1.3.55, #479)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,25 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.55 - 2026-06-22
+
+fix(authoring): chunket komprimering så LLM-forespørsler holder seg under TPM-kvoten (#479)
+
+Retry (v1.3.54) var nødvendig men ikke nok: en *enkelt* for stor forespørsel får aldri plass i
+deployment-ets tokens-per-minutt-kvote (staging **20K**, prod **40K** TPM), så den 429-er for alltid
+uansett retry. Frontend tillater opptil 1M tegn kildemateriale ≈ 250K tokens — komprimerings-kallet
+sendte alt i **ett** kall (12× over kvoten) og kvalte seg selv før det fikk krympet noe; fallbacken
+sendte da det fulle materialet videre → garantert 429 i vurderingsplan + utkast.
+
+`condenseSourceMaterial` deler nå materiale > 30K tegn i biter (~7,5K tokens hver, trygt under TPM),
+komprimerer hver bit sekvensielt (callLlm-retryen sprer dem over minutter så minuttbudsjettet
+respekteres), og slår sammen — med ett ekstra pass hvis summen fortsatt er stor. Da lykkes
+komprimeringen, og de nedstrøms kallene (vurderingsplan/utkast/MCQ) får et lite, krympet input.
+
+`splitIntoChunks` (grense-bevisst splitter) eksportert + unit-testet; chunked condense dekket
+ende-til-ende med mocket fetch. **Anbefaling:** hev TPM-kapasiteten (staging 20→ ?, prod 40→ ?) for
+raskere authoring — chunking gjør store crawls *mulige*, men trege ved 20K TPM.
+
 ## 1.3.54 - 2026-06-22
 
 fix(authoring): retry Azure OpenAI 429/5xx i innholds-genereringen (#479)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.54",
+  "version": "1.3.55",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/llmContentGenerationService.ts
+++ b/src/modules/adminContent/llmContentGenerationService.ts
@@ -1838,9 +1838,38 @@ Return one JSON object:
   return { systemPrompt, userPrompt };
 }
 
-export async function condenseSourceMaterial(
-  input: CondenseSourceMaterialInput,
-): Promise<CondenseSourceMaterialResult> {
+// #479: every LLM request must fit the deployment's tokens-per-minute quota (staging 20K, prod
+// 40K TPM). ~30K chars ≈ 7.5K input tokens; with the 8K-token output budget that's ~15.5K
+// tokens/request — safely under 20K TPM. The frontend allows up to 1M chars of source, which as a
+// single condense request is ~250K tokens — 12× over quota, so it 429s FOREVER (no retry can help).
+// Source larger than one chunk is therefore condensed in chunks: each chunk fits a single request,
+// they run sequentially (callLlm's 429 retry/backoff spaces them across minutes so the per-minute
+// budget is respected), and the condensed chunks are combined — with one final pass if still large.
+const CONDENSE_CHUNK_CHARS = 30_000;
+
+// Splits text into <=maxChars chunks, preferring a paragraph/sentence boundary near the end of each
+// chunk so we don't cut mid-sentence (which would degrade the LLM's condensation).
+export function splitIntoChunks(text: string, maxChars: number): string[] {
+  if (text.length <= maxChars) return text.trim() ? [text] : [];
+  const chunks: string[] = [];
+  let start = 0;
+  while (start < text.length) {
+    let end = Math.min(start + maxChars, text.length);
+    if (end < text.length) {
+      const window = text.slice(start, end);
+      const paraBreak = window.lastIndexOf("\n\n");
+      const sentenceBreak = window.lastIndexOf(". ");
+      const breakAt = paraBreak > maxChars * 0.8 ? paraBreak : sentenceBreak;
+      if (breakAt > maxChars * 0.8) end = start + breakAt + 1;
+    }
+    const piece = text.slice(start, end).trim();
+    if (piece) chunks.push(piece);
+    start = end;
+  }
+  return chunks;
+}
+
+async function condenseOnce(input: CondenseSourceMaterialInput): Promise<string> {
   const { systemPrompt, userPrompt } = buildCondensationPrompts(input);
   // 8000 tokens ≈ 30K-40K chars output budget; matches default target of 30K.
   const raw = await callLlm(systemPrompt, userPrompt, 8000);
@@ -1850,11 +1879,43 @@ export async function condenseSourceMaterial(
   if (!condensedText) {
     throw new Error("Condensation LLM response missing condensedText.");
   }
-  return {
-    condensedText,
-    originalLength: input.sourceMaterial.length,
-    condensedLength: condensedText.length,
-  };
+  return condensedText;
+}
+
+export async function condenseSourceMaterial(
+  input: CondenseSourceMaterialInput,
+): Promise<CondenseSourceMaterialResult> {
+  const originalLength = input.sourceMaterial.length;
+  const targetMax = input.targetMaxChars ?? 30_000;
+
+  // Small enough for a single request — original single-pass behaviour.
+  if (originalLength <= CONDENSE_CHUNK_CHARS) {
+    const condensedText = await condenseOnce(input);
+    return { condensedText, originalLength, condensedLength: condensedText.length };
+  }
+
+  // Too large for one request: condense each chunk to a proportional share of the target budget,
+  // then combine. Each chunk request fits the TPM quota; callLlm spaces them via 429 backoff.
+  const chunks = splitIntoChunks(input.sourceMaterial, CONDENSE_CHUNK_CHARS);
+  const perChunkTarget = Math.max(2_000, Math.floor(targetMax / Math.max(1, chunks.length)));
+  const condensedChunks: string[] = [];
+  for (const chunk of chunks) {
+    condensedChunks.push(
+      await condenseOnce({ ...input, sourceMaterial: chunk, targetMaxChars: perChunkTarget }),
+    );
+  }
+  let combined = condensedChunks.join("\n\n").trim();
+
+  // If the combined condensate is itself still larger than one chunk, condense it once more so the
+  // downstream blueprint/draft calls also stay within the token budget.
+  if (combined.length > CONDENSE_CHUNK_CHARS) {
+    combined = await condenseOnce({ ...input, sourceMaterial: combined, targetMaxChars: targetMax });
+  }
+
+  if (!combined) {
+    throw new Error("Condensation produced empty output.");
+  }
+  return { condensedText: combined, originalLength, condensedLength: combined.length };
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/llm-content-generation-service.test.ts
+++ b/test/unit/llm-content-generation-service.test.ts
@@ -14,7 +14,37 @@ import {
   isLikelyWrongLocale,
   parseRetryAfterMs,
   computeLlmBackoffMs,
+  splitIntoChunks,
 } from "../../src/modules/adminContent/llmContentGenerationService.js";
+
+// #479: chunking for condensation. Source larger than one TPM-safe request must be split so each
+// chunk fits the deployment's tokens-per-minute quota (staging 20K / prod 40K). Pins the splitter.
+describe("splitIntoChunks", () => {
+  it("returns a single chunk when text fits", () => {
+    expect(splitIntoChunks("short text", 1000)).toEqual(["short text"]);
+  });
+
+  it("returns no chunks for empty/whitespace", () => {
+    expect(splitIntoChunks("   ", 1000)).toEqual([]);
+  });
+
+  it("splits oversized text into chunks each within the limit", () => {
+    const text = "a".repeat(2500);
+    const chunks = splitIntoChunks(text, 1000);
+    expect(chunks.length).toBeGreaterThanOrEqual(3);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(1000);
+    // No content lost (modulo trimming).
+    expect(chunks.join("").length).toBe(2500);
+  });
+
+  it("prefers a paragraph boundary near the chunk end", () => {
+    const para = "x".repeat(850);
+    const text = `${para}\n\n${"y".repeat(850)}`;
+    const chunks = splitIntoChunks(text, 1000);
+    // First chunk ends at the paragraph break, not mid-run.
+    expect(chunks[0]).toBe(para);
+  });
+});
 
 // #479: Azure OpenAI 429/5xx retry helpers. A single un-retried 429 used to abort the whole
 // authoring pipeline (condense → blueprint → draft), which crawl made easy to trigger via large

--- a/test/unit/llm-retry.test.ts
+++ b/test/unit/llm-retry.test.ts
@@ -72,6 +72,31 @@ describe("callLlm Azure OpenAI retry (via condenseSourceMaterial)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
+  it("condenses oversized source in chunks (one request per chunk, then combines)", async () => {
+    // 3 chunks at 30K-char chunking → 3 condense calls; combined stays small so no extra pass.
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(okPayload("Sammendrag bit 1."))
+      .mockResolvedValueOnce(okPayload("Sammendrag bit 2."))
+      .mockResolvedValueOnce(okPayload("Sammendrag bit 3."));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { condenseSourceMaterial } = await import(
+      "../../src/modules/adminContent/llmContentGenerationService.js"
+    );
+    const result = await condenseSourceMaterial({
+      sourceMaterial: "Avsnitt med innhold.\n\n".repeat(4000), // ~88K chars → 3 chunks
+      certificationLevel: "intermediate",
+      locale: "nb",
+    });
+
+    // One LLM request per chunk; no single request carried the whole oversized payload.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(result.condensedText).toContain("Sammendrag bit 1.");
+    expect(result.condensedText).toContain("Sammendrag bit 3.");
+    expect(result.originalLength).toBeGreaterThan(30_000);
+  });
+
   it("does not retry a non-retryable 400", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()


### PR DESCRIPTION
## Bug (bruker, staging 1.3.54)
Etter crawl → generering: **samme** 429-kaskade som før retry-fiksen (komprimering feilet → vurderingsplan feilet → 500/429 `too_many_requests`).

## Hvorfor retry (1.3.54) ikke holdt
Verifisert med `az`: deploymentet `gpt-4.1-mini` har **kapasitet 20 = 20 000 TPM** på staging (**40 000** på prod). Frontend tillater opptil **1 000 000 tegn** kildemateriale ≈ **250 000 tokens**, og komprimerings-kallet sendte alt i **ett** request — 12× over minuttkvoten. En enkelt forespørsel som overstiger TPM 429-er **permanent**; retry kan aldri få den til å passe. Komprimeringen, som skulle krympe materialet, kvalte seg selv på sin egen input → fallback sendte fullt materiale nedstrøms → 429 i vurderingsplan + utkast.

## Fiks
`condenseSourceMaterial` deler materiale > 30K tegn (~7,5K tokens) i biter som hver får plass i TPM, komprimerer hver bit sekvensielt (callLlm-retryen fra #604 sprer dem over minutter så minuttbudsjettet respekteres), og slår sammen — med ett ekstra pass hvis summen fortsatt er stor. Når komprimeringen lykkes, får vurderingsplan/utkast/MCQ et lite, krympet input som passer kvoten.

## Test
- `splitIntoChunks` (grense-bevisst) eksportert + unit-testet (4 caser).
- Chunked condense dekket ende-til-ende med mocket fetch (3 biter → 3 kall → kombinert).
- `tsc` rent; 57/57 i de berørte testfilene.

## Anbefaling (infra, egen avgjørelse)
TPM-kapasiteten er lav: **staging 20K / prod 40K**. Chunking gjør store crawls *mulige*, men trege ved 20K (sekvensielle kall spres over minutter). Vurder å heve kapasiteten (f.eks. staging 20→100, prod 40→100) i Bicep for rask authoring. Egen PR siden det er infra med kvote/kost-implikasjoner.

## Rollback
Revert; ingen migrasjoner, ingen infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)