### PR TITLE
fix(sections): markdown-input vokser til å matche forhåndsvisningen (v1.3.80, #662)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,16 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.80 - 2026-06-25
+
+fix(sections): markdown-input vokser til å matche forhåndsvisningens høyde (#662)
+
+I seksjonseditoren sto markdown-`<textarea>` fast på sin 320px-minimumshøyde mens forhåndsvisnings-
+panelet vokste med innholdet — så forfatteren redigerte i en liten boks ved siden av en høy preview.
+Hver kolonne er nå en flex-kolonne, og textarea + preview fyller grid-raden (som strekker seg til den
+høyeste). Resultat: input-feltet vokser til å matche forhåndsvisningen (og kan fortsatt dra-justeres).
+Dekket av en Playwright-e2e som måler at textarea-høyden følger en høy preview.
+
 ## 1.3.79 - 2026-06-25
 
 feat(course): Enrollment backend API + authz + synlighetsfilter (#641 / #496 EN-2)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.79",
+  "version": "1.3.80",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-sections.html
+++ b/public/admin-content-sections.html
@@ -64,11 +64,15 @@
       .lang-tabs { display: flex; gap: 4px; margin-bottom: var(--space-2); }
       .lang-tab { padding: 6px 12px; font-size: 13px; font-weight: 600; border: 1px solid var(--color-border-soft); background: none; border-radius: var(--radius-btn); cursor: pointer; color: var(--color-meta); }
       .lang-tab.active { color: var(--color-link-active); border-color: var(--color-blue); background: var(--color-row-hover); }
-      .editor-cols { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-2); }
+      .editor-cols { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-2); align-items: stretch; }
       @media (max-width: 760px) { .editor-cols { grid-template-columns: 1fr; } }
-      .editor-cols textarea { width: 100%; min-height: 320px; padding: var(--space-2); border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); font-family: var(--font-mono, monospace); font-size: 13px; resize: vertical; }
+      /* #662: each column is a flex column so the markdown textarea and the preview pane fill the
+         grid row, which stretches to the taller of the two. The result: the input grows to match
+         the preview's height instead of staying pinned at its 320px minimum. */
+      .editor-cols > div { display: flex; flex-direction: column; min-width: 0; }
+      .editor-cols textarea { width: 100%; min-height: 320px; flex: 1 1 auto; padding: var(--space-2); border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); font-family: var(--font-mono, monospace); font-size: 13px; resize: vertical; }
       .editor-pane-label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-meta); margin-bottom: 4px; }
-      .preview-pane { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-2); min-height: 320px; overflow-y: auto; }
+      .preview-pane { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-2); min-height: 320px; flex: 1 1 auto; overflow-y: auto; }
       .preview-pane img { max-width: 100%; height: auto; }
       .preview-pane iframe { max-width: 100%; }
       .editor-actions { margin-top: var(--space-3); display: flex; gap: var(--space-2); align-items: center; }

--- a/test/e2e/section-editor.spec.ts
+++ b/test/e2e/section-editor.spec.ts
@@ -90,6 +90,41 @@ test("section editor: no raw i18n keys, and image upload is sent as multipart", 
   await expect(page.locator("#markdownInput")).toHaveValue(/asset:a1/);
 });
 
+// #662: the markdown input must grow to match the (taller) preview pane instead of staying pinned
+// at its 320px minimum, so the author isn't editing in a small box beside a tall preview.
+test("section editor: markdown input grows to match a taller preview pane", async ({ page }) => {
+  await mockBaseApis(page);
+  await page.route("**/api/admin/content/sections", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ sections: [] }) }),
+  );
+  // A deliberately tall preview (well over the 320px min-height).
+  const tallHtml = "<p>Preview line that takes vertical space.</p>".repeat(60);
+  await page.route("**/api/admin/content/sections/preview", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ html: tallHtml }) }),
+  );
+  await page.addInitScript(() => {
+    try { localStorage.setItem("participant.locale", "nb"); } catch { /* ignore */ }
+  });
+
+  await page.goto("/admin-content/sections");
+  await page.getByRole("button", { name: /Ny seksjon/ }).click();
+  await page.locator("#markdownInput").fill("# Hei\n\nNoe innhold.");
+
+  // Preview renders the tall mocked HTML.
+  await expect(page.locator("#previewPane")).toContainText("Preview line", { timeout: 5000 });
+
+  // The preview is taller than the 320px floor, and the textarea has grown to (about) match it —
+  // not stuck at 320. Allow a small tolerance for the label-row height difference between columns.
+  await expect
+    .poll(async () => {
+      const ta = await page.locator("#markdownInput").boundingBox();
+      const pv = await page.locator("#previewPane").boundingBox();
+      if (!ta || !pv) return -1;
+      return pv.height > 320 && Math.abs(ta.height - pv.height) <= 48 ? 1 : 0;
+    })
+    .toBe(1);
+});
+
 // #540: the section editor must show the blocking consent dialog when consent is not yet
 // accepted — not dump the raw "403 consent_required" JSON into the content area.
 test("section editor: shows consent dialog (not raw 403) when consent not accepted", async ({ page }) => {


### PR DESCRIPTION
I seksjonseditoren sto markdown-`<textarea>` fast på sin `min-height: 320px` mens forhåndsvisnings-panelet vokste med innholdet — så forfatteren redigerte i en liten boks ved siden av en høy preview.

**Fiks** ([admin-content-sections.html](public/admin-content-sections.html)): hver kolonne i `.editor-cols` er nå en flex-kolonne, og både textarea og `.preview-pane` har `flex: 1` så de fyller grid-raden, som strekker seg til den høyeste av de to. Resultat: input-feltet vokser til å matche forhåndsvisningen (320px forblir gulvet; `resize: vertical` beholdt).

**Test:** ny Playwright-e2e i [section-editor.spec.ts](test/e2e/section-editor.spec.ts) — med en høy mocket preview (>320px) måles at textarea-høyden følger preview-høyden (innenfor toleranse). Hele section-editor-suiten (4 tester) grønn lokalt.

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)
