### PR TITLE
fix(course): utsted kursbevis for lese-/seksjonskurs uten moduler (v1.3.65, #580)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,19 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.65 - 2026-06-24
+
+fix(course): utsted kursbevis for lese-/seksjonskurs uten moduler (#580)
+
+**Bug (bruker-rapportert, forts.):** etter 1.3.64 vistes fortsatt ingen kursbevis for «Fullførte»
+kurs. Årsak: et kurs **uten assessment-moduler** (LMS Tier 2, markdown-først, #476) vises som
+«Fullført» når alle seksjoner er lest, men `evaluateCourseCompletion` bailet på
+`moduleIds.length === 0` (gammel `if (total === 0) return` telte kun moduler) og utstedte aldri
+bevis. Porten regner nå **både moduler og seksjoner**: bevis utstedes når alle moduler er bestått
+OG alle seksjoner lest, så lenge kurset har minst ett element. Dette fikser både live-utstedelse
+(seksjon-lest-event) og backfill via avstemmingen. Avstemmingen isolerer nå hvert kurs i try/catch
+så ett dårlig kurs ikke kan blanke hele bevis-lista eller 500-e `/api/courses/completions`.
+
 ## 1.3.64 - 2026-06-24
 
 fix(course): backfill manglende kursbevis + «Fullførte moduler» i menyen (#580)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.64",
+  "version": "1.3.65",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/course/courseCompletionService.ts
+++ b/src/modules/course/courseCompletionService.ts
@@ -22,17 +22,26 @@ async function evaluateCourseCompletion(
   tx?: CompletionTxClient,
 ): Promise<void> {
   const moduleIds = course.modules.map((m) => m.moduleId);
-  const total = moduleIds.length;
-  if (total === 0) return;
 
-  const passedCount = await repo.countPassedModulesForUser(userId, moduleIds);
-  if (passedCount < total) return;
-
-  // All learning sections must be read before the certificate is issued.
+  // A course can be pure-reading (no assessment modules) — the LMS Tier 2 markdown-first
+  // courses (#476). For those, reading every learning section is the only certification gate,
+  // so we must NOT bail on `moduleIds.length === 0`. Gates are computed over BOTH modules and
+  // sections, exactly matching the "completed" definition the progress view uses
+  // (passed === all modules AND read === all sections). The old `if (total === 0) return` only
+  // counted modules, so reading-only courses showed "Fullført" in the list yet never issued a
+  // certificate (#580 follow-up).
   const courseItems = await repo.findCourseItems(course.id);
   const requiredSectionIds = courseItems
     .filter((item) => item.itemType === "SECTION" && item.section != null && item.section.archivedAt == null)
     .map((item) => item.section!.id);
+
+  // Truly empty course (no modules AND no sections) is never completable.
+  if (moduleIds.length === 0 && requiredSectionIds.length === 0) return;
+
+  if (moduleIds.length > 0) {
+    const passedCount = await repo.countPassedModulesForUser(userId, moduleIds);
+    if (passedCount < moduleIds.length) return;
+  }
 
   if (requiredSectionIds.length > 0) {
     const readSectionIds = new Set(await repo.findReadSectionIds(userId, course.id));
@@ -104,6 +113,15 @@ export async function reconcileCourseCompletionsForUser(userId: string, tx?: Com
 
   const courses = await repo.findPublishedCourses();
   for (const course of courses) {
-    await evaluateCourseCompletion(repo, userId, course, tx);
+    // Per-course isolation: a single malformed course must never blank the user's entire
+    // certificate list (or 500 the page that triggers this sweep). Backfill is best-effort.
+    try {
+      await evaluateCourseCompletion(repo, userId, course, tx);
+    } catch (error) {
+      console.warn(
+        `[course-completion] reconcile skipped course ${course.id} for user ${userId}:`,
+        error,
+      );
+    }
   }
 }

--- a/test/m2-course-completions.test.ts
+++ b/test/m2-course-completions.test.ts
@@ -159,6 +159,69 @@ describe("Course completion issuance", () => {
     ).toBe(1);
   });
 
+  // #580 follow-up: a reading-only course (LMS Tier 2, #476 — sections, NO assessment modules)
+  // must issue a certificate once every section is read. The old gate bailed on
+  // `moduleIds.length === 0`, so such courses showed "Fullført" in the progress view yet never
+  // got a certificate. Here the section-read event is never fired (data predates the fix) — the
+  // reconcile sweep on the certificates page must backfill it.
+  it("backfills a reading-only (module-less) course once all sections are read", async () => {
+    const suffix = Date.now();
+    const headers = {
+      "x-user-id": `reading-user-${suffix}`,
+      "x-user-email": `reading.${suffix}@company.com`,
+      "x-user-name": "Reading User",
+      "x-user-department": "Learning",
+      "x-user-roles": "PARTICIPANT",
+      "x-locale": "nb",
+    };
+    const participant = await prisma.user.create({
+      data: {
+        externalId: headers["x-user-id"],
+        email: headers["x-user-email"],
+        name: headers["x-user-name"],
+        department: headers["x-user-department"],
+      },
+      select: { id: true },
+    });
+
+    const course = await prisma.course.create({
+      data: {
+        title: JSON.stringify({ "en-GB": `Reading Course ${suffix}`, nb: `Lesekurs ${suffix}`, nn: `Lesekurs ${suffix}` }),
+        description: JSON.stringify({ "en-GB": "x", nb: "x", nn: "x" }),
+        publishedAt: new Date(),
+      },
+      select: { id: true },
+    });
+    const section = await prisma.courseSection.create({
+      data: { title: JSON.stringify({ "en-GB": "Only section", nb: "Eneste seksjon" }) },
+      select: { id: true },
+    });
+    const version = await prisma.courseSectionVersion.create({
+      data: { sectionId: section.id, versionNo: 1, bodyMarkdown: JSON.stringify({ "en-GB": "Body." }), publishedAt: new Date() },
+      select: { id: true },
+    });
+    await prisma.courseSection.update({ where: { id: section.id }, data: { activeVersionId: version.id } });
+    await prisma.courseItem.create({ data: { courseId: course.id, itemType: "SECTION", sectionId: section.id, sortOrder: 0 } });
+
+    // Read the section directly (no event fired) → gates met, but no completion exists yet.
+    await prisma.courseSectionRead.create({
+      data: { userId: participant.id, courseId: course.id, sectionId: section.id },
+    });
+    expect(
+      await prisma.courseCompletion.count({ where: { userId: participant.id, courseId: course.id } }),
+    ).toBe(0);
+
+    // Opening the certificates page reconciles and backfills the module-less course.
+    const response = await request(app).get("/api/courses/completions").set(headers);
+    expect(response.status).toBe(200);
+    expect(response.body.completions).toEqual([
+      expect.objectContaining({ courseId: course.id, courseTitle: `Lesekurs ${suffix}` }),
+    ]);
+    expect(
+      await prisma.courseCompletion.count({ where: { userId: participant.id, courseId: course.id } }),
+    ).toBe(1);
+  });
+
   // #550: printable certificate view backs onto GET /completions/:certificateId, owner-scoped.
   it("returns a single completion by certificate id for the owner and 404 for others", async () => {
     const suffix = Date.now();

--- a/test/m2-course-section-read.test.ts
+++ b/test/m2-course-section-read.test.ts
@@ -51,6 +51,9 @@ describe("Participant section read progress", () => {
     expect(sectionAfter?.read).toBe(true);
     expect(after.body.course.progress).toMatchObject({ completed: 1, total: 1, courseStatus: "COMPLETED" });
 
+    // Reading the only section of a module-less course now issues a course completion (#580):
+    // remove it first since CourseCompletion → Course is onDelete: Restrict.
+    await prisma.courseCompletion.deleteMany({ where: { courseId: course.id } });
     await prisma.course.delete({ where: { id: course.id } });
     await prisma.courseSection.update({ where: { id: section.id }, data: { activeVersionId: null } });
     await prisma.courseSectionVersion.deleteMany({ where: { sectionId: section.id } });


### PR DESCRIPTION
## Problem (bruker-rapportert, forts. fra #626/1.3.64)
Etter 1.3.64 vistes **fortsatt** ingen kursbevis for kurs merket «Fullført», og bevis-åpning ga 404.

## Rotårsak
Kurs-listas «Fullført» er seksjons-inklusiv (alle moduler bestått **+** alle seksjoner lest). Det eneste kode-stien der lista kan vise «Fullført» mens bevis-utstedelsen IKKE skjer, er **kurs uten moduler**: `evaluateCourseCompletion` bailet på `if (total === 0) return` der `total = moduleIds.length`. Et **rent lese-/seksjonskurs** (LMS Tier 2, markdown-først, #476) vises altså som fullført når alle seksjoner er lest, men fikk aldri bevis — og 1.3.64-avstemmingen hjalp ikke fordi den kalte samme funksjon.

## Fiks
- Porten regner nå **både moduler og seksjoner**. Bevis utstedes når alle moduler er bestått OG alle seksjoner lest, så lenge kurset har minst ett element (tomt kurs returnerer fortsatt tidlig).
- Fikser **både** live-utstedelse (seksjon-lest-event via `checkCourseCompletionForCourse`) og backfill via `reconcileCourseCompletionsForUser`.
- Avstemmingen isolerer nå hvert kurs i `try/catch` — ett malformert kurs kan ikke lenger blanke hele bevis-lista eller 500-e `/api/courses/completions`.

## Test
Ny integrasjonstest: modul-løst lesekurs, seksjon lest direkte (event aldri fyrt) → `GET /api/courses/completions` backfiller bevis (0 → 1). CI verify (fersk DB) er fasit.

## Rollback
Ren kode-endring (ingen infra). Revert commit for å gå tilbake til 1.3.64-adferd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)