### PR TITLE
test(sections): explicit /sections/localize coverage (#494)

### DIFF
--- a/test/m2-admin-sections.test.ts
+++ b/test/m2-admin-sections.test.ts
@@ -70,6 +70,44 @@ describe("Admin course-section management", () => {
     expect(gone.status).toBe(404);
   });
 
+  // #494 AC: localisation of section subfields is an EXPLICIT author action via the
+  // /localize endpoint — translation never happens implicitly on save. The endpoint returns
+  // the translated title + bodyMarkdown for the target locale, which the author reviews and
+  // then saves separately. (LLM stub mode tags output as "[<locale>] …".)
+  it("explicitly localises section title + body to another locale without mutating the source", async () => {
+    const create = await request(app)
+      .post("/api/admin/content/sections")
+      .set(adminHeaders)
+      .send({
+        title: { "en-GB": `Localise me ${Date.now()}` },
+        bodyMarkdown: { "en-GB": "# Heading\n\nBody text." },
+      });
+    const sectionId = create.body.section.id as string;
+
+    const localized = await request(app)
+      .post("/api/admin/content/sections/localize")
+      .set(adminHeaders)
+      .send({
+        title: "Localise me",
+        bodyMarkdown: "# Heading\n\nBody text.",
+        sourceLocale: "en-GB",
+        targetLocale: "nb",
+      });
+    expect(localized.status).toBe(200);
+    expect(localized.body.title).toContain("[nb]");
+    expect(localized.body.bodyMarkdown).toContain("[nb]");
+
+    // The localize call must NOT have persisted anything: the stored nb field is still empty
+    // until the author explicitly saves the reviewed translation.
+    const detail = await request(app)
+      .get(`/api/admin/content/sections/${sectionId}`)
+      .set(adminHeaders);
+    const storedBody = JSON.parse(detail.body.section.bodyMarkdown) as Record<string, string>;
+    expect(storedBody.nb ?? "").toBe("");
+
+    await request(app).delete(`/api/admin/content/sections/${sectionId}`).set(adminHeaders);
+  });
+
   it("refuses to delete a section that is attached to a course", async () => {
     const create = await request(app)
       .post("/api/admin/content/sections")


### PR DESCRIPTION
Verifies and closes #494 (localisation of section subfields, en-GB/nb/nn).

The feature is already implemented across the stack:
- **Editor:** `public/static/admin-content-sections.js` has nb/nn/en-GB language tabs; per-locale title/body stored as localized JSON (`localizedTextCodec`).
- **Explicit translation (AC #2):** the «Oversett fra dette språket» button calls `/api/admin/content/sections/localize` and shows «se over før du lagrer» — translation is a separate, reviewed step, never implicit on save.
- **Participant render (AC #3):** `src/routes/courses.ts` serves locale-correct title/body via `localizeContentText` with fallback.

The only gap was a direct test for the explicit localize endpoint. This adds one: it asserts the endpoint returns the translated title+body for the target locale (stub mode) and does **not** persist anything until the author saves — locking AC #2.

Test-only; no version bump. Verified in CI (fresh DB).

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)
