### PR TITLE
refactor(frontend): single source of truth for date-time formatting (v1.3.59, #596 skive 4)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,22 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.59 - 2026-06-22
+
+refactor(frontend): single source of truth for date-time formatting — #596 skive 4 (EPIC #595)
+
+Fjerde skive. `public/static/format-display.js` får `createDateTimeFormatter(getLocale, placeholder)`
+(samme lazy-locale-factory som tall). De 7 `formatDateTime`/`formatDateTimeValue`-kopiene
+(`participant.js`, `participant-completed.js`, `profile.js`, `calibration.js`, `review.js`,
+`results.js`, `static/admin-content-calibration.js`) erstattes av
+`const formatDateTime = createDateTimeFormatter(() => currentLocale)`.
+
+No-op: alle 7 gjorde `Intl.DateTimeFormat(currentLocale,{dateStyle:"medium",timeStyle:"short"})` med
+falsy-guard + `try/catch → String(value)`. Eneste forskjell var placeholderen (`"-"` for 5, em-dash
+`"—"` for results/profile — bevart via param). Dato-varianter med annen form (`dateStyle`
+long/medium-only, `toLocaleDateString` numerisk, og admin-content.js sin NaN-guard-variant) er
+bevisst latt stå til senere skiver. Unit-test pinner factory + placeholder + catch-fallback.
+
 ## 1.3.58 - 2026-06-22
 
 refactor(frontend): single source of truth for resolveInitialLocale — #596 skive 3 (EPIC #595)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.58",
+  "version": "1.3.59",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/calibration.js
+++ b/public/calibration.js
@@ -1,5 +1,6 @@
 import { resolveInitialLocale } from "/static/i18n-locale.js";
-import { createNumberFormatter } from "/static/format-display.js";
+import { createNumberFormatter, createDateTimeFormatter } from "/static/format-display.js";
+const formatDateTime = createDateTimeFormatter(() => currentLocale);
 const formatNumber = createNumberFormatter(() => currentLocale);
 import { localeLabels, supportedLocales, translations } from "/static/i18n/calibration-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, fetchQueueCounts, applyNavReviewBadge } from "/static/api-client.js";
@@ -205,20 +206,6 @@ async function runWithBusyButton(button, action) {
   }
 }
 
