### PR TITLE
feat(classes): e-postvarsel når klassen tildeles et kurs (v1.3.85, #684)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,18 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.85 - 2026-06-26
+
+feat(classes): e-postvarsel til studenter når klassen tildeles et kurs (#684)
+
+Når en MANUAL-klasse tildeles et kurs (#675), får hvert medlem en e-post med kursnavn, evt. frist og
+lenke til deltaker-arbeidsflaten. **Unntak:** systemklassen «Alle deltakere» (ville spammet hele
+organisasjonen) og ENTRA-klasser (ingen lagrede medlemsrader). Gjenbruker
+`participantNotificationService` (kanal-dispatch: `log` i dev/test, `acs_email` på stage/prod).
+**Fire-and-forget:** tildelingen lykkes og blokkeres aldri av e-post. Ny valgfri config
+`PUBLIC_APP_BASE_URL` for absolutt kurs-lenke (uten den: e-posten ber bruker logge inn). Unit-tester
+for varsel-bygging (emne/tekst/lenke + login-fallback).
+
 ## 1.3.84 - 2026-06-26
 
 feat(course): synlighets-kontroll (Åpen / Begrenset) på kurs (#645/#496)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.84",
+  "version": "1.3.85",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -89,6 +89,13 @@ const envSchema = z.object({
     (value) => (typeof value === "string" && value.trim().length === 0 ? undefined : value),
     z.string().optional(),
   ),
+  // #684: public base URL of the participant app, used to build absolute course links in
+  // notification emails (e.g. class course-assignment). Optional — when unset, emails omit the
+  // clickable link and ask the participant to log in instead.
+  PUBLIC_APP_BASE_URL: z.preprocess(
+    (value) => (typeof value === "string" && value.trim().length === 0 ? undefined : value),
+    z.string().url().optional(),
+  ),
   ACS_EMAIL_SENDER_DISPLAY_NAME: z.string().default("A2 Assessment Platform"),
   PARTICIPANT_CONSOLE_CONFIG_FILE: z.string().default("config/participant-console.json"),
   PARTICIPANT_CONSOLE_DEBUG_MODE: z.enum(["auto", "true", "false"]).default("auto"),

--- a/src/modules/certification/participantNotificationService.ts
+++ b/src/modules/certification/participantNotificationService.ts
@@ -354,3 +354,52 @@ export async function notifyAppealStatusTransition(input: AppealNotificationInpu
     },
   });
 }
+
+// #684: notify a participant that their class was assigned a course. Reuses the same channel
+// dispatch (disabled/log/acs_email) as other participant notifications. Webhook is treated as a
+// log for this notification type. Norwegian copy (primary locale).
+export interface CourseAssignmentNotificationInput {
+  recipientEmail: string;
+  recipientName?: string | null;
+  courseTitle: string;
+  className: string;
+  dueAt?: Date | null;
+  courseUrl?: string | null;
+}
+
+export async function sendCourseAssignmentNotification(
+  input: CourseAssignmentNotificationInput,
+): Promise<NotificationResult> {
+  const subject = `Nytt kurs tildelt: ${input.courseTitle}`;
+  const dueLine = input.dueAt ? `\nFrist: ${input.dueAt.toISOString().slice(0, 10)}.` : "";
+  const linkLine = input.courseUrl
+    ? `\n\nGå til kurset: ${input.courseUrl}`
+    : "\n\nLogg inn på plattformen for å starte.";
+  const body = `Hei!\n\nKlassen din «${input.className}» har blitt tildelt kurset «${input.courseTitle}».${dueLine}${linkLine}`;
+
+  const payload = {
+    notificationType: "class_course_assignment",
+    courseTitle: input.courseTitle,
+    className: input.className,
+    recipient: { email: input.recipientEmail, name: input.recipientName ?? null },
+    subject,
+    emittedAt: new Date().toISOString(),
+  };
+
+  const channel = env.PARTICIPANT_NOTIFICATION_CHANNEL;
+  if (channel === "disabled") {
+    return { delivered: false, channel, subject, nextStepGuidance: body, failureReason: "channel_disabled" };
+  }
+  if (channel === "acs_email") {
+    return sendViaAcs({
+      recipientEmail: input.recipientEmail,
+      recipientName: input.recipientName ?? undefined,
+      subject,
+      body,
+      logPayload: payload,
+    });
+  }
+  // log channel (and webhook → log for this notification type).
+  logOperationalEvent(operationalEvents.certification.participantNotificationSent, { channel, ...payload });
+  return { delivered: true, channel, subject, nextStepGuidance: body };
+}

--- a/src/modules/course/classService.ts
+++ b/src/modules/course/classService.ts
@@ -2,6 +2,9 @@ import { prisma } from "../../db/prisma.js";
 import { NotFoundError, ValidationError } from "../../errors/AppError.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
+import { env } from "../../config/env.js";
+import { localizeContentText } from "../../i18n/content.js";
+import { sendCourseAssignmentNotification } from "../certification/participantNotificationService.js";
 import { classRepository, SYSTEM_ALL_PARTICIPANTS_CLASS_ID } from "./classRepository.js";
 import { isClassEntraLinkingEnabled } from "./classConfig.js";
 
@@ -90,8 +93,8 @@ export async function listClassCourseAssignments(classId: string) {
 }
 
 export async function assignCourseToClass(courseId: string, classId: string, dueAt: Date | null, actorId: string | null) {
-  await requireClass(classId);
-  const course = await prisma.course.findUnique({ where: { id: courseId }, select: { id: true } });
+  const klass = await requireClass(classId);
+  const course = await prisma.course.findUnique({ where: { id: courseId }, select: { id: true, title: true } });
   if (!course) throw new NotFoundError("Course", "course_not_found", "Course not found.");
   await classRepository.assignCourseToClass(courseId, classId, dueAt, actorId);
   await recordAuditEvent({
@@ -101,6 +104,42 @@ export async function assignCourseToClass(courseId: string, classId: string, due
     actorId: actorId ?? undefined,
     metadata: { classId, courseId },
   });
+
+  // #684: email the members that their class was assigned a course. Skipped for the "Alle deltakere"
+  // system class (would email the whole org) and for ENTRA classes (no stored member rows). Fire-and-
+  // forget so the assignment is not blocked or failed by email delivery.
+  if (klass.kind === "MANUAL" && !klass.isSystem) {
+    void notifyClassMembersOfCourseAssignment(classId, klass.name, course.title, dueAt);
+  }
+}
+
+async function notifyClassMembersOfCourseAssignment(
+  classId: string,
+  className: string,
+  courseTitleJson: string,
+  dueAt: Date | null,
+): Promise<void> {
+  try {
+    const courseTitle = localizeContentText("nb", courseTitleJson) ?? courseTitleJson;
+    const courseUrl = env.PUBLIC_APP_BASE_URL ? `${env.PUBLIC_APP_BASE_URL.replace(/\/+$/, "")}/participant` : null;
+    const members = await classRepository.listMembers(classId);
+    await Promise.allSettled(
+      members
+        .filter((m) => m.user.email)
+        .map((m) =>
+          sendCourseAssignmentNotification({
+            recipientEmail: m.user.email,
+            recipientName: m.user.name,
+            courseTitle,
+            className,
+            dueAt,
+            courseUrl,
+          }),
+        ),
+    );
+  } catch {
+    /* never let notification failure surface — assignment already succeeded */
+  }
 }
 
 export async function unassignCourseFromClass(courseId: string, classId: string, actorId: string | null) {

--- a/test/unit/course-assignment-notification.test.ts
+++ b/test/unit/course-assignment-notification.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { sendCourseAssignmentNotification } from "../../src/modules/certification/participantNotificationService.js";
+
+// #684: class course-assignment email. In the default "log" channel (dev/test) it does not send a
+// real email — it returns a delivered result with the built subject/body. These tests pin the copy
+// and the link behaviour without touching ACS.
+
+describe("sendCourseAssignmentNotification (#684)", () => {
+  it("builds a subject + body with the course title, class name, due date and link", async () => {
+    const result = await sendCourseAssignmentNotification({
+      recipientEmail: "kari@example.test",
+      recipientName: "Kari",
+      courseTitle: "Arbeidsmiljø",
+      className: "Onboarding 2026",
+      dueAt: new Date("2026-09-01T00:00:00.000Z"),
+      courseUrl: "https://app.example.test/participant",
+    });
+
+    expect(result.delivered).toBe(true);
+    expect(result.channel).toBe("log");
+    expect(result.subject).toContain("Arbeidsmiljø");
+    expect(result.nextStepGuidance).toContain("Onboarding 2026");
+    expect(result.nextStepGuidance).toContain("Arbeidsmiljø");
+    expect(result.nextStepGuidance).toContain("2026-09-01");
+    expect(result.nextStepGuidance).toContain("https://app.example.test/participant");
+  });
+
+  it("falls back to a login prompt when no course URL is configured", async () => {
+    const result = await sendCourseAssignmentNotification({
+      recipientEmail: "ola@example.test",
+      courseTitle: "Brannvern",
+      className: "Kull B",
+      dueAt: null,
+      courseUrl: null,
+    });
+
+    expect(result.delivered).toBe(true);
+    expect(result.nextStepGuidance).toContain("Logg inn");
+    expect(result.nextStepGuidance).not.toContain("http");
+  });
+});


### PR DESCRIPTION
Når en klasse tildeles et kurs, får hvert medlem en e-post med kursnavn, evt. frist og lenke. Closes #684.

**Oppførsel:**
- Kun **MANUAL**-klasser med medlemmer. **Hopper over** systemklassen «Alle deltakere» (ville spammet hele org) og ENTRA-klasser (ingen medlemsrader).
- Gjenbruker [`participantNotificationService`](src/modules/certification/participantNotificationService.ts) sin kanal-dispatch: `log` (dev/test, logger kun) / `acs_email` (stage/prod, faktisk send).
- **Fire-and-forget** ([classService.ts](src/modules/course/classService.ts)): tildelingen lykkes umiddelbart og blokkeres/feiler aldri av e-post; feil svelges.
- Ny valgfri config **`PUBLIC_APP_BASE_URL`** for absolutt kurs-lenke. Uten den: e-posten ber bruker logge inn (degraderer pent).

**Test:** unit-tester for varsel-bygging (emne/tekst/frist/lenke + login-fallback). Eksisterende `m2-classes`-integrasjonstester dekker at tildeling til manuell klasse m/medlem og systemklasse fortsatt lykkes. `tsc` rent.

**Infra-oppfølging (ikke i denne PR-en):** for klikkbar lenke i stage/prod, sett `PUBLIC_APP_BASE_URL`-app-setting (stg-app-x6eyx4 / prd-app-hea5kl). Funksjonen virker uten (login-prompt). `PARTICIPANT_NOTIFICATION_CHANNEL=acs_email` er allerede satt på begge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
