### PR TITLE
infra(openai): Azure OpenAI inn i Bicep (v1.3.71, #607) — WHAT-IF ONLY, ikke merge ennå

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,17 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.71 - 2026-06-24
+
+infra(openai): ta Azure OpenAI-konto + modell-deployment inn i Bicep (#607)
+
+Azure OpenAI-kontoen + `gpt-4.1-mini`-deploymentet var ikke i IaC — TPM-kapasiteten (hevet manuelt
+til 100 via `az` under #479) var verken dokumentert eller reproduserbar. `main.bicep` deklarerer nå
+`Microsoft.CognitiveServices/accounts` + `/deployments` med navn som matcher de eksisterende
+ressursene EKSAKT (`a2-assessment-<stg|prod>-openai-weu-<suffix>` — eget env-token `stg`/`prod`, ikke
+envCode `stg`/`prd`), så en Incremental-deploy ADOPTERER dem. `capacity` er nå en parameter
+(default 100). **Deployes ikke før what-if er gjennomgått** (verifiser Modify/NoChange, aldri Create).
+
 ## 1.3.70 - 2026-06-24
 
 feat(admin): advarsel ved bildetungt/lav-tekst kildemateriale (#601 Fase 1)

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -626,6 +626,10 @@ resource openAiModelDeployment 'Microsoft.CognitiveServices/accounts/deployments
       name: azureOpenAiModelName
       version: azureOpenAiModelVersion
     }
+    // #607: pin the live content-filter policy and version-upgrade behaviour so adoption does NOT
+    // strip them (what-if confirmed both staging and prod currently have exactly these values).
+    raiPolicyName: 'Microsoft.DefaultV2'
+    versionUpgradeOption: 'OnceNewDefaultVersionAvailable'
   }
 }
 

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -137,6 +137,23 @@ param azureOpenAiTokenLimitParameter string = 'auto'
 ])
 param azureOpenAiAuthoringTokenLimitParameter string = ''
 
+// #607: the Azure OpenAI account + model deployment, brought into IaC so the TPM capacity is
+// codified/reproducible (previously provisioned + capacity-bumped manually via az).
+@description('Azure OpenAI model deployment short name (appended after the env token: a2-assessment-<stg|prod>-<this>). Matches the existing deployment.')
+param azureOpenAiModelDeploymentShortName string = 'gpt-4.1-mini'
+
+@description('Azure OpenAI model name.')
+param azureOpenAiModelName string = 'gpt-4.1-mini'
+
+@description('Azure OpenAI model version.')
+param azureOpenAiModelVersion string = '2025-04-14'
+
+@description('Azure OpenAI deployment SKU (capacity tier).')
+param azureOpenAiDeploymentSkuName string = 'GlobalStandard'
+
+@description('Azure OpenAI deployment capacity (TPM units; 1 unit ~= 1K TPM). Raised to 100 during #479 so authoring stays fast with larger crawl source material.')
+param azureOpenAiDeploymentCapacity int = 100
+
 @description('Skip Key Vault secret role assignments. Set to true when the deployment SP lacks roleAssignments/write (e.g. has Contributor but not Owner). Existing assignments are preserved; missing ones will not be created. Default false.')
 param skipRoleAssignments bool = false
 
@@ -223,6 +240,12 @@ var acsName = toLower('${appNamePrefix}-${envCode}-acs-${suffix}')
 var createAcsEmail = participantNotificationChannel == 'acs_email'
 var postgresHost = '${postgresServerName}.postgres.database.azure.com'
 var keyVaultName = 'a2-${envCode}-kv-${suffix}'
+// #607: the Azure OpenAI account uses a DISTINCT env token (stg / prod) — NOT envCode (stg / prd) —
+// plus a -weu region tag, matching the names it was provisioned with before being brought into IaC.
+// Reproduces a2-assessment-stg-openai-weu-x6eyx4 (staging) and a2-assessment-prod-openai-weu-hea5kl (prod).
+var openAiEnvToken = environmentName == 'production' ? 'prod' : 'stg'
+var openAiAccountName = toLower('a2-assessment-${openAiEnvToken}-openai-weu-${suffix}')
+var openAiModelDeploymentName = 'a2-assessment-${openAiEnvToken}-${azureOpenAiModelDeploymentShortName}'
 // Storage account for course learning-section assets (#483/F4). Storage account names must be
 // 3-24 chars, lowercase alphanumeric only (no hyphens), globally unique.
 var courseAssetsStorageName = toLower('a2${envCode}assets${suffix}')