-function formatDateTime(value) {
-  if (!value) {
-    return "-";
-  }
-
-  try {
-    return new Intl.DateTimeFormat(currentLocale, {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(new Date(value));
-  } catch {
-    return String(value);
-  }
-}
 
 
 function localizeSubmissionStatus(value) {

--- a/public/participant-completed.js
+++ b/public/participant-completed.js
@@ -1,5 +1,6 @@
 import { resolveInitialLocale } from "/static/i18n-locale.js";
-import { createNumberFormatter } from "/static/format-display.js";
+import { createNumberFormatter, createDateTimeFormatter } from "/static/format-display.js";
+const formatDateTime = createDateTimeFormatter(() => currentLocale);
 const formatNumber = createNumberFormatter(() => currentLocale);
 import { escapeHtml as escapeHtmlC } from "/static/html-escape.js";
 import { localeLabels, supportedLocales, translations } from "/static/i18n/participant-completed-translations.js";
@@ -173,20 +174,6 @@ async function runWithBusyButton(button, action) {
   }
 }
 
-function formatDateTime(value) {
-  if (!value) {
-    return "-";
-  }
-
-  try {
-    return new Intl.DateTimeFormat(currentLocale, {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(new Date(value));
-  } catch {
-    return String(value);
-  }
-}
 
 
 function localizeSubmissionStatus(value) {

--- a/public/participant.js
+++ b/public/participant.js
@@ -1,5 +1,6 @@
 import { resolveInitialLocale } from "/static/i18n-locale.js";
-import { createNumberFormatter } from "/static/format-display.js";
+import { createNumberFormatter, createDateTimeFormatter } from "/static/format-display.js";
+const formatDateTime = createDateTimeFormatter(() => currentLocale);
 const formatNumber = createNumberFormatter(() => currentLocale);
 import { escapeHtml as escapeHtmlP } from "/static/html-escape.js";
 import { localeLabels, supportedLocales, translations } from "/static/i18n/participant-translations.js";
@@ -1674,20 +1675,6 @@ async function loadVersion() {
   }
 }
 
-function formatDateTime(value) {
-  if (!value) {
-    return "-";
-  }
-
-  try {
-    return new Intl.DateTimeFormat(currentLocale, {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(new Date(value));
-  } catch {
-    return String(value);
-  }
-}
 
 function isCompletedModuleStatus(value) {
   return COMPLETED_MODULE_STATUSES.has(typeof value === "string" ? value.toUpperCase() : "");

--- a/public/profile.js
+++ b/public/profile.js
@@ -1,5 +1,6 @@
 import { resolveInitialLocale } from "/static/i18n-locale.js";
-import { createNumberFormatter } from "/static/format-display.js";
+import { createNumberFormatter, createDateTimeFormatter } from "/static/format-display.js";
+const formatDateTime = createDateTimeFormatter(() => currentLocale, "—");
 import { localeLabels, supportedLocales, translations } from "/static/i18n/profile-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, fetchQueueCounts, applyNavReviewBadge } from "/static/api-client.js";
 import {
@@ -168,14 +169,6 @@ function headers() {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function formatDateTime(value) {
-  if (!value) return "—";
-  try {
-    return new Intl.DateTimeFormat(currentLocale, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
-  } catch {
-    return String(value);
-  }
-}
 
 function formatDate(value) {
   if (!value) return "—";

--- a/public/results.js
+++ b/public/results.js
@@ -1,3 +1,5 @@
+import { createDateTimeFormatter } from "/static/format-display.js";
+const formatDateTime = createDateTimeFormatter(() => currentLocale, "—");
 import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { escapeHtml as escapeHtmlR } from "/static/html-escape.js";
 import { localeLabels, supportedLocales, translations } from "/static/i18n/results-translations.js";
@@ -102,17 +104,6 @@ function pct(value) {
   return `${Math.round(value * 100)} %`;
 }
 
-function formatDateTime(value) {
-  if (!value) return "—";
-  try {
-    return new Intl.DateTimeFormat(currentLocale, {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(new Date(value));
-  } catch {
-    return String(value);
-  }
-}
 
 function formatScore(value) {
   if (typeof value !== "number") return "—";

--- a/public/review.js
+++ b/public/review.js
@@ -1,5 +1,6 @@
 import { resolveInitialLocale } from "/static/i18n-locale.js";
-import { createNumberFormatter } from "/static/format-display.js";
+import { createNumberFormatter, createDateTimeFormatter } from "/static/format-display.js";
+const formatDateTime = createDateTimeFormatter(() => currentLocale);
 const formatNumber = createNumberFormatter(() => currentLocale);
 import { localeLabels, supportedLocales, translations } from "/static/i18n/review-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, applyNavReviewBadge } from "/static/api-client.js";
@@ -229,14 +230,6 @@ async function runWithBusyButton(button, action) {
   }
 }
 
-function formatDateTime(value) {
-  if (!value) return "-";
-  try {
-    return new Intl.DateTimeFormat(currentLocale, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
-  } catch {
-    return String(value);
-  }
-}
 
 
 function normalizeMultilineText(value) {

--- a/public/static/admin-content-calibration.js
+++ b/public/static/admin-content-calibration.js
@@ -1,4 +1,5 @@
-import { createNumberFormatter } from "/static/format-display.js";
+import { createNumberFormatter, createDateTimeFormatter } from "/static/format-display.js";
+const formatDateTimeValue = createDateTimeFormatter(() => currentLocale);
 const formatNumber = createNumberFormatter(() => currentLocale);
 import {
   supportedLocales,
@@ -134,17 +135,6 @@ function renderAccessDenied() {
 // ---------------------------------------------------------------------------
 
 
-function formatDateTimeValue(value) {
-  if (!value) return "-";
-  try {
-    return new Intl.DateTimeFormat(currentLocale, {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(new Date(value));
-  } catch {
-    return String(value);
-  }
-}
 
 function localizeSubmissionStatus(value) {
   const normalized = typeof value === "string" ? value.toUpperCase() : "";

--- a/public/static/format-display.js
+++ b/public/static/format-display.js
@@ -18,3 +18,25 @@ export function createNumberFormatter(getLocale, placeholder = "-") {
     }).format(value);
   };
 }
+
+// #596 slice 4 — date-time formatting. Replaces 7 copies of `formatDateTime`/`formatDateTimeValue`
+// (participant.js, participant-completed.js, profile.js, calibration.js, review.js, results.js,
+// static/admin-content-calibration.js) that all did `Intl.DateTimeFormat(currentLocale,
+// { dateStyle: "medium", timeStyle: "short" }).format(new Date(value))` with a falsy guard and a
+// try/catch → String(value) fallback. Same lazy-locale factory as numbers; the only difference was
+// the falsy placeholder ("-" vs the em-dash "—", kept via the param). Date variants that differ in
+// shape (dateStyle long/medium-only, the toLocaleDateString numeric form, and admin-content.js's
+// NaN-guard variant) are intentionally left for later slices.
+export function createDateTimeFormatter(getLocale, placeholder = "-") {
+  return function formatDateTime(value) {
+    if (!value) return placeholder;
+    try {
+      return new Intl.DateTimeFormat(getLocale(), {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(new Date(value));
+    } catch {
+      return String(value);
+    }
+  };
+}

--- a/test/unit/format-display.test.js
+++ b/test/unit/format-display.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createNumberFormatter } from "../../public/static/format-display.js";
+import { createNumberFormatter, createDateTimeFormatter } from "../../public/static/format-display.js";
 
 // #596 slice 2: pins the consolidated number formatter, including the lazy locale getter and the
 // configurable non-number placeholder (the one behaviour that differed across the 7 copies).
@@ -31,5 +31,27 @@ describe("createNumberFormatter (shared, #596)", () => {
   it("supports a custom placeholder (profile.js uses the em-dash)", () => {
     const fmt = createNumberFormatter(() => "en-GB", "—");
     expect(fmt(null)).toBe("—");
+  });
+});
+
+describe("createDateTimeFormatter (shared, #596)", () => {
+  it("formats a date-time with the lazily-read locale (medium date, short time)", () => {
+    const fmt = createDateTimeFormatter(() => "en-GB");
+    const out = fmt("2026-06-22T08:30:00Z");
+    // Locale/timezone-dependent exact string; assert it produced a non-empty formatted value
+    // containing the year, not the raw ISO input.
+    expect(out).toContain("2026");
+    expect(out).not.toBe("2026-06-22T08:30:00Z");
+  });
+
+  it("returns the placeholder for falsy values (default '-' or custom)", () => {
+    expect(createDateTimeFormatter(() => "en-GB")(null)).toBe("-");
+    expect(createDateTimeFormatter(() => "en-GB")("")).toBe("-");
+    expect(createDateTimeFormatter(() => "en-GB", "—")(undefined)).toBe("—");
+  });
+
+  it("falls back to String(value) when the date cannot be formatted", () => {
+    // An unparseable date → new Date("nope") is Invalid Date → Intl throws → catch → String(value).
+    expect(createDateTimeFormatter(() => "en-GB")("not-a-date")).toBe("not-a-date");
   });
 });


### PR DESCRIPTION
Fjerde skive i frontend-dedupliseringen (EPIC #595, #596).

## Hva
`public/static/format-display.js` får `createDateTimeFormatter(getLocale, placeholder)` (samme lazy-locale-factory som `createNumberFormatter`). De **7** `formatDateTime`/`formatDateTimeValue`-kopiene erstattes:
- `participant.js`, `participant-completed.js`, `profile.js`, `calibration.js`, `review.js`, `results.js`, `static/admin-content-calibration.js`

## No-op
Alle 7 gjorde `Intl.DateTimeFormat(currentLocale, { dateStyle: "medium", timeStyle: "short" }).format(new Date(value))` med falsy-guard + `try/catch → String(value)`. Eneste forskjell: placeholder (`"-"` for 5; em-dash `"—"` for results/profile — bevart via param).

**Bevisst utenfor scope** (andre dato-former → senere skiver): `dateStyle` long (certificate), medium-only (profile.formatDate), `toLocaleDateString` numerisk (courses/library), og admin-content.js sin NaN-guard-variant.

## Test
- Unit (3 nye): formatering m/ lazy locale, placeholder (default + em-dash), catch→String-fallback.
- `tsc` rent. **Full e2e-suite: 54 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)