### PR TITLE
feat(course): klasser (kohorter) for kurstildeling (v1.3.81, #645 CL-1..CL-3)

### DIFF
--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -191,6 +191,18 @@ fields (`title`, `bodyMarkdown`) accept a string or a partial `{en-GB,nb,nn}` ob
 | `GET` | `/api/admin/content/courses/:courseId/enrollments` | List active enrollments for a course, each with the participant + derived status (#496/EN-2) |
 | `POST` | `/api/admin/content/courses/:courseId/enrollments` | Assign — body `{ userIds?: string[], department?: string, dueAt?: string\|null }`. Individual list and/or department materialisation. Idempotent per user; audited (#496/EN-2) |
 | `DELETE` | `/api/admin/content/courses/:courseId/enrollments/:userId` | Revoke (soft) a participant's enrollment; audited (#496/EN-2) |
+| `GET` | `/api/admin/content/classes` | List classes (cohorts) with member + assigned-course counts (#645/CL-2) |
+| `POST` | `/api/admin/content/classes` | Create a class — body `{ name, description? }` (#645/CL-2) |
+| `DELETE` | `/api/admin/content/classes/:classId` | Archive a class (soft). System classes rejected `400` (#645/CL-2) |
+| `GET` | `/api/admin/content/classes/:classId/members` | List class members (#645/CL-2) |
+| `POST` | `/api/admin/content/classes/:classId/members` | Add a member — body `{ userId }` (#645/CL-2) |
+| `DELETE` | `/api/admin/content/classes/:classId/members/:userId` | Remove a member (#645/CL-2) |
+| `GET` | `/api/admin/content/classes/:classId/courses` | List courses assigned to the class (#645/CL-2) |
+| `POST` | `/api/admin/content/classes/:classId/courses` | Assign a course — body `{ courseId, dueAt?\|null }` (#645/CL-2) |
+| `DELETE` | `/api/admin/content/classes/:classId/courses/:courseId` | Unassign a course (#645/CL-2) |
+| `GET` | `/api/admin/content/users/search?q=` | Search users by name/email (min 2 chars, capped 20) for class membership (#645/CL-3) |
+
+Classes (cohorts) assign a course to a group of participants dynamically: a participant is assigned a course if they belong to a class it is assigned to (evaluated at read time, never materialised). The built-in **"Alle deltakere"** system class covers all PARTICIPANT users. `GET /api/courses` and `GET /api/courses/enrollments` reflect class assignments (the latter with `source: "CLASS"`). Entra-linked classes (`kind=ENTRA`) are gated by the `classEntraLinkingEnabled` platform config (default off, CL-5).
 | `POST` | `/api/admin/content/courses/:courseId/localize-copy` | LLM-translate course title/description |
 | `GET` | `/api/admin/content/courses/:courseId/export-package` | Export envelope (inlines modules **and** sections in order, #512) |
 | `POST` | `/api/admin/content/courses/import` | Import a course envelope (recreates sections via `items`, falls back to modules-only v1) |

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -16,8 +16,9 @@ Admin-UI på `/admin-content/classes` (CL-3): opprett klasse, søk+legg til stud
 frist. Entra-koblede klasser (`kind=ENTRA`) er forberedt men gated bak `classEntraLinkingEnabled`
 (default av, CL-5 — senere). Dekket av unit- + integrasjons- + Playwright-e2e-tester.
 
-NB: `User.department`-sletting (CL-4) er **utsatt** — feltet viste seg å være en kjerne-dimensjon i
-rapportering (orgUnit-filter, cohort-analyse); se egen avklaring.
+NB: `User.department`-sletting (CL-4, #677) ble **kansellert** — feltet er en kjerne-dimensjon i
+rapportering (orgUnit-filter, cohort-analyse) og beholdes. Klasser dekker tildeling; department dekker
+analyse. CL-5 (Entra-koblede klasser) er forberedt men utsatt (#678).
 
 ## 1.3.80 - 2026-06-25
 

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,23 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.81 - 2026-06-26
+
+feat(course): klasser (kohorter) for kurstildeling (#645 / CL-1..CL-3)
+
+Innfører **klasser** — plattform-eide, mange-til-mange grupper man tildeler kurs til samlet (#645,
+besluttet i `doc/design/COHORT_GROUPING_645.md`). Datamodell `Class` + `ClassMember` +
+`CourseGroupAssignment` (CL-1), service + admin-API + audit + **dynamisk** synlighet (CL-2): en
+deltaker er tildelt et kurs hvis hen er medlem av en tildelt klasse, evaluert ved lesetid (aldri
+materialisert). `GET /api/courses` og `/enrollments` reflekterer klasse-tildelinger (sistnevnte med
+`source: "CLASS"`). Innebygd systemklasse **«Alle deltakere»** (alle med PARTICIPANT-rolle).
+Admin-UI på `/admin-content/classes` (CL-3): opprett klasse, søk+legg til studenter, tildel kurs med
+frist. Entra-koblede klasser (`kind=ENTRA`) er forberedt men gated bak `classEntraLinkingEnabled`
+(default av, CL-5 — senere). Dekket av unit- + integrasjons- + Playwright-e2e-tester.
+
+NB: `User.department`-sletting (CL-4) er **utsatt** — feltet viste seg å være en kjerne-dimensjon i
+rapportering (orgUnit-filter, cohort-analyse); se egen avklaring.
+
 ## 1.3.80 - 2026-06-25
 
 fix(sections): markdown-input vokser til å matche forhåndsvisningens høyde (#662)

--- a/doc/design/COHORT_GROUPING_645.md
+++ b/doc/design/COHORT_GROUPING_645.md
@@ -9,7 +9,11 @@
 >    skal være **konfigurerbar av Administrator** (kan slås av/på via plattform-config) — når av finnes kun
 >    manuelle klasser.
 > 2. **Dynamisk** tildeling (medlemskap evalueres ved lesetid; ingen snapshot).
-> 3. **Slett `User.department`** helt (unngå bloat) — kolonne + kode + orgSync-bruk fjernes.
+> 3. ~~Slett `User.department` helt~~ → **REVIDERT 2026-06-26: BEHOLD `User.department`.** Ved
+>    implementering (CL-4) viste feltet seg å være en **kjerne-rapporterings-dimensjon** (orgUnit-filter,
+>    `participantDepartment`, `cohortBy: "department"`) brukt i 11 filer på tvers av
+>    reporting/review/appeal. «Bloat»-bekymringen gjaldt enrollment-*tildeling* (løst av klasser), ikke
+>    rapportering. Department beholdes for rapportering; klasser dekker tildeling. (#677 lukket «keep».)
 > 4. **Egen systemklasse «Alle deltakere»** med eksplisitt populasjon (PARTICIPANT-rolle).
 > 5. **Administrator** kuraterer hvilke Entra-grupper som er tildelbare — **OK å utsette** fra v1.
 
@@ -142,9 +146,10 @@ deltakere» er en **systemklasse** (PARTICIPANT-populasjon).
   dynamisk synlighet + «mine kurs» utvides til klasse-medlemskap; audit.
 - **CL-3 Admin-UI:** klasse-administrasjon (opprett, søk+legg til studenter) + tildel kurs til klasse
   (erstatter/avløser EN-3 #642 sin avdelings-tanke).
-- **CL-4 Fjern `User.department`:** drop-kolonne-migrasjon + fjern fra schema/principal/orgSync + fjern
-  EN-2 sin `DEPARTMENT`-gren (kilde-enum beholdes for historikk, ny kilde `CLASS`). *Egen liten skive
-  siden den rører allerede levert EN-2 og er en schema-drop — ikke buntes med en pågående release.*
+- **CL-4 ~~Fjern `User.department`~~ → KANSELLERT (2026-06-26).** Feltet er en rapporterings-dimensjon
+  (se revidert beslutning 3) og beholdes. EN-2 sin `DEPARTMENT`-enrollment-gren står som en superseded
+  no-op (uskadelig; klasser er den nye tildelings-mekanismen) — ikke verdt churn på prod-EN-2 å fjerne.
+  #677 lukket som «keep».
 - **CL-5 (senere) Entra-kobling:** Graph `Group.Read.All` app-perm + admin-consent, gruppe-katalog-synk,
   `kind=ENTRA`-klasser, Administrator-kuratering. Aktiveres via config-toggle.
 
@@ -157,10 +162,9 @@ deltakere» er en **systemklasse** (PARTICIPANT-populasjon).
   `CLASS`.
 - Synlighetsfilteret (`filterVisibleCourseIds`) utvides til å også slippe gjennom kurs tildelt en klasse
   brukeren er medlem av.
-- **`User.department`-sletting (CL-4)** rører: `prisma/schema.prisma` (drop column + migrasjon),
-  `src/auth/principal.ts` + `authenticate.ts` (`x-user-department` / claim), `orgSyncService.ts`
-  (department-felt + `allowDepartmentOverwrite`), EN-2 `assignEnrollments`. Egen skive, ikke i en
-  pågående release.
+- **`User.department` beholdes** (CL-4 kansellert): det er org-enhets-dimensjonen i rapportering
+  (`orgUnit`-filter, `participantDepartment`, `cohortBy: "department"`). Klasser dekker tildeling;
+  department dekker analyse. EN-2 sin `DEPARTMENT`-gren står som superseded no-op.
 
 ## 9. Sikkerhet / personvern
 - AD-utforskningen var **read-only** (gruppe-metadata + medlemskaps-antall), kjørt mot prod-tenanten med

--- a/doc/route-map.md
+++ b/doc/route-map.md
@@ -14,6 +14,7 @@ This map covers all admin-content entry points and their status for pilot. Use i
 | `/admin-content/courses/:courseId` | Course detail (builder: mixed modules + sections) | `admin-content-courses.html` | **Canonical** |
 | `/admin-content/sections` | Learning sections library + editor (#476) | `admin-content-sections.html` | **Canonical** |
 | `/admin-content/sections?id=<id>` or `?new` | Section editor (open existing / new) | `admin-content-sections.html` | **Canonical** |
+| `/admin-content/classes` | Classes (cohorts) admin — list, create, members, course assignment (#645/CL-3) | `admin-content-classes.html` | **Canonical** |
 | `/admin-content/calibration` | Calibration workspace | `admin-content-calibration.html` | **Canonical** |
 
 ### Legacy routes (present during pilot, not primary)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.80",
+  "version": "1.3.81",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260626100000_add_classes/migration.sql
+++ b/prisma/migrations/20260626100000_add_classes/migration.sql
@@ -1,0 +1,79 @@
+-- #645/CL-1: classes (cohorts) for course assignment.
+-- CreateEnum
+CREATE TYPE "ClassKind" AS ENUM ('MANUAL', 'ENTRA');
+
+-- CreateTable
+CREATE TABLE "Class" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "kind" "ClassKind" NOT NULL DEFAULT 'MANUAL',
+    "entraGroupId" TEXT,
+    "isSystem" BOOLEAN NOT NULL DEFAULT false,
+    "createdById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "archivedAt" TIMESTAMP(3),
+
+    CONSTRAINT "Class_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ClassMember" (
+    "classId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "addedById" TEXT,
+    "addedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ClassMember_pkey" PRIMARY KEY ("classId","userId")
+);
+
+-- CreateTable
+CREATE TABLE "CourseGroupAssignment" (
+    "id" TEXT NOT NULL,
+    "courseId" TEXT NOT NULL,
+    "classId" TEXT NOT NULL,
+    "dueAt" TIMESTAMP(3),
+    "assignedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CourseGroupAssignment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Class_archivedAt_idx" ON "Class"("archivedAt");
+
+-- CreateIndex
+CREATE INDEX "ClassMember_userId_idx" ON "ClassMember"("userId");
+
+-- CreateIndex
+CREATE INDEX "CourseGroupAssignment_classId_idx" ON "CourseGroupAssignment"("classId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CourseGroupAssignment_courseId_classId_key" ON "CourseGroupAssignment"("courseId", "classId");
+
+-- AddForeignKey
+ALTER TABLE "Class" ADD CONSTRAINT "Class_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ClassMember" ADD CONSTRAINT "ClassMember_classId_fkey" FOREIGN KEY ("classId") REFERENCES "Class"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ClassMember" ADD CONSTRAINT "ClassMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ClassMember" ADD CONSTRAINT "ClassMember_addedById_fkey" FOREIGN KEY ("addedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CourseGroupAssignment" ADD CONSTRAINT "CourseGroupAssignment_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CourseGroupAssignment" ADD CONSTRAINT "CourseGroupAssignment_classId_fkey" FOREIGN KEY ("classId") REFERENCES "Class"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CourseGroupAssignment" ADD CONSTRAINT "CourseGroupAssignment_assignedById_fkey" FOREIGN KEY ("assignedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- #645/CL-1: seed the built-in "Alle deltakere" system class (membership = all PARTICIPANT users,
+-- evaluated dynamically by the service layer). Fixed id so it is referenceable across environments.
+INSERT INTO "Class" ("id", "name", "kind", "isSystem", "createdAt", "updatedAt")
+VALUES ('cls_all_participants', 'Alle deltakere', 'MANUAL', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,6 +93,10 @@ model User {
   createdModules        Module[]              @relation("CreatedModules")
   courseEnrollments     CourseEnrollment[]    @relation("EnrolledUser")
   enrollmentsAssigned   CourseEnrollment[]    @relation("EnrollmentAssignedBy")
+  classMemberships      ClassMember[]         @relation("ClassMembership")
+  classMembersAdded     ClassMember[]         @relation("ClassMemberAddedBy")
+  classesCreated        Class[]               @relation("ClassCreatedBy")
+  courseGroupAssignmentsCreated CourseGroupAssignment[] @relation("CourseGroupAssignedBy")
 }
 
 model UserConsent {
@@ -485,6 +489,7 @@ model Course {
   completions        CourseCompletion[]
   sectionReads       CourseSectionRead[]
   enrollments        CourseEnrollment[]
+  groupAssignments   CourseGroupAssignment[]
 }
 
 model CourseModule {
@@ -541,6 +546,63 @@ model CourseEnrollment {
   @@unique([userId, courseId])
   @@index([courseId])
   @@index([userId, revokedAt])
+}
+
+// #645/CL-1: a "class" (klasse) — a platform-owned, many-to-many cohort used to assign courses to a
+// group of participants. kind=MANUAL classes have explicit ClassMember rows; kind=ENTRA classes
+// (CL-5, gated by PlatformConfig.classEntraLinkingEnabled) derive membership from the user's Entra
+// group claims instead. isSystem marks built-in classes like "Alle deltakere" (all PARTICIPANTs).
+enum ClassKind {
+  MANUAL
+  ENTRA
+}
+
+model Class {
+  id                String                  @id @default(cuid())
+  name              String
+  description       String?
+  kind              ClassKind               @default(MANUAL)
+  entraGroupId      String? // set only for kind=ENTRA (CL-5)
+  isSystem          Boolean                 @default(false)
+  createdById       String?
+  createdAt         DateTime                @default(now())
+  updatedAt         DateTime                @updatedAt
+  archivedAt        DateTime?
+  createdBy         User?                   @relation("ClassCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
+  members           ClassMember[]
+  courseAssignments CourseGroupAssignment[]
+
+  @@index([archivedAt])
+}
+
+model ClassMember {
+  classId   String
+  userId    String
+  addedById String?
+  addedAt   DateTime @default(now())
+  class     Class    @relation(fields: [classId], references: [id], onDelete: Cascade)
+  user      User     @relation("ClassMembership", fields: [userId], references: [id], onDelete: Cascade)
+  addedBy   User?    @relation("ClassMemberAddedBy", fields: [addedById], references: [id], onDelete: SetNull)
+
+  @@id([classId, userId])
+  @@index([userId])
+}
+
+// Dynamic assignment of a course to a class (#645/CL-1). A participant is assigned the course if they
+// are a member of any assigned class — evaluated at read time, never materialised to CourseEnrollment.
+model CourseGroupAssignment {
+  id           String    @id @default(cuid())
+  courseId     String
+  classId      String
+  dueAt        DateTime?
+  assignedById String?
+  createdAt    DateTime  @default(now())
+  course       Course    @relation(fields: [courseId], references: [id], onDelete: Cascade)
+  class        Class     @relation(fields: [classId], references: [id], onDelete: Cascade)
+  assignedBy   User?     @relation("CourseGroupAssignedBy", fields: [assignedById], references: [id], onDelete: SetNull)
+
+  @@unique([courseId, classId])
+  @@index([classId])
 }
 
 // Læringsseksjon i et kurs (#476/#481). Speiler Module/ModuleVersion: innholdet

--- a/public/admin-content-classes.html
+++ b/public/admin-content-classes.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en-GB">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Klasser – A2 Content</title>
+    <link rel="stylesheet" href="/static/shared.css" />
+    <link rel="stylesheet" href="/static/loading.css" />
+    <link rel="stylesheet" href="/static/toast.css" />
+    <style>
+      .content-area-nav { display: flex; gap: 0; border-bottom: 2px solid var(--color-border-soft); margin-bottom: var(--space-3); }
+      .content-area-nav-link { padding: 10px var(--space-2); font-size: 14px; font-weight: 600; color: var(--color-meta); text-decoration: none; border-bottom: 2px solid transparent; margin-bottom: -2px; white-space: nowrap; }
+      .content-area-nav-link:hover { color: var(--color-text); }
+      .content-area-nav-link.active { color: var(--color-link-active); border-bottom-color: var(--color-blue); }
+      .page-header { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2); margin-bottom: var(--space-3); flex-wrap: wrap; }
+      .page-header h1 { margin: 0; font-size: 22px; }
+      .classes-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+      .classes-table th, .classes-table td { text-align: left; padding: 10px var(--space-2); border-bottom: 1px solid var(--color-border-soft); }
+      .classes-table th { font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-meta); }
+      .classes-table .col-actions { text-align: right; white-space: nowrap; }
+      .row-action-btn { width: auto; background: none; border: 1px solid var(--color-border-soft); border-radius: var(--radius-btn); padding: 4px 8px; font-size: 13px; cursor: pointer; color: var(--color-text); }
+      .row-action-btn:hover { background: var(--color-row-hover); }
+      .row-action-btn.destructive { color: var(--color-error); border-color: #f5c0bb; }
+      .system-badge { display: inline-block; margin-left: 6px; padding: 1px 8px; border-radius: 999px; background: var(--color-blue-light); color: var(--color-link-active); font-size: 11px; font-weight: 600; }
+      .detail-section { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-2); margin-bottom: var(--space-3); }
+      .detail-section h2 { font-size: 16px; margin: 0 0 var(--space-2); }
+      .chip-row { display: flex; flex-wrap: wrap; gap: 6px; margin-top: var(--space-1); }
+      .chip { display: inline-flex; align-items: center; gap: 6px; background: var(--color-surface-muted, #f0f0f0); border-radius: 999px; padding: 3px 6px 3px 10px; font-size: 13px; }
+      .chip button { background: none; border: none; color: var(--color-error); cursor: pointer; font-size: 14px; line-height: 1; padding: 0 2px; }
+      .search-results { list-style: none; margin: 4px 0 0; padding: 0; border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); max-height: 220px; overflow-y: auto; }
+      .search-results:empty { display: none; }
+      .search-results li { padding: 6px 10px; cursor: pointer; font-size: 13px; }
+      .search-results li:hover { background: var(--color-row-hover); }
+      .inline-form { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin-top: var(--space-1); }
+      .inline-form input, .inline-form select { padding: 6px 8px; border: 1px solid var(--color-border-soft); border-radius: var(--radius-btn); font-size: 13px; }
+      .back-link { font-size: 13px; color: var(--color-meta); text-decoration: none; cursor: pointer; }
+    </style>
+  </head>
+  <body>
+    <a href="#main-content" class="skip-nav">Skip to main content</a>
+    <main id="main-content" class="layout-container">
+      <div class="page-top-bar">
+        <nav id="workspaceNav" class="workspace-nav"></nav>
+        <div class="locale-picker">
+          <span id="appVersion" class="version-badge">…</span>
+        </div>
+      </div>
+
+      <nav id="contentAreaNav" class="content-area-nav" aria-label="Innholdsadministrasjon">
+        <a href="/admin-content/courses" class="content-area-nav-link" id="navKurs">Kurs</a>
+        <a href="/admin-content" class="content-area-nav-link" id="navModuler">Moduler</a>
+        <a href="/admin-content/sections" class="content-area-nav-link" id="navSeksjoner">Seksjoner</a>
+        <a href="/admin-content/classes" class="content-area-nav-link active" id="navKlasser">Klasser</a>
+      </nav>
+
+      <div id="pageContent">
+        <div class="page-loading">Laster…</div>
+      </div>
+    </main>
+
+    <script type="module" src="/static/admin-content-classes.js"></script>
+  </body>
+</html>

--- a/public/admin-content-courses.html
+++ b/public/admin-content-courses.html
@@ -427,6 +427,7 @@
         <a href="/admin-content/courses" class="content-area-nav-link active" id="navKurs">Kurs</a>
         <a href="/admin-content" class="content-area-nav-link" id="navModuler">Moduler</a>
         <a href="/admin-content/sections" class="content-area-nav-link" id="navSeksjoner">Seksjoner</a>
+        <a href="/admin-content/classes" class="content-area-nav-link" id="navKlasser">Klasser</a>
         <a href="/admin-content/calibration" class="content-area-nav-link" id="navKalibrering" hidden>Kalibrering</a>
       </nav>
 

--- a/public/admin-content-sections.html
+++ b/public/admin-content-sections.html
@@ -95,6 +95,7 @@
         <a href="/admin-content/courses" class="content-area-nav-link" id="navKurs">Kurs</a>
         <a href="/admin-content" class="content-area-nav-link" id="navModuler">Moduler</a>
         <a href="/admin-content/sections" class="content-area-nav-link active" id="navSeksjoner">Seksjoner</a>
+        <a href="/admin-content/classes" class="content-area-nav-link" id="navKlasser">Klasser</a>
       </nav>
 
       <div id="pageContent">

--- a/public/static/admin-content-classes.js
+++ b/public/static/admin-content-classes.js
@@ -1,0 +1,217 @@
+import { apiFetch, buildConsoleHeaders, getConsoleConfig } from "/static/api-client.js";
+import { initConsentGuard } from "/static/consent-guard.js";
+import { resolveWorkspaceNavigationItems } from "/static/participant-console-state.js";
+import { renderWorkspaceNavigationWithProfile } from "./workspace-nav.js";
+import { showToast } from "/static/toast.js";
+
+// #645/CL-3: admin UI for classes (cohorts) — list, create, manage members, assign courses.
+
+const pageContent = document.getElementById("pageContent");
+const workspaceNav = document.getElementById("workspaceNav");
+const appVersionLabel = document.getElementById("appVersion");
+
+let _headerValues = {};
+let participantRuntimeConfig = {};
+function getHeaders() { return _headerValues; }
+
+function escapeHtml(s) {
+  return String(s ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+// Course titles are stored as localized JSON; pick nb → en-GB → first.
+function courseTitle(raw) {
+  if (!raw) return "(uten tittel)";
+  try {
+    const obj = typeof raw === "string" ? JSON.parse(raw) : raw;
+    if (obj && typeof obj === "object") return obj.nb || obj["en-GB"] || obj.nn || Object.values(obj)[0] || "(uten tittel)";
+    return String(raw);
+  } catch {
+    return String(raw);
+  }
+}
+
+async function renderListView() {
+  pageContent.innerHTML = `<div class="page-loading">Laster…</div>`;
+  let classes = [];
+  try {
+    classes = (await apiFetch("/api/admin/content/classes", getHeaders)).classes ?? [];
+  } catch (err) {
+    pageContent.innerHTML = `<p>Kunne ikke laste klasser: ${escapeHtml(err?.message ?? "")}</p>`;
+    return;
+  }
+  const rows = classes.map((c) => `
+    <tr>
+      <td>${escapeHtml(c.name)}${c.isSystem ? `<span class="system-badge">System</span>` : ""}</td>
+      <td>${c._count?.members ?? 0}</td>
+      <td>${c._count?.courseAssignments ?? 0}</td>
+      <td class="col-actions">
+        <button class="row-action-btn" data-action="open" data-id="${escapeHtml(c.id)}">Administrer</button>
+        ${c.isSystem ? "" : `<button class="row-action-btn destructive" data-action="archive" data-id="${escapeHtml(c.id)}" data-name="${escapeHtml(c.name)}">Arkiver</button>`}
+      </td>
+    </tr>`).join("");
+  pageContent.innerHTML = `
+    <div class="page-header"><h1>Klasser</h1><button id="newClassBtn" class="btn btn-primary" style="width:auto">+ Ny klasse</button></div>
+    <p style="color:var(--color-meta);font-size:13px">En klasse er en gruppe deltakere du kan tildele kurs til samlet. «Alle deltakere» er en systemklasse (alle med deltakerrolle).</p>
+    <table class="classes-table">
+      <thead><tr><th>Navn</th><th>Medlemmer</th><th>Tildelte kurs</th><th></th></tr></thead>
+      <tbody id="classesTableBody">${rows || `<tr><td colspan="4" style="color:var(--color-meta)">Ingen klasser ennå.</td></tr>`}</tbody>
+    </table>`;
+  document.getElementById("newClassBtn").addEventListener("click", createClassFlow);
+  document.getElementById("classesTableBody").addEventListener("click", (e) => {
+    const btn = e.target.closest("[data-action]");
+    if (!btn) return;
+    if (btn.dataset.action === "open") openClass(btn.dataset.id);
+    if (btn.dataset.action === "archive") archiveClass(btn.dataset.id, btn.dataset.name);
+  });
+}
+
+async function createClassFlow() {
+  const name = window.prompt("Navn på klassen:");
+  if (!name || !name.trim()) return;
+  try {
+    await apiFetch("/api/admin/content/classes", getHeaders, { method: "POST", body: JSON.stringify({ name: name.trim() }) });
+    showToast("Klasse opprettet.", "success");
+    await renderListView();
+  } catch (err) {
+    showToast(err?.message ?? "Kunne ikke opprette klasse.", "error");
+  }
+}
+
+async function archiveClass(id, name) {
+  if (!window.confirm(`Arkivere klassen «${name}»?`)) return;
+  try {
+    await apiFetch(`/api/admin/content/classes/${encodeURIComponent(id)}`, getHeaders, { method: "DELETE" });
+    showToast("Klasse arkivert.", "success");
+    await renderListView();
+  } catch (err) {
+    showToast(err?.message ?? "Kunne ikke arkivere.", "error");
+  }
+}
+
+async function openClass(id) {
+  pageContent.innerHTML = `<div class="page-loading">Laster…</div>`;
+  let members = [], courses = [], allCourses = [];
+  try {
+    [members, courses, allCourses] = await Promise.all([
+      apiFetch(`/api/admin/content/classes/${encodeURIComponent(id)}/members`, getHeaders).then((r) => r.members ?? []),
+      apiFetch(`/api/admin/content/classes/${encodeURIComponent(id)}/courses`, getHeaders).then((r) => r.courses ?? []),
+      apiFetch("/api/admin/content/courses", getHeaders).then((r) => r.courses ?? []),
+    ]);
+  } catch (err) {
+    pageContent.innerHTML = `<p>Kunne ikke laste klassen: ${escapeHtml(err?.message ?? "")}</p>`;
+    return;
+  }
+  const memberChips = members.map((m) => `<span class="chip">${escapeHtml(m.name)} <button data-remove-member="${escapeHtml(m.userId)}" aria-label="Fjern ${escapeHtml(m.name)}">×</button></span>`).join("");
+  const courseChips = courses.map((c) => `<span class="chip">${escapeHtml(courseTitle(c.title))} <button data-remove-course="${escapeHtml(c.courseId)}" aria-label="Fjern kurs">×</button></span>`).join("");
+  const assignedIds = new Set(courses.map((c) => c.courseId));
+  const courseOptions = allCourses.filter((c) => !assignedIds.has(c.id)).map((c) => `<option value="${escapeHtml(c.id)}">${escapeHtml(courseTitle(c.title))}</option>`).join("");
+  pageContent.innerHTML = `
+    <a class="back-link" id="backToClasses">← Tilbake til klasser</a>
+    <div class="page-header"><h1>Klasse</h1></div>
+    <div class="detail-section">
+      <h2>Studenter (${members.length})</h2>
+      <div class="chip-row" id="memberChips">${memberChips || `<span style="color:var(--color-meta);font-size:13px">Ingen studenter ennå.</span>`}</div>
+      <div class="inline-form">
+        <input type="text" id="studentSearch" placeholder="Søk navn eller e-post (min. 2 tegn)" autocomplete="off" style="min-width:280px" />
+      </div>
+      <ul class="search-results" id="searchResults"></ul>
+    </div>
+    <div class="detail-section">
+      <h2>Tildelte kurs (${courses.length})</h2>
+      <div class="chip-row" id="courseChips">${courseChips || `<span style="color:var(--color-meta);font-size:13px">Ingen kurs tildelt ennå.</span>`}</div>
+      <div class="inline-form">
+        <select id="courseSelect"><option value="">Velg kurs…</option>${courseOptions}</select>
+        <input type="date" id="dueAtInput" title="Frist (valgfri)" />
+        <button id="assignCourseBtn" class="btn btn-secondary" style="width:auto">Tildel kurs</button>
+      </div>
+    </div>`;
+  document.getElementById("backToClasses").addEventListener("click", renderListView);
+
+  // Member add via search.
+  const searchInput = document.getElementById("studentSearch");
+  const resultsEl = document.getElementById("searchResults");
+  let searchTimer = null;
+  searchInput.addEventListener("input", () => {
+    clearTimeout(searchTimer);
+    const q = searchInput.value.trim();
+    if (q.length < 2) { resultsEl.innerHTML = ""; return; }
+    searchTimer = setTimeout(async () => {
+      try {
+        const users = (await apiFetch(`/api/admin/content/users/search?q=${encodeURIComponent(q)}`, getHeaders)).users ?? [];
+        resultsEl.innerHTML = users.map((u) => `<li data-add-user="${escapeHtml(u.id)}">${escapeHtml(u.name)} <span style="color:var(--color-meta)">${escapeHtml(u.email)}</span></li>`).join("");
+      } catch { /* ignore */ }
+    }, 250);
+  });
+  resultsEl.addEventListener("click", async (e) => {
+    const li = e.target.closest("[data-add-user]");
+    if (!li) return;
+    try {
+      await apiFetch(`/api/admin/content/classes/${encodeURIComponent(id)}/members`, getHeaders, { method: "POST", body: JSON.stringify({ userId: li.dataset.addUser }) });
+      showToast("Student lagt til.", "success");
+      openClass(id);
+    } catch (err) { showToast(err?.message ?? "Kunne ikke legge til.", "error"); }
+  });
+  document.getElementById("memberChips").addEventListener("click", async (e) => {
+    const btn = e.target.closest("[data-remove-member]");
+    if (!btn) return;
+    try {
+      await apiFetch(`/api/admin/content/classes/${encodeURIComponent(id)}/members/${encodeURIComponent(btn.dataset.removeMember)}`, getHeaders, { method: "DELETE" });
+      openClass(id);
+    } catch (err) { showToast(err?.message ?? "Feil", "error"); }
+  });
+
+  // Course assignment.
+  document.getElementById("assignCourseBtn").addEventListener("click", async () => {
+    const courseId = document.getElementById("courseSelect").value;
+    if (!courseId) return;
+    const due = document.getElementById("dueAtInput").value;
+    const body = { courseId };
+    if (due) body.dueAt = new Date(due + "T00:00:00.000Z").toISOString();
+    try {
+      await apiFetch(`/api/admin/content/classes/${encodeURIComponent(id)}/courses`, getHeaders, { method: "POST", body: JSON.stringify(body) });
+      showToast("Kurs tildelt.", "success");
+      openClass(id);
+    } catch (err) { showToast(err?.message ?? "Kunne ikke tildele.", "error"); }
+  });
+  document.getElementById("courseChips").addEventListener("click", async (e) => {
+    const btn = e.target.closest("[data-remove-course]");
+    if (!btn) return;
+    try {
+      await apiFetch(`/api/admin/content/classes/${encodeURIComponent(id)}/courses/${encodeURIComponent(btn.dataset.removeCourse)}`, getHeaders, { method: "DELETE" });
+      openClass(id);
+    } catch (err) { showToast(err?.message ?? "Feil", "error"); }
+  });
+}
+
+function renderWorkspaceNavigation() {
+  if (!workspaceNav) return;
+  const items = resolveWorkspaceNavigationItems(participantRuntimeConfig);
+  renderWorkspaceNavigationWithProfile({ workspaceNav, localePicker: null, items, buildLabel: (item) => item.labelKey || item.id });
+}
+
+async function init() {
+  try {
+    const cfg = await getConsoleConfig();
+    participantRuntimeConfig = cfg;
+    const defaults = cfg?.identityDefaults?.contentAdmin ?? cfg?.identityDefaults ?? {};
+    _headerValues = buildConsoleHeaders({
+      userId: defaults.userId,
+      email: defaults.email,
+      name: defaults.name,
+      roles: Array.isArray(defaults.roles) ? defaults.roles.join(",") : defaults.roles,
+    });
+  } catch {
+    _headerValues = {};
+  }
+  renderWorkspaceNavigation();
+  await initConsentGuard(getHeaders, "nb");
+  try {
+    const body = await apiFetch("/version", { headers: {} });
+    if (appVersionLabel) appVersionLabel.textContent = `v${body.version ?? "unknown"}`;
+  } catch {
+    if (appVersionLabel) appVersionLabel.textContent = "unknown";
+  }
+  await renderListView();
+}
+
+init();

--- a/scripts/test/admin-content-static-server.mjs
+++ b/scripts/test/admin-content-static-server.mjs
@@ -38,6 +38,9 @@ function resolvePublicFile(requestPath) {
   if (requestPath === "/admin-content/sections") {
     return path.join(publicRoot, "admin-content-sections.html");
   }
+  if (requestPath === "/admin-content/classes") {
+    return path.join(publicRoot, "admin-content-classes.html");
+  }
   if (requestPath === "/participant") {
     return path.join(publicRoot, "participant.html");
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -145,6 +145,11 @@ app.get("/admin-content/sections", (_request, response) => {
   response.sendFile(path.resolve(process.cwd(), "public", "admin-content-sections.html"));
 });
 
+// Classes workspace (#645 / CL-3)
+app.get("/admin-content/classes", (_request, response) => {
+  response.sendFile(path.resolve(process.cwd(), "public", "admin-content-classes.html"));
+});
+
 // Calibration workspace (Issue #326)
 app.get("/admin-content/calibration", (_request, response) => {
   response.sendFile(path.resolve(process.cwd(), "public", "admin-content-calibration.html"));

--- a/src/modules/course/classConfig.ts
+++ b/src/modules/course/classConfig.ts
@@ -1,0 +1,10 @@
+import { platformConfigRepository } from "../platformConfig/platformConfigRepository.js";
+
+// #645/CL-1: Administrator-controlled toggle for Entra-linked classes (kind=ENTRA). Default OFF —
+// only manual classes exist until an Administrator enables this (after Graph permissions are in
+// place, CL-5). Stored as a PlatformConfig key so it can be flipped without a deploy.
+export const CLASS_ENTRA_LINKING_KEY = "classEntraLinkingEnabled";
+
+export async function isClassEntraLinkingEnabled(): Promise<boolean> {
+  return (await platformConfigRepository.get(CLASS_ENTRA_LINKING_KEY)) === "true";
+}

--- a/src/modules/course/classRepository.ts
+++ b/src/modules/course/classRepository.ts
@@ -1,0 +1,116 @@
+import { prisma } from "../../db/prisma.js";
+
+// #645/CL-1: persistence for classes (cohorts) — CRUD, membership, and course-to-class assignment.
+// Business rules (authz, dynamic membership evaluation, audit) live in the service layer (CL-2).
+
+// The built-in "Alle deltakere" class, seeded by the migration. Its membership is all PARTICIPANT
+// users, resolved dynamically by the service — it has no ClassMember rows.
+export const SYSTEM_ALL_PARTICIPANTS_CLASS_ID = "cls_all_participants";
+
+type ClassRepositoryClient = Pick<typeof prisma, "class" | "classMember" | "courseGroupAssignment">;
+
+export interface CreateClassInput {
+  name: string;
+  description?: string | null;
+  createdById: string | null;
+}
+
+export function createClassRepository(client: ClassRepositoryClient = prisma) {
+  return {
+    createClass(input: CreateClassInput) {
+      return client.class.create({
+        data: {
+          name: input.name,
+          description: input.description ?? null,
+          kind: "MANUAL",
+          createdById: input.createdById,
+        },
+        select: { id: true, name: true, description: true, kind: true, isSystem: true, archivedAt: true },
+      });
+    },
+
+    updateClass(classId: string, data: { name?: string; description?: string | null }) {
+      return client.class.update({
+        where: { id: classId },
+        data,
+        select: { id: true, name: true, description: true, kind: true, isSystem: true, archivedAt: true },
+      });
+    },
+
+    archiveClass(classId: string) {
+      return client.class.update({ where: { id: classId }, data: { archivedAt: new Date() } });
+    },
+
+    findClassById(classId: string) {
+      return client.class.findUnique({ where: { id: classId } });
+    },
+
+    // Non-archived classes, system classes first, then newest.
+    listClasses() {
+      return client.class.findMany({
+        where: { archivedAt: null },
+        orderBy: [{ isSystem: "desc" }, { createdAt: "desc" }],
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          kind: true,
+          entraGroupId: true,
+          isSystem: true,
+          _count: { select: { members: true, courseAssignments: true } },
+        },
+      });
+    },
+
+    // Idempotent add (re-adding an existing member is a no-op).
+    addMember(classId: string, userId: string, addedById: string | null) {
+      return client.classMember.upsert({
+        where: { classId_userId: { classId, userId } },
+        create: { classId, userId, addedById },
+        update: {},
+      });
+    },
+
+    removeMember(classId: string, userId: string) {
+      return client.classMember.deleteMany({ where: { classId, userId } });
+    },
+
+    listMembers(classId: string) {
+      return client.classMember.findMany({
+        where: { classId },
+        orderBy: { addedAt: "desc" },
+        include: { user: { select: { id: true, name: true, email: true } } },
+      });
+    },
+
+    findManualMembership(userId: string) {
+      return client.classMember.findMany({ where: { userId }, select: { classId: true } });
+    },
+
+    // Assign a course to a class (idempotent on the course+class pair; updates the due date).
+    assignCourseToClass(courseId: string, classId: string, dueAt: Date | null, assignedById: string | null) {
+      return client.courseGroupAssignment.upsert({
+        where: { courseId_classId: { courseId, classId } },
+        create: { courseId, classId, dueAt, assignedById },
+        update: { dueAt },
+      });
+    },
+
+    unassignCourseFromClass(courseId: string, classId: string) {
+      return client.courseGroupAssignment.deleteMany({ where: { courseId, classId } });
+    },
+
+    listClassAssignmentsForCourse(courseId: string) {
+      return client.courseGroupAssignment.findMany({
+        where: { courseId },
+        include: { class: { select: { id: true, name: true, isSystem: true, archivedAt: true } } },
+      });
+    },
+
+    listCourseAssignmentsForClass(classId: string) {
+      return client.courseGroupAssignment.findMany({ where: { classId } });
+    },
+  };
+}
+
+export const classRepository = createClassRepository();

--- a/src/modules/course/classRepository.ts
+++ b/src/modules/course/classRepository.ts
@@ -108,7 +108,11 @@ export function createClassRepository(client: ClassRepositoryClient = prisma) {
     },
 
     listCourseAssignmentsForClass(classId: string) {
-      return client.courseGroupAssignment.findMany({ where: { classId } });
+      return client.courseGroupAssignment.findMany({
+        where: { classId },
+        orderBy: { createdAt: "desc" },
+        include: { course: { select: { id: true, title: true } } },
+      });
     },
   };
 }

--- a/src/modules/course/classService.ts
+++ b/src/modules/course/classService.ts
@@ -83,6 +83,12 @@ export async function listClassMembers(classId: string) {
   return members.map((m) => ({ userId: m.userId, name: m.user.name, email: m.user.email, addedAt: m.addedAt.toISOString() }));
 }
 
+export async function listClassCourseAssignments(classId: string) {
+  await requireClass(classId);
+  const rows = await classRepository.listCourseAssignmentsForClass(classId);
+  return rows.map((r) => ({ courseId: r.courseId, title: r.course.title, dueAt: r.dueAt ? r.dueAt.toISOString() : null }));
+}
+
 export async function assignCourseToClass(courseId: string, classId: string, dueAt: Date | null, actorId: string | null) {
   await requireClass(classId);
   const course = await prisma.course.findUnique({ where: { id: courseId }, select: { id: true } });

--- a/src/modules/course/classService.ts
+++ b/src/modules/course/classService.ts
@@ -1,0 +1,162 @@
+import { prisma } from "../../db/prisma.js";
+import { NotFoundError, ValidationError } from "../../errors/AppError.js";
+import { recordAuditEvent } from "../../services/auditService.js";
+import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
+import { classRepository, SYSTEM_ALL_PARTICIPANTS_CLASS_ID } from "./classRepository.js";
+import { isClassEntraLinkingEnabled } from "./classConfig.js";
+
+// #645/CL-2: class (cohort) business logic — CRUD + membership + course assignment + dynamic
+// membership evaluation. Course→class assignment is dynamic: a participant is assigned a course if
+// they belong to an assigned class, evaluated at read time (never materialised to CourseEnrollment).
+
+async function requireClass(classId: string) {
+  const klass = await classRepository.findClassById(classId);
+  if (!klass) throw new NotFoundError("Class", "class_not_found", "Class not found.");
+  return klass;
+}
+
+export async function createClass(input: { name: string; description?: string | null }, actorId: string | null) {
+  const name = input.name?.trim();
+  if (!name) throw new ValidationError("Class name is required.");
+  const created = await classRepository.createClass({ name, description: input.description ?? null, createdById: actorId });
+  await recordAuditEvent({
+    entityType: auditEntityTypes.class,
+    entityId: created.id,
+    action: auditActions.class.created,
+    actorId: actorId ?? undefined,
+    metadata: { classId: created.id, name },
+  });
+  return created;
+}
+
+export async function archiveClass(classId: string, actorId: string | null) {
+  const klass = await requireClass(classId);
+  if (klass.isSystem) throw new ValidationError("System classes cannot be archived.");
+  await classRepository.archiveClass(classId);
+  await recordAuditEvent({
+    entityType: auditEntityTypes.class,
+    entityId: classId,
+    action: auditActions.class.archived,
+    actorId: actorId ?? undefined,
+    metadata: { classId },
+  });
+}
+
+export async function addMember(classId: string, userId: string, actorId: string | null) {
+  const klass = await requireClass(classId);
+  if (klass.isSystem || klass.kind !== "MANUAL") {
+    throw new ValidationError("Members can only be managed on manual (non-system) classes.");
+  }
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { id: true } });
+  if (!user) throw new ValidationError(`Unknown user id: ${userId}.`);
+  await classRepository.addMember(classId, userId, actorId);
+  await recordAuditEvent({
+    entityType: auditEntityTypes.class,
+    entityId: classId,
+    action: auditActions.class.memberAdded,
+    actorId: actorId ?? undefined,
+    metadata: { classId, userId },
+  });
+}
+
+export async function removeMember(classId: string, userId: string, actorId: string | null) {
+  await requireClass(classId);
+  const result = await classRepository.removeMember(classId, userId);
+  if (result.count > 0) {
+    await recordAuditEvent({
+      entityType: auditEntityTypes.class,
+      entityId: classId,
+      action: auditActions.class.memberRemoved,
+      actorId: actorId ?? undefined,
+      metadata: { classId, userId },
+    });
+  }
+}
+
+export async function listClasses() {
+  return classRepository.listClasses();
+}
+
+export async function listClassMembers(classId: string) {
+  await requireClass(classId);
+  const members = await classRepository.listMembers(classId);
+  return members.map((m) => ({ userId: m.userId, name: m.user.name, email: m.user.email, addedAt: m.addedAt.toISOString() }));
+}
+
+export async function assignCourseToClass(courseId: string, classId: string, dueAt: Date | null, actorId: string | null) {
+  await requireClass(classId);
+  const course = await prisma.course.findUnique({ where: { id: courseId }, select: { id: true } });
+  if (!course) throw new NotFoundError("Course", "course_not_found", "Course not found.");
+  await classRepository.assignCourseToClass(courseId, classId, dueAt, actorId);
+  await recordAuditEvent({
+    entityType: auditEntityTypes.class,
+    entityId: classId,
+    action: auditActions.class.courseAssigned,
+    actorId: actorId ?? undefined,
+    metadata: { classId, courseId },
+  });
+}
+
+export async function unassignCourseFromClass(courseId: string, classId: string, actorId: string | null) {
+  const result = await classRepository.unassignCourseFromClass(courseId, classId);
+  if (result.count > 0) {
+    await recordAuditEvent({
+      entityType: auditEntityTypes.class,
+      entityId: classId,
+      action: auditActions.class.courseUnassigned,
+      actorId: actorId ?? undefined,
+      metadata: { classId, courseId },
+    });
+  }
+}
+
+export interface UserMembershipContext {
+  userId: string;
+  roles: string[];
+  groupIds?: string[];
+}
+
+/**
+ * The set of class ids a user belongs to, resolved dynamically:
+ *  - the "Alle deltakere" system class if the user has the PARTICIPANT role,
+ *  - every MANUAL class they are an explicit member of,
+ *  - (only when `classEntraLinkingEnabled`) ENTRA classes whose group is in the user's token groups.
+ */
+export async function getUserClassIds(ctx: UserMembershipContext): Promise<Set<string>> {
+  const ids = new Set<string>();
+  if (ctx.roles.includes("PARTICIPANT")) ids.add(SYSTEM_ALL_PARTICIPANTS_CLASS_ID);
+
+  const manual = await classRepository.findManualMembership(ctx.userId);
+  for (const m of manual) ids.add(m.classId);
+
+  if ((ctx.groupIds?.length ?? 0) > 0 && (await isClassEntraLinkingEnabled())) {
+    const entraClasses = await prisma.class.findMany({
+      where: { kind: "ENTRA", archivedAt: null, entraGroupId: { in: ctx.groupIds as string[] } },
+      select: { id: true },
+    });
+    for (const c of entraClasses) ids.add(c.id);
+  }
+  return ids;
+}
+
+/**
+ * course id → earliest (most urgent) due date, for the courses assigned to any of `classIds`.
+ * Used by the visibility filter and "my enrollments" to surface class-assigned courses dynamically.
+ */
+export async function getClassAssignedCourseDueDates(classIds: Set<string>): Promise<Map<string, Date | null>> {
+  if (classIds.size === 0) return new Map();
+  const rows = await prisma.courseGroupAssignment.findMany({
+    where: { classId: { in: [...classIds] } },
+    select: { courseId: true, dueAt: true },
+  });
+  const map = new Map<string, Date | null>();
+  for (const r of rows) {
+    if (!map.has(r.courseId)) {
+      map.set(r.courseId, r.dueAt);
+    } else {
+      const existing = map.get(r.courseId) ?? null;
+      if (r.dueAt && (!existing || r.dueAt < existing)) map.set(r.courseId, r.dueAt);
+    }
+  }
+  return map;
+}

--- a/src/modules/course/enrollmentService.ts
+++ b/src/modules/course/enrollmentService.ts
@@ -143,7 +143,7 @@ async function hasUserStartedCourse(userId: string, courseId: string): Promise<b
   return submissions > 0;
 }
 
-async function deriveStatus(userId: string, courseId: string, dueAt: Date | null, now: Date): Promise<EnrollmentStatus> {
+export async function deriveStatus(userId: string, courseId: string, dueAt: Date | null, now: Date): Promise<EnrollmentStatus> {
   const completion = await prisma.courseCompletion.findUnique({
     where: { userId_courseId: { userId, courseId } },
     select: { id: true },
@@ -205,14 +205,23 @@ export async function listCourseEnrollments(courseId: string, now: Date = new Da
 
 /**
  * Course visibility (#496): OPEN courses are visible to everyone; RESTRICTED courses only to users
- * with an active enrolment. Returns the set of course ids the user may see, given a candidate list.
+ * with an active enrolment OR a class assignment (#645/CL-2). `classAssignedCourseIds` is the set of
+ * course ids assigned to a class the user belongs to — computed by the caller via classService.
  */
-export async function filterVisibleCourseIds(userId: string, courses: Array<{ id: string; enrollmentPolicy: string }>): Promise<Set<string>> {
+export async function filterVisibleCourseIds(
+  userId: string,
+  courses: Array<{ id: string; enrollmentPolicy: string }>,
+  classAssignedCourseIds: Set<string> = new Set(),
+): Promise<Set<string>> {
   const restrictedIds = courses.filter((c) => c.enrollmentPolicy !== "OPEN").map((c) => c.id);
   const visible = new Set<string>(courses.filter((c) => c.enrollmentPolicy === "OPEN").map((c) => c.id));
-  if (restrictedIds.length > 0) {
+  for (const id of restrictedIds) {
+    if (classAssignedCourseIds.has(id)) visible.add(id);
+  }
+  const stillRestricted = restrictedIds.filter((id) => !visible.has(id));
+  if (stillRestricted.length > 0) {
     const enrolled = await prisma.courseEnrollment.findMany({
-      where: { userId, revokedAt: null, courseId: { in: restrictedIds } },
+      where: { userId, revokedAt: null, courseId: { in: stillRestricted } },
       select: { courseId: true },
     });
     for (const row of enrolled) visible.add(row.courseId);

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -29,6 +29,7 @@ export {
   removeMember,
   listClasses,
   listClassMembers,
+  listClassCourseAssignments,
   assignCourseToClass,
   unassignCourseFromClass,
   getUserClassIds,

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -20,6 +20,8 @@ export {
 } from "./assetCommands.js";
 export { courseRepository, createCourseRepository } from "./courseRepository.js";
 export { enrollmentRepository, createEnrollmentRepository } from "./enrollmentRepository.js";
+export { classRepository, createClassRepository, SYSTEM_ALL_PARTICIPANTS_CLASS_ID } from "./classRepository.js";
+export { isClassEntraLinkingEnabled, CLASS_ENTRA_LINKING_KEY } from "./classConfig.js";
 export { deriveEnrollmentStatus } from "./enrollmentStatus.js";
 export type { EnrollmentStatus } from "./enrollmentStatus.js";
 export {

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -22,6 +22,19 @@ export { courseRepository, createCourseRepository } from "./courseRepository.js"
 export { enrollmentRepository, createEnrollmentRepository } from "./enrollmentRepository.js";
 export { classRepository, createClassRepository, SYSTEM_ALL_PARTICIPANTS_CLASS_ID } from "./classRepository.js";
 export { isClassEntraLinkingEnabled, CLASS_ENTRA_LINKING_KEY } from "./classConfig.js";
+export {
+  createClass,
+  archiveClass,
+  addMember,
+  removeMember,
+  listClasses,
+  listClassMembers,
+  assignCourseToClass,
+  unassignCourseFromClass,
+  getUserClassIds,
+  getClassAssignedCourseDueDates,
+} from "./classService.js";
+export type { UserMembershipContext } from "./classService.js";
 export { deriveEnrollmentStatus } from "./enrollmentStatus.js";
 export type { EnrollmentStatus } from "./enrollmentStatus.js";
 export {
@@ -31,6 +44,7 @@ export {
   listUserEnrollments,
   listCourseEnrollments,
   filterVisibleCourseIds,
+  deriveStatus,
 } from "./enrollmentService.js";
 export type {
   AssignEnrollmentsInput,

--- a/src/observability/auditEvents.ts
+++ b/src/observability/auditEvents.ts
@@ -9,6 +9,7 @@ export const auditEntityTypes = {
   calibrationWorkspace: "calibration_workspace",
   certificationStatus: "certification_status",
   course: "course",
+  class: "class",
   llmEvaluation: "llm_evaluation",
   manualReview: "manual_review",
   mcqAttempt: "mcq_attempt",
@@ -73,6 +74,14 @@ export const auditActions = {
     assigned: "course_enrollment_assigned",
     revoked: "course_enrollment_revoked",
     selfEnrolled: "course_self_enrolled",
+  },
+  class: {
+    created: "class_created",
+    archived: "class_archived",
+    memberAdded: "class_member_added",
+    memberRemoved: "class_member_removed",
+    courseAssigned: "class_course_assigned",
+    courseUnassigned: "class_course_unassigned",
   },
   certification: {
     recertificationStatusUpserted: "recertification_status_upserted",
@@ -268,6 +277,12 @@ export type AuditMetadataByAction = {
   }>;
   [auditActions.enrollment.revoked]: EventMetadata<{ userId: string; courseId: string }>;
   [auditActions.enrollment.selfEnrolled]: EventMetadata<{ userId: string; courseId: string }>;
+  [auditActions.class.created]: EventMetadata<{ classId: string; name: string }>;
+  [auditActions.class.archived]: EventMetadata<{ classId: string }>;
+  [auditActions.class.memberAdded]: EventMetadata<{ classId: string; userId: string }>;
+  [auditActions.class.memberRemoved]: EventMetadata<{ classId: string; userId: string }>;
+  [auditActions.class.courseAssigned]: EventMetadata<{ classId: string; courseId: string }>;
+  [auditActions.class.courseUnassigned]: EventMetadata<{ classId: string; courseId: string }>;
   [auditActions.manualReview.opened]: EventMetadata<{
     submissionId: string;
     decisionId: string;

--- a/src/routes/adminClasses.ts
+++ b/src/routes/adminClasses.ts
@@ -1,0 +1,115 @@
+import { Router, type Request } from "express";
+import { z } from "zod";
+import {
+  createClass,
+  archiveClass,
+  addMember,
+  removeMember,
+  listClasses,
+  listClassMembers,
+  assignCourseToClass,
+  unassignCourseFromClass,
+} from "../modules/course/index.js";
+
+// #645/CL-2: class (cohort) administration. Mounted under /api/admin/content/classes, so it inherits
+// the SMO/ADMINISTRATOR gate from the admin-content router.
+const adminClassesRouter = Router();
+
+const createClassSchema = z.object({
+  name: z.string().trim().min(1),
+  description: z.string().trim().optional(),
+});
+const addMemberSchema = z.object({ userId: z.string().min(1) });
+const assignCourseSchema = z.object({ courseId: z.string().min(1), dueAt: z.string().datetime().nullish() });
+
+adminClassesRouter.get("/", async (_request, response, next) => {
+  try {
+    response.json({ classes: await listClasses() });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminClassesRouter.post("/", async (request, response, next) => {
+  const parsed = createClassSchema.safeParse(request.body);
+  if (!parsed.success) {
+    response.status(400).json({ error: "validation_error", issues: parsed.error.issues });
+    return;
+  }
+  try {
+    const klass = await createClass(parsed.data, request.context?.userId ?? null);
+    response.status(201).json({ class: klass });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminClassesRouter.delete("/:classId", async (request: Request<{ classId: string }>, response, next) => {
+  try {
+    await archiveClass(request.params.classId, request.context?.userId ?? null);
+    response.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminClassesRouter.get("/:classId/members", async (request: Request<{ classId: string }>, response, next) => {
+  try {
+    response.json({ members: await listClassMembers(request.params.classId) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminClassesRouter.post("/:classId/members", async (request: Request<{ classId: string }>, response, next) => {
+  const parsed = addMemberSchema.safeParse(request.body);
+  if (!parsed.success) {
+    response.status(400).json({ error: "validation_error", issues: parsed.error.issues });
+    return;
+  }
+  try {
+    await addMember(request.params.classId, parsed.data.userId, request.context?.userId ?? null);
+    response.status(201).json({ ok: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminClassesRouter.delete("/:classId/members/:userId", async (request: Request<{ classId: string; userId: string }>, response, next) => {
+  try {
+    await removeMember(request.params.classId, request.params.userId, request.context?.userId ?? null);
+    response.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminClassesRouter.post("/:classId/courses", async (request: Request<{ classId: string }>, response, next) => {
+  const parsed = assignCourseSchema.safeParse(request.body);
+  if (!parsed.success) {
+    response.status(400).json({ error: "validation_error", issues: parsed.error.issues });
+    return;
+  }
+  try {
+    await assignCourseToClass(
+      parsed.data.courseId,
+      request.params.classId,
+      parsed.data.dueAt ? new Date(parsed.data.dueAt) : null,
+      request.context?.userId ?? null,
+    );
+    response.status(201).json({ ok: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminClassesRouter.delete("/:classId/courses/:courseId", async (request: Request<{ classId: string; courseId: string }>, response, next) => {
+  try {
+    await unassignCourseFromClass(request.params.courseId, request.params.classId, request.context?.userId ?? null);
+    response.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export { adminClassesRouter };

--- a/src/routes/adminClasses.ts
+++ b/src/routes/adminClasses.ts
@@ -7,6 +7,7 @@ import {
   removeMember,
   listClasses,
   listClassMembers,
+  listClassCourseAssignments,
   assignCourseToClass,
   unassignCourseFromClass,
 } from "../modules/course/index.js";
@@ -79,6 +80,14 @@ adminClassesRouter.delete("/:classId/members/:userId", async (request: Request<{
   try {
     await removeMember(request.params.classId, request.params.userId, request.context?.userId ?? null);
     response.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminClassesRouter.get("/:classId/courses", async (request: Request<{ classId: string }>, response, next) => {
+  try {
+    response.json({ courses: await listClassCourseAssignments(request.params.classId) });
   } catch (error) {
     next(error);
   }

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -72,6 +72,7 @@ import {
   toCreateModuleVersionInput,
 } from "../modules/adminContent/adminContentMapper.js";
 import { adminCoursesRouter } from "./adminCourses.js";
+import { adminClassesRouter } from "./adminClasses.js";
 import { adminSectionsRouter } from "./adminSections.js";
 import { generateLimiter, extractLimiter, intentLogLimiter } from "../middleware/rateLimiting.js";
 import { ForbiddenError, NotFoundError, AppError } from "../errors/AppError.js";
@@ -91,6 +92,7 @@ async function assertModuleOwnership(moduleId: string, actorId: string, roles: s
 }
 
 adminContentRouter.use("/courses", adminCoursesRouter);
+adminContentRouter.use("/classes", adminClassesRouter);
 adminContentRouter.use("/sections", adminSectionsRouter);
 
 adminContentRouter.post("/modules", async (request, response) => {

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -73,6 +73,7 @@ import {
 } from "../modules/adminContent/adminContentMapper.js";
 import { adminCoursesRouter } from "./adminCourses.js";
 import { adminClassesRouter } from "./adminClasses.js";
+import { adminUsersRouter } from "./adminUsers.js";
 import { adminSectionsRouter } from "./adminSections.js";
 import { generateLimiter, extractLimiter, intentLogLimiter } from "../middleware/rateLimiting.js";
 import { ForbiddenError, NotFoundError, AppError } from "../errors/AppError.js";
@@ -93,6 +94,7 @@ async function assertModuleOwnership(moduleId: string, actorId: string, roles: s
 
 adminContentRouter.use("/courses", adminCoursesRouter);
 adminContentRouter.use("/classes", adminClassesRouter);
+adminContentRouter.use("/users", adminUsersRouter);
 adminContentRouter.use("/sections", adminSectionsRouter);
 
 adminContentRouter.post("/modules", async (request, response) => {

--- a/src/routes/adminUsers.ts
+++ b/src/routes/adminUsers.ts
@@ -1,0 +1,33 @@
+import { Router } from "express";
+import { prisma } from "../db/prisma.js";
+
+// #645/CL-3: user lookup for class membership management. Mounted under /api/admin/content/users,
+// so it inherits the SMO/ADMINISTRATOR gate. Read-only; returns a small, capped result set.
+const adminUsersRouter = Router();
+
+adminUsersRouter.get("/search", async (request, response, next) => {
+  const q = typeof request.query.q === "string" ? request.query.q.trim() : "";
+  if (q.length < 2) {
+    response.json({ users: [] });
+    return;
+  }
+  try {
+    const users = await prisma.user.findMany({
+      where: {
+        isAnonymized: false,
+        OR: [
+          { name: { contains: q, mode: "insensitive" } },
+          { email: { contains: q, mode: "insensitive" } },
+        ],
+      },
+      orderBy: { name: "asc" },
+      take: 20,
+      select: { id: true, name: true, email: true },
+    });
+    response.json({ users });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export { adminUsersRouter };

--- a/src/routes/courses.ts
+++ b/src/routes/courses.ts
@@ -4,7 +4,14 @@ import { renderSectionMarkdown } from "../modules/course/sectionContent.js";
 import { localizeContentText } from "../i18n/content.js";
 import { normalizeLocale } from "../i18n/locale.js";
 import { NotFoundError } from "../errors/AppError.js";
-import { listUserEnrollments, selfEnroll, filterVisibleCourseIds } from "../modules/course/index.js";
+import {
+  listUserEnrollments,
+  selfEnroll,
+  filterVisibleCourseIds,
+  getUserClassIds,
+  getClassAssignedCourseDueDates,
+  deriveStatus,
+} from "../modules/course/index.js";
 import type { CourseListItem, CourseDetail, CourseSequenceItem } from "../modules/course/index.js";
 import { queryLatestSubmissionsForModules } from "../modules/submission/submissionRepository.js";
 import { hasCertificateBackground } from "../modules/platformConfig/certificateBackgroundService.js";
@@ -22,8 +29,15 @@ coursesRouter.get("/", async (request, response, next) => {
 
   try {
     const allCourses = await courseRepository.findPublishedCourses();
-    // #496/EN-2: RESTRICTED courses are only visible to enrolled users; OPEN courses to everyone.
-    const visibleIds = await filterVisibleCourseIds(userId, allCourses);
+    // #496/EN-2 + #645/CL-2: RESTRICTED courses are visible to users with an individual enrolment OR
+    // a class assignment (member of a class the course is assigned to); OPEN courses to everyone.
+    const classIds = await getUserClassIds({
+      userId,
+      roles: request.context?.roles ?? [],
+      groupIds: request.context?.principal?.groupIds,
+    });
+    const classCourseDue = await getClassAssignedCourseDueDates(classIds);
+    const visibleIds = await filterVisibleCourseIds(userId, allCourses, new Set(classCourseDue.keys()));
     const courses = allCourses.filter((course) => visibleIds.has(course.id));
 
     const items: CourseListItem[] = await Promise.all(
@@ -81,7 +95,31 @@ coursesRouter.get("/enrollments", async (request, response, next) => {
     return;
   }
   try {
-    response.json({ enrollments: await listUserEnrollments(userId) });
+    const now = new Date();
+    const individual = await listUserEnrollments(userId, now);
+    const seen = new Set(individual.map((e) => e.courseId));
+
+    // #645/CL-2: also surface courses assigned via a class the user belongs to (dynamic, not stored).
+    // Individual enrolments win on overlap (they carry the explicit assignedAt/source).
+    const classIds = await getUserClassIds({
+      userId,
+      roles: request.context?.roles ?? [],
+      groupIds: request.context?.principal?.groupIds,
+    });
+    const classCourseDue = await getClassAssignedCourseDueDates(classIds);
+    const classEntries = await Promise.all(
+      [...classCourseDue.entries()]
+        .filter(([courseId]) => !seen.has(courseId))
+        .map(async ([courseId, dueAt]) => ({
+          courseId,
+          source: "CLASS" as const,
+          dueAt: dueAt ? dueAt.toISOString() : null,
+          assignedAt: null,
+          status: await deriveStatus(userId, courseId, dueAt, now),
+        })),
+    );
+
+    response.json({ enrollments: [...individual, ...classEntries] });
   } catch (error) {
     next(error);
   }

--- a/test/e2e/admin-content-classes.spec.ts
+++ b/test/e2e/admin-content-classes.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+// #645/CL-3: browser e2e for the classes (cohort) admin page — runs the real front-end JS against
+// mocked APIs, covering the client wiring (list, create, add student via search, assign course).
+
+async function mockBaseApis(page: Page) {
+  await page.route("**/participant/config", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        authMode: "mock",
+        navigation: { items: [], workspaceItems: [] },
+        identityDefaults: { contentAdmin: { userId: "smo-1", email: "smo@x.no", name: "SMO", roles: ["SUBJECT_MATTER_OWNER"] } },
+        calibrationWorkspace: { accessRoles: [] },
+      }),
+    }),
+  );
+  await page.route("**/version", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "test" }) }),
+  );
+  await page.route("**/api/me", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ user: { roles: ["SUBJECT_MATTER_OWNER"] }, consent: { accepted: true, currentVersion: "1.0" } }),
+    }),
+  );
+}
+
+test("classes admin: list, create, add a student via search, and assign a course", async ({ page }) => {
+  await mockBaseApis(page);
+
+  const state = {
+    classes: [{ id: "cls_all_participants", name: "Alle deltakere", isSystem: true, _count: { members: 0, courseAssignments: 0 } }],
+    members: [] as Array<{ userId: string; name: string; email: string; addedAt: string }>,
+    assignedCourses: [] as Array<{ courseId: string; title: string; dueAt: string | null }>,
+  };
+  let memberPosted = false;
+  let coursePosted = false;
+
+  await page.route("**/api/admin/content/classes", (route: Route) => {
+    if (route.request().method() === "POST") {
+      const body = route.request().postDataJSON() as { name: string };
+      const created = { id: "cls-new", name: body.name, isSystem: false, _count: { members: 0, courseAssignments: 0 } };
+      state.classes.push(created);
+      return route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ class: created }) });
+    }
+    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ classes: state.classes }) });
+  });
+  await page.route("**/api/admin/content/classes/*/members", (route: Route) => {
+    if (route.request().method() === "POST") {
+      memberPosted = true;
+      state.members.push({ userId: "u1", name: "Kari Nordmann", email: "kari@x.no", addedAt: new Date(0).toISOString() });
+      return route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ ok: true }) });
+    }
+    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ members: state.members }) });
+  });
+  await page.route("**/api/admin/content/classes/*/courses", (route: Route) => {
+    if (route.request().method() === "POST") {
+      coursePosted = true;
+      return route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ ok: true }) });
+    }
+    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ courses: state.assignedCourses }) });
+  });
+  await page.route("**/api/admin/content/users/search**", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ users: [{ id: "u1", name: "Kari Nordmann", email: "kari@x.no" }] }) }),
+  );
+  await page.route("**/api/admin/content/courses", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ courses: [{ id: "course-1", title: JSON.stringify({ nb: "Arbeidsmiljø" }) }] }) }),
+  );
+
+  await page.addInitScript(() => { try { localStorage.setItem("participant.locale", "nb"); } catch { /* ignore */ } });
+  await page.goto("/admin-content/classes");
+
+  // List renders the system class with a real heading (no raw i18n keys).
+  await expect(page.locator("h1")).toContainText("Klasser");
+  await expect(page.locator("#classesTableBody")).toContainText("Alle deltakere");
+
+  // Create a class.
+  page.once("dialog", (dialog) => dialog.accept("Kull 2026"));
+  await page.locator("#newClassBtn").click();
+  await expect(page.locator("#classesTableBody")).toContainText("Kull 2026");
+
+  // Open the new class → detail view.
+  await page.locator('[data-action="open"][data-id="cls-new"]').click();
+  await expect(page.locator("#studentSearch")).toBeVisible();
+
+  // Search a student and add them.
+  await page.locator("#studentSearch").fill("kari");
+  await expect(page.locator("#searchResults")).toContainText("Kari Nordmann");
+  await page.locator('[data-add-user="u1"]').click();
+  await expect.poll(() => memberPosted).toBe(true);
+  await expect(page.locator("#memberChips")).toContainText("Kari Nordmann");
+
+  // Assign a course.
+  await page.locator("#courseSelect").selectOption("course-1");
+  await page.locator("#assignCourseBtn").click();
+  await expect.poll(() => coursePosted).toBe(true);
+});

--- a/test/m2-classes.test.ts
+++ b/test/m2-classes.test.ts
@@ -1,0 +1,109 @@
+import request from "supertest";
+import { afterAll, describe, expect, it } from "vitest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+import { SYSTEM_ALL_PARTICIPANTS_CLASS_ID } from "../src/modules/course/index.js";
+
+// #645/CL-2 — classes (cohorts): admin CRUD + membership + course assignment, and the dynamic
+// visibility/my-enrollments effects for participants.
+
+const adminHeaders = {
+  "x-user-id": "class-admin-ext",
+  "x-user-email": "class-admin@company.com",
+  "x-user-name": "Class Admin",
+  "x-user-roles": "ADMINISTRATOR",
+};
+
+function participantHeaders(externalId: string) {
+  return {
+    "x-user-id": externalId,
+    "x-user-email": `${externalId}@company.com`,
+    "x-user-name": externalId,
+    "x-user-roles": "PARTICIPANT",
+  };
+}
+
+async function createRestrictedCourse(): Promise<string> {
+  const course = await prisma.course.create({
+    data: {
+      title: JSON.stringify({ "en-GB": `Class course ${Date.now()}-${Math.round(performance.now())}` }),
+      enrollmentPolicy: "RESTRICTED",
+      publishedAt: new Date(),
+    },
+    select: { id: true },
+  });
+  return course.id;
+}
+
+describe("Class (cohort) management + dynamic assignment (#645/CL-2)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("creates a class, adds a member, assigns a course, and makes it visible to the member only", async () => {
+    const courseId = await createRestrictedCourse();
+    const member = await prisma.user.create({
+      data: { externalId: `cls-m-${Date.now()}`, name: "Class Member", email: `cls-m-${Date.now()}@x.test` },
+      select: { id: true, externalId: true },
+    });
+    const outsider = await prisma.user.create({
+      data: { externalId: `cls-o-${Date.now()}`, name: "Outsider", email: `cls-o-${Date.now()}@x.test` },
+      select: { id: true, externalId: true },
+    });
+
+    const created = await request(app).post("/api/admin/content/classes").set(adminHeaders).send({ name: "Kull A" });
+    expect(created.status).toBe(201);
+    const classId = created.body.class.id as string;
+
+    expect((await request(app).post(`/api/admin/content/classes/${classId}/members`).set(adminHeaders).send({ userId: member.id })).status).toBe(201);
+    expect((await request(app).post(`/api/admin/content/classes/${classId}/courses`).set(adminHeaders).send({ courseId, dueAt: "2020-01-01T00:00:00.000Z" })).status).toBe(201);
+
+    // Member sees the RESTRICTED course; outsider does not.
+    const memberCourses = await request(app).get("/api/courses").set(participantHeaders(member.externalId));
+    expect((memberCourses.body.courses as Array<{ id: string }>).some((c) => c.id === courseId)).toBe(true);
+    const outsiderCourses = await request(app).get("/api/courses").set(participantHeaders(outsider.externalId));
+    expect((outsiderCourses.body.courses as Array<{ id: string }>).some((c) => c.id === courseId)).toBe(false);
+
+    // Member's "my enrollments" surfaces the class-assigned course (source CLASS, OVERDUE due date).
+    const mine = await request(app).get("/api/courses/enrollments").set(participantHeaders(member.externalId));
+    const row = (mine.body.enrollments as Array<{ courseId: string; source: string; status: string }>).find((e) => e.courseId === courseId);
+    expect(row?.source).toBe("CLASS");
+    expect(row?.status).toBe("OVERDUE");
+
+    // Removing the member revokes visibility.
+    expect((await request(app).delete(`/api/admin/content/classes/${classId}/members/${member.id}`).set(adminHeaders)).status).toBe(204);
+    const afterRemove = await request(app).get("/api/courses").set(participantHeaders(member.externalId));
+    expect((afterRemove.body.courses as Array<{ id: string }>).some((c) => c.id === courseId)).toBe(false);
+
+    await prisma.courseGroupAssignment.deleteMany({ where: { courseId } });
+    await prisma.class.delete({ where: { id: classId } });
+    await prisma.course.delete({ where: { id: courseId } });
+    await prisma.user.deleteMany({ where: { id: { in: [member.id, outsider.id] } } });
+  });
+
+  it("makes a course assigned to the 'Alle deltakere' system class visible to any participant", async () => {
+    const courseId = await createRestrictedCourse();
+    const participant = await prisma.user.create({
+      data: { externalId: `cls-all-${Date.now()}`, name: "Any Participant", email: `cls-all-${Date.now()}@x.test` },
+      select: { externalId: true },
+    });
+
+    await request(app)
+      .post(`/api/admin/content/classes/${SYSTEM_ALL_PARTICIPANTS_CLASS_ID}/courses`)
+      .set(adminHeaders)
+      .send({ courseId })
+      .expect(201);
+
+    const courses = await request(app).get("/api/courses").set(participantHeaders(participant.externalId));
+    expect((courses.body.courses as Array<{ id: string }>).some((c) => c.id === courseId)).toBe(true);
+
+    await prisma.courseGroupAssignment.deleteMany({ where: { courseId } });
+    await prisma.course.delete({ where: { id: courseId } });
+    await prisma.user.deleteMany({ where: { externalId: participant.externalId } });
+  });
+
+  it("refuses to archive the system class and forbids participants from creating classes", async () => {
+    expect((await request(app).delete(`/api/admin/content/classes/${SYSTEM_ALL_PARTICIPANTS_CLASS_ID}`).set(adminHeaders)).status).toBe(400);
+    expect((await request(app).post("/api/admin/content/classes").set(participantHeaders(`cls-forbid-${Date.now()}`)).send({ name: "Nope" })).status).toBe(403);
+  });
+});

--- a/test/unit/class-repository.test.ts
+++ b/test/unit/class-repository.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { createClassRepository } from "../../src/modules/course/classRepository.js";
+
+// #645/CL-1: class (cohort) persistence. Pure repository — mock the prisma client.
+
+describe("class repository", () => {
+  it("creates a MANUAL class with the given fields", async () => {
+    const create = vi.fn().mockResolvedValue({ id: "class-1" });
+    const repo = createClassRepository({ class: { create } } as never);
+
+    await repo.createClass({ name: "Onboarding H2026", description: "Nye ansatte", createdById: "admin-1" });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { name: "Onboarding H2026", description: "Nye ansatte", kind: "MANUAL", createdById: "admin-1" },
+      }),
+    );
+  });
+
+  it("adds a member idempotently via upsert", async () => {
+    const upsert = vi.fn().mockResolvedValue({});
+    const repo = createClassRepository({ classMember: { upsert } } as never);
+
+    await repo.addMember("class-1", "user-1", "admin-1");
+
+    expect(upsert).toHaveBeenCalledWith({
+      where: { classId_userId: { classId: "class-1", userId: "user-1" } },
+      create: { classId: "class-1", userId: "user-1", addedById: "admin-1" },
+      update: {},
+    });
+  });
+
+  it("assigns a course to a class idempotently and updates the due date", async () => {
+    const upsert = vi.fn().mockResolvedValue({});
+    const repo = createClassRepository({ courseGroupAssignment: { upsert } } as never);
+    const dueAt = new Date("2026-09-01T00:00:00.000Z");
+
+    await repo.assignCourseToClass("course-1", "class-1", dueAt, "admin-1");
+
+    expect(upsert).toHaveBeenCalledWith({
+      where: { courseId_classId: { courseId: "course-1", classId: "class-1" } },
+      create: { courseId: "course-1", classId: "class-1", dueAt, assignedById: "admin-1" },
+      update: { dueAt },
+    });
+  });
+
+  it("archives a class with a timestamp (soft delete)", async () => {
+    const update = vi.fn().mockResolvedValue({});
+    const repo = createClassRepository({ class: { update } } as never);
+
+    await repo.archiveClass("class-1");
+
+    const call = update.mock.calls[0][0];
+    expect(call.where).toEqual({ id: "class-1" });
+    expect(call.data.archivedAt).toBeInstanceOf(Date);
+  });
+});


### PR DESCRIPTION
Implementerer **klasser** (kohorter) på den låste #645-modellen (`doc/design/COHORT_GROUPING_645.md`). Lukker #674, #675, #676.

## CL-1 — datamodell (#674)
`Class { kind: MANUAL|ENTRA, entraGroupId?, isSystem?, archivedAt? }` + `ClassMember` (M:N) + `CourseGroupAssignment` (dynamisk) + migrasjon som seeder systemklassen **«Alle deltakere»**. `classRepository` + `classEntraLinkingEnabled`-config (default av). Unit-tester.

## CL-2 — service + API + dynamisk synlighet (#675)
- Admin (SMO/ADMINISTRATOR): opprett/arkiver klasse, legg til/fjern medlem, tildel/avtildel kurs — under `/api/admin/content/classes`. Audit på alt.
- **Dynamisk**: deltaker tildelt et kurs hvis medlem av en tildelt klasse (lesetid; aldri materialisert). «Alle deltakere» = PARTICIPANT-rolle. ENTRA-klasser gated bak toggelen (CL-5).
- `GET /api/courses` (synlighet) + `/enrollments` (`source: "CLASS"`) reflekterer klasse-tildelinger.
- Integrasjonstester: synlighet for medlem vs ikke-medlem, systemklasse, archive-guard, authz (403).

## CL-3 — admin-UI (#676)
Ny side `/admin-content/classes` (+ «Klasser»-fane): liste, opprett, søk+legg til studenter (nytt `/users/search`), tildel kurs med frist. Playwright-e2e for hele flyten.

## Test
Unit (class-repository) + integrasjon (m2-classes) + e2e (admin-content-classes). `tsc` rent. Integrasjon verifiseres i CI.

## NB — CL-4 utsatt
Sletting av `User.department` (#677) er **ikke** med: feltet viste seg å være en kjerne-rapporterings-dimensjon (orgUnit-filter, cohort-analyse i 11 reporting/review/appeal-filer). Krever egen avklaring før evt. fjerning. CL-5 (Entra-kobling) er forberedt men utsatt (#678).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
