### PR TITLE
feat(sections): trygg SVG-opplasting + lokaliserte SVG-tegninger (v1.3.74, #657)

### DIFF
--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -201,6 +201,11 @@ fields (`title`, `bodyMarkdown`) accept a string or a partial `{en-GB,nb,nn}` ob
 | `DELETE` | `/api/admin/content/sections/:sectionId` | Delete (blocked `400` if the section is used in a course) |
 | `POST` | `/api/admin/content/sections/preview` | Render markdown → sanitised HTML (same F3/X1 policy as participant view) |
 | `POST` | `/api/admin/content/sections/localize` | LLM-translate title + bodyMarkdown to another locale (markdown-preserving). Rate-limited. |
+| `POST` | `/api/admin/content/sections/:sectionId/assets` | Upload a section image (multipart `file`). PNG/JPEG/GIF/WebP/SVG, max 5 MB. SVG is sanitised server-side before storage (scripts/handlers/`foreignObject`/`<a>` stripped, #657). Returns `asset` + `ref` (`asset:<id>`). |
+| `GET` | `/api/admin/content/sections/:sectionId/assets` | List section assets. |
+| `POST` | `/api/admin/content/sections/:sectionId/assets/localize` | Generate translated SVG variants for the section's SVG drawings. Body `{ sourceLocale }`. Extracts `<text>`/`<tspan>` labels, translates to each other supported locale, stores a per-locale variant. Explicit author action (never implicit). Rate-limited (#657). |
+
+The participant/preview serve endpoint `GET /api/content-assets/:assetId` accepts an optional `?locale=` query: when a translated SVG variant exists for that locale it is returned, else the original. SVG responses carry `Content-Security-Policy: …; sandbox` + `X-Content-Type-Options: nosniff` as defence-in-depth for direct navigation (#657).
 
 ---
 

--- a/doc/FEATURE_SURFACE_MAP.md
+++ b/doc/FEATURE_SURFACE_MAP.md
@@ -154,3 +154,22 @@ quota; one un-retried/oversize call cascades.
 - Deployment TPM capacity is **not** in IaC (#607); current capacity recorded there.
 
 **Guards:** `test/unit/llm-retry.test.ts` (retry + chunked condense), `test/unit/llm-content-generation-service.test.ts` (backoff helpers + `splitIntoChunks`).
+
+## 11. Section SVG assets — sanitisation + localisation (#657)
+
+SVG section drawings touch upload (sanitise), serving (CSP/nosniff + per-locale variant), and
+rendering (preview + participant must thread the locale). A fix in one path (e.g. accept SVG in the
+upload mime list) silently leaves the others wrong (an unsanitised serve, or a translated variant
+that never reaches the viewer because the locale isn't threaded).
+
+| Surface | Where | Notes |
+|---------|-------|-------|
+| Allowlist + sanitise on upload | `src/modules/course/assetCommands.ts` → `ALLOWED_ASSET_MIME_TYPES`, `createSectionAsset` | SVG sanitised before `putAsset` |
+| Sanitiser (source of truth) | `src/modules/course/svgSanitizer.ts` → `sanitizeSvg` + text helpers | strips script/handlers/`foreignObject`/`<a>` |
+| Localise command | `assetCommands.ts` → `localizeSectionAssets`; LLM `localizeSvgTexts` | per-locale variants → `localizedBlobPaths` |
+| Localise route (explicit) | `src/routes/adminSections.ts` `POST /:sectionId/assets/localize` | author "Translate" action only |
+| Serve (headers + variant) | `src/routes/contentAssets.ts`; `getSectionAssetContent(assetId, locale)` | CSP `sandbox` + nosniff for SVG; `?locale=` picks variant |
+| Locale threading (render) | `src/modules/course/sectionContent.ts` → `renderSectionMarkdown(md, locale)` → `resolveAssetUrls` appends `?locale=` | participant: `src/routes/courses.ts`; preview: `adminSections.ts /preview` |
+| Client upload + translate trigger | `public/static/admin-content-sections.js` (`accept` incl. svg; translate loop calls `/assets/localize`; preview sends `locale`) | `hydrateContentAssetImages` preserves the `?locale=` query |
+
+**Guards:** `test/unit/svg-sanitizer.test.ts` (XSS vectors + text round-trip), `test/unit/svg-text-localization.test.ts` (stub + order/count), `test/m2-section-assets.test.ts` (upload sanitised + serve headers + localise→variant).

--- a/doc/LEARNING_SECTIONS_GUIDE.md
+++ b/doc/LEARNING_SECTIONS_GUIDE.md
@@ -38,12 +38,24 @@ rekkefølgen forfatteren bestemmer.
 - En deltaker ser seksjonen på sitt profilspråk; mangler et språk, faller visningen tilbake til
   et utfylt språk (aldri tomt).
 
-### 3. Embedded video
+### 3. Bilder og SVG-tegninger
+
+- **«Last opp bilde»** legger et bilde inn i seksjonen (`![alt](asset:…)`). Støttede formater:
+  **PNG, JPEG, GIF, WebP og SVG** (maks 5 MB). Alt-tekst er påkrevd (universell utforming).
+- **SVG saneres automatisk** ved opplasting: skript, hendelseshåndterere og utrygge elementer
+  fjernes, så bare selve tegningen lagres. Du trenger ikke gjøre noe — det skjer i bakgrunnen.
+- **Tekst i SVG oversettes med «Oversett fra dette språket».** Når en SVG-tegning har tekst-etiketter,
+  genererer oversett-handlingen lokaliserte varianter (én per språk) der etikettene er oversatt.
+  Deltakeren ser tegningen på sitt eget språk. **Verifiser hvert språk visuelt** i forhåndsvisningen:
+  oversatt tekst kan bli lengre/kortere, og SVG-tekst flyter ikke om automatisk — kontroller at den
+  fortsatt får plass. (Tegningen må være lagret før den kan oversettes.)
+
+### 4. Embedded video
 
 Du kan lime inn en `<iframe>` mot **betrodde video-verter** (YouTube, youtube-nocookie, Vimeo).
 Andre iframes fjernes av sikkerhetshensyn.
 
-### 4. Legg seksjonen inn i et kurs
+### 5. Legg seksjonen inn i et kurs
 
 1. **Innholdsforvaltning → Kurs** → åpne kurset.
 2. Under **«Innhold i kurset»**: bruk nedtrekkslista nederst og **«Legg til seksjon»** (velg fra
@@ -51,7 +63,7 @@ Andre iframes fjernes av sikkerhetshensyn.
 3. Bruk **↑/↓** for å plassere seksjonen i ønsket rekkefølge mellom modulene.
 4. **«Lagre kurs»**, deretter **«Publiser kurs»**.
 
-### 5. Eksport / import
+### 6. Eksport / import
 
 Kurs-eksport (**«Eksporter»** på et kurs) tar med seksjonene og rekkefølgen i pakkefila, og
 **«Importer kurs-pakke»** gjenskaper dem i målmiljøet. (Eldre pakker uten seksjoner importeres
@@ -71,7 +83,7 @@ fortsatt.)
 
 ## Begrensninger / på vei
 
-- **Bilde-opplasting** (`{{asset:...}}`) i seksjoner er under arbeid (#483/#489) — foreløpig
-  refereres bilder via URL.
+- **SVG-tekstlayout per språk:** oversatte SVG-etiketter flyter ikke om — ved store lengdeforskjeller
+  må tegningen justeres manuelt. Verifiser hvert språk visuelt (#657).
 - **Versjons-pinning per deltaker** (at en deltaker midt i kurset beholder en bestemt versjon)
   kommer senere; nå vises siste versjon.

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,25 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.74 - 2026-06-25
+
+feat(sections): trygg SVG-opplasting + lokaliserte SVG-tegninger (#657)
+
+Seksjonsbilder støtter nå SVG. SVG var tidligere bevisst utelatt (XSS-vektor, #483/F4); det er nå
+tillatt fordi hver opplastede SVG **saneres server-side** med DOMPurify (`<script>`, `on*`-handlere,
+`<foreignObject>`, `<a>`, `javascript:` fjernes) før den lagres, så bytene på disk er inerte. Bilder
+rendres som `<img>` (kjører ikke script), og serve-endepunktet legger på `Content-Security-Policy: …;
+sandbox` + `X-Content-Type-Options: nosniff` som dybdeforsvar mot direkte-navigering.
+
+I tillegg: når en SVG inneholder tekst, genererer forfatterens **«Oversett»**-handling lokaliserte
+varianter — `<text>`/`<tspan>`-etiketter ekstraheres, oversettes til hvert støttede språk (nb/nn/en-GB)
+via samme LLM-localize som modultekst, og lagres som per-språk-varianter. Oversettelse er en **eksplisitt
+handling** (aldri implisitt ved lagring), konsistent med lærer-locale-kontroll. Servering velger variant
+etter leserens språk (`?locale=`, fallback til original). Geometrien er uendret, så forfatter må
+verifisere layout per språk (oversatt tekst reflower ikke). Datamodell: `SectionAsset.sourceLocale` +
+`localizedBlobPaths`. Dekket av unit-tester (sanering + XSS-vektorer + tekst-round-trip) og
+integrasjonstester (opplasting saneres, serve-headers, localize→variant).
+
 ## 1.3.73 - 2026-06-25
 
 fix(admin): MCQ-only-modul kan revideres i samtale + Modultype-radioer (#655)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.73",
+  "version": "1.3.74",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260625120000_add_section_asset_localization/migration.sql
+++ b/prisma/migrations/20260625120000_add_section_asset_localization/migration.sql
@@ -1,0 +1,5 @@
+-- #657: localized SVG variants for section assets.
+-- sourceLocale: the language of the text baked into the original asset.
+-- localizedBlobPaths: JSON map of locale -> blob path for translated SVG variants.
+ALTER TABLE "SectionAsset" ADD COLUMN "sourceLocale" TEXT;
+ALTER TABLE "SectionAsset" ADD COLUMN "localizedBlobPaths" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -572,7 +572,12 @@ model SectionAsset {
   blobPath  String
   sizeBytes Int
   createdAt DateTime      @default(now())
-  section   CourseSection @relation(fields: [sectionId], references: [id], onDelete: Cascade)
+  // #657: localized SVG variants. sourceLocale is the language of the text baked into the
+  // original (blobPath); localizedBlobPaths maps each OTHER supported locale → the blob path of
+  // a variant whose <text> has been translated. Both null for raster images and untranslated SVGs.
+  sourceLocale       String?
+  localizedBlobPaths Json?
+  section            CourseSection @relation(fields: [sectionId], references: [id], onDelete: Cascade)
 
   @@index([sectionId])
 }

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -26,6 +26,7 @@ const LABELS = {
     confirmDelete: "Delete this section?", loadError: "Could not load sections.",
     needContent: "Add a title and content in at least one language.",
     translate: "Translate from this language", translating: "Translating…", translated: "Translated — review before saving.",
+    translatingImages: "Translating drawings…", imagesTranslated: "SVG drawings translated — verify each language visually.",
     uploadImage: "Upload image", altPrompt: "Alt text (describes the image for screen readers):", saveFirst: "Save the section first, then upload images.", imageInserted: "Image inserted.",
   },
   nb: {
@@ -36,6 +37,7 @@ const LABELS = {
     confirmDelete: "Slette denne seksjonen?", loadError: "Kunne ikke laste seksjoner.",
     needContent: "Fyll inn tittel og innhold på minst ett språk.",
     translate: "Oversett fra dette språket", translating: "Oversetter…", translated: "Oversatt — se over før du lagrer.",
+    translatingImages: "Oversetter tegninger…", imagesTranslated: "SVG-tegninger oversatt — verifiser hvert språk visuelt.",
     uploadImage: "Last opp bilde", altPrompt: "Alt-tekst (beskriver bildet for skjermlesere):", saveFirst: "Lagre seksjonen først, så kan du laste opp bilder.", imageInserted: "Bilde satt inn.",
   },
   nn: {
@@ -46,6 +48,7 @@ const LABELS = {
     confirmDelete: "Slette denne seksjonen?", loadError: "Kunne ikkje laste seksjonar.",
     needContent: "Fyll inn tittel og innhald på minst eitt språk.",
     translate: "Omset frå dette språket", translating: "Omset…", translated: "Omsett — sjå over før du lagrar.",
+    translatingImages: "Omset teikningar…", imagesTranslated: "SVG-teikningar omsette — kontroller kvart språk visuelt.",
     uploadImage: "Last opp bilete", altPrompt: "Alt-tekst (skildrar biletet for skjermlesarar):", saveFirst: "Lagre seksjonen først, så kan du laste opp bilete.", imageInserted: "Bilete sett inn.",
   },
 };
@@ -214,7 +217,7 @@ async function renderEditorView(sectionId) {
           <div class="editor-pane-label" style="display:flex;justify-content:space-between;align-items:center;gap:8px">
             <span>${escapeHtml(L("markdown"))}</span>
             <button type="button" id="uploadImageBtn" class="btn btn-secondary" style="width:auto;font-size:12px;padding:2px 8px">${escapeHtml(L("uploadImage"))}</button>
-            <input type="file" id="imageFileInput" accept="image/png,image/jpeg,image/gif,image/webp" hidden />
+            <input type="file" id="imageFileInput" accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml,.svg" hidden />
           </div>
           <textarea id="markdownInput">${escapeHtml(editing.body[editing.editLocale])}</textarea>
         </div>
@@ -281,7 +284,7 @@ async function refreshPreview() {
   try {
     const data = await apiFetch("/api/admin/content/sections/preview", getHeaders, {
       method: "POST",
-      body: JSON.stringify({ markdown: editing.body[editing.editLocale] ?? "" }),
+      body: JSON.stringify({ markdown: editing.body[editing.editLocale] ?? "", locale: editing.editLocale }),
     });
     pane.innerHTML = data.html ?? "";
     await hydrateContentAssetImages(pane, getHeaders);
@@ -376,6 +379,21 @@ async function translateFromCurrent() {
       });
       if (res.title) editing.title[target] = res.title;
       if (res.bodyMarkdown) editing.body[target] = res.bodyMarkdown;
+    }
+    // #657: also generate translated SVG-drawing variants for this section's SVG assets, so a
+    // drawing's baked-in labels follow the same language as the surrounding text. Only possible on
+    // a saved section (assets need a section id); non-fatal if it fails — text is already translated.
+    if (editing.id) {
+      try {
+        if (btn) btn.textContent = L("translatingImages");
+        const assetRes = await apiFetch(`/api/admin/content/sections/${encodeURIComponent(editing.id)}/assets/localize`, getHeaders, {
+          method: "POST",
+          body: JSON.stringify({ sourceLocale: src }),
+        });
+        if (assetRes?.localizedAssetCount > 0) showToast(L("imagesTranslated"));
+      } catch (assetErr) {
+        showToast(assetErr?.message ?? "Image translation failed", "error");
+      }
     }
     showToast(L("translated"));
     renderEditorFields();

--- a/src/modules/adminContent/llmContentGenerationService.ts
+++ b/src/modules/adminContent/llmContentGenerationService.ts
@@ -1726,6 +1726,74 @@ export async function localizeSectionContent(input: SectionLocalizationInput): P
 }
 
 // ---------------------------------------------------------------------------
+// SVG text localisation (#657)
+// ---------------------------------------------------------------------------
+// Translates the short, ordered text runs extracted from a section SVG drawing. Strings are
+// translated as a batch so the model sees sibling labels together (better consistency for a
+// diagram's terminology). The response MUST preserve order and count so the caller can map each
+// translation back to its source run by index.
+
+export interface SvgTextLocalizationInput {
+  texts: string[];
+  sourceLocale: GenerationLocale;
+  targetLocale: GenerationLocale;
+}
+
+const svgTextLocalizationResponseCodec = z.object({
+  translations: z.array(z.string()),
+});
+
+export function buildSvgTextLocalizationPrompts(input: SvgTextLocalizationInput): {
+  systemPrompt: string;
+  userPrompt: string;
+} {
+  const systemPrompt =
+    "You are a professional translator for a certification platform. You translate the short text labels found inside a vector drawing (SVG). Return strict JSON only - no commentary.";
+  const userPrompt = `Translate each text label of an SVG diagram from ${LOCALE_DISPLAY[input.sourceLocale]} to ${LOCALE_DISPLAY[input.targetLocale]}.
+
+${buildLanguageEnforcementDirective(input.targetLocale)}
+
+## Rules
+- Translate ONLY the human-readable label text. Preserve meaning and terminology consistency across labels.
+- Keep translations concise — these render inside fixed-size drawings and do not reflow.
+- Do NOT translate numbers, units, codes, or proper nouns that should stay as-is.
+- Return EXACTLY one translation per input label, in the SAME order. Never add, drop, merge, or reorder.
+
+## Labels (JSON array, in order)
+${JSON.stringify(input.texts)}
+
+## Return format
+A single valid JSON object with a "translations" array of the same length and order:
+{
+  "translations": ["translated label 1", "translated label 2"]
+}`;
+  return { systemPrompt, userPrompt };
+}
+
+export async function localizeSvgTexts(input: SvgTextLocalizationInput): Promise<string[]> {
+  if (input.texts.length === 0) return [];
+
+  // Stub mode (local dev / CI): deterministic, clearly-tagged output that preserves order/count so
+  // the apply-back round-trip is exercisable without a live LLM.
+  if (env.LLM_MODE !== "azure_openai") {
+    return input.texts.map((text) => `[${input.targetLocale}] ${text}`);
+  }
+
+  const { systemPrompt, userPrompt } = buildSvgTextLocalizationPrompts(input);
+  const raw = await callLlm(systemPrompt, userPrompt, 2000);
+  const parsed = svgTextLocalizationResponseCodec.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(`SVG text localization failed validation: ${JSON.stringify(parsed.error.issues)}`);
+  }
+  if (parsed.data.translations.length !== input.texts.length) {
+    throw new Error(
+      `SVG text localization returned ${parsed.data.translations.length} translations for ${input.texts.length} labels.`,
+    );
+  }
+  return parsed.data.translations;
+}
+
+// ---------------------------------------------------------------------------
 // Assessment blueprint generation (#372)
 // ---------------------------------------------------------------------------
 

--- a/src/modules/course/assetCommands.ts
+++ b/src/modules/course/assetCommands.ts
@@ -2,9 +2,15 @@ import { randomUUID } from "node:crypto";
 import { prisma } from "../../db/prisma.js";
 import { NotFoundError, ValidationError } from "../../errors/AppError.js";
 import { putAsset, getAsset } from "./assetStorage.js";
+import { sanitizeSvg, svgHasText, extractSvgTexts, applySvgTextTranslations } from "./svgSanitizer.js";
+import { localizeSvgTexts, type GenerationLocale } from "../adminContent/llmContentGenerationService.js";
+import { SUPPORTED_LOCALES, type SupportedLocale } from "../../i18n/locale.js";
 
-// SVG is intentionally excluded — it can carry scripts (XSS). Raster images only (#483/F4).
-export const ALLOWED_ASSET_MIME_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+export const SVG_MIME_TYPE = "image/svg+xml";
+// Raster images plus SVG. SVG is accepted ONLY after server-side sanitisation strips its
+// active content (scripts, handlers, foreignObject) — see svgSanitizer.ts (#657). It was
+// previously excluded outright (#483/F4) because raw SVG is an XSS vector.
+export const ALLOWED_ASSET_MIME_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp", SVG_MIME_TYPE];
 export const MAX_ASSET_BYTES = 5 * 1024 * 1024; // 5 MB
 
 export async function createSectionAsset(input: {
@@ -21,10 +27,22 @@ export async function createSectionAsset(input: {
     throw new NotFoundError("CourseSection", "section_not_found", "Course section not found.");
   }
   if (!ALLOWED_ASSET_MIME_TYPES.includes(input.mimeType)) {
-    throw new ValidationError(`Unsupported image type (${input.mimeType || "unknown"}). Allowed: PNG, JPEG, GIF, WebP.`);
+    throw new ValidationError(`Unsupported image type (${input.mimeType || "unknown"}). Allowed: PNG, JPEG, GIF, WebP, SVG.`);
   }
   if (input.buffer.byteLength > MAX_ASSET_BYTES) {
     throw new ValidationError(`Image too large (${input.buffer.byteLength} bytes, max ${MAX_ASSET_BYTES}).`);
+  }
+
+  // #657: SVG is sanitised before storage — active content (scripts, handlers, foreignObject)
+  // is stripped so the stored bytes are inert. A payload that contains no usable <svg> after
+  // sanitisation is rejected rather than stored.
+  let storedBuffer = input.buffer;
+  if (input.mimeType === SVG_MIME_TYPE) {
+    const sanitized = sanitizeSvg(input.buffer.toString("utf8"));
+    if (!sanitized) {
+      throw new ValidationError("SVG could not be processed (empty or invalid after sanitisation).");
+    }
+    storedBuffer = Buffer.from(sanitized, "utf8");
   }
 
   const safeName = (input.filename || "file").replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 100) || "file";
@@ -32,7 +50,7 @@ export async function createSectionAsset(input: {
 
   // Upload binary first; only persist metadata once the blob is stored. A failed upload
   // leaves no row; a failed row-insert leaves an orphan blob (rare, tolerable for v1).
-  await putAsset(blobPath, input.buffer, input.mimeType);
+  await putAsset(blobPath, storedBuffer, input.mimeType);
 
   return prisma.sectionAsset.create({
     data: {
@@ -40,7 +58,7 @@ export async function createSectionAsset(input: {
       filename: safeName,
       mimeType: input.mimeType,
       blobPath,
-      sizeBytes: input.buffer.byteLength,
+      sizeBytes: storedBuffer.byteLength,
     },
     select: { id: true, sectionId: true, filename: true, mimeType: true, sizeBytes: true },
   });
@@ -54,11 +72,94 @@ export async function listSectionAssets(sectionId: string) {
   });
 }
 
-export async function getSectionAssetContent(assetId: string): Promise<{ mimeType: string; filename: string; buffer: Buffer }> {
+function readLocalizedBlobPaths(value: unknown): Record<string, string> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, string>;
+  }
+  return {};
+}
+
+export async function getSectionAssetContent(
+  assetId: string,
+  locale?: string,
+): Promise<{ mimeType: string; filename: string; buffer: Buffer }> {
   const asset = await prisma.sectionAsset.findUnique({ where: { id: assetId } });
   if (!asset) {
     throw new NotFoundError("SectionAsset", "asset_not_found", "Asset not found.");
   }
-  const buffer = await getAsset(asset.blobPath);
+  // #657: serve the localized SVG variant for the viewer's locale when one exists; otherwise the
+  // original. Raster assets and untranslated SVGs always serve the original blob.
+  let blobPath = asset.blobPath;
+  if (locale) {
+    const variant = readLocalizedBlobPaths(asset.localizedBlobPaths)[locale];
+    if (variant) blobPath = variant;
+  }
+  const buffer = await getAsset(blobPath);
   return { mimeType: asset.mimeType, filename: asset.filename, buffer };
+}
+
+export interface LocalizeSectionAssetsResult {
+  localizedAssetCount: number;
+  targetLocales: SupportedLocale[];
+}
+
+/**
+ * #657: generates translated SVG variants for every SVG asset in a section that carries text.
+ * The text runs are extracted from the original, translated into each OTHER supported locale, and
+ * written back into a positional copy (geometry preserved). Each variant is sanitised again and
+ * stored as a sibling blob; the asset row records the source locale and the per-locale blob map.
+ * Idempotent: re-running re-translates from the (new) source locale and overwrites the variants.
+ */
+export async function localizeSectionAssets(
+  sectionId: string,
+  sourceLocale: SupportedLocale,
+): Promise<LocalizeSectionAssetsResult> {
+  const section = await prisma.courseSection.findUnique({ where: { id: sectionId }, select: { id: true } });
+  if (!section) {
+    throw new NotFoundError("CourseSection", "section_not_found", "Course section not found.");
+  }
+
+  const assets = await prisma.sectionAsset.findMany({
+    where: { sectionId, mimeType: SVG_MIME_TYPE },
+    select: { id: true, blobPath: true, filename: true },
+  });
+
+  const targetLocales = SUPPORTED_LOCALES.filter((l) => l !== sourceLocale);
+  let localizedAssetCount = 0;
+
+  for (const asset of assets) {
+    const baseSvg = (await getAsset(asset.blobPath)).toString("utf8");
+    if (!svgHasText(baseSvg)) continue;
+
+    const originals = extractSvgTexts(baseSvg);
+    if (originals.length === 0) continue;
+
+    const localizedBlobPaths: Record<string, string> = {};
+    for (const target of targetLocales) {
+      const translated = await localizeSvgTexts({
+        texts: originals,
+        sourceLocale: sourceLocale as GenerationLocale,
+        targetLocale: target as GenerationLocale,
+      });
+      const translationMap: Record<string, string> = {};
+      originals.forEach((original, index) => {
+        const value = translated[index];
+        if (typeof value === "string" && value.length > 0) translationMap[original] = value;
+      });
+
+      const localizedSvg = applySvgTextTranslations(baseSvg, translationMap);
+      if (!localizedSvg) continue;
+      const variantPath = `sections/${sectionId}/${randomUUID()}-${target}-${asset.filename}`;
+      await putAsset(variantPath, Buffer.from(localizedSvg, "utf8"), SVG_MIME_TYPE);
+      localizedBlobPaths[target] = variantPath;
+    }
+
+    await prisma.sectionAsset.update({
+      where: { id: asset.id },
+      data: { sourceLocale, localizedBlobPaths },
+    });
+    localizedAssetCount += 1;
+  }
+
+  return { localizedAssetCount, targetLocales };
 }

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -14,6 +14,7 @@ export {
   createSectionAsset,
   listSectionAssets,
   getSectionAssetContent,
+  localizeSectionAssets,
   ALLOWED_ASSET_MIME_TYPES,
   MAX_ASSET_BYTES,
 } from "./assetCommands.js";

--- a/src/modules/course/sectionContent.ts
+++ b/src/modules/course/sectionContent.ts
@@ -77,16 +77,20 @@ export function sanitizeSectionHtml(html: string): string {
 // authenticated serve endpoint. Runs BEFORE sanitisation so DOMPurify sees a normal relative
 // URL (the `asset:` scheme would otherwise be stripped as an unknown protocol). The indirection
 // keeps references portable for cross-environment export/import (ids can be remapped).
-function resolveAssetUrls(html: string): string {
-  return html.replace(/(<img\b[^>]*\bsrc=")asset:([a-zA-Z0-9]+)(")/gi, "$1/api/content-assets/$2$3");
+// When a locale is supplied (#657), it is appended as `?locale=` so the serve endpoint can return
+// the translated SVG variant for that language pane (raster/untranslated assets ignore it).
+function resolveAssetUrls(html: string, locale?: string): string {
+  const suffix = locale ? `?locale=${encodeURIComponent(locale)}` : "";
+  return html.replace(/(<img\b[^>]*\bsrc=")asset:([a-zA-Z0-9]+)(")/gi, `$1/api/content-assets/$2${suffix}$3`);
 }
 
 /**
  * Renders SMO-authored markdown to sanitised HTML safe to inject into the
  * participant view. Returns an empty string for empty / non-string input.
+ * `locale` (optional) selects translated SVG asset variants for that language.
  */
-export function renderSectionMarkdown(markdownInput: string): string {
+export function renderSectionMarkdown(markdownInput: string, locale?: string): string {
   if (typeof markdownInput !== "string" || markdownInput.length === 0) return "";
   const rawHtml = marked.parse(markdownInput, { async: false }) as string;
-  return sanitizeSectionHtml(resolveAssetUrls(rawHtml));
+  return sanitizeSectionHtml(resolveAssetUrls(rawHtml, locale));
 }

--- a/src/modules/course/svgSanitizer.ts
+++ b/src/modules/course/svgSanitizer.ts
@@ -1,0 +1,132 @@
+import DOMPurify from "dompurify";
+import { JSDOM } from "jsdom";
+
+/**
+ * Server-side SVG sanitisation for section assets (#657 / #483/F4).
+ *
+ * SVG is XML and can carry active content — `<script>`, inline `on*` event
+ * handlers, `javascript:` URIs, `<foreignObject>` (embeds XHTML/iframes), and
+ * external references. Raster images cannot. Because section images render via
+ * `<img src="/api/content-assets/<id>">`, an `<img>`-loaded SVG already runs in
+ * the browser's "secure static" mode (no scripts), but a victim navigated
+ * DIRECTLY to the asset URL would get the SVG rendered as a same-origin document
+ * where scripts WOULD run. This module is the primary defence: every uploaded SVG
+ * is sanitised here before it is ever stored, so the bytes on disk are inert.
+ * (The serve endpoint adds CSP + nosniff as defence-in-depth.)
+ *
+ * Intentionally pure (no DB, no I/O) so it can be unit-tested against XSS vectors
+ * in isolation.
+ */
+
+const svgPurifier = DOMPurify(new JSDOM("").window as unknown as Window & typeof globalThis);
+
+// `<a>`, `<foreignObject>`, and `<script>` are removed outright. Drawings do not need
+// hyperlinks, and both foreignObject (embeds arbitrary XHTML/iframes) and script are
+// classic SVG XSS vectors. DOMPurify already strips `on*` handlers and `javascript:`
+// URIs by default; forbidding these tags closes the remaining holes.
+const FORBIDDEN_SVG_TAGS = ["script", "foreignObject", "a"] as const;
+
+/**
+ * Sanitises a raw SVG document, returning safe SVG markup or an empty string if
+ * the input is not a usable SVG. The returned markup is guaranteed to contain a
+ * root `<svg>` element with an `xmlns` so it renders when loaded via `<img>`.
+ */
+export function sanitizeSvg(rawSvg: string): string {
+  if (typeof rawSvg !== "string" || rawSvg.trim().length === 0) return "";
+
+  const clean = svgPurifier.sanitize(rawSvg, {
+    USE_PROFILES: { svg: true, svgFilters: true },
+    FORBID_TAGS: [...FORBIDDEN_SVG_TAGS],
+    // Never resolve external/data documents; keep everything self-contained.
+    ADD_URI_SAFE_ATTR: [],
+  });
+
+  // DOMPurify returns a string in HTML serialisation; a non-SVG payload yields no
+  // <svg> root, which we reject rather than store.
+  if (!/<svg[\s>]/i.test(clean)) return "";
+
+  // Some DOMPurify/jsdom versions drop the SVG namespace when serialising in HTML
+  // mode; re-add it so the file renders as an image. No-op when already present.
+  return ensureSvgNamespace(clean);
+}
+
+function ensureSvgNamespace(svg: string): string {
+  return svg.replace(/<svg\b([^>]*)>/i, (match, attrs: string) => {
+    if (/\bxmlns\s*=/.test(attrs)) return match;
+    return `<svg xmlns="http://www.w3.org/2000/svg"${attrs}>`;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// SVG text localisation (#657)
+// ---------------------------------------------------------------------------
+// Section drawings may carry baked-in <text>/<tspan> labels. To localise an SVG we extract those
+// text runs in document order, translate them, and write them back into the same positions — the
+// geometry is untouched, so layout is preserved (the author still verifies per-locale visually,
+// because translated strings do not reflow). Extraction and re-application share the same ordered
+// walk so indices line up exactly.
+
+const SVG_TEXT_SELECTOR = "text, tspan, textPath, title";
+
+function svgTextNodes(doc: Document): Element[] {
+  const svg = doc.querySelector("svg");
+  if (!svg) return [];
+  // Only leaf-level text content: a <text> that contains <tspan> children contributes its tspans,
+  // not its own concatenated text, so we never translate the same run twice.
+  return Array.from(svg.querySelectorAll(SVG_TEXT_SELECTOR)).filter((el) => {
+    const hasElementChildren = Array.from(el.children).some((child) =>
+      /^(tspan|textPath)$/i.test(child.tagName),
+    );
+    return !hasElementChildren && (el.textContent ?? "").trim().length > 0;
+  });
+}
+
+function parseSvgDoc(svg: string): Document {
+  // jsdom parses SVG inside an HTML document fine for our read/write needs.
+  return new JSDOM(svg, { contentType: "text/html" }).window.document;
+}
+
+/** True if the SVG has at least one non-empty translatable text run. */
+export function svgHasText(svg: string): boolean {
+  if (typeof svg !== "string" || svg.trim().length === 0) return false;
+  try {
+    return svgTextNodes(parseSvgDoc(svg)).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Extracts translatable text runs in document order (deduplicated for a smaller translation payload). */
+export function extractSvgTexts(svg: string): string[] {
+  if (typeof svg !== "string" || svg.trim().length === 0) return [];
+  const seen = new Set<string>();
+  const texts: string[] = [];
+  for (const node of svgTextNodes(parseSvgDoc(svg))) {
+    const value = (node.textContent ?? "").trim();
+    if (value && !seen.has(value)) {
+      seen.add(value);
+      texts.push(value);
+    }
+  }
+  return texts;
+}
+
+/**
+ * Returns a new SVG with each original text run replaced by its translation. `translations` maps
+ * the trimmed original string → translated string; runs without a mapping are left as-is. The
+ * result is re-sanitised so a localisation round-trip can never reintroduce active content.
+ */
+export function applySvgTextTranslations(svg: string, translations: Record<string, string>): string {
+  if (typeof svg !== "string" || svg.trim().length === 0) return "";
+  const doc = parseSvgDoc(svg);
+  for (const node of svgTextNodes(doc)) {
+    const original = (node.textContent ?? "").trim();
+    const translated = translations[original];
+    if (translated !== undefined && translated !== "") {
+      node.textContent = translated;
+    }
+  }
+  const svgEl = doc.querySelector("svg");
+  const serialized = svgEl ? svgEl.outerHTML : "";
+  return sanitizeSvg(serialized);
+}

--- a/src/routes/adminSections.ts
+++ b/src/routes/adminSections.ts
@@ -10,6 +10,7 @@ import {
   deleteSection,
   createSectionAsset,
   listSectionAssets,
+  localizeSectionAssets,
   MAX_ASSET_BYTES,
 } from "../modules/course/index.js";
 import { localizedTextPatchSchema, generationLocaleSchema } from "../modules/adminContent/adminContentSchemas.js";
@@ -42,7 +43,7 @@ const createSectionSchema = z.object({
 });
 const titleSchema = z.object({ title: localizedTextPatchSchema });
 const contentSchema = z.object({ bodyMarkdown: localizedTextPatchSchema });
-const previewSchema = z.object({ markdown: z.string() });
+const previewSchema = z.object({ markdown: z.string(), locale: generationLocaleSchema.optional() });
 const localizeSchema = z.object({
   title: z.string().trim().min(1).optional(),
   bodyMarkdown: z.string().trim().min(1).optional(),
@@ -98,7 +99,7 @@ adminSectionsRouter.post("/preview", async (request, response, next) => {
     return;
   }
   try {
-    response.json({ html: renderSectionMarkdown(parsed.data.markdown) });
+    response.json({ html: renderSectionMarkdown(parsed.data.markdown, parsed.data.locale) });
   } catch (error) {
     next(error);
   }
@@ -212,6 +213,23 @@ adminSectionsRouter.post("/:sectionId/assets", uploadAsset, async (request: Requ
 adminSectionsRouter.get("/:sectionId/assets", async (request, response, next) => {
   try {
     response.json({ assets: await listSectionAssets(request.params.sectionId) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// #657: generate translated SVG variants for the section's SVG assets. Triggered explicitly by the
+// author's "Translate" action (never implicit on save), consistent with module/MCQ localisation.
+const localizeAssetsSchema = z.object({ sourceLocale: generationLocaleSchema });
+adminSectionsRouter.post("/:sectionId/assets/localize", generateLimiter, async (request: Request<{ sectionId: string }>, response, next) => {
+  const parsed = localizeAssetsSchema.safeParse(request.body);
+  if (!parsed.success) {
+    response.status(400).json({ error: "validation_error", issues: parsed.error.issues });
+    return;
+  }
+  try {
+    const result = await localizeSectionAssets(request.params.sectionId, parsed.data.sourceLocale);
+    response.json(result);
   } catch (error) {
     next(error);
   }

--- a/src/routes/contentAssets.ts
+++ b/src/routes/contentAssets.ts
@@ -12,9 +12,24 @@ contentAssetsRouter.get("/:assetId", async (request, response, next) => {
     return;
   }
   try {
-    const { mimeType, buffer } = await getSectionAssetContent(request.params.assetId);
+    // #657: `?locale=` selects a translated SVG variant when one exists (set by the section
+    // markdown renderer, which knows which locale pane it is rendering). Falls back to original.
+    const localeParam = typeof request.query.locale === "string" ? request.query.locale : undefined;
+    const { mimeType, buffer } = await getSectionAssetContent(request.params.assetId, localeParam);
     response.setHeader("Content-Type", mimeType);
     response.setHeader("Cache-Control", "private, max-age=3600");
+    // #657: defence-in-depth for SVG. The stored bytes are already sanitised, but if a victim
+    // navigates DIRECTLY to this URL the browser would render the SVG as a same-origin document.
+    // `sandbox` + `default-src 'none'` neutralise any script that slipped through, and `nosniff`
+    // stops content-type confusion. These headers are ignored when the SVG is loaded via `<img>`,
+    // so normal section rendering is unaffected.
+    if (mimeType === "image/svg+xml") {
+      response.setHeader(
+        "Content-Security-Policy",
+        "default-src 'none'; style-src 'unsafe-inline'; sandbox",
+      );
+      response.setHeader("X-Content-Type-Options", "nosniff");
+    }
     response.send(buffer);
   } catch (error) {
     next(error);

--- a/src/routes/courses.ts
+++ b/src/routes/courses.ts
@@ -267,7 +267,7 @@ coursesRouter.get("/:courseId/sections/:sectionId", async (request, response, ne
     }
     const localizedTitle = localizeContentText(locale, section.title) ?? section.title;
     const localizedBody = localizeContentText(locale, section.activeVersion?.bodyMarkdown ?? "") ?? "";
-    response.json({ title: localizedTitle, html: renderSectionMarkdown(localizedBody) });
+    response.json({ title: localizedTitle, html: renderSectionMarkdown(localizedBody, locale) });
   } catch (error) {
     next(error);
   }

--- a/test/m2-section-assets.test.ts
+++ b/test/m2-section-assets.test.ts
@@ -72,6 +72,68 @@ describe("Section asset upload + serve", () => {
     await deleteSectionFully(sectionId);
   });
 
+  // #657: SVG is accepted but sanitised before storage; the served bytes must be inert and the
+  // serve endpoint must add hardening headers.
+  it("sanitises an uploaded SVG and serves it with hardening headers", async () => {
+    const sectionId = await createSection();
+    const dirtySvg = Buffer.from(
+      `<svg xmlns="http://www.w3.org/2000/svg" width="50" height="20"><script>alert(1)</script><rect onload="x()" width="50" height="20"/><text x="2" y="12">Hei</text></svg>`,
+      "utf8",
+    );
+
+    const upload = await request(app)
+      .post(`/api/admin/content/sections/${sectionId}/assets`)
+      .set(adminHeaders)
+      .attach("file", dirtySvg, { filename: "drawing.svg", contentType: "image/svg+xml" });
+    expect(upload.status).toBe(201);
+    const assetId = upload.body.asset.id as string;
+
+    const served = await request(app)
+      .get(`/api/content-assets/${assetId}`)
+      .set(participantHeaders);
+    expect(served.status).toBe(200);
+    expect(served.headers["content-type"]).toContain("image/svg+xml");
+    expect(served.headers["x-content-type-options"]).toBe("nosniff");
+    expect(served.headers["content-security-policy"]).toContain("sandbox");
+    const body = served.text ?? served.body.toString();
+    expect(body).not.toMatch(/<script/i);
+    expect(body).not.toMatch(/onload/i);
+    expect(body).toMatch(/Hei/);
+
+    await deleteSectionFully(sectionId);
+  });
+
+  // #657: the explicit localize action generates a translated SVG variant per other locale; the
+  // serve endpoint returns the variant for `?locale=`. LLM stub mode tags text as `[<locale>] …`.
+  it("localises SVG text and serves the per-locale variant", async () => {
+    const sectionId = await createSection();
+    const svg = Buffer.from(
+      `<svg xmlns="http://www.w3.org/2000/svg" width="50" height="20"><text x="2" y="12">Start</text></svg>`,
+      "utf8",
+    );
+    const upload = await request(app)
+      .post(`/api/admin/content/sections/${sectionId}/assets`)
+      .set(adminHeaders)
+      .attach("file", svg, { filename: "d.svg", contentType: "image/svg+xml" });
+    const assetId = upload.body.asset.id as string;
+
+    const localize = await request(app)
+      .post(`/api/admin/content/sections/${sectionId}/assets/localize`)
+      .set(adminHeaders)
+      .send({ sourceLocale: "nb" });
+    expect(localize.status).toBe(200);
+    expect(localize.body.localizedAssetCount).toBe(1);
+
+    // Source locale → original text; another locale → stub-translated text.
+    const original = await request(app).get(`/api/content-assets/${assetId}?locale=nb`).set(participantHeaders);
+    expect((original.text ?? original.body.toString())).toMatch(/>Start</);
+
+    const english = await request(app).get(`/api/content-assets/${assetId}?locale=en-GB`).set(participantHeaders);
+    expect((english.text ?? english.body.toString())).toMatch(/\[en-GB\] Start/);
+
+    await deleteSectionFully(sectionId);
+  });
+
   it("rejects a disallowed mime type", async () => {
     const sectionId = await createSection();
     const res = await request(app)

--- a/test/unit/svg-sanitizer.test.ts
+++ b/test/unit/svg-sanitizer.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  sanitizeSvg,
+  svgHasText,
+  extractSvgTexts,
+  applySvgTextTranslations,
+} from "../../src/modules/course/svgSanitizer.js";
+
+// #657: SVG is accepted for section drawings only because it is sanitised server-side. These
+// tests pin the XSS-stripping behaviour and the text extract/translate round-trip.
+
+const benignSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60">
+  <rect x="0" y="0" width="120" height="60" fill="#eef"/>
+  <text x="10" y="30">Start</text>
+  <text x="10" y="50"><tspan>Neste steg</tspan></text>
+</svg>`;
+
+describe("sanitizeSvg — XSS vectors", () => {
+  it("strips <script> elements", () => {
+    const dirty = `<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script><rect/></svg>`;
+    const clean = sanitizeSvg(dirty);
+    expect(clean).not.toMatch(/<script/i);
+    expect(clean).toMatch(/<rect/i);
+  });
+
+  it("strips inline event handlers", () => {
+    const dirty = `<svg xmlns="http://www.w3.org/2000/svg"><rect onload="alert(1)" onclick="steal()"/></svg>`;
+    const clean = sanitizeSvg(dirty);
+    expect(clean).not.toMatch(/onload/i);
+    expect(clean).not.toMatch(/onclick/i);
+  });
+
+  it("removes <foreignObject> (HTML/script embedding vector)", () => {
+    const dirty = `<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><body><img src=x onerror=alert(1)></body></foreignObject></svg>`;
+    const clean = sanitizeSvg(dirty);
+    expect(clean).not.toMatch(/foreignObject/i);
+    expect(clean).not.toMatch(/onerror/i);
+  });
+
+  it("drops javascript: hrefs and <a> links", () => {
+    const dirty = `<svg xmlns="http://www.w3.org/2000/svg"><a href="javascript:alert(1)"><text x="1" y="1">x</text></a></svg>`;
+    const clean = sanitizeSvg(dirty);
+    expect(clean).not.toMatch(/javascript:/i);
+    expect(clean).not.toMatch(/<a[\s>]/i);
+  });
+
+  it("returns empty string when there is no usable <svg>", () => {
+    expect(sanitizeSvg("<html><body>not an svg</body></html>")).toBe("");
+    expect(sanitizeSvg("")).toBe("");
+  });
+
+  it("keeps a valid drawing with its xmlns so it renders via <img>", () => {
+    const clean = sanitizeSvg(benignSvg);
+    expect(clean).toMatch(/<svg[^>]*xmlns="http:\/\/www\.w3\.org\/2000\/svg"/i);
+    expect(clean).toMatch(/<rect/i);
+    expect(clean).toMatch(/Start/);
+  });
+});
+
+describe("SVG text extraction + translation round-trip", () => {
+  it("detects text presence", () => {
+    expect(svgHasText(benignSvg)).toBe(true);
+    expect(svgHasText(`<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>`)).toBe(false);
+  });
+
+  it("extracts text runs in order without duplicates", () => {
+    expect(extractSvgTexts(benignSvg)).toEqual(["Start", "Neste steg"]);
+  });
+
+  it("applies translations in place and preserves geometry", () => {
+    const out = applySvgTextTranslations(benignSvg, { Start: "Begin", "Neste steg": "Next step" });
+    expect(out).toMatch(/Begin/);
+    expect(out).toMatch(/Next step/);
+    expect(out).not.toMatch(/Start/);
+    expect(out).not.toMatch(/Neste steg/);
+    // Geometry untouched.
+    expect(out).toMatch(/x="10" y="30"/);
+    expect(out).toMatch(/<rect/i);
+  });
+
+  it("re-sanitises on apply so a translation round-trip cannot reintroduce script", () => {
+    const out = applySvgTextTranslations(benignSvg, { Start: "Begin" });
+    expect(out).not.toMatch(/<script/i);
+  });
+});

--- a/test/unit/svg-text-localization.test.ts
+++ b/test/unit/svg-text-localization.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import {
+  localizeSvgTexts,
+  buildSvgTextLocalizationPrompts,
+} from "../../src/modules/adminContent/llmContentGenerationService.js";
+
+// #657: SVG label translation. In non-azure (CI/dev) mode the function is a deterministic stub so
+// the localize round-trip is exercisable without a live LLM.
+
+describe("localizeSvgTexts (stub mode)", () => {
+  it("returns one tagged translation per label, in order", async () => {
+    const out = await localizeSvgTexts({ texts: ["Start", "Slutt"], sourceLocale: "nb", targetLocale: "en-GB" });
+    expect(out).toEqual(["[en-GB] Start", "[en-GB] Slutt"]);
+  });
+
+  it("returns an empty array for no labels", async () => {
+    expect(await localizeSvgTexts({ texts: [], sourceLocale: "nb", targetLocale: "nn" })).toEqual([]);
+  });
+});
+
+describe("buildSvgTextLocalizationPrompts", () => {
+  it("includes the labels as a JSON array and demands order/count preservation", () => {
+    const { systemPrompt, userPrompt } = buildSvgTextLocalizationPrompts({
+      texts: ["A", "B"],
+      sourceLocale: "nb",
+      targetLocale: "nn",
+    });
+    expect(systemPrompt).toMatch(/translator/i);
+    expect(userPrompt).toContain('["A","B"]');
+    expect(userPrompt).toMatch(/same order/i);
+  });
+});


### PR DESCRIPTION
Lar forfattere bruke **SVG-tegninger** i læringsseksjoner, trygt, og med oversettelse av tekst i tegningen. Closes #657.

## Sikkerhet (hvorfor SVG var utelatt før)
SVG er XML og kan bære `<script>`, `on*`-handlere, `<foreignObject>`, `javascript:` → lagret XSS. Det var derfor bevisst blokkert (#483/F4). Nå tillatt fordi:
1. **Sanering ved opplasting** (primærforsvar): hver SVG kjøres gjennom DOMPurify (svg-profil) som fjerner script/handlere/`foreignObject`/`<a>`/`javascript:` **før** lagring — bytene på disk er inerte. [svgSanitizer.ts](src/modules/course/svgSanitizer.ts).
2. Bilder rendres som `![alt](asset:…)` → `<img>`, som kjører SVG i «secure static mode» (ingen script).
3. **Serve-headers** (dybdeforsvar mot direkte-nav): `Content-Security-Policy: …; sandbox` + `X-Content-Type-Options: nosniff` på SVG-svar. [contentAssets.ts](src/routes/contentAssets.ts).

## Oversettelse av tekst i SVG
Konsistent med lærer-locale-kontroll: **eksplisitt handling**, aldri implisitt ved lagring. Forfatterens «Oversett fra dette språket» genererer nå også lokaliserte SVG-varianter:
- `<text>`/`<tspan>`-etiketter ekstraheres → oversettes per støttet språk (nb/nn/en-GB) via samme LLM-localize som modultekst → skrives tilbake i samme posisjon → re-saneres → lagres som per-språk-variant.
- Servering velger variant etter leserens språk (`?locale=`, fallback original). Locale threades gjennom `renderSectionMarkdown` → `resolveAssetUrls`.
- Geometri uendret → forfatter **må verifisere layout per språk** (SVG-tekst reflower ikke). UI varsler om dette.

## Datamodell
`SectionAsset.sourceLocale` + `localizedBlobPaths` (Json, locale→blobPath) + migrasjon `20260625120000_add_section_asset_localization`.

## Test
- Unit (grønne lokalt): [svg-sanitizer.test.ts](test/unit/svg-sanitizer.test.ts) (XSS-vektorer: script/onload/foreignObject/javascript:/`<a>` + tekst-round-trip), [svg-text-localization.test.ts](test/unit/svg-text-localization.test.ts) (stub + order/count-guard).
- Integrasjon (CI, fersk DB): [m2-section-assets.test.ts](test/m2-section-assets.test.ts) — opplasting saneres + serve-headers + localize→variant per `?locale=`.
- `tsc --noEmit` rent. (Lokal full-suite hadde 6 urelaterte feil pga. DB nede/parallell-forurensning; passerer isolert.)

## Docs
API_REFERENCE, LEARNING_SECTIONS_GUIDE (forfatter), FEATURE_SURFACE_MAP (#11 — distribuert oppførsel), VERSIONS.

## Rollback
Rent additivt: migrasjonen legger bare til to nullable-kolonner; eksisterende raster-assets uberørt. Revert av PR + drop columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)