### PR TITLE
test(e2e): fjern racy shellStatusAnnouncer-assertions (#614)

### DIFF
--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -266,7 +266,6 @@ test.describe("admin content browser coverage", () => {
     await expect(page.getByText("Module created.")).toBeVisible();
     await clickEnabledButton(page, "Save draft");
 
-    await expect(page.locator("#shellStatusAnnouncer")).toHaveText("Draft saved as a new module version.");
     await expect(page.getByText("Open or create a module before saving.")).toHaveCount(0);
     await expect(page.getByText(/Trade unions.*loaded\./)).toBeVisible();
   });
@@ -309,7 +308,6 @@ test.describe("admin content browser coverage", () => {
     await expect(page.getByText("Module created.")).toBeVisible();
     await clickEnabledButton(page, "Save draft");
 
-    await expect(page.locator("#shellStatusAnnouncer")).toHaveText("Draft saved as a new module version.");
     await expect.poll(() => versionPayload?.assessmentMode).toBe("FREETEXT_ONLY");
     expect(versionPayload?.mcqSetVersionId).toBeUndefined();
     expect(versionPayload?.taskText).toBeTruthy();
@@ -485,7 +483,6 @@ test.describe("admin content browser coverage", () => {
     await expect(page.getByText("Module created.")).toBeVisible();
     await clickEnabledButton(page, "Save draft");
 
-    await expect(page.locator("#shellStatusAnnouncer")).toHaveText("Draft saved as a new module version.");
     await expect.poll(() => versionPayload?.assessmentMode).toBe("MCQ_ONLY");
     expect(versionPayload?.taskText).toBeUndefined();
     expect(versionPayload?.rubricVersionId).toBeUndefined();
@@ -624,7 +621,6 @@ test.describe("admin content browser coverage", () => {
     await expect.poll(() => state.lastDraftLocalizationBody?.sourceLocale).toBe("nb");
     await clickEnabledButton(page, /Save draft|Lagre utkast/);
 
-    await expect(page.locator("#shellStatusAnnouncer")).toHaveText("Draft saved as a new module version.");
     await expect.poll(() => state.lastTitlePatchBody?.title?.nb).toBe("Fagforeninger");
     await expect(state.lastTitlePatchBody?.title?.["en-GB"]).toContain("[en-GB]");
     await expect(page.locator("#srModuleName")).toHaveText("Fagforeninger");
@@ -683,7 +679,6 @@ test.describe("admin content browser coverage", () => {
 
     await clickEnabledButton(page, /Save draft|Lagre utkast/);
 
-    await expect(page.locator("#shellStatusAnnouncer")).toHaveText("Draft saved as a new module version.");
     await expect.poll(() => state.lastTitlePatchBody?.title?.["en-GB"]).toBe("Trade union dialogue");
     await expect(page.locator("#srModuleName")).toHaveText("Trade union dialogue");
   });
@@ -748,7 +743,6 @@ test.describe("admin content browser coverage", () => {
 
     await clickEnabledButton(page, /Save draft|Lagre utkast/);
 
-    await expect(page.locator("#shellStatusAnnouncer")).toHaveText("Draft saved as a new module version.");
     await expect(page.getByText("Oppdatert norsk sporsmal")).toBeVisible();
     await expect(page.getByText("Oppdatert alternativ B").first()).toBeVisible();
   });


### PR DESCRIPTION
## Rotårsak (bekreftet, ikke spekulasjon)
`announceStatus` i `public/static/admin-content-shell.js` setter `#shellStatusAnnouncer`-teksten og **nullstiller den etter 1200 ms** (aria-live-region). `await expect(...).toHaveText("Draft saved as a new module version.")` på en region som tømmes etter 1,2s er iboende racy: under full-suite-last (~3,6 min, delt `reuseExistingServer`) kan assertion-pollen lande *etter* nullstillingen → ser `""` → timeout. En timeout-bump forverrer det.

## Fiks
Alle 6 announcer-assertionene fulgtes umiddelbart av et **durabelt** signal som allerede beviser lagring:
- reload-tekst (`/Trade unions.*loaded\./`)
- `expect.poll(() => versionPayload?.assessmentMode)` / `state.lastTitlePatchBody`
- `#srModuleName` / oppdatert spørsmålstekst

Fjernet de transiente announcer-assertionene; de durable står igjen (sterkere, deterministiske).

## Verifisering
Hele `admin-content-workspaces.spec.ts` kjørt lokalt mot delt statisk server: **35/35 grønne (57,7s)**. Test-only — ingen version-bump, ingen deploy.

## Merknad
Mister eksplisitt verifikasjon av selve a11y-annonseringen. Kan re-introduseres robust via en MutationObserver-capture (lav prioritet) hvis ønskelig — den transiente toHaveText kunne uansett ikke verifisere det pålitelig.

Closes #614
🤖 Generated with [Claude Code](https://claude.com/claude-code)