### PR TITLE
ci(deploy): git_ref-input for pinnet prod-promotering

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -29,6 +29,10 @@ on:
         description: "Skip staging deploy — only valid when staging is already verified"
         required: false
         default: "false"
+      git_ref:
+        description: "Git ref (tag/SHA) to build & deploy. Empty = main HEAD. Use a verified tag (e.g. v1.3.67) to promote a pinned version to prod while main advances."
+        required: false
+        default: ""
 
 permissions:
   id-token: write
@@ -50,6 +54,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
+        with:
+          # Build the requested ref (a verified tag/SHA) instead of always main HEAD, so a pinned
+          # version can ship while main advances. Empty input → the triggering commit (main HEAD).
+          ref: ${{ github.event.inputs.git_ref || github.sha }}
 
       - name: Build deployment package
         id: package
@@ -107,6 +115,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
+        with:
+          # Promote a pinned, verified ref (e.g. v1.3.67) to prod regardless of how far main has moved.
+          ref: ${{ github.event.inputs.git_ref || github.sha }}
 
       - name: Build deployment package
         id: package

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -14,6 +14,10 @@ on:
         description: "Skip staging deploy — use only when staging is already verified green"
         required: false
         default: "false"
+      git_ref:
+        description: "Git ref (tag/SHA) to build & deploy. Empty = main HEAD. Pin a verified tag to promote it while main advances. NOTE: for infra this also applies that ref's Bicep — usually leave empty for infra deploys."
+        required: false
+        default: ""
 
 permissions:
   id-token: write
@@ -37,6 +41,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
+        with:
+          # Empty input → triggering commit (main HEAD); a tag/SHA pins the build to that ref.
+          ref: ${{ github.event.inputs.git_ref || github.sha }}
 
       - name: Build deployment package
         id: package
@@ -138,6 +145,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
+        with:
+          # Empty input → triggering commit (main HEAD); a tag/SHA pins the build to that ref.
+          ref: ${{ github.event.inputs.git_ref || github.sha }}
 
       - name: Build deployment package
         id: package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,18 @@ A2 Assessment Platform — Next.js + Prisma + PostgreSQL on Azure App Service.
 - CI/CD: `.github/workflows/deploy-azure.yml`
 - Environments runbook: `doc/AZURE_ENVIRONMENTS.md`
 
+### Promoting a verified version to prod while `main` advances
+
+Both deploy workflows accept a `git_ref` input. The workflow is still triggered from `main` (gating + prod
+approval gate intact), but checkout/build uses the pinned ref instead of `main` HEAD — so prod can be
+promoted to a stage-verified tag without dragging unverified `main` commits along:
+
+1. `git tag v1.3.67 <sha> && git push origin v1.3.67`
+2. `gh workflow run deploy-app.yml --ref main -f git_ref=v1.3.67 -f deploy_production=true -f skip_staging=true`
+
+`main`/stage keep moving (empty `git_ref` = `main` HEAD). Use `deploy-app.yml` for code-only promotions; for
+infra leave `git_ref` empty (an old tag would re-apply that ref's Bicep). Verify `/version` on prod after.
+
 ### Pre-merge Bicep what-if (production)
 
 Before merging a PR that touches `infra/azure/*.bicep` or `scripts/azure/deploy-environment.ps1`, run a production what-if to see the ARM diff:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,23 @@ coverage** — unless the user has given a different instruction for that wait.
 | Changes to `scripts/azure/deploy-environment.ps1` | Either | Both workflows use the same script; the change auto-picks via main |
 | Secret rotation requiring KV-ref refresh | `.github/workflows/deploy-azure.yml` | KV-ref propagation + container restart needed |
 
+### Promoting a verified version to prod while `main` advances
+
+Both deploy workflows accept a `git_ref` input. The workflow is still **triggered from `main`** (all
+`ref_name == default_branch` gating and the production-environment approval gate stay intact), but the
+checkout/build uses the pinned ref instead of `main` HEAD. This decouples "what's verified on stage and
+promoted to prod" from "what's currently on `main`" — so feature work can keep flowing to local/stage on
+`main` without dragging unverified commits into a prod promotion.
+
+**Flow:**
+1. Tag the stage-verified commit: `git tag v1.3.67 <sha> && git push origin v1.3.67`.
+2. Promote that tag to prod (skipping a redundant stage redeploy):
+   `gh workflow run deploy-app.yml --ref main -f git_ref=v1.3.67 -f deploy_production=true -f skip_staging=true`
+3. `main` keeps moving; stage deploys still default to `main` HEAD (empty `git_ref`).
+
+Use `deploy-app.yml` for code-only promotions. For infra, leave `git_ref` empty (pinning an old tag would
+also re-apply that ref's Bicep). `/version` on prod reflects the deployed tag — verify it after promotion.
+
 ### Pre-merge Bicep what-if (production)
 
 Before merging a PR that touches `infra/azure/*.bicep` or `scripts/azure/deploy-environment.ps1`, run a production what-if to see the ARM diff:


### PR DESCRIPTION
## Behov (bruker)
«Vi trenger en måte å deploye til prod på mens vi fortsetter å jobbe mot lokalt og stage.»

I dag deployer begge workflowene alltid **main HEAD**, så en prod-deploy drar med alt nytt (uverifisert) arbeid så snart main beveger seg.

## Løsning
Legg til `git_ref`-input i begge workflowene. Workflowen trigges fortsatt **fra main** (all `ref_name == default_branch`-gating + prod-environment-approval-gate intakt), men `checkout` henter den pinnede ref-en (`${{ github.event.inputs.git_ref || github.sha }}`). Tom input = main HEAD → **uendret standardoppførsel**.

### Promotering
```
git tag v1.3.67 <sha> && git push origin v1.3.67
gh workflow run deploy-app.yml --ref main -f git_ref=v1.3.67 -f deploy_production=true -f skip_staging=true
```
Stage fortsetter å deploye main HEAD. Prod-approval-gaten er fortsatt den reelle sikkerheten.

## Verifisering
- `actionlint 1.7.12` lokalt: ren (exit 0) på begge filer.
- Ingen app-kode endret → ingen version-bump.
- For infra: la `git_ref` stå tom (gammel tag ville re-applisert den ref-ens Bicep) — notert i input-beskrivelsen + docs.

## Docs
CLAUDE.md (workflow-tabell) + AGENTS.md oppdatert med promoterings-flyten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)