### PR TITLE
docs(epic): Feature Surface Map (#597)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,9 +83,11 @@ These rules exist because their violation caused or worsened the May 2026 produc
   Not "done" until the e2e passes locally + in CI.
 - **Map the full UI surface before building/fixing (standing order):** most of our deploy→bug→deploy
   churn is *"correct fix, incomplete surface"* — fixing the one path in the screenshot while sibling
-  paths break next. Before coding a UI feature/fix: (1) `grep` the feature/i18n label across **all**
-  pages and enumerate every entry point + surface (e.g. module creation has two entries; a
-  certificate shows in three places), fixing them in the same PR; (2) write the e2e for the
+  paths break next. Before coding a UI feature/fix: (1) **check `doc/FEATURE_SURFACE_MAP.md`** (a
+  catalogue of the known distributed behaviours with every surface + guard test) — change all listed
+  surfaces in the same PR; if the behaviour isn't there, `grep` the feature/i18n label across **all**
+  pages, enumerate every entry point + surface (e.g. module creation has two entries; a certificate
+  shows in three places), fix them in the same PR, and **add the entry to the map**; (2) write the e2e for the
   **documented/recommended user journey**, not the code path you built; (3) for "move/reorder a step"
   changes, grep where else that sequence occurs; (4) for conditional visibility use
   `setHidden(el, on)` (`public/static/dom-visibility.js`) / inline `style.display` — **never** the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,8 +127,11 @@ the fix landed in the one code path in the screenshot, while sibling paths produ
 1. **Enumerate every entry point and every surface before coding.** A behaviour usually appears in
    more than one place. Module creation has **two** entries (the library "create module" dialog
    `#348` → conversation regen, AND the conversation idle "new module"); a course certificate shows
-   in **three** places (result banner, `/participant/completed`, `/profile`). `grep` the feature
-   name / i18n label across **all** pages first, list the paths, and fix them in the same PR.
+   in **three** places (result banner, `/participant/completed`, `/profile`). **First check
+   `doc/FEATURE_SURFACE_MAP.md`** — it catalogues the known distributed behaviours with every
+   surface + guard test. If the behaviour is there, change all listed surfaces in the same PR; if
+   not, `grep` the feature name / i18n label across **all** pages, fix them together, and **add the
+   entry to the map**.
 2. **E2e must follow the documented/recommended user journey — not the code path you happened to
    build.** A green e2e that exercises the convenient path gives false confidence when users take a
    different one. (We shipped a module-type step into a flow users don't use; the e2e passed.)

--- a/doc/FEATURE_SURFACE_MAP.md
+++ b/doc/FEATURE_SURFACE_MAP.md
@@ -1,0 +1,129 @@
+# Feature Surface Map
+
+> **Purpose.** A living lookup of the user-facing behaviours that live in **more than one place**.
+> Most of our deploy→bug→deploy churn is *"correct fix, incomplete surface"*: a fix lands in the
+> one path in the screenshot while a sibling path breaks next (retrospective: 6 bugs / 5 deploys,
+> v1.3.37→1.3.42; the #479 file-size limit that lived in 4 places; the 429 cascade across the LLM
+> pipeline). This map is the antidote to grepping from scratch every time.
+>
+> **How to use.** Before building or fixing any behaviour below, open this entry, change **every**
+> listed surface in the same PR, and make the listed guard test(s) green. If the behaviour isn't
+> here yet, `grep` the feature/i18n label across all of `public/` + `src/`, list the surfaces, fix
+> them together, and **add the entry**.
+>
+> **How it stays honest.** Each entry names its **guard test(s)**. When a guard test breaks, the
+> map is telling you a surface moved — update both. Don't add line numbers that will rot; name
+> files + functions + tests (stable) and only pin a line when it genuinely helps.
+>
+> Maintained as part of EPIC #595. Informed by the architecture review `doc/design/FRONTEND_ARCHITECTURE_REVIEW_598.md`.
+
+---
+
+## 1. Source-material upload size limit (#479)
+
+A single "max upload size" value lived in **four** places; raising it in three and missing one
+shipped a 2.6 MB file rejected with a "10 MB" message, then a 5.6 MB file 413'd by the parser.
+
+| Surface | Where | Notes |
+|---------|-------|-------|
+| File cap (source of truth) | `src/modules/adminContent/sourceMaterialExtractionService.ts` → `SOURCE_MATERIAL_MAX_BYTES` | 10 MB |
+| Upload-body limit (derived) | same file → `SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES` | base64 ×4/3 + headroom; consumed by both servers |
+| Main app body parser | `src/app.ts` (`/api/admin/content/source-material/extract`) | uses the derived constant |
+| Parser-worker body parser | `src/parserApp.ts` | **separate service** — easy to miss; uses the derived constant |
+| Client guard | `public/static/admin-content-shell.js` → `SOURCE_MATERIAL_MAX_BYTES` | comment binds it to the server constant |
+| UI text | `public/i18n/admin-content-translations.js` → `shell.source.fileTooLarge` (×3 locales) | must match the cap |
+
+**Guards:** `test/unit/source-material-extraction-service.test.ts` (sync-guard: body limit ≥ max-file base64); `test/e2e/admin-content-workspaces.spec.ts` "accepts a file between 2 and 10 MB".
+
+## 2. Source-material ingest entry points (#454 / #479)
+
+The "source" step in the conversational shell has several ways to add material — a fix to one
+(e.g. the size guard, a chip label) usually applies to all.
+
+- **Upload file**, **Fetch from URL**, **Crawl site**, **External-LLM handoff**, and the **notes** textarea — all in `public/static/admin-content-shell.js` (the source-step render + `fetchedUrlSources`/`uploadedFileSources` + `refreshUploadHint`).
+- Endpoints: `POST /source-material/extract` (+ `/extract/:jobId` poll), `/fetch-url`, `/crawl-url`, `/condense` in `src/routes/adminContent.ts`.
+
+**Guards (e2e, `test/e2e/admin-content-workspaces.spec.ts`):** "fetches a single URL…", "can crawl a site…", "accepts a file between 2 and 10 MB". User doc: `doc/SOURCE_MATERIAL_INGEST_GUIDE.md`.
+
+## 3. Module creation — two entry points (#348)
+
+Creating a module is reachable from **two** places; a flow/step change must cover both.
+
+- **Library "create module" dialog** — `public/static/admin-content-library.js` (`createModuleBtn`, `emptyCreateBtn`, `createModuleDialog`, `openCreateDialog`).
+- **Conversation idle "new module"** — `public/static/admin-content-shell.js` (and the regen flow, #579).
+
+**Guards:** `test/e2e/admin-content-module-library.spec.ts` (library dialog → POST → conversation route); `test/e2e/admin-content-workspaces.spec.ts` "shell can create a new module…".
+
+## 4. Module-type (assessment mode) selection — 3-way (#525/#578)
+
+`FREETEXT_PLUS_MCQ` / `MCQ_ONLY` / `FREETEXT_ONLY` is chosen in **three** surfaces:
+
+- Conversation new-module step and conversation **regen** step — `public/static/admin-content-shell.js`.
+- Advanced editor radio fieldset — `public/admin-content.js` + `public/admin-content-advanced.html`.
+
+**Guards (`test/e2e/admin-content-workspaces.spec.ts`):** "authors a FREETEXT_ONLY module version", "authors an MCQ-only module version", "shell regen flow can switch the module to …".
+
+## 5. Result score-row display per mode (#591)
+
+`renderResultSummary` (`public/participant.js`) shows/hides score rows by mode — each branch is a surface:
+
+- `MCQ_ONLY` → hide practical row · `FREETEXT_ONLY` → hide MCQ row · `FREETEXT_PLUS_MCQ` → show both.
+
+**Guards (`test/e2e/participant-mcq-only.spec.ts`):** the triad — "MCQ-only result … not practical", "FREETEXT_ONLY result hides the MCQ score row", "FREETEXT_PLUS_MCQ result shows both …".
+
+## 6. Course certificate display — multiple places (#550)
+
+A completed-course certificate surfaces in several views; a rendering change must hit all:
+
+- Participant result banner + `/participant` (`public/participant.js`), `/participant/completed` (`public/participant-completed.js`), `/profile` (`public/profile.js`), and the printable `/certificate` view (`public/certificate.js`).
+
+**Guards:** `test/e2e/participant-certificate.spec.ts`, `test/e2e/profile-certificate-link.spec.ts`.
+
+## 7. Conditional visibility — the `.hidden` cascade trap
+
+`.hidden` (`display:none` without `!important`) loses the cascade to `display`-setting classes
+(`.row`/`.card`/`.content-card`/`.module-brief`/grid…), so the element never hides. Use
+`setHidden(el, on)` / inline `style.display`.
+
+- Helper: `public/static/dom-visibility.js` (`setHidden`).
+- Recurring offenders: any `.row`/`.card`/grid element toggled conditionally (e.g. `#selectedModuleBrief`, `#mcqSection`).
+
+**Guard pattern:** assert the element is actually hidden (`toBeHidden()`) in the e2e, not just that a class was toggled.
+
+## 8. Locale resolution + per-page `currentLocale`
+
+Initial-locale resolution is now **single-source** (`public/static/i18n-locale.js` → `resolveInitialLocale(supportedLocales)`), but each page still owns a mutable `currentLocale` that the display formatters read lazily. A locale-handling change touches the shared resolver + each page's `setLocale`/re-render.
+
+**Guard:** `test/unit/i18n-locale.test.js`.
+
+## 9. Shared display primitives — single source of truth (#596, EPIC #595)
+
+These were each duplicated across many page scripts and are now one module + unit test. **Use the
+import; do not re-add a local copy.**
+
+| Primitive | Module | Was duplicated in |
+|-----------|--------|-------------------|
+| `escapeHtml` | `public/static/html-escape.js` | 6 files (slice 1) |
+| `formatNumber` | `public/static/format-display.js` (`createNumberFormatter`) | 7 files (slice 2) |
+| `resolveInitialLocale` | `public/static/i18n-locale.js` | 9 files (slice 3) |
+| `formatDateTime` | `public/static/format-display.js` (`createDateTimeFormatter`) | 7 files (slice 4) |
+
+**Guards:** `test/unit/html-escape.test.js`, `test/unit/format-display.test.js`, `test/unit/i18n-locale.test.js`.
+
+### Still duplicated (future #596 slices — do NOT fix one copy in isolation)
+- **`escapeHtml` divergent variants** — `admin-content-preview.js`/`admin-content-shell.js`/`static/loading.js` (`String(x)` without `?? ""`), `static/admin-content-sections.js` (also escapes `'`). Behaviour differs → each needs a decision, not a blind merge.
+- **`renderWorkspaceNavigation` — ×14 files.** Biggest single duplication; DOM/state-coupled (needs `workspaceNav`, config, roles, `t`). Needs characterization e2e first, then careful extraction.
+- **Date variants** not in slice 4: `dateStyle:"long"` (certificate), medium-only (`profile.formatDate`), `toLocaleDateString` numeric (courses/library), and `admin-content.js`'s NaN-guard `formatDateTimeValue`.
+
+## 10. Assessment LLM pipeline — 429/oversize chain (#479)
+
+The authoring pipeline fans into several large Azure OpenAI calls that share one tokens-per-minute
+quota; one un-retried/oversize call cascades.
+
+- Single call + retry/backoff: `src/modules/adminContent/llmContentGenerationService.ts` (`callLlm`, `parseRetryAfterMs`, `computeLlmBackoffMs`).
+- Oversize input handling: `condenseSourceMaterial` chunks via `splitIntoChunks`.
+- Pipeline order (each a call): condense → blueprint → draft → MCQ.
+- **Sibling not yet fixed:** the assessment-side LLM client `src/modules/assessment/llmAssessmentService.ts` lacks the same retry (tracked in #603).
+- Deployment TPM capacity is **not** in IaC (#607); current capacity recorded there.
+
+**Guards:** `test/unit/llm-retry.test.ts` (retry + chunked condense), `test/unit/llm-content-generation-service.test.ts` (backoff helpers + `splitIntoChunks`).


### PR DESCRIPTION
EPIC #595, child #597. **Closes #597.**

Nytt `doc/FEATURE_SURFACE_MAP.md` — et levende oppslagsverk over brukervendte oppførsler som bor på **flere flater**, så «riktig fiks, ufullstendig flate»-bugger unngås. 10 seedede oppføringer fra de reelle buggene/flatene denne arc-en:
1. Ingest-størrelsesgrense (4 flater + delt konstant) · 2. Ingest-innganger · 3. Modul-opprettelse (2 innganger, #348) · 4. Modultype-velger (3 flater) · 5. Skåre-rad-visning (triade) · 6. Kursbevis (flere visninger) · 7. `.hidden`-fellen → `setHidden` · 8. Locale-resolusjon · 9. Delte display-primitiver (single-source) + **gjenværende duplisering** (`renderWorkspaceNavigation` ×14, escapeHtml/dato-varianter) · 10. 429/oversize-LLM-kjeden.

Hver oppføring navngir **vokter-test(er)** — når en guard ryker, har en flate flyttet seg. Alle siterte guards er verifisert å eksistere.

CLAUDE.md + AGENTS.md «kartlegg flaten»-ordren peker nå til kartet som første oppslag (et av #597s akseptkriterier).

Doc-only, ingen version-bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)