### PR TITLE
refactor(frontend): konsolider renderWorkspaceNavigation (v1.3.60, #596 skive 5)

### DIFF
--- a/doc/FEATURE_SURFACE_MAP.md
+++ b/doc/FEATURE_SURFACE_MAP.md
@@ -107,12 +107,12 @@ import; do not re-add a local copy.**
 | `formatNumber` | `public/static/format-display.js` (`createNumberFormatter`) | 7 files (slice 2) |
 | `resolveInitialLocale` | `public/static/i18n-locale.js` | 9 files (slice 3) |
 | `formatDateTime` | `public/static/format-display.js` (`createDateTimeFormatter`) | 7 files (slice 4) |
+| `renderWorkspaceNavigation` | `public/static/workspace-nav.js` (`renderWorkspaceNavigationWithProfile`) | 13 page scripts (slice 5) — all now thin wrappers |
 
-**Guards:** `test/unit/html-escape.test.js`, `test/unit/format-display.test.js`, `test/unit/i18n-locale.test.js`.
+**Guards:** `test/unit/html-escape.test.js`, `test/unit/format-display.test.js`, `test/unit/i18n-locale.test.js`. Nav rendering exercised across e2e page loads. **Rule:** never re-add a local `renderWorkspaceNavigation` body — call the shared helper; pass `localePicker: null` on pages that intentionally omit the profile link (e.g. `profile.js`).
 
 ### Still duplicated (future #596 slices — do NOT fix one copy in isolation)
 - **`escapeHtml` divergent variants** — `admin-content-preview.js`/`admin-content-shell.js`/`static/loading.js` (`String(x)` without `?? ""`), `static/admin-content-sections.js` (also escapes `'`). Behaviour differs → each needs a decision, not a blind merge.
-- **`renderWorkspaceNavigation` — ×14 files.** Biggest single duplication; DOM/state-coupled (needs `workspaceNav`, config, roles, `t`). Needs characterization e2e first, then careful extraction.
 - **Date variants** not in slice 4: `dateStyle:"long"` (certificate), medium-only (`profile.formatDate`), `toLocaleDateString` numeric (courses/library), and `admin-content.js`'s NaN-guard `formatDateTimeValue`.
 
 ## 10. Assessment LLM pipeline — 429/oversize chain (#479)

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,22 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.60 - 2026-06-22
+
+refactor(frontend): konsolider renderWorkspaceNavigation — #596 skive 5 (EPIC #595)
+
+Den største enkelt-dupliseringen fra arkitektur-gjennomgangen (#611): `renderWorkspaceNavigation` lå
+i 14 filer. En delt `renderWorkspaceNavigationWithProfile` fantes allerede i
+`public/static/workspace-nav.js`, men kun 6 filer brukte den. De resterende **7** (`participant.js`,
+`participant-completed.js`, `profile.js`, `calibration.js`, `results.js`, `review.js`,
+`admin-platform.js`) hadde egne fulle implementasjoner — nå erstattet av tynne wrappere som kaller
+den delte funksjonen. Alle 13 sider deler nå én implementasjon.
+
+No-op: de lokale versjonene satte inline `.locale-picker`-styling (display:flex/align/gap) som
+allerede ligger i `shared.css` (redundant). `profile.js` utelot bevisst profil-lenken → migrert med
+`localePicker: null` (samme oppførsel). Den delte funksjonen legger i tillegg til `aria-current` på
+profil-lenken og rydder en foreldet lenke — rene a11y-forbedringer. Surface-map §9 oppdatert.
+
 ## 1.3.59 - 2026-06-22
 
 refactor(frontend): single source of truth for date-time formatting — #596 skive 4 (EPIC #595)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.59",
+  "version": "1.3.60",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-platform.js
+++ b/public/admin-platform.js
@@ -1,3 +1,4 @@
+import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
 import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { localeLabels, supportedLocales, translations } from "/static/i18n/admin-platform-translations.js";
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, fetchQueueCounts, applyNavReviewBadge } from "/static/api-client.js";
@@ -115,43 +116,20 @@ function renderRolePresetControl() {
 }
 
 function renderWorkspaceNavigation() {
-  if (!workspaceNav) return;
-
-  const allItems = resolveWorkspaceNavigationItems(
+  if (!workspaceNav) {
+    return;
+  }
+  const items = resolveWorkspaceNavigationItems(
     participantRuntimeConfig?.navigation?.items,
     rolesInput.value,
     window.location.pathname,
-  ).filter((item) => item.visible);
-
-  const profileItem = allItems.find((item) => item.id === "profile");
-  const items = allItems.filter((item) => item.id !== "profile");
-
-  const localePicker = document.querySelector(".locale-picker");
-  if (localePicker && profileItem) {
-    localePicker.style.display = "flex";
-    localePicker.style.alignItems = "center";
-    localePicker.style.gap = "8px";
-    let profileLink = document.getElementById("profileNavLink");
-    if (!profileLink) {
-      profileLink = document.createElement("a");
-      profileLink.id = "profileNavLink";
-      localePicker.appendChild(profileLink);
-    }
-    profileLink.href = profileItem.path;
-    profileLink.textContent = t(profileItem.labelKey);
-    profileLink.className = profileItem.active ? "workspace-nav-link active" : "workspace-nav-link";
-  }
-
-  workspaceNav.innerHTML = "";
-  workspaceNav.hidden = items.length === 0;
-  for (const item of items) {
-    const link = document.createElement("a");
-    link.href = item.path;
-    link.className = item.active ? "workspace-nav-link active" : "workspace-nav-link";
-    link.textContent = t(item.labelKey);
-    if (item.active) link.setAttribute("aria-current", "page");
-    workspaceNav.appendChild(link);
-  }
+  );
+  renderWorkspaceNavigationWithProfile({
+    workspaceNav,
+    localePicker: document.querySelector(".locale-picker"),
+    items,
+    buildLabel: (item) => t(item.labelKey),
+  });
 }
 
 // ── Headers ───────────────────────────────────────────────────────────────────

--- a/public/calibration.js
+++ b/public/calibration.js
@@ -1,3 +1,4 @@
+import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
 import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { createNumberFormatter, createDateTimeFormatter } from "/static/format-display.js";
 const formatDateTime = createDateTimeFormatter(() => currentLocale);
@@ -243,48 +244,17 @@ function renderWorkspaceNavigation() {
   if (!workspaceNav) {
     return;
   }
-
-  const allItems = resolveWorkspaceNavigationItems(
+  const items = resolveWorkspaceNavigationItems(
     participantRuntimeConfig?.navigation?.items,
     rolesInput.value,
     window.location.pathname,
-  ).filter((item) => item.visible);
-
-  const profileItem = allItems.find((item) => item.id === "profile");
-  const items = allItems.filter((item) => item.id !== "profile");
-
-  const localePicker = document.querySelector(".locale-picker");
-  if (localePicker && profileItem) {
-    localePicker.style.display = "flex";
-    localePicker.style.alignItems = "center";
-    localePicker.style.gap = "8px";
-    let profileLink = document.getElementById("profileNavLink");
-    if (!profileLink) {
-      profileLink = document.createElement("a");
-      profileLink.id = "profileNavLink";
-      localePicker.appendChild(profileLink);
-    }
-    profileLink.href = profileItem.path;
-    profileLink.textContent = t(profileItem.labelKey);
-    profileLink.className = profileItem.active ? "workspace-nav-link active" : "workspace-nav-link";
-  }
-
-  workspaceNav.innerHTML = "";
-  workspaceNav.hidden = items.length === 0;
-  if (items.length === 0) {
-    return;
-  }
-
-  for (const item of items) {
-    const link = document.createElement("a");
-    link.href = item.path;
-    link.className = item.active ? "workspace-nav-link active" : "workspace-nav-link";
-    link.textContent = t(item.labelKey);
-    if (item.active) {
-      link.setAttribute("aria-current", "page");
-    }
-    workspaceNav.appendChild(link);
-  }
+  );
+  renderWorkspaceNavigationWithProfile({
+    workspaceNav,
+    localePicker: document.querySelector(".locale-picker"),
+    items,
+    buildLabel: (item) => t(item.labelKey),
+  });
 }
 
 function getCheckedPillValues(container) {

--- a/public/participant-completed.js
+++ b/public/participant-completed.js
@@ -1,3 +1,4 @@
+import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
 import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { createNumberFormatter, createDateTimeFormatter } from "/static/format-display.js";
 const formatDateTime = createDateTimeFormatter(() => currentLocale);
@@ -211,48 +212,17 @@ function renderWorkspaceNavigation() {
   if (!workspaceNav) {
     return;
   }
-
-  const allItems = resolveWorkspaceNavigationItems(
+  const items = resolveWorkspaceNavigationItems(
     participantRuntimeConfig?.navigation?.items,
     rolesInput.value,
     window.location.pathname,
-  ).filter((item) => item.visible);
-
-  const profileItem = allItems.find((item) => item.id === "profile");
-  const items = allItems.filter((item) => item.id !== "profile");
-
-  const localePicker = document.querySelector(".locale-picker");
-  if (localePicker && profileItem) {
-    localePicker.style.display = "flex";
-    localePicker.style.alignItems = "center";
-    localePicker.style.gap = "8px";
-    let profileLink = document.getElementById("profileNavLink");
-    if (!profileLink) {
-      profileLink = document.createElement("a");
-      profileLink.id = "profileNavLink";
-      localePicker.appendChild(profileLink);
-    }
-    profileLink.href = profileItem.path;
-    profileLink.textContent = t(profileItem.labelKey);
-    profileLink.className = profileItem.active ? "workspace-nav-link active" : "workspace-nav-link";
-  }
-
-  workspaceNav.innerHTML = "";
-  workspaceNav.hidden = items.length === 0;
-  if (items.length === 0) {
-    return;
-  }
-
-  for (const item of items) {
-    const link = document.createElement("a");
-    link.href = item.path;
-    link.className = item.active ? "workspace-nav-link active" : "workspace-nav-link";
-    link.textContent = t(item.labelKey);
-    if (item.active) {
-      link.setAttribute("aria-current", "page");
-    }
-    workspaceNav.appendChild(link);
-  }
+  );
+  renderWorkspaceNavigationWithProfile({
+    workspaceNav,
+    localePicker: document.querySelector(".locale-picker"),
+    items,
+    buildLabel: (item) => t(item.labelKey),
+  });
 }
 
 function renderCompletedModules(body) {

--- a/public/participant.js
+++ b/public/participant.js
@@ -1,3 +1,4 @@
+import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
 import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { createNumberFormatter, createDateTimeFormatter } from "/static/format-display.js";
 const formatDateTime = createDateTimeFormatter(() => currentLocale);
@@ -1495,48 +1496,17 @@ function renderWorkspaceNavigation() {
   if (!workspaceNav) {
     return;
   }
-
-  const allItems = resolveWorkspaceNavigationItems(
+  const items = resolveWorkspaceNavigationItems(
     participantRuntimeConfig?.navigation?.items,
     rolesInput.value,
     window.location.pathname,
-  ).filter((item) => item.visible);
-
-  const profileItem = allItems.find((item) => item.id === "profile");
-  const items = allItems.filter((item) => item.id !== "profile");
-
-  const localePicker = document.querySelector(".locale-picker");
-  if (localePicker && profileItem) {
-    localePicker.style.display = "flex";
-    localePicker.style.alignItems = "center";
-    localePicker.style.gap = "8px";
-    let profileLink = document.getElementById("profileNavLink");
-    if (!profileLink) {
-      profileLink = document.createElement("a");
-      profileLink.id = "profileNavLink";
-      localePicker.appendChild(profileLink);
-    }
-    profileLink.href = profileItem.path;
-    profileLink.textContent = t(profileItem.labelKey);
-    profileLink.className = profileItem.active ? "workspace-nav-link active" : "workspace-nav-link";
-  }
-
-  workspaceNav.innerHTML = "";
-  workspaceNav.hidden = items.length === 0;
-  if (items.length === 0) {
-    return;
-  }
-
-  for (const item of items) {
-    const link = document.createElement("a");
-    link.href = item.path;
-    link.className = item.active ? "workspace-nav-link active" : "workspace-nav-link";
-    link.textContent = t(item.labelKey);
-    if (item.active) {
-      link.setAttribute("aria-current", "page");
-    }
-    workspaceNav.appendChild(link);
-  }
+  );
+  renderWorkspaceNavigationWithProfile({
+    workspaceNav,
+    localePicker: document.querySelector(".locale-picker"),
+    items,
+    buildLabel: (item) => t(item.labelKey),
+  });
 }
 
 async function loadParticipantConsoleConfig() {

--- a/public/profile.js
+++ b/public/profile.js
@@ -1,3 +1,4 @@
+import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
 import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { createNumberFormatter, createDateTimeFormatter } from "/static/format-display.js";
 const formatDateTime = createDateTimeFormatter(() => currentLocale, "—");
@@ -130,23 +131,20 @@ function renderRolePresetControl() {
 }
 
 function renderWorkspaceNavigation() {
-  if (!workspaceNav) return;
+  if (!workspaceNav) {
+    return;
+  }
   const items = resolveWorkspaceNavigationItems(
     participantRuntimeConfig?.navigation?.items,
     rolesInput.value,
     window.location.pathname,
-  ).filter((item) => item.visible && item.id !== "profile");
-
-  workspaceNav.innerHTML = "";
-  workspaceNav.hidden = items.length === 0;
-  for (const item of items) {
-    const link = document.createElement("a");
-    link.href = item.path;
-    link.className = item.active ? "workspace-nav-link active" : "workspace-nav-link";
-    link.textContent = t(item.labelKey);
-    if (item.active) link.setAttribute("aria-current", "page");
-    workspaceNav.appendChild(link);
-  }
+  );
+  renderWorkspaceNavigationWithProfile({
+    workspaceNav,
+    localePicker: null,
+    items,
+    buildLabel: (item) => t(item.labelKey),
+  });
 }
 
 // ── Headers ───────────────────────────────────────────────────────────────────

--- a/public/results.js
+++ b/public/results.js
@@ -1,3 +1,4 @@
+import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
 import { createDateTimeFormatter } from "/static/format-display.js";
 const formatDateTime = createDateTimeFormatter(() => currentLocale, "—");
 import { resolveInitialLocale } from "/static/i18n-locale.js";
@@ -372,42 +373,20 @@ function renderRolePresetControl() {
 }
 
 function renderWorkspaceNavigation() {
-  if (!workspaceNav) return;
-  const allItems = resolveWorkspaceNavigationItems(
+  if (!workspaceNav) {
+    return;
+  }
+  const items = resolveWorkspaceNavigationItems(
     participantRuntimeConfig?.navigation?.items,
     rolesInput.value,
     window.location.pathname,
-  ).filter((item) => item.visible);
-
-  const profileItem = allItems.find((item) => item.id === "profile");
-  const items = allItems.filter((item) => item.id !== "profile");
-
-  const localePicker = document.querySelector(".locale-picker");
-  if (localePicker && profileItem) {
-    localePicker.style.display = "flex";
-    localePicker.style.alignItems = "center";
-    localePicker.style.gap = "8px";
-    let profileLink = document.getElementById("profileNavLink");
-    if (!profileLink) {
-      profileLink = document.createElement("a");
-      profileLink.id = "profileNavLink";
-      localePicker.appendChild(profileLink);
-    }
-    profileLink.href = profileItem.path;
-    profileLink.textContent = t(profileItem.labelKey);
-    profileLink.className = profileItem.active ? "workspace-nav-link active" : "workspace-nav-link";
-  }
-
-  workspaceNav.innerHTML = "";
-  workspaceNav.hidden = items.length === 0;
-  for (const item of items) {
-    const link = document.createElement("a");
-    link.href = item.path;
-    link.className = item.active ? "workspace-nav-link active" : "workspace-nav-link";
-    link.textContent = t(item.labelKey);
-    if (item.active) link.setAttribute("aria-current", "page");
-    workspaceNav.appendChild(link);
-  }
+  );
+  renderWorkspaceNavigationWithProfile({
+    workspaceNav,
+    localePicker: document.querySelector(".locale-picker"),
+    items,
+    buildLabel: (item) => t(item.labelKey),
+  });
 }
 
 function applyIdentityDefaults() {

--- a/public/review.js
+++ b/public/review.js
@@ -1,3 +1,4 @@
+import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
 import { resolveInitialLocale } from "/static/i18n-locale.js";
 import { createNumberFormatter, createDateTimeFormatter } from "/static/format-display.js";
 const formatDateTime = createDateTimeFormatter(() => currentLocale);
@@ -377,43 +378,20 @@ function renderRolePresetControl() {
 }
 
 function renderWorkspaceNavigation() {
-  if (!workspaceNav) return;
-
-  const allItems = resolveWorkspaceNavigationItems(
+  if (!workspaceNav) {
+    return;
+  }
+  const items = resolveWorkspaceNavigationItems(
     participantRuntimeConfig?.navigation?.items,
     rolesInput.value,
     window.location.pathname,
-  ).filter((item) => item.visible);
-
-  const profileItem = allItems.find((item) => item.id === "profile");
-  const items = allItems.filter((item) => item.id !== "profile");
-
-  const localePicker = document.querySelector(".locale-picker");
-  if (localePicker && profileItem) {
-    localePicker.style.display = "flex";
-    localePicker.style.alignItems = "center";
-    localePicker.style.gap = "8px";
-    let profileLink = document.getElementById("profileNavLink");
-    if (!profileLink) {
-      profileLink = document.createElement("a");
-      profileLink.id = "profileNavLink";
-      localePicker.appendChild(profileLink);
-    }
-    profileLink.href = profileItem.path;
-    profileLink.textContent = t(profileItem.labelKey);
-    profileLink.className = profileItem.active ? "workspace-nav-link active" : "workspace-nav-link";
-  }
-
-  workspaceNav.innerHTML = "";
-  workspaceNav.hidden = items.length === 0;
-  for (const item of items) {
-    const link = document.createElement("a");
-    link.href = item.path;
-    link.className = item.active ? "workspace-nav-link active" : "workspace-nav-link";
-    link.textContent = t(item.labelKey);
-    if (item.active) link.setAttribute("aria-current", "page");
-    workspaceNav.appendChild(link);
-  }
+  );
+  renderWorkspaceNavigationWithProfile({
+    workspaceNav,
+    localePicker: document.querySelector(".locale-picker"),
+    items,
+    buildLabel: (item) => t(item.labelKey),
+  });
 }
 
 function countActionableItems(items, statusKey) {


### PR DESCRIPTION
Femte skive — den **største** enkelt-dupliseringen fra arkitektur-gjennomgangen (#611): `renderWorkspaceNavigation` i 14 filer.

## Hva
En delt `renderWorkspaceNavigationWithProfile` fantes allerede i `public/static/workspace-nav.js`, men kun **6** filer brukte den. De resterende **7** (`participant.js`, `participant-completed.js`, `profile.js`, `calibration.js`, `results.js`, `review.js`, `admin-platform.js`) hadde egne fulle implementasjoner — nå erstattet av tynne wrappere. **Alle 13 sider deler nå én implementasjon.**

## No-op — bevist
- De lokale versjonene satte inline `.locale-picker`-styling (`display:flex; align-items:center; gap:8px`) som **allerede ligger i `shared.css`** (alle 7 sider laster den) → redundant, trygt å droppe.
- `profile.js` utelot bevisst profil-lenken → migrert med `localePicker: null` (den delte fn hopper da over profil-lenke-blokken) = samme oppførsel.
- Den delte fn legger i tillegg til `aria-current` på profil-lenken og rydder en foreldet lenke — rene a11y-forbedringer.

## Test
- `tsc` rent. **Full e2e-suite: 54 passed** (nav rendres ved sidelast på alle disse sidene).
- Surface-map §9 oppdatert (renderWorkspaceNavigation flyttet fra «gjenstår» til konsolidert, med regel om `localePicker: null`).

## Gjenstår i #596 (mindre, dokumentert i kartet)
Divergerende `escapeHtml`-varianter (preview/shell/loading + sections) og dato-varianter (long/numeric/NaN-guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)