### PR TITLE
fix(course): «Arkiver»-knapp i kurslista (v1.3.78, #660-oppfølging)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,15 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.78 - 2026-06-25
+
+fix(course): «Arkiver»-knapp i kurslista (#660-oppfølging)
+
+Slette-blokkeringen i #660 ber forfatteren arkivere kurset i stedet, men arkiv-funksjonen var ikke
+eksponert i UI-et (kun i backend). Kurslista har nå en **«Arkiver»**-handling per kurs (wiret til det
+eksisterende `POST /:courseId/archive`), med en lett bekreftelse. Arkiverte kurs vises med et
+**«Arkivert»**-merke, og arkiver-knappen skjules for dem. Dekket av en Playwright-e2e.
+
 ## 1.3.77 - 2026-06-25
 
 fix(shell): MCQ-only direkte-redigering bevarer modultype + skjuler fritekst-felt (#665)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.77",
+  "version": "1.3.78",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -371,7 +371,7 @@ async function renderListView() {
     localizeTitle: localizedText,
     formatDate,
   }).map((course) => `<tr>
-      <td class="col-title">${escapeHtml(course.title)}</td>
+      <td class="col-title">${escapeHtml(course.title)}${course.archivedAt ? ` <span style="display:inline-block;margin-left:6px;padding:1px 8px;border-radius:999px;background:#f0f0f0;color:#666;font-size:11px;font-weight:600;vertical-align:middle;">Arkivert</span>` : ""}</td>
       <td class="col-level">${certBadge(course.certificationLevel)}</td>
       <td class="col-module-count">${course.moduleCount}</td>
       <td class="col-updated">${escapeHtml(course.updatedLabel)}</td>
@@ -382,6 +382,9 @@ async function renderListView() {
             ? `<button class="row-action-btn" data-action="publish" data-course-id="${escapeHtml(course.courseId)}">Publiser</button>`
             : ""}
           <button class="row-action-btn" data-action="export" data-course-id="${escapeHtml(course.courseId)}" data-course-title="${escapeHtml(course.title)}">Eksporter</button>
+          ${course.archivedAt
+            ? ""
+            : `<button class="row-action-btn" data-action="archive" data-course-id="${escapeHtml(course.courseId)}" data-course-title="${escapeHtml(course.title)}">Arkiver</button>`}
           <button class="row-action-btn destructive" data-action="delete" data-course-id="${escapeHtml(course.courseId)}" data-course-title="${escapeHtml(course.title)}">Slett</button>
         </div>
       </td>
@@ -481,8 +484,29 @@ function handleListTableClick(event) {
     exportCoursePackage(btn.dataset.courseId, btn.dataset.courseTitle);
     return;
   }
+  if (btn.dataset.action === "archive") {
+    archiveCourseInAdmin(btn.dataset.courseId, btn.dataset.courseTitle, btn);
+    return;
+  }
   if (btn.dataset.action === "delete") {
     openDeleteDialog(btn.dataset.courseId, btn.dataset.courseTitle);
+  }
+}
+
+// Archive (soft-delete) a course. Archiving is the alternative to deleting when a course has
+// completions/certificates that must be preserved (#660). Reversible, so a lightweight confirm.
+async function archiveCourseInAdmin(courseId, courseTitle, triggerButton = null) {
+  if (!window.confirm(`Arkivere kurset «${courseTitle}»? Det skjules for deltakere, men beholdes med fullføringer.`)) {
+    return;
+  }
+  if (triggerButton) triggerButton.disabled = true;
+  try {
+    await apiFetch(`/api/admin/content/courses/${encodeURIComponent(courseId)}/archive`, getHeaders, { method: "POST" });
+    showToast("Kurset ble arkivert.", "success");
+    await renderListView();
+  } catch (err) {
+    showToast(err?.message ?? "Kunne ikke arkivere kurs.", "error");
+    if (triggerButton) triggerButton.disabled = false;
   }
 }
 

--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -996,6 +996,49 @@ test.describe("admin content browser coverage", () => {
     await expect(page.locator(".page-loading")).toHaveCount(0);
   });
 
+  // #660 follow-up: the course list exposes an "Arkiver" action (the delete-blocked error tells
+  // authors to archive instead). Archiving marks the course and removes the archive button.
+  test("course list can archive a course, which shows the Arkivert badge and hides the archive button", async ({ page }) => {
+    const state = await mockCommonApis(page, {
+      courses: [
+        {
+          id: "course-1",
+          title: "Labour rights",
+          description: null,
+          certificationLevel: "basic",
+          moduleCount: 0,
+          updatedAt: "2026-04-18T12:00:00.000Z",
+          publishedAt: "2026-04-18T12:00:00.000Z",
+          archivedAt: null,
+          modules: [],
+        },
+      ],
+    });
+    // The shared harness's `courses/*` glob does not match the two-segment archive path, so
+    // register the archive endpoint here: mark the course archived in the mock state so the
+    // list re-render reflects it.
+    await page.route("**/api/admin/content/courses/*/archive", async (route: Route) => {
+      const segments = new URL(route.request().url()).pathname.split("/");
+      const courseId = decodeURIComponent(segments[segments.length - 2] ?? "");
+      const course = state.mutableCourses.find((c) => c.id === courseId);
+      if (course) course.archivedAt = "2026-04-18T12:00:00.000Z";
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ course }) });
+    });
+
+    await page.goto("/admin-content/courses");
+    const row = page.locator("#coursesTableBody tr").filter({ hasText: "Labour rights" });
+    await expect(row).toBeVisible();
+    await expect(row.locator('[data-action="archive"]')).toBeVisible();
+
+    page.once("dialog", (dialog) => dialog.accept());
+    await row.locator('[data-action="archive"]').click();
+
+    // After archiving: the row carries the Arkivert badge and the archive action is gone.
+    const archivedRow = page.locator("#coursesTableBody tr").filter({ hasText: "Labour rights" });
+    await expect(archivedRow).toContainText("Arkivert");
+    await expect(archivedRow.locator('[data-action="archive"]')).toHaveCount(0);
+  });
+
   test("shell idle flow opens the module picker and renders existing module choices", async ({ page }) => {
     await mockCommonApis(page, {
       modules: [


### PR DESCRIPTION
Oppfølging til #660, funnet under stage-verifisering. Slette-blokkeringen ber forfatteren **arkivere** kurset i stedet (for å bevare fullføringer/kursbevis), men arkiv-funksjonen var ikke eksponert i UI-et — bare i backend (`archiveCourse` + `POST /:courseId/archive`). «Riktig fiks, ufullstendig flate».

**Fiks** ([admin-content-courses.js](public/static/admin-content-courses.js)): kurslista har nå en **«Arkiver»**-handling per kurs, wiret til det eksisterende endepunktet, med en lett bekreftelse (reversibelt). Arkiverte kurs vises med et **«Arkivert»**-merke, og arkiver-knappen skjules for dem.

**Test:** ny Playwright-e2e i [admin-content-workspaces.spec.ts](test/e2e/admin-content-workspaces.spec.ts) — arkiver et kurs → «Arkivert»-merke vises + arkiver-knapp borte. Grønn lokalt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
