### PR TITLE
refactor(frontend): single source of truth for resolveInitialLocale (v1.3.58, #596 skive 3)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,21 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.58 - 2026-06-22
+
+refactor(frontend): single source of truth for resolveInitialLocale — #596 skive 3 (EPIC #595)
+
+Tredje skive i frontend-dedupliseringen. Ny ES-modul `public/static/i18n-locale.js` med
+`resolveInitialLocale(supportedLocales)`. De **9** kopiene (`review.js`, `admin-content.js`,
+`calibration.js`, `participant.js`, `participant-completed.js`, `profile.js`, `results.js`,
+`certificate.js`, `admin-platform.js`) erstattes av importen + `resolveInitialLocale(supportedLocales)`
+(supportedLocales sendes inn siden hver side importerer sin egen identiske liste).
+
+No-op for de 8 atferdslike (lagret locale > browser-prefix nb/nn/en > en-GB; `certificate.js` sin
+manglende `en`-gren ga samme output som default). `results.js` brukte en `find()`-match uten
+null-guard — folding inn her fjerner en latent throw på null `navigator.language` (samme output for
+enhver reell browser-streng). Unit-test pinner resolusjonen.
+
 ## 1.3.57 - 2026-06-22
 
 refactor(frontend): single source of truth for formatNumber — #596 skive 2 (EPIC #595)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.57",
+  "version": "1.3.58",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content.js
+++ b/public/admin-content.js
@@ -1,3 +1,4 @@
+import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { createNumberFormatter } from "/static/format-display.js";
 const formatNumber = createNumberFormatter(() => currentLocale);
 import { escapeHtml } from "/static/html-escape.js";
@@ -431,7 +432,7 @@ Return JSON in this exact shape:
 Source material follows:
 [PASTE SOURCE MATERIAL HERE]`;
 
-let currentLocale = resolveInitialLocale();
+let currentLocale = resolveInitialLocale(supportedLocales);
 let modules = [];
 let selectedModuleId = "";
 let activeContentTab = "modules";
@@ -476,28 +477,6 @@ let _dialogTriggerRef = null;
 let advPreviewLocale = null; // set to currentLocale on first open
 let advPreviewOpen = false;
 
-function resolveInitialLocale() {
-  const stored = localStorage.getItem("participant.locale");
-  if (stored && supportedLocales.includes(stored)) {
-    return stored;
-  }
-
-  const browser = navigator.language;
-  if (!browser) {
-    return "en-GB";
-  }
-  const normalized = browser.toLowerCase();
-  if (normalized.startsWith("nb")) {
-    return "nb";
-  }
-  if (normalized.startsWith("nn")) {
-    return "nn";
-  }
-  if (normalized.startsWith("en")) {
-    return "en-GB";
-  }
-  return "en-GB";
-}
 
 function t(key) {
   return translations[currentLocale][key] ?? translations["en-GB"][key] ?? key;

--- a/public/admin-platform.js
+++ b/public/admin-platform.js
@@ -1,3 +1,4 @@
+import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { localeLabels, supportedLocales, translations } from "/static/i18n/admin-platform-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, fetchQueueCounts, applyNavReviewBadge } from "/static/api-client.js";
 import { initConsentGuard } from "/static/consent-guard.js";
@@ -31,7 +32,7 @@ const consentVersionBadge = document.getElementById("consentVersion");
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
-let currentLocale = resolveInitialLocale();
+let currentLocale = resolveInitialLocale(supportedLocales);
 let participantRuntimeConfig = {
   authMode: "mock",
   mockRolePresets: [],
@@ -50,16 +51,6 @@ let roleSwitchState = resolveRoleSwitchState(participantRuntimeConfig);
 
 // ── Locale ────────────────────────────────────────────────────────────────────
 
-function resolveInitialLocale() {
-  const stored = localStorage.getItem("participant.locale");
-  if (stored && supportedLocales.includes(stored)) return stored;
-  const browser = navigator.language ?? "";
-  const normalized = browser.toLowerCase();
-  if (normalized.startsWith("nb")) return "nb";
-  if (normalized.startsWith("nn")) return "nn";
-  if (normalized.startsWith("en")) return "en-GB";
-  return "en-GB";
-}
 
 function t(key) {
   return translations[currentLocale]?.[key] ?? translations["en-GB"]?.[key] ?? key;

--- a/public/calibration.js
+++ b/public/calibration.js
@@ -1,3 +1,4 @@
+import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { createNumberFormatter } from "/static/format-display.js";
 const formatNumber = createNumberFormatter(() => currentLocale);
 import { localeLabels, supportedLocales, translations } from "/static/i18n/calibration-translations.js";
@@ -40,7 +41,7 @@ const publishThresholdsButton = document.getElementById("publishThresholds");
 const thresholdPublishResult = document.getElementById("thresholdPublishResult");
 
 const allSubmissionStatuses = ["SUBMITTED", "PROCESSING", "SCORED", "UNDER_REVIEW", "COMPLETED", "REJECTED"];
-let currentLocale = resolveInitialLocale();
+let currentLocale = resolveInitialLocale(supportedLocales);
 let latestWorkspaceBody = null;
 let participantRuntimeConfig = {
   authMode: "mock",
@@ -73,28 +74,6 @@ let participantRuntimeConfig = {
 };
 let roleSwitchState = resolveRoleSwitchState(participantRuntimeConfig);
 
-function resolveInitialLocale() {
-  const stored = localStorage.getItem("participant.locale");
-  if (stored && supportedLocales.includes(stored)) {
-    return stored;
-  }
-
-  const browser = navigator.language;
-  if (!browser) {
-    return "en-GB";
-  }
-  const normalized = browser.toLowerCase();
-  if (normalized.startsWith("nb")) {
-    return "nb";
-  }
-  if (normalized.startsWith("nn")) {
-    return "nn";
-  }
-  if (normalized.startsWith("en")) {
-    return "en-GB";
-  }
-  return "en-GB";
-}
 
 function t(key) {
   return translations[currentLocale][key] ?? translations["en-GB"][key] ?? key;

--- a/public/certificate.js
+++ b/public/certificate.js
@@ -1,3 +1,4 @@
+import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { localeLabels, supportedLocales, translations } from "/static/i18n/certificate-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig } from "/static/api-client.js";
 
@@ -7,7 +8,7 @@ const printBtn = document.getElementById("printBtn");
 const certState = document.getElementById("certState");
 const certificateEl = document.getElementById("certificate");
 
-let currentLocale = resolveInitialLocale();
+let currentLocale = resolveInitialLocale(supportedLocales);
 // Identity used for mock-mode headers; in entra mode the Bearer token (added by apiFetch)
 // authenticates and these x-user-* values are ignored.
 let identity = {
@@ -18,14 +19,6 @@ let identity = {
   roles: ["PARTICIPANT"],
 };
 
-function resolveInitialLocale() {
-  const stored = localStorage.getItem("participant.locale");
-  if (stored && supportedLocales.includes(stored)) return stored;
-  const normalized = (navigator.language ?? "").toLowerCase();
-  if (normalized.startsWith("nb")) return "nb";
-  if (normalized.startsWith("nn")) return "nn";
-  return "en-GB";
-}
 
 function t(key) {
   return translations[currentLocale]?.[key] ?? translations["en-GB"][key] ?? key;

--- a/public/participant-completed.js
+++ b/public/participant-completed.js
@@ -1,3 +1,4 @@
+import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { createNumberFormatter } from "/static/format-display.js";
 const formatNumber = createNumberFormatter(() => currentLocale);
 import { escapeHtml as escapeHtmlC } from "/static/html-escape.js";
@@ -33,7 +34,7 @@ const completedAppealFeedback = document.getElementById("completedAppealFeedback
 
 let pendingAppealSubmissionId = null;
 
-let currentLocale = resolveInitialLocale();
+let currentLocale = resolveInitialLocale(supportedLocales);
 let participantRuntimeConfig = {
   authMode: "mock",
   debugMode: true,
@@ -52,28 +53,6 @@ let participantRuntimeConfig = {
 };
 let roleSwitchState = resolveRoleSwitchState(participantRuntimeConfig);
 
-function resolveInitialLocale() {
-  const stored = localStorage.getItem("participant.locale");
-  if (stored && supportedLocales.includes(stored)) {
-    return stored;
-  }
-
-  const browser = navigator.language;
-  if (!browser) {
-    return "en-GB";
-  }
-  const normalized = browser.toLowerCase();
-  if (normalized.startsWith("nb")) {
-    return "nb";
-  }
-  if (normalized.startsWith("nn")) {
-    return "nn";
-  }
-  if (normalized.startsWith("en")) {
-    return "en-GB";
-  }
-  return "en-GB";
-}
 
 function t(key) {
   return translations[currentLocale][key] ?? translations["en-GB"][key] ?? key;

--- a/public/participant.js
+++ b/public/participant.js
@@ -1,3 +1,4 @@
+import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { createNumberFormatter } from "/static/format-display.js";
 const formatNumber = createNumberFormatter(() => currentLocale);
 import { escapeHtml as escapeHtmlP } from "/static/html-escape.js";
@@ -90,7 +91,7 @@ const PARTICIPANT_PREVIEW_STORAGE_KEY = "adminContent.participantPreview.v1";
 const COMPLETED_MODULE_STATUSES = new Set(["COMPLETED"]);
 
 let currentQuestions = [];
-let currentLocale = resolveInitialLocale();
+let currentLocale = resolveInitialLocale(supportedLocales);
 let latestResult = null;
 // #549: ensures the pass celebration (confetti + banner) fires once per submission, not on every
 // result poll. Reset when the module context changes / a new submission starts.
@@ -158,28 +159,6 @@ const DEFAULT_SUBMISSION_FIELDS = [
 
 let currentSubmissionFields = DEFAULT_SUBMISSION_FIELDS;
 
-function resolveInitialLocale() {
-  const stored = localStorage.getItem("participant.locale");
-  if (stored && supportedLocales.includes(stored)) {
-    return stored;
-  }
-
-  const browser = navigator.language;
-  if (!browser) {
-    return "en-GB";
-  }
-  const normalized = browser.toLowerCase();
-  if (normalized.startsWith("nb")) {
-    return "nb";
-  }
-  if (normalized.startsWith("nn")) {
-    return "nn";
-  }
-  if (normalized.startsWith("en")) {
-    return "en-GB";
-  }
-  return "en-GB";
-}
 
 function t(key) {
   return translations[currentLocale][key] ?? translations["en-GB"][key] ?? key;

--- a/public/profile.js
+++ b/public/profile.js
@@ -1,3 +1,4 @@
+import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { createNumberFormatter } from "/static/format-display.js";
 import { localeLabels, supportedLocales, translations } from "/static/i18n/profile-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, fetchQueueCounts, applyNavReviewBadge } from "/static/api-client.js";
@@ -41,7 +42,7 @@ const deletionFeedback = document.getElementById("deletionFeedback");
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
-let currentLocale = resolveInitialLocale();
+let currentLocale = resolveInitialLocale(supportedLocales);
 let participantRuntimeConfig = {
   authMode: "mock",
   debugMode: true,
@@ -64,16 +65,6 @@ let cachedDataExport = null;
 
 // ── Locale ────────────────────────────────────────────────────────────────────
 
-function resolveInitialLocale() {
-  const stored = localStorage.getItem("participant.locale");
-  if (stored && supportedLocales.includes(stored)) return stored;
-  const browser = navigator.language ?? "";
-  const normalized = browser.toLowerCase();
-  if (normalized.startsWith("nb")) return "nb";
-  if (normalized.startsWith("nn")) return "nn";
-  if (normalized.startsWith("en")) return "en-GB";
-  return "en-GB";
-}
 
 function t(key) {
   return translations[currentLocale]?.[key] ?? translations["en-GB"]?.[key] ?? key;

--- a/public/results.js
+++ b/public/results.js
@@ -1,3 +1,4 @@
+import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { escapeHtml as escapeHtmlR } from "/static/html-escape.js";
 import { localeLabels, supportedLocales, translations } from "/static/i18n/results-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, getAccessToken, fetchQueueCounts, applyNavReviewBadge } from "/static/api-client.js";
@@ -33,7 +34,7 @@ const exportPassRatesButton = document.getElementById("exportPassRates");
 const participantBody = document.getElementById("participantBody");
 const moduleDetailMeta = document.getElementById("moduleDetailMeta");
 
-let currentLocale = resolveInitialLocale();
+let currentLocale = resolveInitialLocale(supportedLocales);
 let participantRuntimeConfig = {
   authMode: "mock",
   mockRolePresets: [],
@@ -52,12 +53,6 @@ let roleSwitchState = resolveRoleSwitchState(participantRuntimeConfig);
 let selectedModuleRow = null;
 let selectedCourseRow = null;
 
-function resolveInitialLocale() {
-  const stored = localStorage.getItem("participant.locale");
-  if (stored && supportedLocales.includes(stored)) return stored;
-  const browser = navigator.language;
-  return supportedLocales.find((l) => browser.startsWith(l)) ?? "en-GB";
-}
 
 function t(key) {
   return translations[currentLocale]?.[key] ?? translations["en-GB"]?.[key] ?? key;

--- a/public/review.js
+++ b/public/review.js
@@ -1,3 +1,4 @@
+import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { createNumberFormatter } from "/static/format-display.js";
 const formatNumber = createNumberFormatter(() => currentLocale);
 import { localeLabels, supportedLocales, translations } from "/static/i18n/review-translations.js";
@@ -86,7 +87,7 @@ const defaultResolutionPassFailValue = "true";
 const reviewStatusOptions = ["OPEN", "IN_REVIEW", "RESOLVED"];
 const actionableQueueStatuses = new Set(["OPEN", "IN_REVIEW"]);
 
-let currentLocale = resolveInitialLocale();
+let currentLocale = resolveInitialLocale(supportedLocales);
 let activeReviewTab = "manualReview";
 
 // MR state
@@ -131,16 +132,6 @@ let roleSwitchState = resolveRoleSwitchState(participantRuntimeConfig);
 
 // ── Locale ─────────────────────────────────────────────────────────────────────
 
-function resolveInitialLocale() {
-  const stored = localStorage.getItem("participant.locale");
-  if (stored && supportedLocales.includes(stored)) return stored;
-  const browser = navigator.language ?? "";
-  const normalized = browser.toLowerCase();
-  if (normalized.startsWith("nb")) return "nb";
-  if (normalized.startsWith("nn")) return "nn";
-  if (normalized.startsWith("en")) return "en-GB";
-  return "en-GB";
-}
 
 function t(key) {
   return translations[currentLocale]?.[key] ?? translations["en-GB"]?.[key] ?? key;

--- a/public/static/i18n-locale.js
+++ b/public/static/i18n-locale.js
@@ -1,0 +1,22 @@
+// #596 (EPIC #595) slice 3 — single source of truth for initial-locale resolution.
+//
+// Replaces 9 copies of `resolveInitialLocale` across the page scripts (review, admin-content,
+// calibration, participant, participant-completed, profile, results, certificate, admin-platform).
+// `supportedLocales` is passed in because each page imports its own (identical) list from its
+// translations module.
+//
+// Behaviour matches the dominant 8 copies: a valid stored "participant.locale" wins, otherwise the
+// browser language prefix maps nb/nn/en → nb/nn/en-GB, otherwise "en-GB". (certificate.js omitted
+// the `en` branch, but since the default is also "en-GB" its output was identical.) results.js
+// previously matched via `supportedLocales.find(l => browser.startsWith(l))` WITHOUT a null guard —
+// folding it in here removes that latent throw on a null `navigator.language`; the output is the
+// same for every real browser string.
+export function resolveInitialLocale(supportedLocales) {
+  const stored = localStorage.getItem("participant.locale");
+  if (stored && supportedLocales.includes(stored)) return stored;
+  const normalized = (navigator.language ?? "").toLowerCase();
+  if (normalized.startsWith("nb")) return "nb";
+  if (normalized.startsWith("nn")) return "nn";
+  if (normalized.startsWith("en")) return "en-GB";
+  return "en-GB";
+}

--- a/test/unit/i18n-locale.test.js
+++ b/test/unit/i18n-locale.test.js
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { resolveInitialLocale } from "../../public/static/i18n-locale.js";
+
+// #596 slice 3: pins the consolidated initial-locale resolution (stored > browser-prefix > en-GB).
+const SUPPORTED = ["en-GB", "nb", "nn"];
+
+function setLanguage(value) {
+  Object.defineProperty(navigator, "language", { value, configurable: true });
+}
+
+describe("resolveInitialLocale (shared, #596)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns a valid stored locale, ignoring the browser", () => {
+    localStorage.setItem("participant.locale", "nn");
+    setLanguage("en-US");
+    expect(resolveInitialLocale(SUPPORTED)).toBe("nn");
+  });
+
+  it("ignores an unsupported stored locale and falls back to the browser", () => {
+    localStorage.setItem("participant.locale", "de");
+    setLanguage("nb-NO");
+    expect(resolveInitialLocale(SUPPORTED)).toBe("nb");
+  });
+
+  it("maps the browser language prefix nb/nn/en", () => {
+    setLanguage("nb-NO");
+    expect(resolveInitialLocale(SUPPORTED)).toBe("nb");
+    setLanguage("nn-NO");
+    expect(resolveInitialLocale(SUPPORTED)).toBe("nn");
+    setLanguage("en-US");
+    expect(resolveInitialLocale(SUPPORTED)).toBe("en-GB");
+  });
+
+  it("defaults to en-GB for unknown or empty browser languages", () => {
+    setLanguage("de-DE");
+    expect(resolveInitialLocale(SUPPORTED)).toBe("en-GB");
+    setLanguage("");
+    expect(resolveInitialLocale(SUPPORTED)).toBe("en-GB");
+  });
+});


### PR DESCRIPTION
Tredje skive i frontend-dedupliseringen (EPIC #595, #596; arkitektur #611).

## Hva
Ny ES-modul `public/static/i18n-locale.js` med `resolveInitialLocale(supportedLocales)`. De **9** kopiene erstattes av importen + `resolveInitialLocale(supportedLocales)`:
- `review.js`, `admin-content.js`, `calibration.js`, `participant.js`, `participant-completed.js`, `profile.js`, `results.js`, `certificate.js`, `admin-platform.js`

`supportedLocales` sendes inn fordi hver side importerer sin egen (identiske) liste.

## Atferd
No-op for de 8 atferdslike: lagret `participant.locale` > browser-prefix (nb/nn/en → nb/nn/en-GB) > `en-GB`. (`certificate.js` manglet `en`-grenen, men default er også `en-GB` → identisk output.) `results.js` brukte `supportedLocales.find(l => browser.startsWith(l))` **uten null-guard** — folding inn her fjerner en latent throw på null `navigator.language`; output er likt for enhver reell browser-streng.

## Test
- Unit `test/unit/i18n-locale.test.js` (4, jsdom): lagret-locale, ugyldig-lagret-fallback, prefix-mapping, default.
- `tsc` rent. **Full e2e-suite: 54 passed** (lærdom fra slice 2 anvendt — hele suiten, ikke subsett).

## Deploy
Kode-only no-op → `deploy-app.yml`. Etter denne deployer vi 1.3.56–1.3.58 til stage (som avtalt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)