### PR TITLE
ci(whatif): les diff fra fil i comment-poster — fiks E2BIG (#472)

### DIFF
--- a/.github/workflows/bicep-whatif-prod.yml
+++ b/.github/workflows/bicep-whatif-prod.yml
@@ -80,20 +80,23 @@ jobs:
               deployPrincipalId="${{ vars.DEPLOY_PRINCIPAL_ID }}" \
               skipRoleAssignments="${{ vars.SKIP_ROLE_ASSIGNMENTS || 'false' }}" \
             2>&1 || true)
-          echo "result<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$output" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          # #472: large diffs (hundreds of KB) blow the E2BIG limit when passed via env to
+          # github-script. Write to a file; the comment/log steps read it instead.
+          printf '%s' "$output" > "$RUNNER_TEMP/whatif-prod.txt"
 
       - name: Post what-if result as PR comment
         if: inputs.pr_number != ''
         uses: actions/github-script@v9.0.0
-        # #472: pass the diff via env, not template-literal interpolation — large diffs with
-        # backticks/${ /control chars otherwise break the script.
+        # #472: read the diff from a file (not env/template-literal) — avoids both control-char
+        # breakage and E2BIG "Argument list too long" on large diffs.
         env:
-          WHATIF_RESULT: ${{ steps.whatif.outputs.result }}
+          WHATIF_FILE: ${{ runner.temp }}/whatif-prod.txt
         with:
           script: |
-            const result = process.env.WHATIF_RESULT || '';
+            const fs = require('fs');
+            let result = '';
+            try { result = fs.readFileSync(process.env.WHATIF_FILE, 'utf8'); }
+            catch { result = '(what-if output unavailable — see the workflow logs)'; }
             const body = [
               '## Bicep what-if — production (manual)',
               '',
@@ -134,10 +137,7 @@ jobs:
 
       - name: Log what-if to job output (no PR)
         if: inputs.pr_number == ''
-        # #472: pass via env, not inline interpolation — echo '${{ ... }}' breaks on single
-        # quotes / special chars in the diff (e.g. KQL in alert rules).
-        env:
-          WHATIF_RESULT: ${{ steps.whatif.outputs.result }}
+        # #472: read from the file written by the what-if step (avoids oversized-env issues).
         run: |
           echo "Production what-if output:"
-          printf '%s\n' "$WHATIF_RESULT"
+          cat "$RUNNER_TEMP/whatif-prod.txt"

--- a/.github/workflows/bicep-whatif.yml
+++ b/.github/workflows/bicep-whatif.yml
@@ -52,19 +52,23 @@ jobs:
               deployPrincipalId="${{ vars.DEPLOY_PRINCIPAL_ID }}" \
               skipRoleAssignments="${{ vars.SKIP_ROLE_ASSIGNMENTS || 'false' }}" \
             2>&1 || true)
-          echo "result<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$output" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          # #472: the diff can be hundreds of KB. Passing it through an env var to github-script
+          # spawns node with an oversized environment → "Argument list too long" (E2BIG). Write it
+          # to a file and have the comment step read it via fs (only the small path goes through env).
+          printf '%s' "$output" > "$RUNNER_TEMP/whatif-staging.txt"
 
       - name: Post what-if result as PR comment
         uses: actions/github-script@v9.0.0
-        # #472: pass the diff via env, not template-literal interpolation — large diffs with
-        # backticks/${ /control chars (e.g. KQL in alert rules) otherwise break the script.
+        # #472: read the diff from a file (not env/template-literal). Env passing broke twice —
+        # first on backticks/${ /control chars, then on E2BIG for large diffs (KQL alert rules).
         env:
-          WHATIF_RESULT: ${{ steps.whatif.outputs.result }}
+          WHATIF_FILE: ${{ runner.temp }}/whatif-staging.txt
         with:
           script: |
-            const result = process.env.WHATIF_RESULT || '';
+            const fs = require('fs');
+            let result = '';
+            try { result = fs.readFileSync(process.env.WHATIF_FILE, 'utf8'); }
+            catch { result = '(what-if output unavailable — see the workflow logs)'; }
             const body = [
               '## Bicep what-if — staging',
               '',


### PR DESCRIPTION
## Problem
Staging-what-if på #468 (PR #633) feilet — men **selve what-if-en lyktes** (`"status":"Succeeded"`). Det var comment-poster-steget (`actions/github-script`) som kræsjet:
```
##[error]An error occurred trying to start process '.../node' ... Argument list too long
```
Hele ARM-diffen (hundrevis av KB, inkl. KQL i Azure Monitor alert-regler) ble sendt via env-var `WHATIF_RESULT`. En så stor env-blokk sprenger `ARG_MAX` (E2BIG) når node spawnes for github-script-action. Det forrige #472-forsøket (env i stedet for template-literal) løste kontrolltegn-bruddet, men ikke størrelsen.

## Fiks
What-if-steget skriver diffen til `$RUNNER_TEMP/whatif-{staging,prod}.txt`. Comment-stegene leser fila via `fs.readFileSync`, log-steget via `cat`. Kun den lille filstien går gjennom env. Gjelder begge workflowene (`bicep-whatif.yml` staging + `bicep-whatif-prod.yml`).

## Hvorfor nå
#607 (Azure OpenAI inn i Bicep) trenger en fungerende what-if-kommentar, og den diffen blir enda større. Dette er på kritisk sti for #607.

## Verifisering
- `actionlint 1.7.12`: ren på begge filer.
- CI-only (ingen app-kode, ingen version-bump). Selve what-if-effekten verifiseres ved neste infra-PR (#607).

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)