### PR TITLE
refactor(frontend): single source of truth for formatNumber (v1.3.57, #596 skive 2)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,25 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.57 - 2026-06-22
+
+refactor(frontend): single source of truth for formatNumber — #596 skive 2 (EPIC #595)
+
+Andre skive i frontend-dedupliseringen. Ny ES-modul `public/static/format-display.js` med en
+**factory** `createNumberFormatter(getLocale, placeholder = "-")`. De 7 nær-identiske `formatNumber`-
+kopiene (`participant.js`, `participant-completed.js`, `profile.js`, `calibration.js`,
+`admin-content.js`, `review.js`, `static/admin-content-calibration.js`) erstattes av
+`const formatNumber = createNumberFormatter(() => currentLocale)` — kall-stedene er urørt.
+
+Factory fordi `formatNumber` er koblet til hver fils egen muterbare `currentLocale`: getteren leses
+**lazy** ved kall-tid, så locale-byttet fortsatt reflekteres. No-op: alle 7 gjorde
+`Intl.NumberFormat(currentLocale,{min:0,max})` + ikke-tall-guard; eneste forskjell var placeholderen
+(6 brukte `"-"`, `profile.js` brukte em-dash `"—"` — bevart via placeholder-param). Unit-test pinner
+factory + lazy locale + placeholder.
+
+(Locale-koblingen her motiverer en kommende `i18n-resolve`-skive — `currentLocale`/locale-fallback
+er selv duplisert på tvers av filene.)
+
 ## 1.3.56 - 2026-06-22
 
 refactor(frontend): single source of truth for HTML-escaping — #596 skive 1 (EPIC #595)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.56",
+  "version": "1.3.57",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content.js
+++ b/public/admin-content.js
@@ -4342,7 +4342,6 @@ function enablePillArrowNavigation(container) {
   });
 }
 
-$CONST
 
 function localizeSubmissionStatus(value) {
   const normalized = typeof value === "string" ? value.toUpperCase() : "";

--- a/public/admin-content.js
+++ b/public/admin-content.js
@@ -1,3 +1,5 @@
+import { createNumberFormatter } from "/static/format-display.js";
+const formatNumber = createNumberFormatter(() => currentLocale);
 import { escapeHtml } from "/static/html-escape.js";
 import {
   localeLabels,
@@ -4340,16 +4342,7 @@ function enablePillArrowNavigation(container) {
   });
 }
 
-function formatNumber(value, maxFractionDigits = 2) {
-  if (typeof value !== "number") {
-    return "-";
-  }
-
-  return new Intl.NumberFormat(currentLocale, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: maxFractionDigits,
-  }).format(value);
-}
+$CONST
 
 function localizeSubmissionStatus(value) {
   const normalized = typeof value === "string" ? value.toUpperCase() : "";

--- a/public/calibration.js
+++ b/public/calibration.js
@@ -241,7 +241,6 @@ function formatDateTime(value) {
   }
 }
 
-$CONST
 
 function localizeSubmissionStatus(value) {
   const normalized = typeof value === "string" ? value.toUpperCase() : "";

--- a/public/calibration.js
+++ b/public/calibration.js
@@ -1,3 +1,5 @@
+import { createNumberFormatter } from "/static/format-display.js";
+const formatNumber = createNumberFormatter(() => currentLocale);
 import { localeLabels, supportedLocales, translations } from "/static/i18n/calibration-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, fetchQueueCounts, applyNavReviewBadge } from "/static/api-client.js";
 import { initConsentGuard } from "/static/consent-guard.js";
@@ -239,16 +241,7 @@ function formatDateTime(value) {
   }
 }
 
-function formatNumber(value, maxFractionDigits = 2) {
-  if (typeof value !== "number") {
-    return "-";
-  }
-
-  return new Intl.NumberFormat(currentLocale, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: maxFractionDigits,
-  }).format(value);
-}
+$CONST
 
 function localizeSubmissionStatus(value) {
   const normalized = typeof value === "string" ? value.toUpperCase() : "";

--- a/public/participant-completed.js
+++ b/public/participant-completed.js
@@ -1,3 +1,5 @@
+import { createNumberFormatter } from "/static/format-display.js";
+const formatNumber = createNumberFormatter(() => currentLocale);
 import { escapeHtml as escapeHtmlC } from "/static/html-escape.js";
 import { localeLabels, supportedLocales, translations } from "/static/i18n/participant-completed-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, fetchQueueCounts, applyNavReviewBadge } from "/static/api-client.js";
@@ -207,16 +209,7 @@ function formatDateTime(value) {
   }
 }
 
