### PR TITLE
fix(authoring): samtale-basert MCQ-endring krasjet med 500 i prod (v1.3.83, #682)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,22 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.83 - 2026-06-26
+
+fix(authoring): samtale-basert MCQ-endring krasjet med 500 i prod (#682)
+
+To kode-bugs i MCQ-revise-stien (`reviseMcqQuestions`), observert i prod:
+1. **Over-produksjon av alternativer:** LLM-en returnerte av og til et spørsmål med >6 svaralternativer;
+   codec-en tillater maks 6 → hard 500 («Array must contain at most 6 element(s)»), ingen retry. Nå
+   **coerces** rå-svaret før validering — alternativer klippes til maks (riktig svar beholdes) via
+   `clampMcqOptionCount`, rutet inn i generate/revise/localize.
+2. **Heuristikk-hard-fail:** `hasMeaningfulMcqRevision` ga 500 («did not produce a material change») på
+   falske negativer (endringen landet, men ikke på det parsede målet). Heuristikken styrer nå kun
+   *retry*; bare en ekte no-op (revisjon identisk med kilden) gir feil — ellers returneres revisjonen
+   for forfatter-gjennomgang.
+
+Unit-tester for coercion (>6 → 6, riktig svar bevart). `tsc` rent.
+
 ## 1.3.82 - 2026-06-26
 
 fix(nav): «Klasser»-fane på alle innholdsforvaltnings-sider (#645/CL-3 oppfølging)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.82",
+  "version": "1.3.83",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/llmContentGenerationService.ts
+++ b/src/modules/adminContent/llmContentGenerationService.ts
@@ -202,12 +202,16 @@ const mcqDistractorMetadataCodec = z.object({
   wouldBeCorrectIf: z.string(),
 });
 
+// #682: hard cap on MCQ options. Shared by the codec and the coercion step below so a single source
+// of truth governs both validation and the "trim over-produced options" repair.
+const MCQ_MAX_OPTIONS = 6;
+
 const mcqGenerationResponseCodec = z.object({
   questions: z
     .array(
       z.object({
         stem: z.string().min(1),
-        options: z.array(z.string().min(1)).min(2).max(6),
+        options: z.array(z.string().min(1)).min(2).max(MCQ_MAX_OPTIONS),
         correctAnswer: z.string().min(1),
         rationale: z.string().min(1),
         distractorMetadata: z.array(mcqDistractorMetadataCodec).optional(),
@@ -216,6 +220,40 @@ const mcqGenerationResponseCodec = z.object({
     )
     .min(1),
 });
+
+// #682: LLMs occasionally emit a question with MORE than the allowed options (observed in MCQ
+// revision: a 7-option question failed validation and hard-500'd the edit). Coerce the raw response
+// into a valid shape BEFORE strict validation: trim each question's options to the cap, keeping the
+// correctAnswer within the kept set. A recoverable hallucination should not block authoring.
+export function clampMcqOptionCount(raw: unknown): unknown {
+  if (!raw || typeof raw !== "object") return raw;
+  const obj = raw as { questions?: unknown };
+  if (!Array.isArray(obj.questions)) return raw;
+  for (const entry of obj.questions) {
+    if (!entry || typeof entry !== "object") continue;
+    const question = entry as { options?: unknown; correctAnswer?: unknown };
+    if (Array.isArray(question.options) && question.options.length > MCQ_MAX_OPTIONS) {
+      const correct = question.correctAnswer;
+      let kept = question.options.slice(0, MCQ_MAX_OPTIONS);
+      if (typeof correct === "string" && !kept.includes(correct) && question.options.includes(correct)) {
+        // Ensure the correct answer survives the trim by seating it first.
+        kept = [correct, ...question.options.filter((option) => option !== correct)].slice(0, MCQ_MAX_OPTIONS);
+      }
+      question.options = kept;
+    }
+  }
+  return raw;
+}
+
+// Coerce-then-validate an MCQ generation/revision/localization response. Throws a descriptive error
+// only when the response is still invalid after coercion.
+function parseMcqGenerationResponse(raw: unknown, context: string) {
+  const parsed = mcqGenerationResponseCodec.safeParse(clampMcqOptionCount(raw));
+  if (!parsed.success) {
+    throw new Error(`${context} failed validation: ${JSON.stringify(parsed.error.issues)}`);
+  }
+  return parsed.data;
+}
 
 const courseCopyLocalizationResponseCodec = z.object({
   title: z.string().min(1).optional(),
@@ -1430,10 +1468,7 @@ export async function generateMcqQuestions(input: McqGenerationInput): Promise<M
   const attempt = async (extraDirective: string | null): Promise<McqGenerationResult> => {
     const promptToUse = extraDirective ? `${userPrompt}\n\n${extraDirective}` : userPrompt;
     const raw = await callLlm(systemPrompt, promptToUse, maxTokens);
-    const parsed = mcqGenerationResponseCodec.safeParse(raw);
-    if (!parsed.success) {
-      throw new Error(`MCQ generation LLM response failed validation: ${JSON.stringify(parsed.error.issues)}`);
-    }
+    const parsed = { data: parseMcqGenerationResponse(raw, "MCQ generation LLM response") };
     // Defensive guard: the LLM occasionally returns one extra question even when the prompt
     // says "exactly N". Truncate to the requested count. If it returned fewer, leave as-is
     // and let downstream validation surface that. See #424.
@@ -1493,11 +1528,7 @@ export async function reviseMcqQuestions(input: McqRevisionInput): Promise<McqGe
 
   const parseRevision = async (promptText: string) => {
     const raw = await callLlm(systemPrompt, promptText);
-    const parsed = mcqGenerationResponseCodec.safeParse(raw);
-    if (!parsed.success) {
-      throw new Error(`MCQ revision LLM response failed validation: ${JSON.stringify(parsed.error.issues)}`);
-    }
-    return parsed.data;
+    return parseMcqGenerationResponse(raw, "MCQ revision LLM response");
   };
 
   const sourceQuestions: GeneratedMcqQuestion[] = input.questions.map((question) => ({
@@ -1519,8 +1550,13 @@ Your previous attempt did not apply the requested change concretely enough.
 If the instruction names a specific question or option reference such as "question 3", "Q3", "3b", or "option B in question 3", you must change that exact target in a clearly visible way.
 Return a revised question set where the requested change is concrete, visible, and materially different from the source questions.`;
   const secondAttempt = await parseRevision(retryPrompt);
-  if (!hasMeaningfulMcqRevision(sourceQuestions, secondAttempt.questions, input.instruction)) {
-    throw new Error("MCQ revision did not produce a material change. Please request a more specific change and try again.");
+
+  // #682: the "meaningful revision" heuristic drives the RETRY, but it must not hard-fail the edit
+  // with a 500 on a false negative (e.g. the change landed but not on the exact parsed target). Only
+  // a genuine no-op — a revision byte-identical to the source — is worth surfacing as an error.
+  // Otherwise return the revision; the author reviews it and can re-instruct if it missed.
+  if (normalizeGeneratedMcqQuestions(sourceQuestions) === normalizeGeneratedMcqQuestions(secondAttempt.questions)) {
+    throw new Error("MCQ revision produced no change. Please describe the change you want and try again.");
   }
 
   return secondAttempt;
@@ -1541,11 +1577,7 @@ export async function localizeMcqQuestions(input: McqLocalizationInput): Promise
   const { systemPrompt, userPrompt } = buildMcqLocalizationPrompts(input);
 
   const raw = await callLlm(systemPrompt, userPrompt);
-  const parsed = mcqGenerationResponseCodec.safeParse(raw);
-  if (!parsed.success) {
-    throw new Error(`MCQ localization failed validation: ${JSON.stringify(parsed.error.issues)}`);
-  }
-  return parsed.data;
+  return parseMcqGenerationResponse(raw, "MCQ localization");
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/llm-content-generation-service.test.ts
+++ b/test/unit/llm-content-generation-service.test.ts
@@ -15,6 +15,7 @@ import {
   parseRetryAfterMs,
   computeLlmBackoffMs,
   splitIntoChunks,
+  clampMcqOptionCount,
 } from "../../src/modules/adminContent/llmContentGenerationService.js";
 
 // #479: chunking for condensation. Source larger than one TPM-safe request must be split so each
@@ -684,5 +685,28 @@ describe("isLikelyWrongLocale (#444)", () => {
     const ambiguous = "JSON HTTP API REST OAuth SAML XML YAML";
     expect(isLikelyWrongLocale(ambiguous, "nb")).toBe(false);
     expect(isLikelyWrongLocale(ambiguous, "en-GB")).toBe(false);
+  });
+});
+
+// #682: an MCQ revision where the LLM over-produced options (7) hard-500'd the edit because the
+// codec caps options at 6. Coercion trims to the cap before validation, keeping the correct answer.
+describe("clampMcqOptionCount (#682)", () => {
+  it("trims a question's options to the cap of 6", () => {
+    const raw = { questions: [{ stem: "Q", options: ["a", "b", "c", "d", "e", "f", "g"], correctAnswer: "b", rationale: "r" }] };
+    const out = clampMcqOptionCount(raw) as typeof raw;
+    expect(out.questions[0].options).toHaveLength(6);
+  });
+
+  it("keeps the correct answer even when it was beyond the cap", () => {
+    const raw = { questions: [{ stem: "Q", options: ["a", "b", "c", "d", "e", "f", "CORRECT"], correctAnswer: "CORRECT", rationale: "r" }] };
+    const out = clampMcqOptionCount(raw) as typeof raw;
+    expect(out.questions[0].options).toHaveLength(6);
+    expect(out.questions[0].options).toContain("CORRECT");
+  });
+
+  it("leaves a valid question (≤6 options) untouched", () => {
+    const raw = { questions: [{ stem: "Q", options: ["a", "b", "c"], correctAnswer: "a", rationale: "r" }] };
+    const out = clampMcqOptionCount(raw) as typeof raw;
+    expect(out.questions[0].options).toEqual(["a", "b", "c"]);
   });
 });


### PR DESCRIPTION
Prod-bug: samtale-basert endring av MCQ-spørsmål feilet med 500. To distinkte kode-bugs i `reviseMcqQuestions` (bekreftet revise-spesifikke — prod Azure OpenAI er riktig konfigurert, annen authoring virker):

1. **Over-produserte alternativer:** LLM-en returnerte av og til et spørsmål med **>6** svaralternativer; codec-en tillater maks 6 → hard 500 (`Array must contain at most 6 element(s)`), ingen retry. Nå **coerces** rå-svaret før validering: [`clampMcqOptionCount`](src/modules/adminContent/llmContentGenerationService.ts) klipper alternativer til maks (beholder riktig svar), rutet inn i generate/revise/localize.
2. **Heuristikk-hard-fail:** `hasMeaningfulMcqRevision` ga 500 (`did not produce a material change`) på falske negativer. Heuristikken styrer nå kun *retry*; bare en ekte no-op (revisjon byte-identisk med kilden) gir feil — ellers returneres revisjonen for forfatter-gjennomgang.

**Test:** unit-tester for coercion (7→6 alternativer, riktig svar bevart selv når det lå utenfor cap, gyldig spørsmål urørt). `tsc` rent. 56/56 i den eksisterende suiten grønne.

Closes #682. Prod-bug → bør promoteres til prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
