### PR TITLE
[codex] feat(course): add enrollment data model

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,16 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.72 - 2026-06-25
+
+feat(course): CourseEnrollment datamodel foundation (#640 / #496 EN-1)
+
+Adds the enrollment persistence foundation for Tier 2 course assignment: `Course.enrollmentPolicy`
+(`OPEN` by default for backward compatibility), `CourseEnrollment` with individual/department/self
+sources, optional due date, soft revoke, and cascade cleanup for user/course deletion. Enrollment
+status remains derived, not stored, using completion/progress/due-date precedence. The new repository
+and status helper are exported from the course module and covered by unit tests.
+
 ## 1.3.71 - 2026-06-24
 
 infra(openai): ta Azure OpenAI-konto + modell-deployment inn i Bicep (#607)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.71",
+  "version": "1.3.72",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260624140000_add_course_enrollment/migration.sql
+++ b/prisma/migrations/20260624140000_add_course_enrollment/migration.sql
@@ -1,0 +1,41 @@
+-- CreateEnum
+CREATE TYPE "CourseEnrollmentPolicy" AS ENUM ('OPEN', 'RESTRICTED');
+
+-- CreateEnum
+CREATE TYPE "CourseEnrollmentSource" AS ENUM ('INDIVIDUAL', 'DEPARTMENT', 'SELF');
+
+-- AlterTable
+ALTER TABLE "Course" ADD COLUMN     "enrollmentPolicy" "CourseEnrollmentPolicy" NOT NULL DEFAULT 'OPEN';
+
+-- CreateTable
+CREATE TABLE "CourseEnrollment" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "courseId" TEXT NOT NULL,
+    "assignedById" TEXT,
+    "source" "CourseEnrollmentSource" NOT NULL,
+    "dueAt" TIMESTAMP(3),
+    "assignedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "CourseEnrollment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CourseEnrollment_courseId_idx" ON "CourseEnrollment"("courseId");
+
+-- CreateIndex
+CREATE INDEX "CourseEnrollment_userId_revokedAt_idx" ON "CourseEnrollment"("userId", "revokedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CourseEnrollment_userId_courseId_key" ON "CourseEnrollment"("userId", "courseId");
+
+-- AddForeignKey
+ALTER TABLE "CourseEnrollment" ADD CONSTRAINT "CourseEnrollment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CourseEnrollment" ADD CONSTRAINT "CourseEnrollment_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CourseEnrollment" ADD CONSTRAINT "CourseEnrollment_assignedById_fkey" FOREIGN KEY ("assignedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,6 +91,8 @@ model User {
   courseCompletions     CourseCompletion[]
   courseSectionReads    CourseSectionRead[]
   createdModules        Module[]              @relation("CreatedModules")
+  courseEnrollments     CourseEnrollment[]    @relation("EnrolledUser")
+  enrollmentsAssigned   CourseEnrollment[]    @relation("EnrollmentAssignedBy")
 }
 
 model UserConsent {
@@ -471,6 +473,9 @@ model Course {
   title              String             // lokalisert JSON: {"en-GB":"...","nb":"...","nn":"..."}
   description        String?            // lokalisert JSON
   certificationLevel String?
+  // #496/EN-1: OPEN = visible to everyone (current behavior, default for existing courses);
+  // RESTRICTED = visible/available only to enrolled users.
+  enrollmentPolicy   CourseEnrollmentPolicy @default(OPEN)
   publishedAt        DateTime?
   archivedAt         DateTime?
   createdAt          DateTime           @default(now())
@@ -479,6 +484,7 @@ model Course {
   items              CourseItem[]
   completions        CourseCompletion[]
   sectionReads       CourseSectionRead[]
+  enrollments        CourseEnrollment[]
 }
 
 model CourseModule {
@@ -503,6 +509,38 @@ model CourseCompletion {
   course             Course   @relation(fields: [courseId], references: [id], onDelete: Restrict)
 
   @@unique([userId, courseId])
+}
+
+// #496/EN-1: assignment of a course to a participant (individual, department, or self-enrollment),
+// with an optional due date. Status (ASSIGNED/IN_PROGRESS/OVERDUE/COMPLETED) is NOT STORED; it is
+// derived from CourseCompletion + section/module progress + dueAt to avoid status drift.
+enum CourseEnrollmentPolicy {
+  OPEN
+  RESTRICTED
+}
+
+enum CourseEnrollmentSource {
+  INDIVIDUAL
+  DEPARTMENT
+  SELF
+}
+
+model CourseEnrollment {
+  id           String                 @id @default(cuid())
+  userId       String
+  courseId     String
+  assignedById String? // SMO/admin who assigned; null for self-enrollment (source=SELF)
+  source       CourseEnrollmentSource
+  dueAt        DateTime? // optional due date
+  assignedAt   DateTime               @default(now())
+  revokedAt    DateTime? // soft revoke: keep history/audit
+  user         User                   @relation("EnrolledUser", fields: [userId], references: [id], onDelete: Cascade)
+  course       Course                 @relation(fields: [courseId], references: [id], onDelete: Cascade)
+  assignedBy   User?                  @relation("EnrollmentAssignedBy", fields: [assignedById], references: [id], onDelete: SetNull)
+
+  @@unique([userId, courseId])
+  @@index([courseId])
+  @@index([userId, revokedAt])
 }
 
 // Læringsseksjon i et kurs (#476/#481). Speiler Module/ModuleVersion: innholdet

--- a/src/modules/course/enrollmentRepository.ts
+++ b/src/modules/course/enrollmentRepository.ts
@@ -1,0 +1,69 @@
+import { prisma } from "../../db/prisma.js";
+import type { CourseEnrollmentSource } from "@prisma/client";
+
+// #496/EN-1: persistence for course enrollments (assign / revoke / read). Status is NOT stored here
+// - it is derived (see enrollmentStatus.ts) by the service layer (EN-2) from CourseCompletion +
+// progress + dueAt.
+
+type EnrollmentRepositoryClient = Pick<typeof prisma, "courseEnrollment">;
+
+export interface AssignEnrollmentInput {
+  userId: string;
+  courseId: string;
+  assignedById: string | null;
+  source: CourseEnrollmentSource;
+  dueAt: Date | null;
+}
+
+export function createEnrollmentRepository(client: EnrollmentRepositoryClient = prisma) {
+  return {
+    // Idempotent assign: re-assigning an existing (or previously revoked) enrollment updates the
+    // due date / source and clears revokedAt, rather than failing on the @@unique(userId,courseId).
+    assignEnrollment(input: AssignEnrollmentInput) {
+      const data = {
+        assignedById: input.assignedById,
+        source: input.source,
+        dueAt: input.dueAt,
+        revokedAt: null,
+      };
+      return client.courseEnrollment.upsert({
+        where: { userId_courseId: { userId: input.userId, courseId: input.courseId } },
+        create: { userId: input.userId, courseId: input.courseId, ...data },
+        update: { ...data, assignedAt: new Date() },
+      });
+    },
+
+    // Soft revoke - keep the row for history/audit.
+    revokeEnrollment(userId: string, courseId: string) {
+      return client.courseEnrollment.updateMany({
+        where: { userId, courseId, revokedAt: null },
+        data: { revokedAt: new Date() },
+      });
+    },
+
+    findEnrollment(userId: string, courseId: string) {
+      return client.courseEnrollment.findUnique({
+        where: { userId_courseId: { userId, courseId } },
+      });
+    },
+
+    // Active (non-revoked) enrollments for a participant.
+    findActiveEnrollmentsForUser(userId: string) {
+      return client.courseEnrollment.findMany({
+        where: { userId, revokedAt: null },
+        orderBy: { assignedAt: "desc" },
+      });
+    },
+
+    // Active enrollments for a course (admin view), newest first, with the participant.
+    findActiveEnrollmentsForCourse(courseId: string) {
+      return client.courseEnrollment.findMany({
+        where: { courseId, revokedAt: null },
+        orderBy: { assignedAt: "desc" },
+        include: { user: { select: { id: true, name: true, email: true, department: true } } },
+      });
+    },
+  };
+}
+
+export const enrollmentRepository = createEnrollmentRepository();

--- a/src/modules/course/enrollmentStatus.ts
+++ b/src/modules/course/enrollmentStatus.ts
@@ -1,0 +1,21 @@
+// #496/EN-1: enrollment status is DERIVED, never stored - single source of truth against
+// CourseCompletion + progress + dueAt, so it can never drift from the actual completion state
+// (the same lesson as the certificate backfill bug, #627).
+
+export type EnrollmentStatus = "ASSIGNED" | "IN_PROGRESS" | "OVERDUE" | "COMPLETED";
+
+/**
+ * Derives the status of a course enrollment. Precedence: COMPLETED -> OVERDUE -> IN_PROGRESS ->
+ * ASSIGNED. A past-due enrollment that is not yet completed is OVERDUE regardless of progress.
+ */
+export function deriveEnrollmentStatus(input: {
+  isCompleted: boolean;
+  hasStarted: boolean;
+  dueAt: Date | null;
+  now: Date;
+}): EnrollmentStatus {
+  if (input.isCompleted) return "COMPLETED";
+  if (input.dueAt && input.dueAt.getTime() < input.now.getTime()) return "OVERDUE";
+  if (input.hasStarted) return "IN_PROGRESS";
+  return "ASSIGNED";
+}

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -18,6 +18,9 @@ export {
   MAX_ASSET_BYTES,
 } from "./assetCommands.js";
 export { courseRepository, createCourseRepository } from "./courseRepository.js";
+export { enrollmentRepository, createEnrollmentRepository } from "./enrollmentRepository.js";
+export { deriveEnrollmentStatus } from "./enrollmentStatus.js";
+export type { EnrollmentStatus } from "./enrollmentStatus.js";
 export { computeCourseStatus } from "./courseQueries.js";
 export type {
   CourseStatus,

--- a/test/unit/enrollment-repository.test.ts
+++ b/test/unit/enrollment-repository.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { createEnrollmentRepository } from "../../src/modules/course/enrollmentRepository.js";
+
+describe("enrollment repository", () => {
+  it("upserts an enrollment and clears revokedAt on re-assignment", async () => {
+    const upsert = vi.fn().mockResolvedValue({ id: "enrollment-1" });
+    const repository = createEnrollmentRepository({
+      courseEnrollment: {
+        upsert,
+      },
+    } as never);
+    const dueAt = new Date("2026-07-10T12:00:00.000Z");
+
+    await repository.assignEnrollment({
+      userId: "user-1",
+      courseId: "course-1",
+      assignedById: "admin-1",
+      source: "INDIVIDUAL",
+      dueAt,
+    });
+
+    expect(upsert).toHaveBeenCalledWith({
+      where: { userId_courseId: { userId: "user-1", courseId: "course-1" } },
+      create: {
+        userId: "user-1",
+        courseId: "course-1",
+        assignedById: "admin-1",
+        source: "INDIVIDUAL",
+        dueAt,
+        revokedAt: null,
+      },
+      update: {
+        assignedById: "admin-1",
+        source: "INDIVIDUAL",
+        dueAt,
+        revokedAt: null,
+        assignedAt: expect.any(Date),
+      },
+    });
+  });
+
+  it("soft-revokes only active enrollments", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const repository = createEnrollmentRepository({
+      courseEnrollment: {
+        updateMany,
+      },
+    } as never);
+
+    await repository.revokeEnrollment("user-1", "course-1");
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", courseId: "course-1", revokedAt: null },
+      data: { revokedAt: expect.any(Date) },
+    });
+  });
+
+  it("finds active enrollments for a participant newest first", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const repository = createEnrollmentRepository({
+      courseEnrollment: {
+        findMany,
+      },
+    } as never);
+
+    await repository.findActiveEnrollmentsForUser("user-1");
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", revokedAt: null },
+      orderBy: { assignedAt: "desc" },
+    });
+  });
+
+  it("finds active course enrollments with participant context", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const repository = createEnrollmentRepository({
+      courseEnrollment: {
+        findMany,
+      },
+    } as never);
+
+    await repository.findActiveEnrollmentsForCourse("course-1");
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: { courseId: "course-1", revokedAt: null },
+      orderBy: { assignedAt: "desc" },
+      include: {
+        user: {
+          select: { id: true, name: true, email: true, department: true },
+        },
+      },
+    });
+  });
+});