@@ -564,6 +587,46 @@ resource courseAssetsStorage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
 resource courseAssetsBlobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
   parent: courseAssetsStorage
   name: 'default'
+}
+
+// #607: Azure OpenAI account + model deployment, brought into IaC so the TPM capacity is codified
+// and reproducible (previously provisioned + capacity-bumped manually via az). The names match the
+// already-deployed resources EXACTLY (see openAiAccountName/openAiModelDeploymentName), so an
+// Incremental deploy ADOPTS them rather than creating new ones. location/sku/customSubDomain are
+// pinned to the live values (westeurope, S0) — ALWAYS verify via what-if before deploying that the
+// diff is "Modify/NoChange", never "Create", which would mean a name mismatch.
+resource openAiAccount 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
+  name: openAiAccountName
+  location: 'westeurope'
+  kind: 'OpenAI'
+  sku: {
+    name: 'S0'
+  }
+  properties: {
+    customSubDomainName: openAiAccountName
+    publicNetworkAccess: 'Enabled'
+  }
+  tags: {
+    environment: environmentName
+    costCenter: costCenter
+    owner: owner
+  }
+}
+
+resource openAiModelDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
+  parent: openAiAccount
+  name: openAiModelDeploymentName
+  sku: {
+    name: azureOpenAiDeploymentSkuName
+    capacity: azureOpenAiDeploymentCapacity
+  }
+  properties: {
+    model: {
+      format: 'OpenAI'
+      name: azureOpenAiModelName
+      version: azureOpenAiModelVersion
+    }
+  }
 }
 
 resource courseAssetsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.70",
+  "version": "1.3.71",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",


### PR DESCRIPTION
## Mål (#607)
Azure OpenAI-kontoen + `gpt-4.1-mini`-deploymentet var **ikke** i IaC. TPM-kapasiteten (hevet manuelt til 100 via `az` under #479) var verken dokumentert eller reproduserbar i kode.

## ⚠️ Ikke merge før what-if er gjennomgått
Å adoptere en **live** ressurs i Bicep er risikabelt: feil navn → ARM lager en *ny* konto. Navnene er verifisert mot begge miljøer:

| | Konto (live) | Bicep |
|---|---|---|
| staging | `a2-assessment-stg-openai-weu-x6eyx4` | matcher ✓ |
| prod | `a2-assessment-prod-openai-weu-hea5kl` | matcher ✓ |

**Felle unngått:** kontoene bruker env-token `stg`/**`prod`**, IKKE `envCode` (`stg`/**`prd`**). Suffiks (`uniqueString(subId,rgName)[0..6]`) = `x6eyx4` (stg) / `hea5kl` (prod), bekreftet mot app-navnene.

## Endring
- `CognitiveServices/accounts` (OpenAI, S0, westeurope, customSubDomain=navnet, publicNetworkAccess Enabled).
- `…/deployments`: `gpt-4.1-mini` @ `2025-04-14`, `GlobalStandard`, **capacity som parameter (default 100)**.
- Ingen rewiring av app-settings — minimal additiv adopsjon.

## Validering
- `az bicep build`: ren.
- **Staging what-if kjører automatisk** (comment-poster fungerer nå etter #472). **Forventet Modify/NoChange — ALDRI Create.** Create = navn-mismatch → ikke merge.
- Prod what-if manuelt: `gh workflow run bicep-whatif-prod.yml -f pr_number=<dette nr>`.

## Rollback (invariant #9)
Revert commit. Incremental sletter ingenting ved revert. Adopsjon endrer ingen immutable felter når navn/location/sku matcher (det what-if bekrefter).

Refs #607
🤖 Generated with [Claude Code](https://claude.com/claude-code)