### PR TITLE
refactor(frontend): single source of truth for escapeHtml (v1.3.56, #596 skive 1)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,22 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.56 - 2026-06-22
+
+refactor(frontend): single source of truth for HTML-escaping — #596 skive 1 (EPIC #595)
+
+Første skive i frontend-dedupliseringen (jf. arkitekturgjennomgangen #598/#611): ny ES-modul
+`public/static/html-escape.js` med én `escapeHtml`, importert av de **6 byte-identiske** kopiene
+(`admin-content.js`, `participant.js` (escapeHtmlP), `participant-completed.js` (escapeHtmlC),
+`results.js` (escapeHtmlR), `static/admin-content-courses.js`, `static/admin-content-library.js`).
+Ren no-op: alle seks gjorde `String(x ?? "")` + samme 4-tegns escape, og kanonisk versjon matcher
+eksakt (importert med alias så kall-stedene er urørt). Unit-test pinner oppførselen.
+
+**Bevisst utenfor skiven (hver er en reell atferdsforskjell → egen oppfølging):**
+`admin-content-preview.js`/`admin-content-shell.js`/`static/loading.js` bruker `String(x)` uten
+`?? ""`-vakten (null→"null"), og `static/admin-content-sections.js` escaper også `'`. Disse 4
+kopiene står igjen til senere skiver.
+
 ## 1.3.55 - 2026-06-22
 
 fix(authoring): chunket komprimering så LLM-forespørsler holder seg under TPM-kvoten (#479)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.55",
+  "version": "1.3.56",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content.js
+++ b/public/admin-content.js
@@ -1,3 +1,4 @@
+import { escapeHtml } from "/static/html-escape.js";
 import {
   localeLabels,
   supportedLocales,
@@ -4866,9 +4867,6 @@ function renderCourseList() {
   }
 }
 
-function escapeHtml(str) {
-  return String(str ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-}
 
 function buildCourseCard(course) {
   const card = document.createElement("div");

--- a/public/participant-completed.js
+++ b/public/participant-completed.js
@@ -1,3 +1,4 @@
+import { escapeHtml as escapeHtmlC } from "/static/html-escape.js";
 import { localeLabels, supportedLocales, translations } from "/static/i18n/participant-completed-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, fetchQueueCounts, applyNavReviewBadge } from "/static/api-client.js";
 import { initConsentGuard } from "/static/consent-guard.js";
@@ -509,13 +510,6 @@ rolesInput.addEventListener("input", () => {
 
 const courseCertList = document.getElementById("courseCertList");
 
-function escapeHtmlC(str) {
-  return String(str ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
 
 function renderCourseCertificates(completions) {
   courseCertList.innerHTML = "";

--- a/public/participant.js
+++ b/public/participant.js
@@ -1,3 +1,4 @@
+import { escapeHtml as escapeHtmlP } from "/static/html-escape.js";
 import { localeLabels, supportedLocales, translations } from "/static/i18n/participant-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, fetchQueueCounts, applyNavReviewBadge, hydrateContentAssetImages } from "/static/api-client.js";
 import { initConsentGuard } from "/static/consent-guard.js";
@@ -2837,9 +2838,6 @@ const celebratedCompletedCourses = new Set();
 let courseAccordionInitialized = false;
 let courseDetailCache = {};        // courseId -> CourseDetail
 
-function escapeHtmlP(str) {
-  return String(str ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-}
 
 document.getElementById("loadCoursesBtn")?.addEventListener("click", async () => {
   const btn = document.getElementById("loadCoursesBtn");

--- a/public/results.js
+++ b/public/results.js
@@ -1,3 +1,4 @@
+import { escapeHtml as escapeHtmlR } from "/static/html-escape.js";
 import { localeLabels, supportedLocales, translations } from "/static/i18n/results-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, getAccessToken, fetchQueueCounts, applyNavReviewBadge } from "/static/api-client.js";
 import { initConsentGuard } from "/static/consent-guard.js";
@@ -521,13 +522,6 @@ const courseReportBody = document.getElementById("courseReportBody");
 const courseLearnerBody = document.getElementById("courseLearnerBody");
 const courseDetailMeta = document.getElementById("courseDetailMeta");
 
-function escapeHtmlR(str) {
-  return String(str ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
 
 function renderCourseReport(rows) {
   courseReportBody.innerHTML = "";

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -1,3 +1,4 @@
+import { escapeHtml } from "/static/html-escape.js";
 import {
   supportedLocales,
   localeLabels,
@@ -72,9 +73,6 @@ const deleteCancelBtn = document.getElementById("deleteCancelBtn");
 // Helpers
 // ---------------------------------------------------------------------------
 
-function escapeHtml(s) {
-  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-}
 
 function formatDate(iso) {
   if (!iso) return "—";

--- a/public/static/admin-content-library.js
+++ b/public/static/admin-content-library.js
@@ -1,3 +1,4 @@
+import { escapeHtml } from "/static/html-escape.js";
 import {
   supportedLocales,
   localeLabels,
@@ -161,9 +162,6 @@ function certBadge(level) {
   return `<span class="cert-badge">${escapeHtml(label)}</span>`;
 }
 
-function escapeHtml(s) {
-  return String(s ?? "").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
-}
 
 function formatDate(iso) {
   if (!iso) return "—";

--- a/public/static/html-escape.js
+++ b/public/static/html-escape.js
@@ -1,0 +1,18 @@
+// #596 (EPIC #595) slice 1 — single source of truth for HTML escaping.
+//
+// Replaces 6 byte-identical copies that each did `String(x ?? "")` followed by the 4-char entity
+// escape (& < > "): admin-content.js (escapeHtml), participant.js (escapeHtmlP),
+// participant-completed.js (escapeHtmlC), results.js (escapeHtmlR), admin-content-courses.js and
+// admin-content-library.js (escapeHtml). All six are ES modules and import this canonical version.
+//
+// Intentionally NOT folded in here (each is a real behaviour difference → its own follow-up slice):
+//   - admin-content-preview.js / admin-content-shell.js / static/loading.js use `String(x)` WITHOUT
+//     the `?? ""` guard, so null/undefined render as "null"/"undefined" rather than "".
+//   - admin-content-sections.js also escapes the single quote (' → &#39;).
+export function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/test/unit/html-escape.test.js
+++ b/test/unit/html-escape.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { escapeHtml } from "../../public/static/html-escape.js";
+
+// #596 slice 1: pins the consolidated escapeHtml behaviour — including what it deliberately does
+// NOT do (single quotes), which is the documented divergence from the sections variant.
+describe("escapeHtml (shared, #596)", () => {
+  it("escapes the four dangerous HTML chars", () => {
+    expect(escapeHtml('<a href="x">&</a>')).toBe("&lt;a href=&quot;x&quot;&gt;&amp;&lt;/a&gt;");
+  });
+
+  it("escapes ampersand first so existing entities are not double-mangled inconsistently", () => {
+    expect(escapeHtml("&lt;")).toBe("&amp;lt;");
+  });
+
+  it("null/undefined become an empty string (the ?? \"\" guard)", () => {
+    expect(escapeHtml(null)).toBe("");
+    expect(escapeHtml(undefined)).toBe("");
+  });
+
+  it("coerces non-string values via String()", () => {
+    expect(escapeHtml(42)).toBe("42");
+    expect(escapeHtml(0)).toBe("0");
+  });
+
+  it("does NOT escape single quotes (matches the 6 consolidated variants, not sections)", () => {
+    expect(escapeHtml("it's a 'quote'")).toBe("it's a 'quote'");
+  });
+
+  it("leaves safe text unchanged", () => {
+    expect(escapeHtml("Fagforeninger og tariff")).toBe("Fagforeninger og tariff");
+  });
+});


### PR DESCRIPTION
Første skive i frontend-dedupliseringen (EPIC #595, #596) — bygger på arkitekturgjennomgangen #598/#611 som fant `escapeHtml` kopiert i 10 filer under 5 navn.

## Hva
Ny ES-modul `public/static/html-escape.js` med én `escapeHtml`. De **6 byte-identiske** kopiene importerer den (med alias så kall-stedene er urørt):
- `admin-content.js` (escapeHtml)
- `participant.js` (escapeHtmlP)
- `participant-completed.js` (escapeHtmlC)
- `results.js` (escapeHtmlR)
- `static/admin-content-courses.js` (escapeHtml)
- `static/admin-content-library.js` (escapeHtml)

Alle seks gjorde `String(x ?? "")` + samme 4-tegns escape (& < > "), så kanonisk versjon matcher eksakt → **ren no-op**.

## Bevisst utenfor skiven (verifisert atferdsforskjell → egne oppfølgings-skiver)
- `admin-content-preview.js` / `admin-content-shell.js` / `static/loading.js`: `String(x)` **uten** `?? ""` (null→"null"/"undefined", ikke "").
- `static/admin-content-sections.js`: escaper også `'` (→ `&#39;`).

## Test
- Ny unit-test `test/unit/html-escape.test.js` (6) pinner kanonisk oppførsel, inkl. at den IKKE escaper `'` (dokumenterer divergensen fra sections).
- `tsc` rent. **49 e2e** grønne (admin-content workspaces + bibliotek + participant-mcq-only + sertifikat) — sidene laster modulene i ekte nettleser, så ødelagt import/navn ville feilet.

## Deploy
Kode-only → `deploy-app.yml`. No-behavior-change refactor; kan deployes med neste batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)