### PR TITLE
fix(nav): «Klasser»-fane på alle innholdsforvaltnings-sider (v1.3.82, #645)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,15 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.82 - 2026-06-26
+
+fix(nav): «Klasser»-fane på alle innholdsforvaltnings-sider (#645/CL-3 oppfølging)
+
+CL-3 la «Klasser»-fanen kun til på kurs- og seksjons-sidene; den manglet på modul-biblioteket
+(«Moduler») og kalibrering, så klasse-siden var uoppdagbar derfra. Fanen er nå på alle fem
+content-area-nav-flatene (kurs, moduler/bibliotek, seksjoner, klasser, kalibrering). E2e i
+modul-bibliotek-spec-en låser at fanen finnes.
+
 ## 1.3.81 - 2026-06-26
 
 feat(course): klasser (kohorter) for kurstildeling (#645 / CL-1..CL-3)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.81",
+  "version": "1.3.82",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-calibration.html
+++ b/public/admin-content-calibration.html
@@ -84,6 +84,7 @@
         <a href="/admin-content/courses" class="content-area-nav-link" id="navKurs">Kurs</a>
         <a href="/admin-content" class="content-area-nav-link" id="navModuler">Moduler</a>
         <a href="/admin-content/sections" class="content-area-nav-link" id="navSeksjoner">Seksjoner</a>
+        <a href="/admin-content/classes" class="content-area-nav-link" id="navKlasser">Klasser</a>
         <a href="/admin-content/calibration" class="content-area-nav-link active" id="navKalibrering">Kalibrering</a>
       </nav>
 

--- a/public/admin-content-library.html
+++ b/public/admin-content-library.html
@@ -262,6 +262,7 @@
         <a href="/admin-content/courses" class="content-area-nav-link" id="navKurs">Kurs</a>
         <a href="/admin-content" class="content-area-nav-link active" id="navModuler">Moduler</a>
         <a href="/admin-content/sections" class="content-area-nav-link" id="navSeksjoner">Seksjoner</a>
+        <a href="/admin-content/classes" class="content-area-nav-link" id="navKlasser">Klasser</a>
         <a href="/admin-content/calibration" class="content-area-nav-link" id="navKalibrering" hidden>Kalibrering</a>
       </nav>
 

--- a/test/e2e/admin-content-module-library.spec.ts
+++ b/test/e2e/admin-content-module-library.spec.ts
@@ -29,6 +29,9 @@ test.describe("admin content module library", () => {
 
     await page.goto(LIBRARY_PATH);
 
+    // #645/CL-3: the content-area nav must expose the "Klasser" tab on every admin-content page.
+    await expect(page.locator('a.content-area-nav-link[href="/admin-content/classes"]')).toHaveText("Klasser");
+
     const table = page.locator(".library-table");
     await expect(table).toBeVisible();
     await expect(table).toContainText("Trade unions");


### PR DESCRIPTION
Oppfølging til CL-3 (#676), funnet under stage-verifisering av v1.3.81: «Klasser»-fanen ble bare lagt til på kurs- og seksjons-sidene, så den manglet på **modul-biblioteket** («Moduler») og **kalibrering** — klasse-siden var dermed uoppdagbar derfra.

Fanen er nå på **alle fem** content-area-nav-flatene (kurs, moduler/bibliotek, seksjoner, klasser, kalibrering). E2e-assert i modul-bibliotek-spec-en låser at fanen finnes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)