### PR TITLE
refactor(frontend): siste #596-rester — escapeHtml-varianter + kort-dato (v1.3.61)

### DIFF
--- a/doc/FEATURE_SURFACE_MAP.md
+++ b/doc/FEATURE_SURFACE_MAP.md
@@ -111,9 +111,17 @@ import; do not re-add a local copy.**
 
 **Guards:** `test/unit/html-escape.test.js`, `test/unit/format-display.test.js`, `test/unit/i18n-locale.test.js`. Nav rendering exercised across e2e page loads. **Rule:** never re-add a local `renderWorkspaceNavigation` body — call the shared helper; pass `localePicker: null` on pages that intentionally omit the profile link (e.g. `profile.js`).
 
-### Still duplicated (future #596 slices — do NOT fix one copy in isolation)
-- **`escapeHtml` divergent variants** — `admin-content-preview.js`/`admin-content-shell.js`/`static/loading.js` (`String(x)` without `?? ""`), `static/admin-content-sections.js` (also escapes `'`). Behaviour differs → each needs a decision, not a blind merge.
-- **Date variants** not in slice 4: `dateStyle:"long"` (certificate), medium-only (`profile.formatDate`), `toLocaleDateString` numeric (courses/library), and `admin-content.js`'s NaN-guard `formatDateTimeValue`.
+### Intentionally distinct (NOT duplicates — do not force-merge)
+`#596` consolidation is complete. The following look similar but are genuinely different and stay
+separate:
+- **`escapeHtml` in `static/admin-content-sections.js`** also escapes `'` (`&#39;`) for
+  attribute-context safety — a real superset, not a copy of the text-escape canonical.
+- **Single-of-a-kind date formatters:** `certificate.js` (`dateStyle:"long"`), `profile.js`
+  `formatDate` (`dateStyle:"medium"`), `admin-content.js` `formatDateTimeValue` (NaN-guard form).
+  Distinct formats, not duplication.
+
+The 3 `String(x)` `escapeHtml` variants (preview/shell/loading) and the 2 identical numeric
+`formatDate` copies (courses/library) were consolidated in slice 6 (v1.3.61).
 
 ## 10. Assessment LLM pipeline — 429/oversize chain (#479)
 

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,26 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.61 - 2026-06-22
+
+refactor(frontend): siste #596-rester — escapeHtml-varianter + kort-dato (EPIC #595)
+
+Avslutter #596-dedupliseringen.
+
+- **escapeHtml (divergerende):** `static/admin-content-preview.js`, `static/admin-content-shell.js`,
+  `static/loading.js` brukte `String(x)` uten `?? ""`. Nå importert fra `html-escape.js` (kanonisk).
+  Eneste atferdsendring: null/undefined → `""` i stedet for `"null"`/`"undefined"` (latent bugfix).
+  `static/admin-content-sections.js` lar vi stå — den escaper også `'` (attributt-kontekst-sikkerhet),
+  som er en legitim forskjell, ikke et duplikat.
+- **Kort-dato:** ny `createDateFormatter` i `format-display.js`; de **2 identiske** `formatDate`-kopiene
+  (`static/admin-content-courses.js`, `static/admin-content-library.js`, `toLocaleDateString` numerisk)
+  bruker den nå. (Ternæren `currentLocale === "en-GB" ? "en-GB" : currentLocale` var == `currentLocale`.)
+  Én-av-sitt-slag-formaterne (certificate `dateStyle:"long"`, profile.formatDate `medium`,
+  admin-content NaN-guard) er distinkte formater, ikke duplikater — bevisst latt stå.
+
+**#596 ferdig:** ~40 dupliserte kopier eliminert på tvers av 6 skiver (1.3.56–1.3.61), hver bak én
+testet kilde-til-sannhet. Surface-map oppdatert.
+
 ## 1.3.60 - 2026-06-22
 
 refactor(frontend): konsolider renderWorkspaceNavigation — #596 skive 5 (EPIC #595)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.60",