-function formatNumber(value, maxFractionDigits = 2) {
-  if (typeof value !== "number") {
-    return "-";
-  }
-
-  return new Intl.NumberFormat(currentLocale, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: maxFractionDigits,
-  }).format(value);
-}
+$CONST
 
 function localizeSubmissionStatus(value) {
   const normalized = typeof value === "string" ? value.toUpperCase() : "";

--- a/public/participant-completed.js
+++ b/public/participant-completed.js
@@ -209,7 +209,6 @@ function formatDateTime(value) {
   }
 }
 
-$CONST
 
 function localizeSubmissionStatus(value) {
   const normalized = typeof value === "string" ? value.toUpperCase() : "";

--- a/public/participant.js
+++ b/public/participant.js
@@ -1734,7 +1734,6 @@ function formatModuleStatusSummary(module) {
   return parts.join(" · ");
 }
 
-$CONST
 
 function localizeSubmissionStatus(value) {
   const normalized = typeof value === "string" ? value.toUpperCase() : "";

--- a/public/participant.js
+++ b/public/participant.js
@@ -1,3 +1,5 @@
+import { createNumberFormatter } from "/static/format-display.js";
+const formatNumber = createNumberFormatter(() => currentLocale);
 import { escapeHtml as escapeHtmlP } from "/static/html-escape.js";
 import { localeLabels, supportedLocales, translations } from "/static/i18n/participant-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, fetchQueueCounts, applyNavReviewBadge, hydrateContentAssetImages } from "/static/api-client.js";
@@ -1732,16 +1734,7 @@ function formatModuleStatusSummary(module) {
   return parts.join(" · ");
 }
 
-function formatNumber(value, maxFractionDigits = 2) {
-  if (typeof value !== "number") {
-    return "-";
-  }
-
-  return new Intl.NumberFormat(currentLocale, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: maxFractionDigits,
-  }).format(value);
-}
+$CONST
 
 function localizeSubmissionStatus(value) {
   const normalized = typeof value === "string" ? value.toUpperCase() : "";

--- a/public/profile.js
+++ b/public/profile.js
@@ -1,3 +1,4 @@
+import { createNumberFormatter } from "/static/format-display.js";
 import { localeLabels, supportedLocales, translations } from "/static/i18n/profile-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, fetchQueueCounts, applyNavReviewBadge } from "/static/api-client.js";
 import {
@@ -194,13 +195,7 @@ function formatDate(value) {
   }
 }
 
-function formatNumber(value, maxFractionDigits = 2) {
-  if (typeof value !== "number") return "—";
-  return new Intl.NumberFormat(currentLocale, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: maxFractionDigits,
-  }).format(value);
-}
+const formatNumber = createNumberFormatter(() => currentLocale, "—");
 
 function localizeContentValue(value) {
   if (!value) return "â€”";

--- a/public/review.js
+++ b/public/review.js
@@ -1,3 +1,5 @@
+import { createNumberFormatter } from "/static/format-display.js";
+const formatNumber = createNumberFormatter(() => currentLocale);
 import { localeLabels, supportedLocales, translations } from "/static/i18n/review-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, applyNavReviewBadge } from "/static/api-client.js";
 import { initConsentGuard } from "/static/consent-guard.js";
@@ -245,10 +247,7 @@ function formatDateTime(value) {
   }
 }
 
-function formatNumber(value, maxFractionDigits = 2) {
-  if (typeof value !== "number") return "-";
-  return new Intl.NumberFormat(currentLocale, { minimumFractionDigits: 0, maximumFractionDigits: maxFractionDigits }).format(value);
-}
+$CONST
 
 function normalizeMultilineText(value) {
   if (typeof value !== "string") return "-";

--- a/public/review.js
+++ b/public/review.js
@@ -247,7 +247,6 @@ function formatDateTime(value) {
   }
 }
 
-$CONST
 
 function normalizeMultilineText(value) {
   if (typeof value !== "string") return "-";

--- a/public/static/admin-content-calibration.js
+++ b/public/static/admin-content-calibration.js
@@ -133,7 +133,6 @@ function renderAccessDenied() {
 // Formatters
 // ---------------------------------------------------------------------------
 
-$CONST
 
 function formatDateTimeValue(value) {
   if (!value) return "-";

--- a/public/static/admin-content-calibration.js
+++ b/public/static/admin-content-calibration.js
@@ -1,3 +1,5 @@
+import { createNumberFormatter } from "/static/format-display.js";
+const formatNumber = createNumberFormatter(() => currentLocale);
 import {
   supportedLocales,
   localeLabels,
@@ -131,13 +133,7 @@ function renderAccessDenied() {
 // Formatters
 // ---------------------------------------------------------------------------
 
-function formatNumber(value, maxFractionDigits = 2) {
-  if (typeof value !== "number") return "-";
-  return new Intl.NumberFormat(currentLocale, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: maxFractionDigits,
-  }).format(value);
-}
+$CONST
 
 function formatDateTimeValue(value) {
   if (!value) return "-";

--- a/public/static/format-display.js
+++ b/public/static/format-display.js
@@ -1,0 +1,20 @@
+// #596 (EPIC #595) slice 2 — single source of truth for number formatting.
+//
+// Replaces 7 near-identical `formatNumber` copies (participant.js, participant-completed.js,
+// profile.js, calibration.js, admin-content.js, review.js, static/admin-content-calibration.js).
+// All used `Intl.NumberFormat(currentLocale, { minimumFractionDigits: 0, maximumFractionDigits })`
+// with a non-number guard; the ONLY difference was the placeholder ("-" everywhere except
+// profile.js which used the em-dash "—").
+//
+// Each host file owns its OWN mutable `currentLocale`, so this is a factory: pass a locale GETTER
+// that is read lazily at call time. That keeps every call site unchanged — `formatNumber(value)` /
+// `formatNumber(value, maxFractionDigits)` — while the formatting logic lives in one place.
+export function createNumberFormatter(getLocale, placeholder = "-") {
+  return function formatNumber(value, maxFractionDigits = 2) {
+    if (typeof value !== "number") return placeholder;
+    return new Intl.NumberFormat(getLocale(), {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: maxFractionDigits,
+    }).format(value);
+  };
+}

--- a/test/unit/format-display.test.js
+++ b/test/unit/format-display.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { createNumberFormatter } from "../../public/static/format-display.js";
+
+// #596 slice 2: pins the consolidated number formatter, including the lazy locale getter and the
+// configurable non-number placeholder (the one behaviour that differed across the 7 copies).
+describe("createNumberFormatter (shared, #596)", () => {
+  it("formats numbers using the locale read lazily at call time", () => {
+    let locale = "en-GB";
+    const fmt = createNumberFormatter(() => locale);
+    expect(fmt(1234.5)).toBe("1,234.5");
+    // Changing the captured locale afterwards is reflected on the next call (lazy read).
+    locale = "nb";
+    expect(fmt(1234.5)).toBe("1 234,5"); // nb groups with a non-breaking space, decimal comma
+  });
+
+  it("respects maximumFractionDigits (default 2, minimum 0)", () => {
+    const fmt = createNumberFormatter(() => "en-GB");
+    expect(fmt(1.23456)).toBe("1.23");
+    expect(fmt(5)).toBe("5"); // minimumFractionDigits 0 → no trailing zeros
+    expect(fmt(1.23456, 4)).toBe("1.2346");
+  });
+
+  it("returns the default '-' placeholder for non-numbers", () => {
+    const fmt = createNumberFormatter(() => "en-GB");
+    expect(fmt(null)).toBe("-");
+    expect(fmt(undefined)).toBe("-");
+    expect(fmt("12")).toBe("-"); // strings are NOT coerced (typeof guard)
+    expect(fmt(NaN)).toBe("NaN"); // NaN is typeof number → Intl formats it
+  });
+
+  it("supports a custom placeholder (profile.js uses the em-dash)", () => {
+    const fmt = createNumberFormatter(() => "en-GB", "—");
+    expect(fmt(null)).toBe("—");
+  });
+});


### PR DESCRIPTION
Andre skive i frontend-dedupliseringen (EPIC #595, #596; arkitektur #611).

## Hva
Ny ES-modul `public/static/format-display.js` med **factory** `createNumberFormatter(getLocale, placeholder = "-")`. De 7 `formatNumber`-kopiene erstattes av `const formatNumber = createNumberFormatter(() => currentLocale)`:
- `participant.js`, `participant-completed.js`, `profile.js`, `calibration.js`, `admin-content.js`, `review.js`, `static/admin-content-calibration.js`

## Hvorfor factory (ikke ren funksjon som escapeHtml)
`formatNumber` er koblet til hver fils egen **muterbare `currentLocale`**. Factory-en tar en locale-**getter** som leses **lazy** ved kall-tid, så locale-bytte fortsatt reflekteres — og **kall-stedene (`formatNumber(value[, max])`) er urørt**.

## No-op
Alle 7 gjorde `Intl.NumberFormat(currentLocale, { minimumFractionDigits: 0, maximumFractionDigits })` + ikke-tall-guard. Eneste forskjell: placeholder for ikke-tall — 6 brukte `"-"`, `profile.js` brukte em-dash `"—"` (bevart via placeholder-param).

## Test
- Unit `test/unit/format-display.test.js` (4): formatering, lazy locale (nb vs en-GB), `maximumFractionDigits`, default + em-dash placeholder.
- `tsc` rent. **38 e2e** grønne (participant-mcq-only, participant-certificate, profile-certificate-link, admin-content-workspaces) — sidene laster modulene i ekte nettleser.

## Innsikt
Locale-koblingen her viser at `currentLocale`/locale-fallback selv er duplisert — motiverer en kommende `i18n-resolve`-skive.

## Deploy
Kode-only no-op → `deploy-app.yml`, kan batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)