### PR TITLE
feat(course): Enrollment backend API + authz + synlighetsfilter (v1.3.79, #641 / EN-2)

### DIFF
--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -61,6 +61,10 @@ All routes use the `courses` capability: PARTICIPANT, SUBJECT_MATTER_OWNER, ADMI
 | `GET` | `/api/courses/:courseId` | Course detail. Returns `modules[]` (legacy) and `items[]` — the ordered mixed module/section sequence; SECTION items carry a `read` flag (#491/#492). |
 | `GET` | `/api/courses/:courseId/sections/:sectionId` | Sanitised HTML + title of a learning section in the participant's locale. Validates the section belongs to the published course (#491). |
 | `POST` | `/api/courses/:courseId/sections/:sectionId/read` | Mark a section as read (idempotent). `204` on success (#492). |
+| `GET` | `/api/courses/enrollments` | The user's own active enrollments (assigned courses) with `dueAt` + derived `status` (ASSIGNED/IN_PROGRESS/OVERDUE/COMPLETED) (#496/EN-2). |
+| `POST` | `/api/courses/:courseId/enroll` | Self-enrol on an **OPEN** course (source=SELF). `204`; `400` if the course is RESTRICTED (#496/EN-2). |
+
+`GET /api/courses` hides **RESTRICTED** courses from users without an active enrollment; OPEN courses are visible to everyone (#496/EN-2).
 
 ---
 
@@ -184,6 +188,9 @@ fields (`title`, `bodyMarkdown`) accept a string or a partial `{en-GB,nb,nn}` ob
 | `PUT` | `/api/admin/content/courses/:courseId/items` | Set the ordered sequence — body `{ items: [{type:"MODULE",moduleId} \| {type:"SECTION",sectionId}] }`. Re-syncs CourseModule (#486). |
 | `POST` | `/api/admin/content/courses/:courseId/publish` | Publish course |
 | `POST` | `/api/admin/content/courses/:courseId/archive` | Archive course |
+| `GET` | `/api/admin/content/courses/:courseId/enrollments` | List active enrollments for a course, each with the participant + derived status (#496/EN-2) |
+| `POST` | `/api/admin/content/courses/:courseId/enrollments` | Assign — body `{ userIds?: string[], department?: string, dueAt?: string\|null }`. Individual list and/or department materialisation. Idempotent per user; audited (#496/EN-2) |
+| `DELETE` | `/api/admin/content/courses/:courseId/enrollments/:userId` | Revoke (soft) a participant's enrollment; audited (#496/EN-2) |
 | `POST` | `/api/admin/content/courses/:courseId/localize-copy` | LLM-translate course title/description |
 | `GET` | `/api/admin/content/courses/:courseId/export-package` | Export envelope (inlines modules **and** sections in order, #512) |
 | `POST` | `/api/admin/content/courses/import` | Import a course envelope (recreates sections via `items`, falls back to modules-only v1) |

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,21 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.79 - 2026-06-25
+
+feat(course): Enrollment backend API + authz + synlighetsfilter (#641 / #496 EN-2)
+
+Bygger videre på EN-1-datamodellen. Nye endepunkter: admin (SMO/ADMINISTRATOR) kan tildele kurs til
+deltakere — enten en eksplisitt brukerliste (source=INDIVIDUAL) eller alle aktive i en avdeling
+(source=DEPARTMENT, materialisert til individuelle rader ved tildeling) — med valgfri frist, samt
+fjerne (soft-revoke) og liste tildelinger per kurs. Deltakere ser egne tildelinger
+(`GET /api/courses/enrollments`, med derivert status) og kan selv-melde seg på OPEN-kurs
+(`POST /api/courses/:courseId/enroll`, source=SELF; RESTRICTED avvises). `GET /api/courses` har nå et
+**synlighetsfilter**: RESTRICTED-kurs vises kun for tildelte; OPEN for alle. Tildeling/fjerning
+auditeres. Status er alltid DERIVERT (aldri lagret). Integrasjonstester dekker tildel/list/revoke,
+synlighet, selv-påmelding, og at deltaker ikke kan tildele (403). NB (#645): avdelings-tildeling
+finner ingen brukere før `User.department` er populert; individuell er primær til da.
+
 ## 1.3.78 - 2026-06-25
 
 fix(course): «Arkiver»-knapp i kurslista (#660-oppfølging)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.78",
+  "version": "1.3.79",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/course/enrollmentService.ts
+++ b/src/modules/course/enrollmentService.ts
@@ -1,0 +1,221 @@
+import type { CourseEnrollmentSource } from "@prisma/client";
+import { prisma } from "../../db/prisma.js";
+import { NotFoundError, ValidationError } from "../../errors/AppError.js";
+import { recordAuditEvent } from "../../services/auditService.js";
+import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
+import { enrollmentRepository } from "./enrollmentRepository.js";
+import { deriveEnrollmentStatus, type EnrollmentStatus } from "./enrollmentStatus.js";
+
+// #496/EN-2: enrollment service — assign/revoke/list + self-enroll + course visibility. Status is
+// always DERIVED here (never stored) from CourseCompletion + progress + dueAt, so it cannot drift.
+
+export interface AssignEnrollmentsInput {
+  userIds?: string[];
+  department?: string | null;
+  dueAt?: Date | null;
+}
+
+export interface AssignEnrollmentsResult {
+  assignedUserIds: string[];
+  source: CourseEnrollmentSource;
+}
+
+async function requireCourse(courseId: string): Promise<{ id: string; enrollmentPolicy: string }> {
+  const course = await prisma.course.findUnique({
+    where: { id: courseId },
+    select: { id: true, enrollmentPolicy: true },
+  });
+  if (!course) {
+    throw new NotFoundError("Course", "course_not_found", "Course not found.");
+  }
+  return course;
+}
+
+/**
+ * Assign a course to participants — either an explicit list of users (source=INDIVIDUAL) or all
+ * active users in a department (source=DEPARTMENT, materialised to individual rows at assign time).
+ * Idempotent per user (upsert clears a prior revoke). Each assignment is audited.
+ *
+ * NB (#645): department assignment finds no users until User.department is populated from Entra;
+ * individual assignment is the primary path until then.
+ */
+export async function assignEnrollments(
+  courseId: string,
+  input: AssignEnrollmentsInput,
+  actorId: string | null,
+): Promise<AssignEnrollmentsResult> {
+  await requireCourse(courseId);
+
+  const byDepartment = typeof input.department === "string" && input.department.trim().length > 0;
+  const explicitUserIds = (input.userIds ?? []).filter((id) => typeof id === "string" && id.length > 0);
+  if (!byDepartment && explicitUserIds.length === 0) {
+    throw new ValidationError("Provide userIds or a department to assign.");
+  }
+  const source: CourseEnrollmentSource = byDepartment ? "DEPARTMENT" : "INDIVIDUAL";
+
+  let userIds = explicitUserIds;
+  if (byDepartment) {
+    const deptUsers = await prisma.user.findMany({
+      where: { department: input.department as string, activeStatus: true, isAnonymized: false },
+      select: { id: true },
+    });
+    userIds = deptUsers.map((u) => u.id);
+  } else {
+    // Validate the explicit ids exist so we never create dangling enrollments.
+    const found = await prisma.user.findMany({ where: { id: { in: userIds } }, select: { id: true } });
+    const foundIds = new Set(found.map((u) => u.id));
+    const missing = userIds.filter((id) => !foundIds.has(id));
+    if (missing.length > 0) {
+      throw new ValidationError(`Unknown user id(s): ${missing.join(", ")}.`);
+    }
+  }
+
+  const assignedUserIds: string[] = [];
+  for (const userId of userIds) {
+    await enrollmentRepository.assignEnrollment({
+      userId,
+      courseId,
+      assignedById: actorId,
+      source,
+      dueAt: input.dueAt ?? null,
+    });
+    await recordAuditEvent({
+      entityType: auditEntityTypes.course,
+      entityId: courseId,
+      action: auditActions.enrollment.assigned,
+      actorId: actorId ?? undefined,
+      metadata: { userId, courseId, source },
+    });
+    assignedUserIds.push(userId);
+  }
+
+  return { assignedUserIds, source };
+}
+
+/** Soft-revoke a participant's enrollment. No-op (still 200) if there was no active enrollment. */
+export async function revokeEnrollment(courseId: string, userId: string, actorId: string | null): Promise<void> {
+  await requireCourse(courseId);
+  const result = await enrollmentRepository.revokeEnrollment(userId, courseId);
+  if (result.count > 0) {
+    await recordAuditEvent({
+      entityType: auditEntityTypes.course,
+      entityId: courseId,
+      action: auditActions.enrollment.revoked,
+      actorId: actorId ?? undefined,
+      metadata: { userId, courseId },
+    });
+  }
+}
+
+/**
+ * Self-enrolment: a participant enrols themselves on an OPEN course (source=SELF). RESTRICTED
+ * courses cannot be self-enrolled — they require an SMO/admin assignment.
+ */
+export async function selfEnroll(courseId: string, userId: string): Promise<void> {
+  const course = await requireCourse(courseId);
+  if (course.enrollmentPolicy !== "OPEN") {
+    throw new ValidationError("This course is restricted — self-enrolment is not allowed.");
+  }
+  await enrollmentRepository.assignEnrollment({
+    userId,
+    courseId,
+    assignedById: null,
+    source: "SELF",
+    dueAt: null,
+  });
+  await recordAuditEvent({
+    entityType: auditEntityTypes.course,
+    entityId: courseId,
+    action: auditActions.enrollment.selfEnrolled,
+    actorId: userId,
+    metadata: { userId, courseId },
+  });
+}
+
+// Lightweight "has the user begun this course" probe used for IN_PROGRESS derivation: a read
+// section OR any submission against one of the course's modules.
+async function hasUserStartedCourse(userId: string, courseId: string): Promise<boolean> {
+  const reads = await prisma.courseSectionRead.count({ where: { userId, courseId } });
+  if (reads > 0) return true;
+  const submissions = await prisma.submission.count({
+    where: { userId, module: { courseModules: { some: { courseId } } } },
+  });
+  return submissions > 0;
+}
+
+async function deriveStatus(userId: string, courseId: string, dueAt: Date | null, now: Date): Promise<EnrollmentStatus> {
+  const completion = await prisma.courseCompletion.findUnique({
+    where: { userId_courseId: { userId, courseId } },
+    select: { id: true },
+  });
+  const hasStarted = completion ? true : await hasUserStartedCourse(userId, courseId);
+  return deriveEnrollmentStatus({ isCompleted: !!completion, hasStarted, dueAt, now });
+}
+
+export interface UserEnrollmentView {
+  courseId: string;
+  source: CourseEnrollmentSource;
+  dueAt: string | null;
+  assignedAt: string;
+  status: EnrollmentStatus;
+}
+
+/** A participant's active enrolments, each with derived status. */
+export async function listUserEnrollments(userId: string, now: Date = new Date()): Promise<UserEnrollmentView[]> {
+  const enrollments = await enrollmentRepository.findActiveEnrollmentsForUser(userId);
+  return Promise.all(
+    enrollments.map(async (e) => ({
+      courseId: e.courseId,
+      source: e.source,
+      dueAt: e.dueAt ? e.dueAt.toISOString() : null,
+      assignedAt: e.assignedAt.toISOString(),
+      status: await deriveStatus(userId, e.courseId, e.dueAt, now),
+    })),
+  );
+}
+
+export interface CourseEnrollmentView {
+  userId: string;
+  name: string;
+  email: string;
+  department: string | null;
+  source: CourseEnrollmentSource;
+  dueAt: string | null;
+  assignedAt: string;
+  status: EnrollmentStatus;
+}
+
+/** All active enrolments on a course (admin view), each with the participant and derived status. */
+export async function listCourseEnrollments(courseId: string, now: Date = new Date()): Promise<CourseEnrollmentView[]> {
+  await requireCourse(courseId);
+  const enrollments = await enrollmentRepository.findActiveEnrollmentsForCourse(courseId);
+  return Promise.all(
+    enrollments.map(async (e) => ({
+      userId: e.userId,
+      name: e.user.name,
+      email: e.user.email,
+      department: e.user.department,
+      source: e.source,
+      dueAt: e.dueAt ? e.dueAt.toISOString() : null,
+      assignedAt: e.assignedAt.toISOString(),
+      status: await deriveStatus(e.userId, courseId, e.dueAt, now),
+    })),
+  );
+}
+
+/**
+ * Course visibility (#496): OPEN courses are visible to everyone; RESTRICTED courses only to users
+ * with an active enrolment. Returns the set of course ids the user may see, given a candidate list.
+ */
+export async function filterVisibleCourseIds(userId: string, courses: Array<{ id: string; enrollmentPolicy: string }>): Promise<Set<string>> {
+  const restrictedIds = courses.filter((c) => c.enrollmentPolicy !== "OPEN").map((c) => c.id);
+  const visible = new Set<string>(courses.filter((c) => c.enrollmentPolicy === "OPEN").map((c) => c.id));
+  if (restrictedIds.length > 0) {
+    const enrolled = await prisma.courseEnrollment.findMany({
+      where: { userId, revokedAt: null, courseId: { in: restrictedIds } },
+      select: { courseId: true },
+    });
+    for (const row of enrolled) visible.add(row.courseId);
+  }
+  return visible;
+}

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -22,6 +22,20 @@ export { courseRepository, createCourseRepository } from "./courseRepository.js"
 export { enrollmentRepository, createEnrollmentRepository } from "./enrollmentRepository.js";
 export { deriveEnrollmentStatus } from "./enrollmentStatus.js";
 export type { EnrollmentStatus } from "./enrollmentStatus.js";
+export {
+  assignEnrollments,
+  revokeEnrollment,
+  selfEnroll,
+  listUserEnrollments,
+  listCourseEnrollments,
+  filterVisibleCourseIds,
+} from "./enrollmentService.js";
+export type {
+  AssignEnrollmentsInput,
+  AssignEnrollmentsResult,
+  UserEnrollmentView,
+  CourseEnrollmentView,
+} from "./enrollmentService.js";
 export { computeCourseStatus } from "./courseQueries.js";
 export type {
   CourseStatus,

--- a/src/observability/auditEvents.ts
+++ b/src/observability/auditEvents.ts
@@ -69,6 +69,11 @@ export const auditActions = {
     archived: "course_archived",
     completionIssued: "course_completion_issued",
   },
+  enrollment: {
+    assigned: "course_enrollment_assigned",
+    revoked: "course_enrollment_revoked",
+    selfEnrolled: "course_self_enrolled",
+  },
   certification: {
     recertificationStatusUpserted: "recertification_status_upserted",
     recertificationReminderSent: "recertification_reminder_sent",
@@ -256,6 +261,13 @@ export type AuditMetadataByAction = {
     courseId: string;
     certificateId: string;
   }>;
+  [auditActions.enrollment.assigned]: EventMetadata<{
+    userId: string;
+    courseId: string;
+    source: string;
+  }>;
+  [auditActions.enrollment.revoked]: EventMetadata<{ userId: string; courseId: string }>;
+  [auditActions.enrollment.selfEnrolled]: EventMetadata<{ userId: string; courseId: string }>;
   [auditActions.manualReview.opened]: EventMetadata<{
     submissionId: string;
     decisionId: string;

--- a/src/routes/adminCourses.ts
+++ b/src/routes/adminCourses.ts
@@ -9,6 +9,9 @@ import {
   setCourseItems,
   deleteCourse,
   courseRepository,
+  assignEnrollments,
+  revokeEnrollment,
+  listCourseEnrollments,
 } from "../modules/course/index.js";
 import { generationLocaleSchema, importBodySchema, localizedTextPatchSchema, parseRequest } from "../modules/adminContent/adminContentSchemas.js";
 import { buildCourseExportEnvelope } from "../modules/adminContent/index.js";
@@ -309,6 +312,57 @@ adminCoursesRouter.post("/:courseId/archive", async (request, response, next) =>
 adminCoursesRouter.delete("/:courseId", async (request, response, next) => {
   try {
     await deleteCourse(request.params.courseId, request.context?.userId);
+    response.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+// #496/EN-2: enrollment management (SMO/ADMINISTRATOR — gated by the /api/admin/content mount).
+const assignEnrollmentsSchema = z
+  .object({
+    userIds: z.array(z.string().min(1)).optional(),
+    department: z.string().trim().min(1).optional(),
+    dueAt: z.string().datetime().nullish(),
+  })
+  .refine((v) => (v.userIds?.length ?? 0) > 0 || !!v.department, {
+    message: "Provide userIds or a department.",
+  });
+
+adminCoursesRouter.get("/:courseId/enrollments", async (request, response, next) => {
+  try {
+    const enrollments = await listCourseEnrollments(request.params.courseId);
+    response.json({ enrollments });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminCoursesRouter.post("/:courseId/enrollments", async (request, response, next) => {
+  const parsed = assignEnrollmentsSchema.safeParse(request.body);
+  if (!parsed.success) {
+    response.status(400).json({ error: "validation_error", issues: parsed.error.issues });
+    return;
+  }
+  try {
+    const result = await assignEnrollments(
+      request.params.courseId,
+      {
+        userIds: parsed.data.userIds,
+        department: parsed.data.department ?? null,
+        dueAt: parsed.data.dueAt ? new Date(parsed.data.dueAt) : null,
+      },
+      request.context?.userId ?? null,
+    );
+    response.status(201).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminCoursesRouter.delete("/:courseId/enrollments/:userId", async (request, response, next) => {
+  try {
+    await revokeEnrollment(request.params.courseId, request.params.userId, request.context?.userId ?? null);
     response.status(204).send();
   } catch (error) {
     next(error);

--- a/src/routes/courses.ts
+++ b/src/routes/courses.ts
@@ -4,6 +4,7 @@ import { renderSectionMarkdown } from "../modules/course/sectionContent.js";
 import { localizeContentText } from "../i18n/content.js";
 import { normalizeLocale } from "../i18n/locale.js";
 import { NotFoundError } from "../errors/AppError.js";
+import { listUserEnrollments, selfEnroll, filterVisibleCourseIds } from "../modules/course/index.js";
 import type { CourseListItem, CourseDetail, CourseSequenceItem } from "../modules/course/index.js";
 import { queryLatestSubmissionsForModules } from "../modules/submission/submissionRepository.js";
 import { hasCertificateBackground } from "../modules/platformConfig/certificateBackgroundService.js";
@@ -20,7 +21,10 @@ coursesRouter.get("/", async (request, response, next) => {
   const locale = normalizeLocale(request.context?.locale) ?? "en-GB";
 
   try {
-    const courses = await courseRepository.findPublishedCourses();
+    const allCourses = await courseRepository.findPublishedCourses();
+    // #496/EN-2: RESTRICTED courses are only visible to enrolled users; OPEN courses to everyone.
+    const visibleIds = await filterVisibleCourseIds(userId, allCourses);
+    const courses = allCourses.filter((course) => visibleIds.has(course.id));
 
     const items: CourseListItem[] = await Promise.all(
       courses.map(async (course) => {
@@ -63,6 +67,21 @@ coursesRouter.get("/", async (request, response, next) => {
     );
 
     response.json({ courses: items });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// #496/EN-2: a participant's own active enrolments (assigned courses) with due date + derived
+// status. Registered before "/:courseId" so the literal path is not captured as a course id.
+coursesRouter.get("/enrollments", async (request, response, next) => {
+  const userId = request.context?.userId;
+  if (!userId) {
+    response.status(401).json({ error: "unauthorized" });
+    return;
+  }
+  try {
+    response.json({ enrollments: await listUserEnrollments(userId) });
   } catch (error) {
     next(error);
   }
@@ -295,6 +314,25 @@ coursesRouter.post("/:courseId/sections/:sectionId/read", async (request, respon
     await courseRepository.markSectionRead(userId, course.id, request.params.sectionId);
     // Reading the final section can be the last gate for certification (#476/#525) — re-check.
     await checkCourseCompletionForCourse({ userId, courseId: course.id });
+    response.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+// #496/EN-2: self-enrolment on an OPEN course (source=SELF). RESTRICTED courses reject with 400.
+coursesRouter.post("/:courseId/enroll", async (request, response, next) => {
+  const userId = request.context?.userId;
+  if (!userId) {
+    response.status(401).json({ error: "unauthorized" });
+    return;
+  }
+  try {
+    const course = await courseRepository.findCourseById(request.params.courseId);
+    if (!course || !course.publishedAt || course.archivedAt) {
+      throw new NotFoundError("Course", "course_not_found", "Course not found.");
+    }
+    await selfEnroll(request.params.courseId, userId);
     response.status(204).send();
   } catch (error) {
     next(error);

--- a/test/m2-enrollment.test.ts
+++ b/test/m2-enrollment.test.ts
@@ -1,0 +1,153 @@
+import request from "supertest";
+import { afterAll, describe, expect, it } from "vitest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+
+// #496/EN-2 — enrollment backend API: assign/revoke, my-enrollments, per-course list, self-enrol,
+// and the RESTRICTED-course visibility filter on GET /api/courses.
+
+const adminHeaders = {
+  "x-user-id": "enroll-admin-ext",
+  "x-user-email": "enroll-admin@company.com",
+  "x-user-name": "Enroll Admin",
+  "x-user-roles": "ADMINISTRATOR",
+};
+
+function participantHeaders(externalId: string) {
+  return {
+    "x-user-id": externalId,
+    "x-user-email": `${externalId}@company.com`,
+    "x-user-name": externalId,
+    "x-user-roles": "PARTICIPANT",
+  };
+}
+
+async function createPublishedCourse(policy: "OPEN" | "RESTRICTED"): Promise<string> {
+  const course = await prisma.course.create({
+    data: {
+      title: JSON.stringify({ "en-GB": `Enroll course ${Date.now()}-${Math.round(performance.now())}` }),
+      enrollmentPolicy: policy,
+      publishedAt: new Date(),
+    },
+    select: { id: true },
+  });
+  return course.id;
+}
+
+describe("Course enrollment API (#496/EN-2)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("assigns, lists, shows to the participant, and revokes an enrollment", async () => {
+    const courseId = await createPublishedCourse("OPEN");
+    const learner = await prisma.user.create({
+      data: { externalId: `en-learner-${Date.now()}`, name: "Learner One", email: `en-learner-${Date.now()}@x.test`, department: "Sales" },
+      select: { id: true, externalId: true },
+    });
+
+    // Admin assigns the participant with a past due date → derived status OVERDUE.
+    const assign = await request(app)
+      .post(`/api/admin/content/courses/${courseId}/enrollments`)
+      .set(adminHeaders)
+      .send({ userIds: [learner.id], dueAt: "2020-01-01T00:00:00.000Z" });
+    expect(assign.status).toBe(201);
+    expect(assign.body.source).toBe("INDIVIDUAL");
+    expect(assign.body.assignedUserIds).toContain(learner.id);
+
+    // Admin per-course list shows the participant with derived status.
+    const adminList = await request(app)
+      .get(`/api/admin/content/courses/${courseId}/enrollments`)
+      .set(adminHeaders);
+    expect(adminList.status).toBe(200);
+    const row = (adminList.body.enrollments as Array<{ userId: string; status: string; department: string | null }>)
+      .find((e) => e.userId === learner.id);
+    expect(row).toBeTruthy();
+    expect(row?.status).toBe("OVERDUE");
+    expect(row?.department).toBe("Sales");
+
+    // Participant sees the course among their own enrollments.
+    const mine = await request(app)
+      .get("/api/courses/enrollments")
+      .set(participantHeaders(learner.externalId));
+    expect(mine.status).toBe(200);
+    const mineRow = (mine.body.enrollments as Array<{ courseId: string; status: string }>)
+      .find((e) => e.courseId === courseId);
+    expect(mineRow?.status).toBe("OVERDUE");
+
+    // Revoke → participant no longer enrolled.
+    const revoke = await request(app)
+      .delete(`/api/admin/content/courses/${courseId}/enrollments/${learner.id}`)
+      .set(adminHeaders);
+    expect(revoke.status).toBe(204);
+    const afterRevoke = await request(app)
+      .get("/api/courses/enrollments")
+      .set(participantHeaders(learner.externalId));
+    expect((afterRevoke.body.enrollments as Array<{ courseId: string }>).some((e) => e.courseId === courseId)).toBe(false);
+
+    await prisma.courseEnrollment.deleteMany({ where: { courseId } });
+    await prisma.course.delete({ where: { id: courseId } });
+    await prisma.user.delete({ where: { id: learner.id } });
+  });
+
+  it("hides RESTRICTED courses from non-enrolled users and shows them once enrolled", async () => {
+    const restrictedId = await createPublishedCourse("RESTRICTED");
+    const openId = await createPublishedCourse("OPEN");
+    const learner = await prisma.user.create({
+      data: { externalId: `en-vis-${Date.now()}`, name: "Vis Learner", email: `en-vis-${Date.now()}@x.test` },
+      select: { id: true, externalId: true },
+    });
+    const headers = participantHeaders(learner.externalId);
+
+    const before = await request(app).get("/api/courses").set(headers);
+    const beforeIds = (before.body.courses as Array<{ id: string }>).map((c) => c.id);
+    expect(beforeIds).toContain(openId); // OPEN visible to everyone
+    expect(beforeIds).not.toContain(restrictedId); // RESTRICTED hidden when not enrolled
+
+    await request(app)
+      .post(`/api/admin/content/courses/${restrictedId}/enrollments`)
+      .set(adminHeaders)
+      .send({ userIds: [learner.id] });
+
+    const after = await request(app).get("/api/courses").set(headers);
+    const afterIds = (after.body.courses as Array<{ id: string }>).map((c) => c.id);
+    expect(afterIds).toContain(restrictedId); // now visible
+
+    await prisma.courseEnrollment.deleteMany({ where: { courseId: { in: [restrictedId, openId] } } });
+    await prisma.course.deleteMany({ where: { id: { in: [restrictedId, openId] } } });
+    await prisma.user.delete({ where: { id: learner.id } });
+  });
+
+  it("allows self-enrolment on OPEN courses but rejects it on RESTRICTED", async () => {
+    const openId = await createPublishedCourse("OPEN");
+    const restrictedId = await createPublishedCourse("RESTRICTED");
+    const learner = await prisma.user.create({
+      data: { externalId: `en-self-${Date.now()}`, name: "Self Learner", email: `en-self-${Date.now()}@x.test` },
+      select: { id: true, externalId: true },
+    });
+    const headers = participantHeaders(learner.externalId);
+
+    const openEnrol = await request(app).post(`/api/courses/${openId}/enroll`).set(headers);
+    expect(openEnrol.status).toBe(204);
+    const mine = await request(app).get("/api/courses/enrollments").set(headers);
+    const row = (mine.body.enrollments as Array<{ courseId: string; source: string }>).find((e) => e.courseId === openId);
+    expect(row?.source).toBe("SELF");
+
+    const restrictedEnrol = await request(app).post(`/api/courses/${restrictedId}/enroll`).set(headers);
+    expect(restrictedEnrol.status).toBe(400);
+
+    await prisma.courseEnrollment.deleteMany({ where: { courseId: { in: [openId, restrictedId] } } });
+    await prisma.course.deleteMany({ where: { id: { in: [openId, restrictedId] } } });
+    await prisma.user.delete({ where: { id: learner.id } });
+  });
+
+  it("forbids a participant from assigning enrollments", async () => {
+    const courseId = await createPublishedCourse("OPEN");
+    const res = await request(app)
+      .post(`/api/admin/content/courses/${courseId}/enrollments`)
+      .set(participantHeaders(`en-forbidden-${Date.now()}`))
+      .send({ userIds: ["whoever"] });
+    expect(res.status).toBe(403);
+    await prisma.course.delete({ where: { id: courseId } });
+  });
+});


### PR DESCRIPTION
EN-2 på #496-sporet (bygger på EN-1-datamodellen fra #646).

## Endepunkter
**Admin (SMO/ADMINISTRATOR — gated av `/api/admin/content`-mount):**
- `POST /courses/:courseId/enrollments` — tildel. Body `{ userIds?, department?, dueAt? }`. Individuell liste og/eller avdelings-materialisering (finner aktive brukere i avdelingen). Idempotent per bruker; auditeres.
- `DELETE /courses/:courseId/enrollments/:userId` — soft-revoke; auditeres.
- `GET /courses/:courseId/enrollments` — liste per kurs med deltaker + derivert status.

**Deltaker (`/api/courses`):**
- `GET /enrollments` — egne aktive tildelinger med `dueAt` + derivert status.
- `POST /:courseId/enroll` — selv-påmelding på OPEN (source=SELF); RESTRICTED → 400.

**Synlighet:** `GET /api/courses` skjuler RESTRICTED-kurs for ikke-tildelte; OPEN for alle.

## Design
- Status er alltid **derivert** (aldri lagret) via `deriveEnrollmentStatus` (COMPLETED→OVERDUE→IN_PROGRESS→ASSIGNED) — kan ikke drifte.
- Service-lag [enrollmentService.ts](src/modules/course/enrollmentService.ts); ruter i [adminCourses.ts](src/routes/adminCourses.ts) + [courses.ts](src/routes/courses.ts). Audit-actions lagt til.
- NB (#645): avdelings-tildeling finner ingen brukere før `User.department` er populert fra Entra; individuell er primær til da.

## Test
[m2-enrollment.test.ts](test/m2-enrollment.test.ts) — tildel/list/vis-for-deltaker/revoke (med OVERDUE-status), RESTRICTED-synlighet (skjult→synlig etter tildeling), selv-påmelding (OPEN 204 / RESTRICTED 400), og at deltaker ikke kan tildele (403). `tsc` rent; integrasjon verifiseres i CI.

Docs: API_REFERENCE oppdatert. Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)
