### PR TITLE
fix(assessment): 429/5xx-retry i assessment-LLM-klienten (v1.3.68, #603)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,18 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.68 - 2026-06-24
+
+fix(assessment): 429/5xx-retry i assessment-LLM-klienten (#603)
+
+`llmAssessmentService` manglet retry på transient Azure OpenAI 429 (TPM-kvote) / 5xx — en
+forbigående rate-limit feilet en deltaker-vurdering. Retry-policyen fra authoring-pipelinen
+(#479, v1.3.54) er ekstrahert til en delt `src/modules/llm/azureOpenAiRetry.ts`
+(`fetchAzureOpenAiWithRetry` + Retry-After-parsing + capped exponential backoff m/ jitter) og
+brukes nå av begge klientene. Parameter-fallbacken (token-param/temperatur) i assessment-klienten
+er urørt; den overordnede timeout-signalen begrenser total tid på tvers av retries. Ny unit-test
+dekker Retry-After-parsing, backoff-grenser og retry/exhaust-oppførsel.
+
 ## 1.3.67 - 2026-06-24
 
 fix(participant): auto-last kursbevis på «Fullførte moduler»-siden (#580)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.67",
+  "version": "1.3.68",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/llmContentGenerationService.ts
+++ b/src/modules/adminContent/llmContentGenerationService.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { env } from "../../config/env.js";
+import { fetchAzureOpenAiWithRetry } from "../llm/azureOpenAiRetry.js";
 import type { LocalizedText } from "../../codecs/localizedTextCodec.js";
 
 // ---------------------------------------------------------------------------
@@ -1264,36 +1265,9 @@ Return a single JSON object:
   return { systemPrompt, userPrompt };
 }
 
-// #479: Azure OpenAI returns 429 ("too_many_requests") when the deployment's tokens-per-minute
-// quota is exceeded — easy to hit now that crawl can produce large source material fanning into
-// several big calls (condense → blueprint → draft → MCQ) within seconds. A single un-retried 429
-// aborted the whole pipeline (and the condense fallback then sent the FULL oversized material
-// downstream, guaranteeing more 429s). These calls are now retried with backoff that honours the
-// server's Retry-After. 5xx are transient gateway errors and are retried too.
-const LLM_MAX_ATTEMPTS = 4;
-const LLM_RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
-const LLM_BACKOFF_BASE_MS = 1_000;
-const LLM_BACKOFF_MAX_MS = 20_000;
-
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
-
-// Parses a Retry-After header (delta-seconds or HTTP-date). Returns null when absent/unparseable.
-export function parseRetryAfterMs(header: string | null | undefined): number | null {
-  if (!header) return null;
-  const seconds = Number(header);
-  if (Number.isFinite(seconds) && seconds >= 0) return Math.round(seconds * 1000);
-  const dateMs = Date.parse(header);
-  if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
-  return null;
-}
-
-// Backoff for attempt N (0-based): honour Retry-After if the server sent one, otherwise exponential
-// (1s, 2s, 4s, …) capped, with jitter to avoid thundering-herd retries across concurrent calls.
-export function computeLlmBackoffMs(attempt: number, retryAfterMs: number | null): number {
-  if (retryAfterMs !== null) return Math.min(retryAfterMs, LLM_BACKOFF_MAX_MS);
-  const exponential = Math.min(LLM_BACKOFF_BASE_MS * 2 ** attempt, LLM_BACKOFF_MAX_MS);
-  return Math.round(exponential * (0.5 + Math.random() * 0.5));
-}
+// #479/#603: Azure OpenAI 429/5xx retry now lives in the shared `azureOpenAiRetry` module so the
+// assessment client uses the identical policy. Re-exported here for back-compat with existing tests.
+export { parseRetryAfterMs, computeLlmBackoffMs } from "../llm/azureOpenAiRetry.js";
 
 async function callLlm(systemPrompt: string, userPrompt: string, maxTokens = 4000): Promise<unknown> {
   if (env.LLM_MODE !== "azure_openai") {
@@ -1316,28 +1290,23 @@ async function callLlm(systemPrompt: string, userPrompt: string, maxTokens = 400
     [tokenParam]: maxTokens,
   };
 
-  let response: Response | null = null;
-  for (let attempt = 0; attempt < LLM_MAX_ATTEMPTS; attempt++) {
-    response = await fetch(url, {
+  const response = await fetchAzureOpenAiWithRetry(
+    url,
+    {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "api-key": env.AZURE_OPENAI_API_KEY ?? "",
       },
       body: JSON.stringify(body),
-    });
-
-    if (response.ok || !LLM_RETRYABLE_STATUSES.has(response.status)) break;
-
-    // Retryable (429/5xx). Back off and retry unless this was the last attempt.
-    if (attempt < LLM_MAX_ATTEMPTS - 1) {
-      const waitMs = computeLlmBackoffMs(attempt, parseRetryAfterMs(response.headers.get("retry-after")));
-      console.warn(
-        `[#479] Azure OpenAI ${response.status} — retrying in ${waitMs}ms (attempt ${attempt + 1}/${LLM_MAX_ATTEMPTS}).`,
-      );
-      await sleep(waitMs);
-    }
-  }
+    },
+    {
+      onRetry: ({ status, waitMs, attempt, maxAttempts }) =>
+        console.warn(
+          `[#479] Azure OpenAI ${status} — retrying in ${waitMs}ms (attempt ${attempt}/${maxAttempts}).`,
+        ),
+    },
+  );
 
   if (!response || !response.ok) {
     const status = response?.status ?? 0;

--- a/src/modules/assessment/llmAssessmentService.ts
+++ b/src/modules/assessment/llmAssessmentService.ts
@@ -1,4 +1,5 @@
 import { env } from "../../config/env.js";
+import { fetchAzureOpenAiWithRetry } from "../llm/azureOpenAiRetry.js";
 import type { SupportedLocale } from "../../i18n/locale.js";
 import { buildAllowedRedFlagCodesForPrompt, normalizeRedFlags } from "./assessmentRedFlagPolicy.js";
 import { llmResponseCodec } from "../../codecs/llmResponseCodec.js";
@@ -69,15 +70,28 @@ export async function evaluatePracticalWithAzureOpenAi(
       const tokenParameter = tokenParameterSequence[index];
 
       for (const includeTemperature of [true, false]) {
-        const response = await fetch(buildAzureOpenAiCompletionsUrl(config), {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            "api-key": config.apiKey,
+        // #603: retry transient 429 (TPM-quota) / 5xx with Retry-After-aware backoff — same policy
+        // as the authoring client. Non-retryable statuses (incl. the 400-class unsupported-param /
+        // unsupported-temperature signals) return on the first attempt so the fallback loop below
+        // still drives them. The overall timeout signal bounds total time across retries.
+        const response = await fetchAzureOpenAiWithRetry(
+          buildAzureOpenAiCompletionsUrl(config),
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "api-key": config.apiKey,
+            },
+            body: JSON.stringify(buildAzureOpenAiRequestBody(input, config, tokenParameter, includeTemperature)),
+            signal: timeoutController.signal,
           },
-          body: JSON.stringify(buildAzureOpenAiRequestBody(input, config, tokenParameter, includeTemperature)),
-          signal: timeoutController.signal,
-        });
+          {
+            onRetry: ({ status, waitMs, attempt, maxAttempts }) =>
+              console.warn(
+                `[#603] Azure OpenAI assessment ${status} — retrying in ${waitMs}ms (attempt ${attempt}/${maxAttempts}).`,
+              ),
+          },
+        );
 
         const rawBody = await response.text();
         const responseBody = parseJsonBody(rawBody);

--- a/src/modules/llm/azureOpenAiRetry.ts
+++ b/src/modules/llm/azureOpenAiRetry.ts
@@ -1,0 +1,71 @@
+// Shared Azure OpenAI transient-failure retry (#479 authoring, #603 assessment).
+//
+// Azure OpenAI returns 429 ("too_many_requests") when a deployment's tokens-per-minute quota is
+// exceeded, and 5xx on transient gateway errors. A single un-retried 429/5xx aborts the whole
+// operation — for authoring that loses a generated module, for assessment it fails a participant's
+// evaluation. Both call sites retry with backoff that honours the server's Retry-After.
+//
+// This module is the single source of truth for that retry policy; `llmContentGenerationService`
+// (authoring) and `llmAssessmentService` (assessment) both build on `fetchAzureOpenAiWithRetry`.
+
+export const LLM_MAX_ATTEMPTS = 4;
+export const LLM_RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+const LLM_BACKOFF_BASE_MS = 1_000;
+const LLM_BACKOFF_MAX_MS = 20_000;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Parses a Retry-After header (delta-seconds or HTTP-date). Returns null when absent/unparseable.
+export function parseRetryAfterMs(header: string | null | undefined): number | null {
+  if (!header) return null;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.round(seconds * 1000);
+  const dateMs = Date.parse(header);
+  if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
+  return null;
+}
+
+// Backoff for attempt N (0-based): honour Retry-After if the server sent one, otherwise exponential
+// (1s, 2s, 4s, …) capped, with jitter to avoid thundering-herd retries across concurrent calls.
+export function computeLlmBackoffMs(attempt: number, retryAfterMs: number | null): number {
+  if (retryAfterMs !== null) return Math.min(retryAfterMs, LLM_BACKOFF_MAX_MS);
+  const exponential = Math.min(LLM_BACKOFF_BASE_MS * 2 ** attempt, LLM_BACKOFF_MAX_MS);
+  return Math.round(exponential * (0.5 + Math.random() * 0.5));
+}
+
+export interface LlmRetryNotice {
+  status: number;
+  waitMs: number;
+  attempt: number; // 1-based for display
+  maxAttempts: number;
+}
+
+/**
+ * Performs `fetch(url, init)` and retries on transient 429/5xx with Retry-After-aware backoff.
+ * Returns the final `Response` — including the last still-failing one after the attempt budget is
+ * exhausted, so callers keep full control over non-OK handling (status, body parsing, fallbacks).
+ * Non-retryable statuses (e.g. 400-class) return immediately on the first attempt.
+ */
+export async function fetchAzureOpenAiWithRetry(
+  url: string,
+  init: RequestInit,
+  opts?: { maxAttempts?: number; onRetry?: (notice: LlmRetryNotice) => void },
+): Promise<Response> {
+  const maxAttempts = opts?.maxAttempts ?? LLM_MAX_ATTEMPTS;
+  let response: Response | null = null;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    response = await fetch(url, init);
+
+    if (response.ok || !LLM_RETRYABLE_STATUSES.has(response.status)) return response;
+
+    // Retryable (429/5xx). Back off and retry unless this was the last attempt.
+    if (attempt < maxAttempts - 1) {
+      const waitMs = computeLlmBackoffMs(attempt, parseRetryAfterMs(response.headers.get("retry-after")));
+      opts?.onRetry?.({ status: response.status, waitMs, attempt: attempt + 1, maxAttempts });
+      await sleep(waitMs);
+    }
+  }
+
+  return response as Response;
+}

--- a/test/unit/azure-openai-retry.test.ts
+++ b/test/unit/azure-openai-retry.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  LLM_MAX_ATTEMPTS,
+  computeLlmBackoffMs,
+  fetchAzureOpenAiWithRetry,
+  parseRetryAfterMs,
+} from "../../src/modules/llm/azureOpenAiRetry.js";
+
+// #603: shared Azure OpenAI transient-failure retry, used by both the authoring (#479) and
+// assessment LLM clients. The assessment client previously had no retry — a transient 429 failed a
+// participant evaluation outright.
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseRetryAfterMs", () => {
+  it("parses delta-seconds", () => {
+    expect(parseRetryAfterMs("2")).toBe(2000);
+    expect(parseRetryAfterMs("0")).toBe(0);
+  });
+  it("parses an HTTP-date into a non-negative delay", () => {
+    const future = new Date(Date.now() + 5000).toUTCString();
+    const ms = parseRetryAfterMs(future);
+    expect(ms).not.toBeNull();
+    expect(ms!).toBeGreaterThanOrEqual(0);
+  });
+  it("returns null for absent/unparseable values", () => {
+    expect(parseRetryAfterMs(null)).toBeNull();
+    expect(parseRetryAfterMs(undefined)).toBeNull();
+    expect(parseRetryAfterMs("not-a-date")).toBeNull();
+  });
+});
+
+describe("computeLlmBackoffMs", () => {
+  it("honours Retry-After, capped at the max", () => {
+    expect(computeLlmBackoffMs(0, 3000)).toBe(3000);
+    expect(computeLlmBackoffMs(0, 999_999)).toBe(20_000);
+  });
+  it("uses capped exponential backoff with jitter when no Retry-After", () => {
+    for (let attempt = 0; attempt < 6; attempt++) {
+      const ms = computeLlmBackoffMs(attempt, null);
+      expect(ms).toBeGreaterThanOrEqual(0);
+      expect(ms).toBeLessThanOrEqual(20_000);
+    }
+  });
+});
+
+describe("fetchAzureOpenAiWithRetry", () => {
+  const url = "https://example.test/openai";
+  const init = { method: "POST", body: "{}" };
+
+  it("returns immediately on a successful response (no retry)", async () => {
+    const fetchMock = vi.fn(async () => new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchAzureOpenAiWithRetry(url, init);
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry a non-retryable status (e.g. 400)", async () => {
+    const fetchMock = vi.fn(async () => new Response("bad", { status: 400 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchAzureOpenAiWithRetry(url, init);
+    expect(res.status).toBe(400);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transient 429 then returns the eventual success", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("rate", { status: 429, headers: { "retry-after": "0" } }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onRetry = vi.fn();
+    const res = await fetchAzureOpenAiWithRetry(url, init, { onRetry });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith(expect.objectContaining({ status: 429, attempt: 1, maxAttempts: LLM_MAX_ATTEMPTS }));
+  });
+
+  it("exhausts the attempt budget on persistent 5xx and returns the last failing response", async () => {
+    const fetchMock = vi.fn(async () => new Response("boom", { status: 503, headers: { "retry-after": "0" } }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchAzureOpenAiWithRetry(url, init, { maxAttempts: 3 });
+    expect(res.status).toBe(503);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Problem
`src/modules/assessment/llmAssessmentService.ts` hadde **ingen retry** på transient Azure OpenAI 429 (TPM-kvote) eller 5xx. En forbigående rate-limit feilet en deltaker-vurdering helt. Authoring-pipelinen fikk denne retryen i #479 (v1.3.54) — samme mangel sto igjen i assessment.

## Fiks
Ekstrahert retry-policyen til delt `src/modules/llm/azureOpenAiRetry.ts`:
- `fetchAzureOpenAiWithRetry(url, init, opts)` — fetch + retry på 429/500/502/503/504, returnerer Response (også siste feilende etter budsjett, så caller beholder full kontroll).
- `parseRetryAfterMs` (delta-seconds + HTTP-date), `computeLlmBackoffMs` (Retry-After-aware, capped exponential m/ jitter).

Begge klientene bruker nå helperen. I assessment-klienten er **parameter-fallbacken (token-param/temperatur) urørt** — ikke-retrybare 400-class-signaler returnerer på første forsøk og driver fallbacken som før; den overordnede timeout-signalen begrenser total tid på tvers av retries. `parseRetryAfterMs`/`computeLlmBackoffMs` re-eksporteres fra `llmContentGenerationService` så de 53 eksisterende testene består uendret.

## Test
Ny `test/unit/azure-openai-retry.test.ts` (9 tester): Retry-After-parsing, backoff-grenser, returner-umiddelbart-på-ok, ikke-retry-på-400, retry-429-så-success, exhaust-budget. Lokalt: 62/62 grønne (9 nye + 53 eksisterende). tsc rent.

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)