### PR TITLE
fix(certificate): hold midten-nederst fri for diplom-segl (v1.3.66, #580)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,16 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.66 - 2026-06-24
+
+fix(certificate): hold midten-nederst fri for diplom-segl (#580)
+
+Diplom-bakgrunnen har et sentrert A2-segl nederst i midten. Bevis-malens meta-rad
+hadde tre sentrerte kolonner, og den midterste (sertifiseringsnivå) lå rett oppå
+seglet. Sertifiseringsnivå er flyttet opp som en linje under kurstittelen, og
+bunn-raden har nå kun to elementer (fullført-dato til venstre, moduler til høyre)
+med `space-between` — midten-nederst holdes fri for seglet. Bilde-uavhengig.
+
 ## 1.3.65 - 2026-06-24
 
 fix(course): utsted kursbevis for lese-/seksjonskurs uten moduler (#580)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.65",
+  "version": "1.3.66",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/certificate.html
+++ b/public/certificate.html
@@ -31,8 +31,12 @@
       .cert-heading { font-size: 30px; margin: 8px 0 28px; font-weight: 700; }
       .cert-label { font-size: 14px; color: var(--color-meta, #64748b); margin: 18px 0 6px; }
       .cert-name { font-size: 28px; font-weight: 700; margin: 4px 0; }
-      .cert-course { font-size: 22px; font-weight: 600; margin: 4px 0 8px; }
-      .cert-meta { display: flex; justify-content: center; gap: 40px; flex-wrap: wrap; margin-top: 28px; }
+      .cert-course { font-size: 22px; font-weight: 600; margin: 4px 0 4px; }
+      .cert-sublabel { font-size: 14px; color: var(--color-meta, #64748b); margin: 0 0 8px; }
+      .cert-sublabel #certLevel { font-weight: 600; color: var(--color-text, #0f172a); }
+      /* #580: push the two remaining stats to the left/right edges so the diploma seal
+         (baked into the background image, bottom-centre) is never overlapped by text. */
+      .cert-meta { display: flex; justify-content: space-between; gap: 40px; flex-wrap: wrap; margin-top: 28px; padding: 0 8px; }
       .cert-meta div { font-size: 14px; }
       .cert-meta .cert-meta-label { font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--color-meta, #64748b); }
       .cert-id { margin-top: 28px; font-size: 11px; color: var(--color-meta, #64748b); }
@@ -69,15 +73,16 @@
           <div class="cert-name" id="certName"></div>
           <div class="cert-label" data-i18n="certificate.completedCourse">has successfully completed the course</div>
           <div class="cert-course" id="certCourse"></div>
+          <div class="cert-sublabel">
+            <span data-i18n="certificate.certLevel">Certification level</span>: <span id="certLevel"></span>
+          </div>
           <hr class="cert-rule" />
+          <!-- #580: only edge items in the bottom band — the center is kept clear for the
+               diploma seal/logo baked into the platform background image. -->
           <div class="cert-meta">
             <div>
               <div class="cert-meta-label" data-i18n="certificate.completedAt">Completed</div>
               <div id="certCompletedAt"></div>
-            </div>
-            <div>
-              <div class="cert-meta-label" data-i18n="certificate.certLevel">Certification level</div>
-              <div id="certLevel"></div>
             </div>
             <div id="certModulesWrap">
               <div class="cert-meta-label" data-i18n="certificate.modules">Modules completed</div>


### PR DESCRIPTION
## Problem (bruker-rapportert)
Diplom-bakgrunnen (#580) har et sentrert A2-segl nederst i midten. Bevis-malens meta-rad hadde tre sentrerte kolonner, og den midterste (**Sertifiseringsnivå**) lå rett oppå seglet.

## Fiks (bilde-uavhengig)
- **Sertifiseringsnivå** flyttet opp som en linje rett under kurstittelen.
- Bunn-raden har nå kun to elementer — **Fullført** (venstre) og **Moduler fullført** (høyre) — med `justify-content: space-between`, så **midten-nederst holdes fri** for seglet (klassisk diplom-konvensjon).
- Bevis-ID lå allerede under seglet og kolliderer ikke — uendret.
- For lese-kurs (0 moduler) skjules «Moduler fullført» allerede → kun datoen til venstre, midten fortsatt fri.

DOM-id-ene `#certLevel`/`#certModules` er bevart, så `participant-certificate.spec.ts` (asserter tekst, ikke posisjon) er uendret.

## Rollback
Ren HTML/CSS på bevis-siden. Revert commit for å gå tilbake til 1.3.65-layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)