### PR TITLE
fix(infra): backup-vault role-assignment feiler hardt på ekte feil (v1.3.69, #468)

### DIFF
--- a/.lint-infra-allowlist
+++ b/.lint-infra-allowlist
@@ -9,14 +9,6 @@
 # When fixing an entry, REMOVE the allowlist line — do not just edit the line number to
 # match a moved violation.
 
-# Two `| Out-Null` on `az role assignment create` in the backup-vault setup section.
-# Should be replaced with `| Out-Null; Assert-LastExitCode "az role assignment create"`
-# so a failed role assignment fails the deploy hard (per CLAUDE.md invariant #6) instead
-# of silently leaving the backup vault without permission to read PG snapshots.
-# Behavioural change: failed role assignment becomes blocking instead of silent (must
-# tolerate the idempotent RoleAssignmentExists re-run case — see issue).
-# Track in: #468.
-# Line numbers updated for the v1.2.34 pre-flight insertion above this section (#410/#411);
-# the violation itself is unchanged and still deferred to #468.
-PS-4|scripts/azure/deploy-environment.ps1|1040
-PS-4|scripts/azure/deploy-environment.ps1|1044
+# (PS-4 backup-vault role-assignment Out-Null suppressions removed in #468 — replaced with
+#  Invoke-IdempotentRoleAssignment, which fails hard on genuine errors but tolerates the
+#  idempotent RoleAssignmentExists re-run.)

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,17 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.69 - 2026-06-24
+
+fix(infra): backup-vault role-assignment feiler hardt på ekte feil (#468, invariant #6)
+
+De to `az role assignment create | Out-Null` i backup-vault-seksjonen av
+`deploy-environment.ps1` undertrykte både success-JSON OG feil — et brudd på infra-invariant #6.
+Erstattet med `Invoke-IdempotentRoleAssignment` som fanger stdout+stderr og feiler deployen hardt
+på ekte feil, men tolererer den idempotente `RoleAssignmentExists`-re-runen (samme unntak som
+ARM-siden via `Test-DeploymentFailureIsIdempotent`). Beslutningslogikken er den unit-testede
+`Test-RoleAssignmentSucceeded`-helperen. PS-4-oppføringene fjernet fra `.lint-infra-allowlist`.
+
 ## 1.3.68 - 2026-06-24
 
 fix(assessment): 429/5xx-retry i assessment-LLM-klienten (#603)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.68",
+  "version": "1.3.69",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/scripts/azure/deploy-environment.helpers.ps1
+++ b/scripts/azure/deploy-environment.helpers.ps1
@@ -42,6 +42,22 @@ function Test-DeploymentFailureIsIdempotent {
   return ($nonIdempotent.Count -eq 0)
 }
 
+# Decides whether an `az role assignment create` invocation should be treated as success.
+# Returns $true when it exited 0, OR when it failed solely because the assignment already exists
+# (RoleAssignmentExists) — the same idempotency exemption applied to the ARM-side role assignments
+# in Test-DeploymentFailureIsIdempotent, so a re-deploy on a principal that already has the role
+# does not fail. Returns $false for ANY genuine failure (e.g. auth, missing scope), which the
+# caller MUST treat as fatal — never silently swallowed (CLAUDE.md infra invariant #6, #468).
+function Test-RoleAssignmentSucceeded {
+  param(
+    [int]$ExitCode,
+    [string]$Output
+  )
+  if ($ExitCode -eq 0) { return $true }
+  if ($Output -and $Output -match 'RoleAssignmentExists') { return $true }
+  return $false
+}
+
 # Resolves the 3 App Service names (web/worker/parser) from a mix of ARM deployment
 # outputs and a fallback list of existing app names in the target resource group.
 # Output values from ARM are preferred; any missing name is filled in by matching

--- a/scripts/azure/deploy-environment.ps1
+++ b/scripts/azure/deploy-environment.ps1
@@ -148,6 +148,19 @@ function Assert-LastExitCode([string]$stepName) {
   }
 }
 
+# Creates a role assignment, tolerating the idempotent RoleAssignmentExists re-run but failing the
+# deploy hard on any genuine error (#468 / invariant #6). Captures stdout+stderr so the decision can
+# distinguish the two — decision logic is the unit-tested Test-RoleAssignmentSucceeded helper.
+function Invoke-IdempotentRoleAssignment([string]$Role, [string]$Assignee, [string]$Scope, [string]$StepName) {
+  $output = az role assignment create --role $Role --assignee $Assignee --scope $Scope 2>&1 | Out-String
+  if (-not (Test-RoleAssignmentSucceeded -ExitCode $LASTEXITCODE -Output $output)) {
+    throw "$StepName failed with exit code $LASTEXITCODE.`n$output"
+  }
+  if ($LASTEXITCODE -ne 0) {
+    Write-Host "WARN: $StepName -- role already assigned (RoleAssignmentExists); idempotent, continuing."
+  }
+}
+
 function Refresh-AzureCliOidcLogin([string]$reason = "") {
   if (
     [string]::IsNullOrWhiteSpace($AzureFederatedClientId) -or
@@ -1040,12 +1053,15 @@ if ($EnvironmentName -eq "production" -and -not $skipInfraBool) {
 
   $pgServerId = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.DBforPostgreSQL/flexibleServers/$postgresServerName"
   Write-Host "Assigning backup roles to vault MSI $vaultPrincipalId on $postgresServerName..."
-  # Suppress success JSON output only -- stderr (errors) still surfaces.
-  az role assignment create --role "Reader" --assignee $vaultPrincipalId --scope $pgServerId | Out-Null
-  az role assignment create `
-    --role "PostgreSQL Flexible Server Long Term Retention Backup Role" `
-    --assignee $vaultPrincipalId `
-    --scope $pgServerId | Out-Null
+  # #468: a failed assignment now fails the deploy hard (invariant #6) but tolerates the idempotent
+  # RoleAssignmentExists re-run — no longer silently swallowed with | Out-Null.
+  Invoke-IdempotentRoleAssignment -Role "Reader" -Assignee $vaultPrincipalId -Scope $pgServerId `
+    -StepName "az role assignment create (Reader on PG for backup-vault MSI)"
+  Invoke-IdempotentRoleAssignment `
+    -Role "PostgreSQL Flexible Server Long Term Retention Backup Role" `
+    -Assignee $vaultPrincipalId `
+    -Scope $pgServerId `
+    -StepName "az role assignment create (LTR Backup Role on PG for backup-vault MSI)"
   Write-Host "Backup role assignments applied."
 
   $existingBkpInstance = (az dataprotection backup-instance list `

--- a/test/scripts/deploy-environment.helpers.Tests.ps1
+++ b/test/scripts/deploy-environment.helpers.Tests.ps1
@@ -223,3 +223,24 @@ Describe 'Resolve-PostgresSkipForCredentialSafety' {
     { Resolve-PostgresSkipForCredentialSafety -RequestedSkip $true -ExistingPassword $null -DesiredPassword 'x' } | Should -Not -Throw
   }
 }
+
+Describe 'Test-RoleAssignmentSucceeded' {
+  It 'returns $true when az exited 0 (regardless of output)' {
+    Test-RoleAssignmentSucceeded -ExitCode 0 -Output '' | Should -BeTrue
+    Test-RoleAssignmentSucceeded -ExitCode 0 -Output 'created' | Should -BeTrue
+  }
+
+  It 'returns $true on the idempotent RoleAssignmentExists failure (non-zero exit)' {
+    $msg = "ERROR: (RoleAssignmentExists) The role assignment already exists.`nCode: RoleAssignmentExists"
+    Test-RoleAssignmentSucceeded -ExitCode 1 -Output $msg | Should -BeTrue
+  }
+
+  It 'returns $false on a genuine failure (non-zero exit, no RoleAssignmentExists)' {
+    Test-RoleAssignmentSucceeded -ExitCode 1 -Output 'ERROR: (AuthorizationFailed) does not have authorization' | Should -BeFalse
+    Test-RoleAssignmentSucceeded -ExitCode 2 -Output '' | Should -BeFalse
+  }
+
+  It 'does NOT treat empty output with a non-zero exit as success (invariant #6)' {
+    Test-RoleAssignmentSucceeded -ExitCode 1 -Output $null | Should -BeFalse
+  }
+}


### PR DESCRIPTION
## Problem (invariant #6)
To `az role assignment create … | Out-Null` i backup-vault-seksjonen av `deploy-environment.ps1` undertrykte både success-JSON **og feil**. Hvis en assignment feilet, sto backup-vaulten uten lese-tilgang til PG-snapshots — og deployen rapporterte success. Brudd på CLAUDE.md infra-invariant #6.

## Hvorfor det var utsatt
Den naive fiksen (`Assert-LastExitCode`) ville få en **re-deploy til å feile** når assignmenten allerede finnes (`az` exit≠0 med `RoleAssignmentExists`) — samme idempotens-tilfelle som ARM-siden håndterer via `Test-DeploymentFailureIsIdempotent`.

## Fiks
- Ny ren predikat-helper `Test-RoleAssignmentSucceeded(ExitCode, Output)` i `deploy-environment.helpers.ps1`: $true ved exit 0 eller `RoleAssignmentExists`, $false ved enhver ekte feil. Unit-testbar uten å kalle `az`.
- Tynn wrapper `Invoke-IdempotentRoleAssignment` i deploy-scriptet fanger stdout+stderr (`2>&1 | Out-String`), feiler hardt på ekte feil, logger WARN på idempotent re-run.
- PS-4-oppføringene fjernet fra `.lint-infra-allowlist`.

## Verifisering
- `lint-infra.sh`: OK (ingen anti-patterns; `2>&1 | Out-String` matcher ikke PS-4-regelen som ser etter `2>$null`/`| Out-Null`/`SilentlyContinue`).
- PS-parse (AST) ren på alle tre filer.
- Ny Pester-blokk `Test-RoleAssignmentSucceeded` (4 cases: exit 0, idempotent RAE, ekte feil, tom output→ikke-suksess). CI pester (Pester 5) er fasit — lokalt har Windows PS kun Pester 3.4.

## Rollback
Revert commit. Ingen ARM/Bicep-endring. Runtime-validering skjer ved neste infra-deploy til staging som treffer backup-vault-blokken (verifiser `/healthz` etter).

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)