### PR TITLE
test(flaky): serialise shared-Postgres suite to kill cross-file races (#513)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,13 @@ export default defineConfig({
     include: ["test/**/*.test.ts", "test/**/*.test.js"],
     globals: true,
     testTimeout: 20000,
+    // #513: `npm test` (CI verify) runs the whole suite — unit + DB-backed integration — against a
+    // SINGLE shared Postgres. With file-level parallelism, integration files that touch the same
+    // seed fixtures (the seed module's calibration thresholds, the shared `participant-1`) race:
+    // one file mutates state another is mid-assessment on, intermittently flipping a decision
+    // (observed: assessment-policy TC-POL-YELLOW-001 COMPLETED vs UNDER_REVIEW). Running files
+    // sequentially removes the cross-file DB races at the cost of some wall-clock time. The
+    // unit-only config (`test:unit`) keeps parallelism for fast local pure-logic runs.
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
`npm test` (CI verify) runs the **whole** suite — unit + DB-backed integration — against a **single shared Postgres**. With vitest's default file-level parallelism, integration files that touch the same seed fixtures race:
- the seed module's calibration thresholds (mutated by calibration tests, read during assessment),
- the shared `participant-1` user and its submissions/assessment jobs.

One file mutates state another file is mid-assessment on, intermittently flipping a decision — the reported symptom: `assessment-policy TC-POL-YELLOW-001` getting `COMPLETED` instead of `UNDER_REVIEW` (passes on re-run). The same shared-DB fragility produced other sporadic failures across the full run.

**Fix:** `fileParallelism: false` in the root [vitest.config.ts](vitest.config.ts) (the config `npm test`/CI uses) so files run sequentially — no cross-file DB races. The unit-only config (`test:unit`) keeps parallelism for fast local pure-logic runs. No product code changes; verified by a green CI run.

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)
