### PR TITLE
feat(course): synlighets-kontroll (Åpen/Begrenset) på kurs (v1.3.84, #645/#496)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,17 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.84 - 2026-06-26
+
+feat(course): synlighets-kontroll (Åpen / Begrenset) på kurs (#645/#496)
+
+`enrollmentPolicy` (OPEN/RESTRICTED) lå i datamodellen (#646) men var ikke eksponert noe sted —
+`updateCourse` ignorerte feltet, så alle kurs var låst til OPEN, og klasse-/enrollment-synlighet kunne
+ikke testes ende-til-ende. Kurs-redigeringsskjemaet har nå en **«Synlighet: Åpen / Begrenset»**-velger
+(create + update), API-et (`POST`/`PUT /courses`) tar imot `enrollmentPolicy`, og kurs-detalj-responsen
+returnerer den. Et RESTRICTED-kurs er kun synlig for individuelt tildelte eller medlemmer av en klasse
+kurset er tildelt (#645/CL-2). Playwright-e2e dekker å sette Begrenset.
+
 ## 1.3.83 - 2026-06-26
 
 fix(authoring): samtale-basert MCQ-endring krasjet med 500 i prod (#682)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.83",
+  "version": "1.3.84",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -1040,6 +1040,7 @@ async function renderDetailView(courseId) {
   });
 
   const certLevel = course?.certificationLevel ?? "";
+  const enrollmentPolicy = course?.enrollmentPolicy ?? "OPEN";
   const pageTitle = course ? (localizedText(course.title) || "Rediger kurs") : "Opprett nytt kurs";
   const showPublishButton = canPublishCourse({
     ...course,
@@ -1093,6 +1094,14 @@ async function renderDetailView(courseId) {
             <option value="basic"${certLevel === "basic" ? " selected" : ""}>${escapeHtml(certLabel("basic"))}</option>
             <option value="intermediate"${certLevel === "intermediate" ? " selected" : ""}>${escapeHtml(certLabel("intermediate"))}</option>
             <option value="advanced"${certLevel === "advanced" ? " selected" : ""}>${escapeHtml(certLabel("advanced"))}</option>
+          </select>
+        </div>
+
+        <div class="form-field" style="margin-top: var(--space-2)">
+          <label for="enrollmentPolicy">Synlighet</label>
+          <select id="enrollmentPolicy">
+            <option value="OPEN"${enrollmentPolicy !== "RESTRICTED" ? " selected" : ""}>Åpen – synlig for alle deltakere</option>
+            <option value="RESTRICTED"${enrollmentPolicy === "RESTRICTED" ? " selected" : ""}>Begrenset – kun tildelte (individuelt eller via klasse)</option>
           </select>
         </div>
       </div>
@@ -1397,6 +1406,7 @@ async function saveCourse(courseId) {
 
   const collectedValues = collectLocaleValues();
   const certLevel = document.getElementById("certLevel")?.value ?? "";
+  const enrollmentPolicy = document.getElementById("enrollmentPolicy")?.value === "RESTRICTED" ? "RESTRICTED" : "OPEN";
   const sourceLocale = resolveCourseLocalizationSourceLocale(collectedValues, initialDetailLocaleValues);
   const effectiveValues = sourceLocale
     ? await localizeCourseCopyAcrossLocales({
@@ -1442,6 +1452,7 @@ async function saveCourse(courseId) {
           title: normalizedTitle,
           description: normalizedDescription,
           certificationLevel: certLevel || undefined,
+          enrollmentPolicy,
         }),
       });
       savedCourseId = body.course?.id;
@@ -1454,6 +1465,7 @@ async function saveCourse(courseId) {
           title: normalizedTitle,
           description: normalizedDescription,
           certificationLevel: certLevel || undefined,
+          enrollmentPolicy,
         }),
       });
     }

--- a/src/modules/course/courseCommands.ts
+++ b/src/modules/course/courseCommands.ts
@@ -8,6 +8,7 @@ export async function createCourse(input: {
   title: string;
   description?: string | null;
   certificationLevel?: string | null;
+  enrollmentPolicy?: "OPEN" | "RESTRICTED";
   actorId?: string;
 }) {
   const course = await prisma.course.create({
@@ -15,6 +16,7 @@ export async function createCourse(input: {
       title: input.title,
       description: input.description ?? null,
       certificationLevel: input.certificationLevel ?? null,
+      ...(input.enrollmentPolicy ? { enrollmentPolicy: input.enrollmentPolicy } : {}),
     },
   });
 
@@ -31,7 +33,12 @@ export async function createCourse(input: {
 
 export async function updateCourse(
   courseId: string,
-  input: { title?: string; description?: string | null; certificationLevel?: string | null },
+  input: {
+    title?: string;
+    description?: string | null;
+    certificationLevel?: string | null;
+    enrollmentPolicy?: "OPEN" | "RESTRICTED";
+  },
 ) {
   return prisma.course.update({ where: { id: courseId }, data: input });
 }

--- a/src/modules/course/courseReadModels.ts
+++ b/src/modules/course/courseReadModels.ts
@@ -48,6 +48,7 @@ export interface AdminCourseDetail {
   title: string;
   description: string | null;
   certificationLevel: string | null;
+  enrollmentPolicy: string;
   updatedAt: string;
   publishedAt: string | null;
   archivedAt: string | null;

--- a/src/routes/adminCourses.ts
+++ b/src/routes/adminCourses.ts
@@ -28,6 +28,8 @@ const courseBodySchema = z.object({
   title: localizedTextPatchSchema,
   description: localizedTextPatchSchema.optional(),
   certificationLevel: localizedTextPatchSchema.optional(),
+  // #645/#496: course visibility — OPEN (everyone) or RESTRICTED (only enrolled / class-assigned).
+  enrollmentPolicy: z.enum(["OPEN", "RESTRICTED"]).optional(),
 });
 
 const setCourseModulesBodySchema = z.object({
@@ -69,6 +71,7 @@ adminCoursesRouter.post("/", async (request, response, next) => {
       title: localizedTextCodec.serialize(parsed.data.title),
       description: parsed.data.description ? localizedTextCodec.serialize(parsed.data.description) : null,
       certificationLevel: parsed.data.certificationLevel ? localizedTextCodec.serialize(parsed.data.certificationLevel) : null,
+      enrollmentPolicy: parsed.data.enrollmentPolicy,
       actorId: request.context?.userId,
     });
     response.status(201).json({ course });
@@ -206,6 +209,7 @@ adminCoursesRouter.get("/:courseId", async (request, response, next) => {
       title: course.title,
       description: course.description,
       certificationLevel: course.certificationLevel,
+      enrollmentPolicy: course.enrollmentPolicy,
       updatedAt: course.updatedAt.toISOString(),
       publishedAt: course.publishedAt?.toISOString() ?? null,
       archivedAt: course.archivedAt?.toISOString() ?? null,
@@ -234,6 +238,7 @@ adminCoursesRouter.put("/:courseId", async (request, response, next) => {
       title: parsed.data.title ? localizedTextCodec.serialize(parsed.data.title) : undefined,
       description: parsed.data.description ? localizedTextCodec.serialize(parsed.data.description) : undefined,
       certificationLevel: parsed.data.certificationLevel ? localizedTextCodec.serialize(parsed.data.certificationLevel) : undefined,
+      enrollmentPolicy: parsed.data.enrollmentPolicy,
     });
     response.json({ course });
   } catch (error) {

--- a/test/e2e/admin-content-helpers.ts
+++ b/test/e2e/admin-content-helpers.ts
@@ -21,6 +21,7 @@ type MockCourse = {
   id: string;
   title: Record<string, string> | string;
   certificationLevel: string | null;
+  enrollmentPolicy?: "OPEN" | "RESTRICTED";
   moduleCount?: number;
   updatedAt?: string;
   publishedAt?: string | null;

--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -1039,6 +1039,47 @@ test.describe("admin content browser coverage", () => {
     await expect(archivedRow.locator('[data-action="archive"]')).toHaveCount(0);
   });
 
+  // #645/#496: the course detail form exposes a visibility (enrollmentPolicy) control so an author
+  // can make a course RESTRICTED (only visible to enrolled / class-assigned participants).
+  test("course detail can set visibility (enrollmentPolicy) to RESTRICTED", async ({ page }) => {
+    const state = await mockCommonApis(page, {
+      courses: [
+        {
+          id: "course-1",
+          title: "Labour rights",
+          description: null,
+          certificationLevel: "basic",
+          enrollmentPolicy: "OPEN",
+          moduleCount: 0,
+          updatedAt: "2026-04-18T12:00:00.000Z",
+          publishedAt: null,
+          archivedAt: null,
+          modules: [],
+        },
+      ],
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let putBody: any = null;
+    await page.route("**/api/admin/content/courses/course-1", async (route: Route) => {
+      const course = state.mutableCourses.find((c) => c.id === "course-1");
+      if (route.request().method() === "PUT") {
+        putBody = route.request().postDataJSON();
+        if (course) course.enrollmentPolicy = putBody.enrollmentPolicy;
+      }
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ course }) });
+    });
+
+    await page.goto("/admin-content/courses/course-1");
+
+    const select = page.locator("#enrollmentPolicy");
+    await expect(select).toBeVisible();
+    await expect(select).toHaveValue("OPEN");
+    await select.selectOption("RESTRICTED");
+    await page.locator("#saveCourseBtn").click();
+
+    await expect.poll(() => putBody?.enrollmentPolicy).toBe("RESTRICTED");
+  });
+
   test("shell idle flow opens the module picker and renders existing module choices", async ({ page }) => {
     await mockCommonApis(page, {
       modules: [


### PR DESCRIPTION
Funnet under stage-verifisering (Test 3): det fantes **ingen måte å sette et kurs til «Begrenset»** — `enrollmentPolicy` lå i datamodellen (#646) men var ikke eksponert (`updateCourse` ignorerte feltet), så alle kurs var låst til OPEN og klasse-/enrollment-synlighetsfilteret hadde ingenting å virke på.

**Fiks:**
- **API:** `courseBodySchema` + `createCourse`/`updateCourse` + detalj-respons tar imot/returnerer `enrollmentPolicy` (OPEN/RESTRICTED).
- **UI:** kurs-redigeringsskjemaet har en **«Synlighet: Åpen / Begrenset»**-velger ([admin-content-courses.js](public/static/admin-content-courses.js)), wiret i både create og update.
- Et RESTRICTED-kurs er kun synlig for individuelt tildelte eller medlemmer av en klasse kurset er tildelt (#645/CL-2).

**Test:** Playwright-e2e — last kursdetalj, velg «Begrenset», lagre, verifiser at PUT-body har `enrollmentPolicy=RESTRICTED`. `tsc` rent.

Låser opp ende-til-ende-testing av klasse-synlighet (Test 3 i v1.3.81-testskriptet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
