### PR TITLE
fix(sections): SVG-localize hopper over uendrede tegninger (v1.3.76, #663)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,17 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.76 - 2026-06-25
+
+fix(sections): SVG-localize hopper over uendrede tegninger (#663)
+
+`localizeSectionAssets` re-oversatte alle SVG-tegninger hver gang «Oversett» ble trykket, selv om
+tegningen var uendret — bortkastede LLM-kall og en mulig kilde til drift (LLM kan gi litt ulik
+oversettelse). En asset sin base-SVG er uforanderlig (re-opplasting lager ny asset), så en asset som
+allerede har varianter for alle målspråk fra samme kildespråk hoppes nå over. Endepunktet returnerer
+`skippedAssetCount`, og frontend melder kun «oversatt» når noe faktisk ble oversatt. Integrasjonstest
+dekker at andre localize-kall med samme kildespråk gir `localizedAssetCount=0` / `skippedAssetCount=1`.
+
 ## 1.3.75 - 2026-06-25
 
 fix(course): tydelig feil ved sletting av kurs med fullføringer (#660)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.75",
+  "version": "1.3.76",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/course/assetCommands.ts
+++ b/src/modules/course/assetCommands.ts
@@ -100,6 +100,7 @@ export async function getSectionAssetContent(
 
 export interface LocalizeSectionAssetsResult {
   localizedAssetCount: number;
+  skippedAssetCount: number;
   targetLocales: SupportedLocale[];
 }
 
@@ -108,7 +109,11 @@ export interface LocalizeSectionAssetsResult {
  * The text runs are extracted from the original, translated into each OTHER supported locale, and
  * written back into a positional copy (geometry preserved). Each variant is sanitised again and
  * stored as a sibling blob; the asset row records the source locale and the per-locale blob map.
- * Idempotent: re-running re-translates from the (new) source locale and overwrites the variants.
+ *
+ * Idempotent (#663): an asset's base SVG is immutable (a re-upload makes a new asset), so an asset
+ * that already has variants for every target locale FROM THE SAME source locale is left untouched —
+ * re-translating unchanged drawings wastes LLM calls and risks introducing drift. Only newly
+ * uploaded SVGs, or assets being translated from a different source locale, are (re)generated.
  */
 export async function localizeSectionAssets(
   sectionId: string,
@@ -121,13 +126,21 @@ export async function localizeSectionAssets(
 
   const assets = await prisma.sectionAsset.findMany({
     where: { sectionId, mimeType: SVG_MIME_TYPE },
-    select: { id: true, blobPath: true, filename: true },
+    select: { id: true, blobPath: true, filename: true, sourceLocale: true, localizedBlobPaths: true },
   });
 
   const targetLocales = SUPPORTED_LOCALES.filter((l) => l !== sourceLocale);
   let localizedAssetCount = 0;
+  let skippedAssetCount = 0;
 
   for (const asset of assets) {
+    // Already up to date for this source locale → skip (immutable base, nothing to re-translate).
+    const existingVariants = readLocalizedBlobPaths(asset.localizedBlobPaths);
+    if (asset.sourceLocale === sourceLocale && targetLocales.every((t) => existingVariants[t])) {
+      skippedAssetCount += 1;
+      continue;
+    }
+
     const baseSvg = (await getAsset(asset.blobPath)).toString("utf8");
     if (!svgHasText(baseSvg)) continue;
 
@@ -161,5 +174,5 @@ export async function localizeSectionAssets(
     localizedAssetCount += 1;
   }
 
-  return { localizedAssetCount, targetLocales };
+  return { localizedAssetCount, skippedAssetCount, targetLocales };
 }

--- a/test/m2-section-assets.test.ts
+++ b/test/m2-section-assets.test.ts
@@ -124,6 +124,15 @@ describe("Section asset upload + serve", () => {
     expect(localize.status).toBe(200);
     expect(localize.body.localizedAssetCount).toBe(1);
 
+    // #663: re-running with the same source locale must NOT re-translate the unchanged drawing.
+    const localizeAgain = await request(app)
+      .post(`/api/admin/content/sections/${sectionId}/assets/localize`)
+      .set(adminHeaders)
+      .send({ sourceLocale: "nb" });
+    expect(localizeAgain.status).toBe(200);
+    expect(localizeAgain.body.localizedAssetCount).toBe(0);
+    expect(localizeAgain.body.skippedAssetCount).toBe(1);
+
     // Source locale → original text; another locale → stub-translated text.
     const original = await request(app).get(`/api/content-assets/${assetId}?locale=nb`).set(participantHeaders);
     expect((original.text ?? original.body.toString())).toMatch(/>Start</);


### PR DESCRIPTION
Idempotens-fiks for SVG-oversettelse, oppdaget under stage-verifisering av #657: «Oversett» re-oversatte alle SVG-tegninger hver gang, også uendrede, og meldte «oversatt» hver gang.

**Hvorfor det er galt:** En asset sin base-SVG er uforanderlig (re-opplasting lager ny asset/rad). Å re-oversette en asset som allerede har varianter for samme kildespråk er unødvendig — bortkastede LLM-kall og en mulig kilde til drift (LLM kan gi litt ulik oversettelse per kjøring).

**Fiks:** [`localizeSectionAssets`](src/modules/course/assetCommands.ts) hopper over assets som allerede har varianter for alle målspråk fra samme `sourceLocale`. Returnerer `skippedAssetCount`; frontend melder kun «oversatt» når `localizedAssetCount > 0`. Re-oversetting skjer fortsatt når en ny SVG lastes opp, eller når kildespråket endres.

**Test:** [m2-section-assets.test.ts](test/m2-section-assets.test.ts) — andre localize-kall med samme kildespråk → `localizedAssetCount=0`, `skippedAssetCount=1`. `tsc` rent.

Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)
