### PR TITLE
fix(course): backfill manglende kursbevis + completed-nav (v1.3.64, #580)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,24 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.64 - 2026-06-24
+
+fix(course): backfill manglende kursbevis + «Fullførte moduler» i menyen (#580)
+
+**Bug (bruker-rapportert):** kurs viste «Fullført» i kurs-lista, men ingen kursbevis fantes → 404
+ved åpning av bevis, og «Ingen kursbevis ennå». Årsak: kurs-listas «Fullført» er seksjons-inklusiv
+(alle moduler bestått + alle seksjoner lest) — nøyaktig samme porter som bevis-utstedelse — men
+utstedelsen er **hendelsesdrevet** (fyres når siste modul bestås / siste seksjon leses) **uten
+avstemming**. Om hendelsen ble bommet (data fra før logikken, en sti som ikke fyrte, eller en
+svelget fire-and-forget) ble beviset aldri opprettet.
+
+- **Avstemming:** ny idempotent `reconcileCourseCompletionsForUser` kjøres når deltakeren åpner
+  «Mine kursbevis» (`GET /api/courses/completions`) og backfiller alle bevis hvis porter er møtt.
+- **Nav:** la til «Fullførte moduler» (`/participant/completed`) i workspace-navigasjonen (manglet;
+  `nav.completedModules`-labelen fantes allerede ubrukt).
+- **Test:** integrasjonstest (porter møtt uten utløser → `GET /completions` backfiller); nav-config-
+  kontrakt grønn.
+
 ## 1.3.63 - 2026-06-24
 
 fix(certificate): hev diplom-bakgrunn-grense 5 → 15 MB (#580)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.63",
+  "version": "1.3.64",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/config/capabilities.ts
+++ b/src/config/capabilities.ts
@@ -153,6 +153,12 @@ export function buildWorkspaceNavigationItems(calibrationAccessRoles: AppRoleTyp
       requiredRoles: [AppRole.PARTICIPANT, AppRole.ADMINISTRATOR, AppRole.REVIEWER],
     },
     {
+      id: "completed",
+      path: "/participant/completed",
+      labelKey: "nav.completedModules",
+      requiredRoles: [AppRole.PARTICIPANT, AppRole.ADMINISTRATOR, AppRole.REVIEWER],
+    },
+    {
       id: "review",
       path: "/review",
       labelKey: "nav.review",

--- a/src/modules/course/courseCompletionService.ts
+++ b/src/modules/course/courseCompletionService.ts
@@ -89,3 +89,21 @@ export async function checkCourseCompletionForCourse(
 
   await evaluateCourseCompletion(repo, input.userId, course, tx);
 }
+
+/**
+ * Idempotent reconciliation across ALL published courses for a user. Completion + certificate
+ * issuance is event-driven (fired when the last module passes or the last section is read); if that
+ * event was ever missed — data created before the logic existed, a dropped fire-and-forget, or a
+ * completion path that didn't trigger it — a course can show "completed" in the progress view yet
+ * have no certificate. This sweep, run when the user opens their certificates page, backfills any
+ * completion whose gates (all modules passed + all sections read) are now satisfied.
+ */
+export async function reconcileCourseCompletionsForUser(userId: string, tx?: CompletionTxClient) {
+  const client = (tx ?? prisma) as Parameters<typeof createCourseRepository>[0];
+  const repo = createCourseRepository(client);
+
+  const courses = await repo.findPublishedCourses();
+  for (const course of courses) {
+    await evaluateCourseCompletion(repo, userId, course, tx);
+  }
+}

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -1,4 +1,4 @@
-export { checkAndIssueCourseCompletions, checkCourseCompletionForCourse } from "./courseCompletionService.js";
+export { checkAndIssueCourseCompletions, checkCourseCompletionForCourse, reconcileCourseCompletionsForUser } from "./courseCompletionService.js";
 export { getCourseReport, getCourseLearnerReport } from "./courseReport.js";
 export { createCourse, updateCourse, publishCourse, archiveCourse, setCourseModules, setCourseItems, deleteCourse } from "./courseCommands.js";
 export type { CourseItemInput } from "./courseCommands.js";

--- a/src/routes/courses.ts
+++ b/src/routes/courses.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { courseRepository, computeCourseStatus, getSection, checkCourseCompletionForCourse } from "../modules/course/index.js";
+import { courseRepository, computeCourseStatus, getSection, checkCourseCompletionForCourse, reconcileCourseCompletionsForUser } from "../modules/course/index.js";
 import { renderSectionMarkdown } from "../modules/course/sectionContent.js";
 import { localizeContentText } from "../i18n/content.js";
 import { normalizeLocale } from "../i18n/locale.js";
@@ -78,6 +78,9 @@ coursesRouter.get("/completions", async (request, response, next) => {
   const locale = normalizeLocale(request.context?.locale) ?? "en-GB";
 
   try {
+    // #580 follow-up: backfill any completion whose gates are met but whose certificate was never
+    // issued (event-driven issuance can miss). Idempotent — only creates genuinely-missing ones.
+    await reconcileCourseCompletionsForUser(userId);
     const completions = await courseRepository.findUserCourseCompletions(userId);
     const items = completions.map((cc) => ({
       courseId: cc.courseId,

--- a/test/m2-course-completions.test.ts
+++ b/test/m2-course-completions.test.ts
@@ -101,6 +101,64 @@ describe("Course completion issuance", () => {
     ]);
   });
 
+  // #580 follow-up: a course can meet every certification gate (all modules passed + all sections
+  // read) without a certificate if the event-driven issuance was ever missed. Opening the
+  // certificates page reconciles and backfills the missing completion.
+  it("backfills a missing completion when gates are met but the issuance event never fired", async () => {
+    const suffix = Date.now();
+    const headers = {
+      "x-user-id": `reconcile-user-${suffix}`,
+      "x-user-email": `reconcile.${suffix}@company.com`,
+      "x-user-name": "Reconcile User",
+      "x-user-department": "Learning",
+      "x-user-roles": "PARTICIPANT",
+      "x-locale": "nb",
+    };
+    const participant = await prisma.user.create({
+      data: {
+        externalId: headers["x-user-id"],
+        email: headers["x-user-email"],
+        name: headers["x-user-name"],
+        department: headers["x-user-department"],
+      },
+      select: { id: true },
+    });
+
+    const moduleA = await createPublishedModule(`Reconcile Module A ${suffix}`);
+    const moduleB = await createPublishedModule(`Reconcile Module B ${suffix}`);
+    const course = await prisma.course.create({
+      data: {
+        title: JSON.stringify({ "en-GB": `Reconcile Course ${suffix}`, nb: `Avstemmingskurs ${suffix}`, nn: `Avstemmingskurs ${suffix}` }),
+        description: JSON.stringify({ "en-GB": "x", nb: "x", nn: "x" }),
+        publishedAt: new Date(),
+        modules: {
+          create: [
+            { moduleId: moduleA.module.id, sortOrder: 1 },
+            { moduleId: moduleB.module.id, sortOrder: 2 },
+          ],
+        },
+      },
+      select: { id: true },
+    });
+
+    // Pass BOTH modules (all gates met) but never fire the issuance event → no completion exists.
+    await createPassedCertification(participant.id, moduleA);
+    await createPassedCertification(participant.id, moduleB);
+    expect(
+      await prisma.courseCompletion.count({ where: { userId: participant.id, courseId: course.id } }),
+    ).toBe(0);
+
+    // Opening the certificates page reconciles and backfills the missing completion.
+    const response = await request(app).get("/api/courses/completions").set(headers);
+    expect(response.status).toBe(200);
+    expect(response.body.completions).toEqual([
+      expect.objectContaining({ courseId: course.id, courseTitle: `Avstemmingskurs ${suffix}` }),
+    ]);
+    expect(
+      await prisma.courseCompletion.count({ where: { userId: participant.id, courseId: course.id } }),
+    ).toBe(1);
+  });
+
   // #550: printable certificate view backs onto GET /completions/:certificateId, owner-scoped.
   it("returns a single completion by certificate id for the owner and 404 for others", async () => {
     const suffix = Date.now();


### PR DESCRIPTION
Bruker-rapportert under #580-testing: kurs vises som **«Fullført»** i kurs-lista, men det finnes **ingen kursbevis** → 404 ved åpning av bevis, og «Ingen kursbevis ennå» på Fullført-siden.

## Rotårsak (verifisert i kode)
Kurs-listas «Fullført» er **seksjons-inklusiv**: `completed = beståtte moduler + leste seksjoner`, `total = moduler + seksjoner` ([courses.ts](src/routes/courses.ts)). Det er **nøyaktig samme porter** som bevis-utstedelse ([courseCompletionService.ts](src/modules/course/courseCompletionService.ts)). Men utstedelsen er **kun hendelsesdrevet** (fyres når siste modul bestås / siste seksjon leses) — **ingen avstemming**. Om hendelsen ble bommet (data fra før logikken, en sti som ikke fyrte, eller en svelget fire-and-forget) ble beviset aldri opprettet, og kurset står «Fullført uten bevis» for alltid.

## Fiks
- **`reconcileCourseCompletionsForUser`** (idempotent) — kjøres når deltakeren åpner «Mine kursbevis» (`GET /api/courses/completions`). Sveiper alle publiserte kurs og backfiller bevis hvis portene er møtt (gjenbruker den tested `evaluateCourseCompletion`).
- **Nav:** la til **«Fullførte moduler»** (`/participant/completed`) i workspace-navigasjonen — den manglet helt fra menyen (`nav.completedModules`-labelen fantes allerede, ubrukt).

## Test
- **Integrasjon** (`m2-course-completions`): alle porter møtt uten at utløseren fyrte → `GET /completions` backfiller beviset (count 0 → 1, bevis returneres).
- Nav-config-kontrakt (`participant-console-config`) grønn (11/11) — nav-assertion bruker `buildWorkspaceNavigationItems()` direkte.
- `tsc` rent.

Etter denne fiksen: dine 5 «Fullført»-kurs får bevis utstedt når du åpner «Mine kursbevis», og kursbeviset (med diplom-bakgrunn fra #580) lar seg åpne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)