+  "version": "1.3.61",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-calibration.js
+++ b/public/static/admin-content-calibration.js
@@ -1,4 +1,4 @@
-import { createNumberFormatter, createDateTimeFormatter } from "/static/format-display.js";
+import { createNumberFormatter, createDateTimeFormatter } from "./format-display.js";
 const formatDateTimeValue = createDateTimeFormatter(() => currentLocale);
 const formatNumber = createNumberFormatter(() => currentLocale);
 import {
@@ -19,7 +19,7 @@ import {
 } from "/static/participant-console-state.js";
 import { hideLoading, showEmpty, showLoading } from "/static/loading.js";
 import { showToast } from "/static/toast.js";
-import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
+import { renderWorkspaceNavigationWithProfile } from "./workspace-nav.js";
 
 // ---------------------------------------------------------------------------
 // i18n

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -1,3 +1,5 @@
+import { createDateFormatter } from "/static/format-display.js";
+const formatDate = createDateFormatter(() => currentLocale);
 import { escapeHtml } from "/static/html-escape.js";
 import {
   supportedLocales,
@@ -74,13 +76,6 @@ const deleteCancelBtn = document.getElementById("deleteCancelBtn");
 // ---------------------------------------------------------------------------
 
 
-function formatDate(iso) {
-  if (!iso) return "—";
-  return new Date(iso).toLocaleDateString(
-    currentLocale === "en-GB" ? "en-GB" : currentLocale,
-    { day: "numeric", month: "short", year: "numeric" },
-  );
-}
 
 function localizedText(value) {
   if (!value) return "";

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -1,6 +1,6 @@
-import { createDateFormatter } from "/static/format-display.js";
+import { createDateFormatter } from "./format-display.js";
 const formatDate = createDateFormatter(() => currentLocale);
-import { escapeHtml } from "/static/html-escape.js";
+import { escapeHtml } from "./html-escape.js";
 import {
   supportedLocales,
   localeLabels,
@@ -23,7 +23,7 @@ import {
   buildCourseDeleteDialogText,
   deriveCourseListRows,
 } from "/static/admin-content-courses-state.js";
-import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
+import { renderWorkspaceNavigationWithProfile } from "./workspace-nav.js";
 
 // ---------------------------------------------------------------------------
 // i18n

--- a/public/static/admin-content-library.js
+++ b/public/static/admin-content-library.js
@@ -1,3 +1,5 @@
+import { createDateFormatter } from "/static/format-display.js";
+const formatDate = createDateFormatter(() => currentLocale);
 import { escapeHtml } from "/static/html-escape.js";
 import {
   supportedLocales,
@@ -163,10 +165,6 @@ function certBadge(level) {
 }
 
 
-function formatDate(iso) {
-  if (!iso) return "—";
-  return new Date(iso).toLocaleDateString(currentLocale === "en-GB" ? "en-GB" : currentLocale, { day: "numeric", month: "short", year: "numeric" });
-}
 
 function resolveContentAdminDefaults() {
   const defaults = participantRuntimeConfig?.identityDefaults?.contentAdmin;

--- a/public/static/admin-content-library.js
+++ b/public/static/admin-content-library.js
@@ -1,6 +1,6 @@
-import { createDateFormatter } from "/static/format-display.js";
+import { createDateFormatter } from "./format-display.js";
 const formatDate = createDateFormatter(() => currentLocale);
-import { escapeHtml } from "/static/html-escape.js";
+import { escapeHtml } from "./html-escape.js";
 import {
   supportedLocales,
   localeLabels,
@@ -19,7 +19,7 @@ import {
   resolveWorkspaceNavigationItems,
 } from "/static/participant-console-state.js";
 import { showToast } from "/static/toast.js";
-import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
+import { renderWorkspaceNavigationWithProfile } from "./workspace-nav.js";
 
 // ---------------------------------------------------------------------------
 // i18n

--- a/public/static/admin-content-preview.js
+++ b/public/static/admin-content-preview.js
@@ -1,3 +1,4 @@
+import { escapeHtml } from "/static/html-escape.js";
 /**
  * admin-content-preview.js
  *
@@ -9,13 +10,6 @@
  *   buildPreviewHtml(data, opts)          → HTML string
  */
 
-function escapeHtml(str) {
-  return String(str)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
 
 /**
  * Resolve a potentially-localized field value to a plain string for the given locale.

--- a/public/static/admin-content-preview.js
+++ b/public/static/admin-content-preview.js
@@ -1,4 +1,4 @@
-import { escapeHtml } from "/static/html-escape.js";
+import { escapeHtml } from "./html-escape.js";
 /**
  * admin-content-preview.js
  *

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -6,7 +6,7 @@ import {
 import { apiFetch, buildConsoleHeaders, getConsoleConfig, hydrateContentAssetImages } from "/static/api-client.js";
 import { initConsentGuard } from "/static/consent-guard.js";
 import { resolveWorkspaceNavigationItems } from "/static/participant-console-state.js";
-import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
+import { renderWorkspaceNavigationWithProfile } from "./workspace-nav.js";
 import { showToast } from "/static/toast.js";
 
 // ---------------------------------------------------------------------------

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -1,4 +1,4 @@
-import { escapeHtml } from "/static/html-escape.js";
+import { escapeHtml } from "./html-escape.js";
 import {
   supportedLocales,
   localeLabels,
@@ -16,7 +16,7 @@ import {
   resolveWorkspaceNavigationItems,
 } from "/static/participant-console-state.js";
 import { showToast } from "/static/toast.js";
-import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
+import { renderWorkspaceNavigationWithProfile } from "./workspace-nav.js";
 import { writeHandoff, readAndClearHandoff } from "/static/admin-content-handoff.js";
 import { localizeValueForLocale, buildPreviewHtml } from "/static/admin-content-preview.js";
 import { hashBlueprintAsync, classifyDriftState } from "/static/admin-content-blueprint-hash.js";

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -1,3 +1,4 @@
+import { escapeHtml } from "/static/html-escape.js";
 import {
   supportedLocales,
   localeLabels,
@@ -210,13 +211,6 @@ const SOURCE_MATERIAL_ALLOWED_MIME_TYPES = new Set([
 // Chat rendering — low-level DOM helpers (no logging)
 // ---------------------------------------------------------------------------
 
-function escapeHtml(str) {
-  return String(str)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
 
 function htmlToPlainText(html) {
   const fragment = document.createElement("div");

--- a/public/static/format-display.js
+++ b/public/static/format-display.js
@@ -40,3 +40,22 @@ export function createDateTimeFormatter(getLocale, placeholder = "-") {
     }
   };
 }
+
+// #596 slice 6 — short numeric date (no time). Consolidates the two identical `formatDate` copies
+// in static/admin-content-courses.js and static/admin-content-library.js, which used
+// `toLocaleDateString(currentLocale, { day: "numeric", month: "short", year: "numeric" })` with the
+// em-dash placeholder. (The originals wrote `currentLocale === "en-GB" ? "en-GB" : currentLocale`,
+// which is just `currentLocale` — both ternary branches are equal — so `getLocale()` is identical.)
+// Single-of-a-kind date formatters elsewhere (certificate `dateStyle:"long"`, profile.formatDate
+// `dateStyle:"medium"`, admin-content's NaN-guard variant) are distinct formats, not duplicates,
+// and are intentionally left in place.
+export function createDateFormatter(getLocale, placeholder = "—") {
+  return function formatDate(iso) {
+    if (!iso) return placeholder;
+    return new Date(iso).toLocaleDateString(getLocale(), {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+  };
+}

--- a/public/static/loading.js
+++ b/public/static/loading.js
@@ -1,4 +1,4 @@
-import { escapeHtml } from "/static/html-escape.js";
+import { escapeHtml } from "./html-escape.js";
 
 function clearState(container) {
   container.classList.remove("loading-target", "empty-state");

--- a/public/static/loading.js
+++ b/public/static/loading.js
@@ -1,10 +1,4 @@
-function escapeHtml(value) {
-  return String(value)
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
-}
+import { escapeHtml } from "/static/html-escape.js";
 
 function clearState(container) {
   container.classList.remove("loading-target", "empty-state");

--- a/test/unit/format-display.test.js
+++ b/test/unit/format-display.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createNumberFormatter, createDateTimeFormatter } from "../../public/static/format-display.js";
+import { createNumberFormatter, createDateTimeFormatter, createDateFormatter } from "../../public/static/format-display.js";
 
 // #596 slice 2: pins the consolidated number formatter, including the lazy locale getter and the
 // configurable non-number placeholder (the one behaviour that differed across the 7 copies).
@@ -53,5 +53,19 @@ describe("createDateTimeFormatter (shared, #596)", () => {
   it("falls back to String(value) when the date cannot be formatted", () => {
     // An unparseable date → new Date("nope") is Invalid Date → Intl throws → catch → String(value).
     expect(createDateTimeFormatter(() => "en-GB")("not-a-date")).toBe("not-a-date");
+  });
+});
+
+describe("createDateFormatter (shared, #596)", () => {
+  it("formats a short numeric date (day/short-month/year) with the lazy locale", () => {
+    const out = createDateFormatter(() => "en-GB")("2026-06-22T00:00:00Z");
+    expect(out).toContain("2026");
+    expect(out).toMatch(/Jun/i);
+  });
+
+  it("returns the placeholder (default em-dash) for falsy input", () => {
+    expect(createDateFormatter(() => "en-GB")(null)).toBe("—");
+    expect(createDateFormatter(() => "en-GB")("")).toBe("—");
+    expect(createDateFormatter(() => "en-GB", "-")(undefined)).toBe("-");
   });
 });


### PR DESCRIPTION
Avslutter #596-dedupliseringen (EPIC #595).

## escapeHtml (divergerende → kanonisk)
`static/admin-content-preview.js`, `static/admin-content-shell.js`, `static/loading.js` brukte `String(x)` **uten** `?? ""`. Importerer nå kanonisk `html-escape.js`. Eneste atferdsendring: null/undefined → `""` i stedet for `"null"`/`"undefined"` (latent bugfix; verifisert no-op for reelle strenger). `static/admin-content-sections.js` **beholdes** — den escaper også `'` for attributt-kontekst (legitim forskjell, ikke duplikat).

## Kort-dato
Ny `createDateFormatter` i `format-display.js`; de **2 identiske** `formatDate`-kopiene (`courses`/`library`, `toLocaleDateString` numerisk, em-dash) bruker den. (Ternæren `currentLocale === "en-GB" ? "en-GB" : currentLocale` == `currentLocale`.) Distinkte formatere (certificate `long`, profile `medium`, admin-content NaN-guard) er **ikke** duplikater og latt stå.

## Test
- Unit `format-display.test.js` (9): tall, dato-tid, kort-dato.
- `tsc` rent. **Full e2e-suite: 54 passed.**
- Surface-map oppdatert (#596 markert ferdig; «intentionally distinct»-seksjon).

## #596 ferdig
~40 dupliserte kopier eliminert over 6 skiver (v1.3.56–1.3.61), hver bak én testet kilde-til-sannhet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)