### PR TITLE
fix(course): tydelig feil ved sletting av kurs med fullføringer (v1.3.75, #660)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,17 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.75 - 2026-06-25
+
+fix(course): tydelig feil ved sletting av kurs med fullføringer (#660)
+
+Å slette et kurs som hadde fullføringer (utstedte kursbevis) ga en generisk 500 «An unexpected
+error occurred» — `CourseCompletion.course` er `onDelete: Restrict` (bevisst — kursbevis er
+prestasjons-poster), men `deleteCourse` slettet ikke completions, så `course.delete` feilet med
+FK-violation. `deleteCourse` blokkerer nå med en tydelig 400-melding når kurset har fullføringer, og
+peker på arkivering (soft-delete) i stedet for å slette kursbevis stilltiende. Integrasjonstest
+dekker både blokkering (med completions) og vanlig sletting (uten).
+
 ## 1.3.74 - 2026-06-25
 
 feat(sections): trygg SVG-opplasting + lokaliserte SVG-tegninger (#657)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.74",
+  "version": "1.3.75",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/course/courseCommands.ts
+++ b/src/modules/course/courseCommands.ts
@@ -83,6 +83,18 @@ export async function deleteCourse(courseId: string, actorId?: string) {
   const course = await prisma.course.findUnique({ where: { id: courseId }, select: { id: true } });
   if (!course) throw new NotFoundError("Course", "course_not_found", "Course not found.");
 
+  // #660: CourseCompletion.course is onDelete: Restrict (issued certificates are achievement
+  // records we never silently destroy). Without this guard, course.delete fails with a raw FK
+  // violation and the route surfaces a generic 500. Block with a clear message and point the
+  // author at archiving (the soft-delete) instead.
+  const completionCount = await prisma.courseCompletion.count({ where: { courseId } });
+  if (completionCount > 0) {
+    throw new ValidationError(
+      `Cannot delete a course that has ${completionCount} completion${completionCount === 1 ? "" : "s"} ` +
+        `(issued certificates). Archive the course instead to keep the completion records.`,
+    );
+  }
+
   await runInTransaction(async (tx) => {
     await tx.courseModule.deleteMany({ where: { courseId } });
     await tx.course.delete({ where: { id: courseId } });

--- a/test/m2-admin-courses.test.ts
+++ b/test/m2-admin-courses.test.ts
@@ -153,4 +153,51 @@ describe("Admin course management", () => {
       auditActions.course.archived,
     ]);
   });
+
+  // #660: deleting a course that has completions (issued certificates) must fail with a clear 400,
+  // not a raw FK-violation 500. A course with no completions still deletes (204).
+  it("blocks deletion of a course with completions and allows deletion otherwise", async () => {
+    const stamp = Date.now();
+    const courseWithCompletion = await request(app)
+      .post("/api/admin/content/courses")
+      .set(adminHeaders)
+      .send({ title: { "en-GB": `Completed Course ${stamp}`, nb: "x", nn: "x" } });
+    expect(courseWithCompletion.status).toBe(201);
+    const completedCourseId = courseWithCompletion.body.course.id as string;
+
+    const learner = await prisma.user.create({
+      data: {
+        externalId: `del-course-learner-${stamp}`,
+        name: "Course Learner",
+        email: `del-course-learner-${stamp}@example.test`,
+      },
+      select: { id: true },
+    });
+    await prisma.courseCompletion.create({
+      data: { userId: learner.id, courseId: completedCourseId, moduleSnapshotJson: "[]" },
+    });
+
+    const blocked = await request(app)
+      .delete(`/api/admin/content/courses/${completedCourseId}`)
+      .set(adminHeaders);
+    expect(blocked.status).toBe(400);
+    expect(blocked.body.message).toMatch(/completion/i);
+    // The course must still exist (the failed delete must not have partially removed it).
+    expect(await prisma.course.findUnique({ where: { id: completedCourseId } })).not.toBeNull();
+
+    // A course with no completions deletes cleanly.
+    const deletable = await request(app)
+      .post("/api/admin/content/courses")
+      .set(adminHeaders)
+      .send({ title: { "en-GB": `Deletable Course ${stamp}`, nb: "x", nn: "x" } });
+    const deletableId = deletable.body.course.id as string;
+    const ok = await request(app).delete(`/api/admin/content/courses/${deletableId}`).set(adminHeaders);
+    expect(ok.status).toBe(204);
+    expect(await prisma.course.findUnique({ where: { id: deletableId } })).toBeNull();
+
+    // Cleanup the blocked-delete fixtures (completion FK is Restrict → remove it first).
+    await prisma.courseCompletion.deleteMany({ where: { courseId: completedCourseId } });
+    await prisma.course.delete({ where: { id: completedCourseId } });
+    await prisma.user.delete({ where: { id: learner.id } });
+  });
 });


### PR DESCRIPTION
Sletting av et kurs med fullføringer (utstedte kursbevis) ga generisk **500** «An unexpected error occurred» (observert på stage).

**Rotårsak:** `CourseCompletion.course` er `onDelete: Restrict` (bevisst — kursbevis er prestasjons-poster vi aldri sletter stilltiende). `deleteCourse` slettet `courseModule` + `course`, men ikke completions → `course.delete` feilet med FK-violation (23503) → 500. Eneste Restrict-relasjon på Course.

**Fiks:** [courseCommands.ts](src/modules/course/courseCommands.ts) — `deleteCourse` teller completions først og kaster `ValidationError` (→ 400) med en tydelig melding som peker på arkivering. Frontend viser meldingen i en toast i stedet for den kryptiske 500-en.

**Test:** [m2-admin-courses.test.ts](test/m2-admin-courses.test.ts) — kurs med completion → 400 (og kurset finnes fortsatt); kurs uten → 204. `tsc` rent. (Integrasjon verifiseres i CI — lokal DB nede.)

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)