### PR TITLE
fix(admin): MCQ-only-revisjon i samtale + Modultype-radioer (v1.3.73, #655)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,19 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.73 - 2026-06-25
+
+fix(admin): MCQ-only-modul kan revideres i samtale + Modultype-radioer (#655)
+
+To klient-lags-bugs i Avansert innholdsforfatting. (1) Radioknappene under «Modultype» arvet
+`width:100%` fra base-input-stilen — bare `input[type=checkbox]` var unntatt (#546) — så radioen
+strakk seg over hele panelet og dyttet labelen til høyre; nå får `input[type=radio]` samme
+`width:auto`. (2) En MCQ-only-modul kunne ikke lagres når den ble revidert via «Fortsett å redigere
+i chat»: `createSessionDraftFromLoadedModule` kopierte ikke `assessmentMode` fra den lastede modulen,
+så lagrings-valideringen behandlet den som «Fritekst+flervalg» og krevde scenario/oppgavetekst som
+MCQ-only aldri har. Draften bærer nå over `assessmentMode` + `mcqMinPercent`. Begge dekket av en ny
+Playwright-e2e (`admin-content-mcq-only-revision.spec.ts`).
+
 ## 1.3.72 - 2026-06-25
 
 feat(course): CourseEnrollment datamodel foundation (#640 / #496 EN-1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.72",
+  "version": "1.3.73",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-advanced.html
+++ b/public/admin-content-advanced.html
@@ -88,8 +88,10 @@
       .mcq-q-remove:hover, .mcq-opt-remove:hover, .prompt-ex-remove:hover, .ss-field-remove:hover { opacity: 1; }
       .mcq-option-row { display: grid; grid-template-columns: 20px 1fr 24px; gap: 6px; align-items: center; margin-bottom: 6px; }
       .mcq-option-row input[type="radio"] { margin: 0; }
-      /* #546 feedback: checkboxes must not inherit the full-width text-input styling. */
-      input[type="checkbox"] { width: auto; display: inline-block; vertical-align: middle; margin: 0 6px 0 0; }
+      /* #546 feedback: checkboxes must not inherit the full-width text-input styling.
+         Radios need the same guard, else the module-type radios stretch full-width inside
+         their flex row and push the label to the far right (centred dot, label drifting). */
+      input[type="checkbox"], input[type="radio"] { width: auto; display: inline-block; vertical-align: middle; margin: 0 6px 0 0; }
       /* #546 feedback: group the module-type (MCQ-only) control in a distinct sub-panel so it
          reads as one choice, separate from the free-text fields. */
       .module-type-panel { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-2); margin: var(--space-1) 0; background: var(--color-surface-muted, #f7f8fa); }

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -1505,12 +1505,22 @@ function createSessionDraftFromLoadedModule() {
     return false;
   }
 
+  // #555/#578: carry over the loaded module's type so a conversational revision of an
+  // MCQ-only / free-text-only module saves under the right mode. Without this, assessmentMode
+  // is undefined and saveDraftBundleInBackground treats it as FREETEXT_PLUS_MCQ — which wrongly
+  // demands scenario/task text and blocks saving an MCQ-only revision. mcqMinPercent is carried
+  // too, else the pass threshold silently resets to the default on save.
+  const assessmentMode = moduleVersion?.assessmentMode;
+  const loadedMcqMinPercent = moduleVersion?.assessmentPolicy?.passRules?.mcqMinPercent;
+
   sessionDraft = buildPreviewCandidate({
     title: moduleTitle,
     taskText: moduleVersion?.taskText ?? "",
     assessorExpectedContent: moduleVersion?.assessorExpectedContent ?? "",
     candidateTaskConstraints: moduleVersion?.candidateTaskConstraints ?? "",
     mcqQuestions,
+    ...(assessmentMode ? { assessmentMode } : {}),
+    ...(Number.isFinite(loadedMcqMinPercent) ? { mcqMinPercent: loadedMcqMinPercent } : {}),
   });
   previewDraft = null;
   sessionState = "draft-pending";

--- a/test/e2e/admin-content-mcq-only-revision.spec.ts
+++ b/test/e2e/admin-content-mcq-only-revision.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "@playwright/test";
+import type { Route } from "@playwright/test";
+
+import {
+  mockCommonApis,
+  clickEnabledButton,
+  localizedText,
+  buildMockModuleExport,
+  type MockModuleExport,
+} from "./admin-content-helpers.js";
+
+// Regression coverage for #655 — two client-layer bugs in Advanced authoring that are
+// invisible to supertest:
+//   1. Module-type radios stretched full width (inherited width:100% from the base input
+//      style; only checkboxes were exempted). Pinned by measuring the radio's box width.
+//   2. A conversational revision of an MCQ-only module could not be saved: the loaded draft
+//      dropped assessmentMode, so save-validation treated it as FREETEXT_PLUS_MCQ and demanded
+//      scenario text (shell.save.taskRequired) that MCQ-only modules never have.
+
+test.describe("admin content — module-type bugs (#655)", () => {
+  test("module-type radios are not stretched full width", async ({ page }) => {
+    await mockCommonApis(page, {
+      modules: [{ id: "module-1", title: "Trade unions" }],
+      moduleExports: {
+        "module-1": buildMockModuleExport({
+          id: "module-1",
+          title: "Trade unions",
+          moduleVersionId: "module-1-version-1",
+        }),
+      },
+    });
+
+    await page.goto("/admin-content/module/module-1/advanced");
+    await expect(page.locator("#moduleStatusTitle")).toContainText("Trade unions");
+
+    const radio = page.locator('input[name="moduleVersionType"]').first();
+    await expect(radio).toBeVisible();
+    const box = await radio.boundingBox();
+    expect(box).not.toBeNull();
+    // A real radio control is ~13–20px wide. Before the fix it inherited width:100% and
+    // spanned the whole panel (hundreds of px), pushing its label to the far right.
+    expect(box!.width).toBeLessThan(40);
+  });
+
+  test("an MCQ-only module can be revised in chat and saved without scenario text", async ({ page }) => {
+    // An existing, published MCQ-only module: a module version flagged MCQ_ONLY with NO
+    // free-text (empty taskText) plus a saved MCQ set. This is the shape the export endpoint
+    // returns for a module authored via the MCQ-only path.
+    const mcqQuestions = [
+      {
+        stem: localizedText("Question 1"),
+        options: [localizedText("A"), localizedText("B"), localizedText("C"), localizedText("D")],
+        correctAnswer: localizedText("B"),
+        rationale: localizedText("Rationale"),
+      },
+    ];
+    const moduleVersion = {
+      id: "module-1-version-1",
+      versionNo: 1,
+      assessmentMode: "MCQ_ONLY",
+      taskText: {},
+      assessorExpectedContent: {},
+      candidateTaskConstraints: {},
+      assessmentPolicy: { passRules: { mcqMinPercent: 60 } },
+    };
+    const mcqSetVersion = {
+      id: "module-1-mcq-1",
+      title: localizedText("Trade unions"),
+      questions: mcqQuestions,
+    };
+    const mcqOnlyExport: MockModuleExport = {
+      module: {
+        id: "module-1",
+        title: localizedText("Trade unions"),
+        certificationLevel: "basic",
+        activeVersionId: "module-1-version-1",
+        archivedAt: null,
+      },
+      selectedConfiguration: {
+        source: "draftModuleVersion",
+        moduleVersion,
+        rubricVersion: null,
+        promptTemplateVersion: null,
+        mcqSetVersion,
+      },
+      versions: {
+        moduleVersions: [moduleVersion],
+        rubricVersions: [],
+        promptTemplateVersions: [],
+        mcqSetVersions: [mcqSetVersion],
+      },
+    };
+
+    await mockCommonApis(page, {
+      modules: [{ id: "module-1", title: "Trade unions", activeVersion: { versionNo: 1 } }],
+      moduleExports: { "module-1": mcqOnlyExport },
+    });
+
+    // Capture the saved module-version payload to prove the MCQ-only save path ran.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let savedVersionPayload: any = null;
+    await page.route("**/api/admin/content/modules/*/module-versions", async (route: Route) => {
+      savedVersionPayload = route.request().postDataJSON();
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ moduleVersion: { id: "module-1-version-2", versionNo: 2 } }),
+      });
+    });
+
+    await page.goto("/admin-content/module/module-1/conversation");
+
+    // Module actions menu → "Continue editing in chat" (resumeChatEdit). This is the exact
+    // path that builds the revision draft from the loaded module (#655 bug 2).
+    await clickEnabledButton(page, /Continue editing in chat|Fortsett å redigere i chat|Hald fram med å redigere i chat/);
+
+    // Draft-ready actions → "Save draft".
+    await clickEnabledButton(page, /^Save draft$|^Lagre utkast$/);
+
+    // The save must succeed — NOT be blocked by the scenario-required guard.
+    await expect(
+      page.getByText(/The draft needs scenario text|Utkastet må ha scenario\/oppgavetekst|Utkastet må ha scenario\/oppgåvetekst/),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText(/Draft saved as a new module version|Utkastet er lagret som en ny modulversjon|Utkastet er lagra som ein ny modulversjon/).first(),
+    ).toBeVisible();
+
+    // And the version that was saved carries the MCQ-only mode + the loaded pass threshold.
+    expect(savedVersionPayload?.assessmentMode).toBe("MCQ_ONLY");
+    expect(savedVersionPayload?.taskText).toBeUndefined();
+    expect(savedVersionPayload?.assessmentPolicy?.passRules?.mcqMinPercent).toBe(60);
+  });
+});


### PR DESCRIPTION
Fikser to klient-lags-bugs i Avansert innholdsforfatting (rapportert under sesjon, sporet i #655). Begge er usynlige for supertest — derfor ny Playwright-e2e i samme PR, kjørt lokalt.

## Bug 1 — Modultype-radioene strakk seg full bredde
Radioknappene under «Modultype» arvet `width:100%` fra base-input-stilen; bare `input[type=checkbox]` var unntatt (#546). Resultat: radio-prikken sentreres og labelen dyttes helt til høyre.
**Fiks:** `input[type=radio]` får samme `width:auto` ([admin-content-advanced.html](public/admin-content-advanced.html)).

## Bug 2 — MCQ-only-modul kan ikke lagres ved revisjon i samtale
Når man laster en eksisterende MCQ-only-modul og velger «Fortsett å redigere i chat», bygde `createSessionDraftFromLoadedModule` draften **uten** å kopiere `assessmentMode`. Da ble `isMcqOnly` falsk i `saveDraftBundleInBackground`, valideringen behandlet modulen som «Fritekst+flervalg» og krevde scenario/oppgavetekst (`shell.save.taskRequired`) som MCQ-only ikke har → lagring blokkert.
**Fiks:** draften bærer nå over `assessmentMode` + `mcqMinPercent` fra den lastede modulen ([admin-content-shell.js](public/static/admin-content-shell.js)). Den avanserte editoren leser allerede `moduleVersion.assessmentMode` fra samme bundle, så feltet finnes garantert.

## Test
Ny `test/e2e/admin-content-mcq-only-revision.spec.ts` (2 tester, grønne lokalt):
- radioens box-bredde < 40px (var full panelbredde før fiksen)
- MCQ-only-modul → «Fortsett å redigere i chat» → «Lagre utkast» lagrer uten scenario-blokkering; verifiserer at lagret versjon har `assessmentMode=MCQ_ONLY` + bevart `mcqMinPercent`

Begge testene feiler uten fiksen (save-POST skjer aldri / taskRequired vises).

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)