--- a/test/unit/enrollment-status.test.ts
+++ b/test/unit/enrollment-status.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { deriveEnrollmentStatus } from "../../src/modules/course/enrollmentStatus.js";
+
+describe("deriveEnrollmentStatus", () => {
+  const now = new Date("2026-07-01T12:00:00.000Z");
+
+  it("keeps completed enrollments completed even after the due date", () => {
+    expect(
+      deriveEnrollmentStatus({
+        isCompleted: true,
+        hasStarted: true,
+        dueAt: new Date("2026-06-30T12:00:00.000Z"),
+        now,
+      }),
+    ).toBe("COMPLETED");
+  });
+
+  it("marks incomplete past-due enrollments as overdue before in-progress", () => {
+    expect(
+      deriveEnrollmentStatus({
+        isCompleted: false,
+        hasStarted: true,
+        dueAt: new Date("2026-06-30T12:00:00.000Z"),
+        now,
+      }),
+    ).toBe("OVERDUE");
+  });
+
+  it("marks started non-overdue enrollments as in progress", () => {
+    expect(
+      deriveEnrollmentStatus({
+        isCompleted: false,
+        hasStarted: true,
+        dueAt: new Date("2026-07-02T12:00:00.000Z"),
+        now,
+      }),
+    ).toBe("IN_PROGRESS");
+  });
+
+  it("leaves untouched non-started enrollments assigned", () => {
+    expect(
+      deriveEnrollmentStatus({
+        isCompleted: false,
+        hasStarted: false,
+        dueAt: null,
+        now,
+      }),
+    ).toBe("ASSIGNED");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the EN-1 persistence foundation for enrollment/tildeling/frister under #496.
- Introduces `Course.enrollmentPolicy` with default `OPEN`, plus `CourseEnrollment` with source, due date, assignment actor, assigned timestamp, and soft revoke.
- Adds repository helpers for assign/revoke/read flows and a derived enrollment status helper.
- Bumps package version to `1.3.72` and documents the change in `doc/VERSIONS.md`.

## Linked Issue
- Closes #640
- Part of #496

## Scope
- In scope: Prisma schema + migration, course module exports, enrollment repository, derived status helper, focused unit tests.
- Out of scope: EN-2 API/authz/visibility filtering, EN-3 admin UI, EN-4 participant UI, EN-5 full e2e/docs surface.

## Design/Architecture Evaluation
- [x] I evaluated whether design/architecture work is needed before implementation.
- Decision: sufficient design exists; continue with EN-1 only.
- Rationale: `doc/design/ENROLLMENT_496.md` records the core decisions (`OPEN`/`RESTRICTED`, materialized department assignment, self-enrollment on `OPEN`) and decomposes #496 into #640-#645.
- Link to design note: `doc/design/ENROLLMENT_496.md`

## Refactor Evaluation
- [x] I evaluated whether touched code should be refactored to reduce complexity.
- Decision: no broader refactor.
- Rationale: this is a narrow foundation slice; repository/status helpers follow existing course/module patterns.
- Follow-up issue (if deferred): EN-2/EN-3/EN-4 already track the remaining service/API/UI work.

## Configuration-First Check
- [x] I reviewed hardcoded values and moved evolving rules/settings to configuration where appropriate.
- Config keys/changes: none. `OPEN` is a DB default chosen for backwards compatibility with current course visibility.

## Testing Evaluation
- Unit tests: Added (`test/unit/enrollment-repository.test.ts`, `test/unit/enrollment-status.test.ts`).
- Integration tests: Not added in this slice; EN-2 owns API/service integration behavior.
- E2E tests: Not added in this slice; EN-3/EN-4/EN-5 own user-facing flows.
- Test evidence:
  - `npm run prisma:generate` - passed
  - `npm run test:unit -- test/unit/enrollment-repository.test.ts test/unit/enrollment-status.test.ts` - passed, 8 tests
  - `npm run lint` - passed
  - `npm exec -- dotenv -e .env.test -- prisma validate` - passed
  - CI passed: `infra-lint`, `pester`, `playwright`, `verify`
  - `npm run pretest` - blocked locally because Docker Desktop was not running (`dockerDesktopLinuxEngine` pipe missing), so the test Postgres container could not start.

## Documentation Evaluation
- [x] I evaluated documentation impact.
- Docs updated: `doc/VERSIONS.md`; design was already present in `doc/design/ENROLLMENT_496.md`.
- If not updated, reason + follow-up issue: no API/route/user-facing docs in EN-1 because no route/UI behavior changes; #644 tracks enrollment docs + end-to-end flow docs.

## Versioning
- [x] Version number is bumped for this push.
- [x] `doc/VERSIONS.md` is updated with this version and summary.

## CI/CD and Deployment
- [x] CI passed.
- [ ] Change deployed/validated in staging.
- [x] Production requires human approval and has not been auto-deployed.
- Rollback plan: before deploy, revert this PR. After deploy, app rollback can revert code; DB rollback would require a manual migration to drop `CourseEnrollment`, `CourseEnrollmentPolicy`, `CourseEnrollmentSource`, and `Course.enrollmentPolicy` if full schema removal is required. Leaving the added table/column in place is inert for current runtime until EN-2+ use it.

## Deployment RCA Guardrails (Required for deploy/runtime changes)
- [ ] I documented one testable root-cause hypothesis before applying the fix.
- [ ] I validated evidence in order: workflow logs -> app settings -> deployed artifact contents -> startup contract -> runtime data-path.
- [ ] I verified deployed artifact contract (entrypoint, runtime scripts, hidden runtime dependencies, prune safety).
- [ ] I verified post-deploy smoke checks (`/healthz` and one critical API path).
- RCA summary (single sentence): N/A - this is not a deploy/runtime incident fix; no deploy was performed.
- Evidence links/notes: Local validation and CI only, listed above.

## Infra changes (required when touching `infra/`, `scripts/azure/`, or `.github/workflows/`)

_Skip this section: no infra, Azure script, or workflow files are changed._

## Checklist
- [x] Acceptance criteria are met for EN-1.
- [x] Security/privacy/traceability impacts were reviewed.
- [x] Observability impact was reviewed.