### PR TITLE
fix(shell): MCQ-only direkte-redigering bevarer modultype + skjuler fritekst-felt (v1.3.77, #665)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,19 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.77 - 2026-06-25
+
+fix(shell): MCQ-only direkte-redigering bevarer modultype + skjuler fritekst-felt (#665)
+
+Oppfølging til #655. I samtale-flyten mistet «Rediger direkte» modulens `assessmentMode` for en
+lastet MCQ-only-modul (sessionDraft er null → den rekonstruerte draften falt tilbake til
+FREETEXT_PLUS_MCQ), så påfølgende lagring/publisering feilet med «Utkastet må ha scenario/
+oppgavetekst». Samtidig viste edit-skjemaet alltid tomme, redigerbare fritekst-felt (oppgavetekst/
+føringer/veiledning) som en MCQ-only-modul ikke har. `enterPreviewEditMode` utleder nå
+`assessmentMode` (+ MCQ-terskel) fra `sessionDraft ?? bundle.moduleVersion`, skjuler fritekst-felt +
+kriterier for MCQ-only, og bevarer modustypen på den rekonstruerte draften. Ny Playwright-e2e dekker
+direkte-redigerings-stien. (Rydder også bort en utilsiktet tom fil `0`.)
+
 ## 1.3.76 - 2026-06-25
 
 fix(sections): SVG-localize hopper over uendrede tegninger (#663)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.76",
+  "version": "1.3.77",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -3431,6 +3431,15 @@ function enterPreviewEditMode() {
     editingLocale,
   );
   const currentMcqQuestions = resolveEditableMcqQuestions(editingLocale);
+  // #665: the module type must survive direct-edit. For a loaded MCQ-only/free-text-only module
+  // sessionDraft is null, so read assessmentMode (and the MCQ pass threshold) from the loaded
+  // module version. Without this the rebuilt draft loses its mode → save/publish wrongly demands
+  // scenario text, and the editor shows free-text fields that an MCQ-only module never has.
+  const editAssessmentMode = sessionDraft?.assessmentMode ?? bundle?.selectedConfiguration?.moduleVersion?.assessmentMode;
+  const editIsMcqOnly = editAssessmentMode === "MCQ_ONLY";
+  const editMcqMinPercent = Number.isFinite(sessionDraft?.mcqMinPercent)
+    ? sessionDraft.mcqMinPercent
+    : bundle?.selectedConfiguration?.moduleVersion?.assessmentPolicy?.passRules?.mcqMinPercent;
   // B2 (#449 redesign): pull criteria from sessionDraft override OR existing rubric. Stored
   // as record (id-keyed) — normalize to an ordered array for the editor. Mutated locally;
   // captured back into a record on confirm. Tolerates rich + sparse shapes (#378 vs default).
@@ -3554,20 +3563,19 @@ function enterPreviewEditMode() {
   };
   // Show criteria section if existing rubric OR editor has criteria OR generation in flight.
   // The last branch is what makes the placeholder visible in the race-condition scenario.
-  const showCriteriaSection = bundle?.selectedConfiguration?.rubricVersion
+  // #665: never for MCQ-only — those modules have no rubric/criteria.
+  const showCriteriaSection = !editIsMcqOnly && (bundle?.selectedConfiguration?.rubricVersion
     || criteriaEditorState.length > 0
-    || criteriaGenerationInFlight;
+    || criteriaGenerationInFlight);
   const criteriaSectionHtml = showCriteriaSection
     ? `<div class="preview-section-label">${escapeHtml(tf("shell.criteria.title", { count: criteriaEditorState.length }))}</div>
        <div id="previewEditCriteriaContainer">${renderCriteriaEditor()}</div>`
     : "";
 
-  previewContent.innerHTML = `
-    <div class="preview-module-header">
-      <input id="previewEditTitle" class="preview-edit-title" value="${escapedTitle}"
-        aria-label="${escapeHtml(t("shell.directEdit.titlePlaceholder"))}" />
-      <span class="module-status-badge draft">${escapeHtml(t("shell.directEdit.editingBadge"))}</span>
-    </div>
+  // #665: free-text fields (task / candidate constraints / assessor guidance) only apply to
+  // FREETEXT_PLUS_MCQ and FREETEXT_ONLY. For MCQ-only they are omitted entirely so the author
+  // cannot edit fields the module does not have.
+  const freetextFieldsHtml = editIsMcqOnly ? "" : `
     <div class="preview-section-label">${labelTask}</div>
     <textarea id="previewEditTaskText" class="preview-edit-textarea"
       aria-label="${labelTask}">${escapedTask}</textarea>
@@ -3576,7 +3584,15 @@ function enterPreviewEditMode() {
       aria-label="${labelCandidateConstraints}">${escapedCandidateConstraints}</textarea>
     <div class="preview-section-label">${labelGuidance}</div>
     <textarea id="previewEditGuidanceText" class="preview-edit-textarea preview-edit-textarea--secondary"
-      aria-label="${labelGuidance}">${escapedGuidance}</textarea>
+      aria-label="${labelGuidance}">${escapedGuidance}</textarea>`;
+
+  previewContent.innerHTML = `
+    <div class="preview-module-header">
+      <input id="previewEditTitle" class="preview-edit-title" value="${escapedTitle}"
+        aria-label="${escapeHtml(t("shell.directEdit.titlePlaceholder"))}" />
+      <span class="module-status-badge draft">${escapeHtml(t("shell.directEdit.editingBadge"))}</span>
+    </div>
+    ${freetextFieldsHtml}
     ${mcqHtml}
     ${criteriaSectionHtml}
     <div class="preview-edit-actions">
@@ -3711,9 +3727,10 @@ function enterPreviewEditMode() {
 
   document.getElementById("previewEditConfirm").addEventListener("click", () => {
     const newTitle = document.getElementById("previewEditTitle").value.trim() || currentTitle;
-    const newTaskText = document.getElementById("previewEditTaskText").value.trim() || currentTaskText;
-    const newGuidanceText = document.getElementById("previewEditGuidanceText").value.trim() || currentGuidanceText;
-    const newCandidateTaskConstraints = document.getElementById("previewEditCandidateTaskConstraints").value.trim() || currentCandidateTaskConstraints;
+    // #665: free-text inputs are absent for MCQ-only — guard the reads and keep the fields empty.
+    const newTaskText = editIsMcqOnly ? "" : (document.getElementById("previewEditTaskText")?.value.trim() || currentTaskText);
+    const newGuidanceText = editIsMcqOnly ? "" : (document.getElementById("previewEditGuidanceText")?.value.trim() || currentGuidanceText);
+    const newCandidateTaskConstraints = editIsMcqOnly ? "" : (document.getElementById("previewEditCandidateTaskConstraints")?.value.trim() || currentCandidateTaskConstraints);
     // B2 (#449 redesign): capture criteria-editor state into a normalized record before
     // exitEditMode tears down the DOM. transform to storage shape (id-keyed) with weight
     // derived from maxScore. Empty/blank labels are dropped (matching the validation in
@@ -3758,7 +3775,11 @@ function enterPreviewEditMode() {
           assessorExpectedContent: localizedDraft.assessorExpectedContent,
           candidateTaskConstraints: localizedDraft.candidateTaskConstraints,
           mcqQuestions: localizedMcqQuestions,
-          criteria: newCriteriaRecord,
+          criteria: editIsMcqOnly ? null : newCriteriaRecord,
+          // #665: keep the module type (and MCQ threshold) on the draft so save/publish uses the
+          // right mode instead of falling back to FREETEXT_PLUS_MCQ and demanding scenario text.
+          ...(editAssessmentMode ? { assessmentMode: editAssessmentMode } : {}),
+          ...(Number.isFinite(editMcqMinPercent) ? { mcqMinPercent: editMcqMinPercent } : {}),
         });
         sessionState = "draft-pending";
         clearPreviewCandidate();
@@ -3773,7 +3794,10 @@ function enterPreviewEditMode() {
           assessorExpectedContent: buildLocalizedTextMap(editingLocale, newGuidanceText),
           candidateTaskConstraints: buildLocalizedTextMap(editingLocale, newCandidateTaskConstraints),
           mcqQuestions: buildLocalizedMcqDraft(newMcqQuestions, editingLocale),
-          criteria: newCriteriaRecord,
+          criteria: editIsMcqOnly ? null : newCriteriaRecord,
+          // #665: preserve module type (and MCQ threshold) on the fallback path too.
+          ...(editAssessmentMode ? { assessmentMode: editAssessmentMode } : {}),
+          ...(Number.isFinite(editMcqMinPercent) ? { mcqMinPercent: editMcqMinPercent } : {}),
         });
         sessionState = "draft-pending";
         clearPreviewCandidate();

--- a/test/e2e/admin-content-mcq-only-revision.spec.ts
+++ b/test/e2e/admin-content-mcq-only-revision.spec.ts
@@ -9,13 +9,61 @@ import {
   type MockModuleExport,
 } from "./admin-content-helpers.js";
 
-// Regression coverage for #655 — two client-layer bugs in Advanced authoring that are
-// invisible to supertest:
+// Regression coverage for #655 / #665 — client-layer bugs in Advanced/Conversation authoring
+// of MCQ-only modules, invisible to supertest:
 //   1. Module-type radios stretched full width (inherited width:100% from the base input
 //      style; only checkboxes were exempted). Pinned by measuring the radio's box width.
 //   2. A conversational revision of an MCQ-only module could not be saved: the loaded draft
 //      dropped assessmentMode, so save-validation treated it as FREETEXT_PLUS_MCQ and demanded
 //      scenario text (shell.save.taskRequired) that MCQ-only modules never have.
+//   3. Direct-edit ("Edit directly") of an MCQ-only module exposed editable free-text fields and
+//      dropped assessmentMode, so the subsequent save/publish hit the same scenario guard (#665).
+
+// An existing, published MCQ-only module: a module version flagged MCQ_ONLY with NO free-text
+// (empty taskText) plus a saved MCQ set — the shape the export endpoint returns for the MCQ-only
+// authoring path.
+function buildMcqOnlyExport(): MockModuleExport {
+  const mcqQuestions = [
+    {
+      stem: localizedText("Question 1"),
+      options: [localizedText("A"), localizedText("B"), localizedText("C"), localizedText("D")],
+      correctAnswer: localizedText("B"),
+      rationale: localizedText("Rationale"),
+    },
+  ];
+  const moduleVersion = {
+    id: "module-1-version-1",
+    versionNo: 1,
+    assessmentMode: "MCQ_ONLY",
+    taskText: {},
+    assessorExpectedContent: {},
+    candidateTaskConstraints: {},
+    assessmentPolicy: { passRules: { mcqMinPercent: 60 } },
+  };
+  const mcqSetVersion = { id: "module-1-mcq-1", title: localizedText("Trade unions"), questions: mcqQuestions };
+  return {
+    module: {
+      id: "module-1",
+      title: localizedText("Trade unions"),
+      certificationLevel: "basic",
+      activeVersionId: "module-1-version-1",
+      archivedAt: null,
+    },
+    selectedConfiguration: {
+      source: "draftModuleVersion",
+      moduleVersion,
+      rubricVersion: null,
+      promptTemplateVersion: null,
+      mcqSetVersion,
+    },
+    versions: {
+      moduleVersions: [moduleVersion],
+      rubricVersions: [],
+      promptTemplateVersions: [],
+      mcqSetVersions: [mcqSetVersion],
+    },
+  };
+}
 
 test.describe("admin content — module-type bugs (#655)", () => {
   test("module-type radios are not stretched full width", async ({ page }) => {
@@ -43,57 +91,9 @@ test.describe("admin content — module-type bugs (#655)", () => {
   });
 
   test("an MCQ-only module can be revised in chat and saved without scenario text", async ({ page }) => {
-    // An existing, published MCQ-only module: a module version flagged MCQ_ONLY with NO
-    // free-text (empty taskText) plus a saved MCQ set. This is the shape the export endpoint
-    // returns for a module authored via the MCQ-only path.
-    const mcqQuestions = [
-      {
-        stem: localizedText("Question 1"),
-        options: [localizedText("A"), localizedText("B"), localizedText("C"), localizedText("D")],
-        correctAnswer: localizedText("B"),
-        rationale: localizedText("Rationale"),
-      },
-    ];
-    const moduleVersion = {
-      id: "module-1-version-1",
-      versionNo: 1,
-      assessmentMode: "MCQ_ONLY",
-      taskText: {},
-      assessorExpectedContent: {},
-      candidateTaskConstraints: {},
-      assessmentPolicy: { passRules: { mcqMinPercent: 60 } },
-    };
-    const mcqSetVersion = {
-      id: "module-1-mcq-1",
-      title: localizedText("Trade unions"),
-      questions: mcqQuestions,
-    };
-    const mcqOnlyExport: MockModuleExport = {
-      module: {
-        id: "module-1",
-        title: localizedText("Trade unions"),
-        certificationLevel: "basic",
-        activeVersionId: "module-1-version-1",
-        archivedAt: null,
-      },
-      selectedConfiguration: {
-        source: "draftModuleVersion",
-        moduleVersion,
-        rubricVersion: null,
-        promptTemplateVersion: null,
-        mcqSetVersion,
-      },
-      versions: {
-        moduleVersions: [moduleVersion],
-        rubricVersions: [],
-        promptTemplateVersions: [],
-        mcqSetVersions: [mcqSetVersion],
-      },
-    };
-
     await mockCommonApis(page, {
       modules: [{ id: "module-1", title: "Trade unions", activeVersion: { versionNo: 1 } }],
-      moduleExports: { "module-1": mcqOnlyExport },
+      moduleExports: { "module-1": buildMcqOnlyExport() },
     });
 
     // Capture the saved module-version payload to prove the MCQ-only save path ran.
@@ -128,6 +128,48 @@ test.describe("admin content — module-type bugs (#655)", () => {
     // And the version that was saved carries the MCQ-only mode + the loaded pass threshold.
     expect(savedVersionPayload?.assessmentMode).toBe("MCQ_ONLY");
     expect(savedVersionPayload?.taskText).toBeUndefined();
+    expect(savedVersionPayload?.assessmentPolicy?.passRules?.mcqMinPercent).toBe(60);
+  });
+
+  test("an MCQ-only module edited via 'Edit directly' hides free-text fields and still saves (#665)", async ({ page }) => {
+    await mockCommonApis(page, {
+      modules: [{ id: "module-1", title: "Trade unions", activeVersion: { versionNo: 1 } }],
+      moduleExports: { "module-1": buildMcqOnlyExport() },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let savedVersionPayload: any = null;
+    await page.route("**/api/admin/content/modules/*/module-versions", async (route: Route) => {
+      savedVersionPayload = route.request().postDataJSON();
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ moduleVersion: { id: "module-1-version-2", versionNo: 2 } }),
+      });
+    });
+
+    await page.goto("/admin-content/module/module-1/conversation");
+
+    // Module actions → "Edit directly" (directEdit → enterPreviewEditMode).
+    await clickEnabledButton(page, /Edit directly|Rediger direkte/);
+
+    // The free-text editor fields must NOT exist for an MCQ-only module, but the MCQ editor must.
+    await expect(page.locator("#previewEditTaskText")).toHaveCount(0);
+    await expect(page.locator("#previewEditGuidanceText")).toHaveCount(0);
+    await expect(page.locator("#previewEditMcqStem0")).toBeVisible();
+
+    // Confirm the direct edit, then save.
+    await page.locator("#previewEditConfirm").click();
+    await clickEnabledButton(page, /^Save draft$|^Lagre utkast$/);
+
+    // Save must not hit the scenario-required guard, and must persist MCQ_ONLY.
+    await expect(
+      page.getByText(/The draft needs scenario text|Utkastet må ha scenario\/oppgavetekst|Utkastet må ha scenario\/oppgåvetekst/),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText(/Draft saved as a new module version|Utkastet er lagret som en ny modulversjon|Utkastet er lagra som ein ny modulversjon/).first(),
+    ).toBeVisible();
+    expect(savedVersionPayload?.assessmentMode).toBe("MCQ_ONLY");
     expect(savedVersionPayload?.assessmentPolicy?.passRules?.mcqMinPercent).toBe(60);
   });
 });


### PR DESCRIPTION
Oppfølging til #655, oppdaget under stage-verifisering. To koblede bugs for MCQ-only-moduler i samtale-flyten:

- **Lagring/publisering feilet** med «Utkastet må ha scenario/oppgavetekst …» når en MCQ-only-modul var redigert via «Rediger direkte».
- **«Rediger direkte» viste redigerbare fritekst-felt** (oppgavetekst/føringer/veiledning) som en MCQ-only-modul ikke har.

**Felles rotårsak:** `enterPreviewEditMode` leste ikke modulens `assessmentMode`. For en lastet MCQ-only-modul er `sessionDraft` null, så den rekonstruerte draften (via `buildPreviewCandidate`) mistet `assessmentMode` → behandlet som FREETEXT_PLUS_MCQ, og edit-skjemaet rendret alltid fritekst-textarea-ene.

**Fiks** ([admin-content-shell.js](public/static/admin-content-shell.js)): `enterPreviewEditMode` utleder `assessmentMode` (+ `mcqMinPercent`) fra `sessionDraft ?? bundle.moduleVersion`, skjuler fritekst-felt + kriterier for MCQ-only, og bevarer modus på den rekonstruerte draften (begge grener i confirm-handleren). #655 fikset resume-chat-edit-stien; dette dekker direkte-redigerings-stien.

**Test:** ny e2e i [admin-content-mcq-only-revision.spec.ts](test/e2e/admin-content-mcq-only-revision.spec.ts) — «Edit directly» på MCQ-only: ingen `#previewEditTaskText`, MCQ-editor synlig, save uten taskRequired, payload `assessmentMode=MCQ_ONLY`. 3/3 e2e grønne lokalt.

Rydder også bort en utilsiktet tom fil `0` som ble committet i #664.

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)
