### PR TITLE
fix: stage-funn for v1.3.85 — MCQ-revise datatap + arkiverte kurs + fjern e-post-lenke (v1.3.86, #688)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,18 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.86 - 2026-06-26
+
+fix: stage-funn for v1.3.85 — MCQ-revise datatap, arkiverte kurs, e-post-lenke (#688)
+
+Tre funn under stage-verifisering: (1) **MCQ-revise reduserte spørsmål** — «Endre alternativ 1b»
+kollapset 10 → 1 spørsmål (LLM droppet de andre, heuristikken godtok det). For en målrettet endring
+(eksplisitt mål) MÅ antallet nå bevares; ellers retry, så avvis med tydelig melding (ikke stille
+datatap). (2) **Arkiverte kurs var tildelbare** i klasse-oversikten — nå filtrert bort i UI + backend-
+vakt (`assignCourseToClass` avviser arkivert kurs med 400). (3) **E-post-lenke fjernet** —
+firmapolicy forbyr e-post med lenker (spoofing); varselet ber nå bruker logge inn selv, og
+`PUBLIC_APP_BASE_URL`-config er fjernet (#687 lukket). Unit-/integrasjons-/e2e-tester dekker alle tre.
+
 ## 1.3.85 - 2026-06-26
 
 feat(classes): e-postvarsel til studenter når klassen tildeles et kurs (#684)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.85",
+  "version": "1.3.86",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-classes.js
+++ b/public/static/admin-content-classes.js
@@ -104,7 +104,8 @@ async function openClass(id) {
   const memberChips = members.map((m) => `<span class="chip">${escapeHtml(m.name)} <button data-remove-member="${escapeHtml(m.userId)}" aria-label="Fjern ${escapeHtml(m.name)}">×</button></span>`).join("");
   const courseChips = courses.map((c) => `<span class="chip">${escapeHtml(courseTitle(c.title))} <button data-remove-course="${escapeHtml(c.courseId)}" aria-label="Fjern kurs">×</button></span>`).join("");
   const assignedIds = new Set(courses.map((c) => c.courseId));
-  const courseOptions = allCourses.filter((c) => !assignedIds.has(c.id)).map((c) => `<option value="${escapeHtml(c.id)}">${escapeHtml(courseTitle(c.title))}</option>`).join("");
+  // #688: don't offer archived courses for assignment — they are retired and shouldn't be assigned.
+  const courseOptions = allCourses.filter((c) => !assignedIds.has(c.id) && !c.archivedAt).map((c) => `<option value="${escapeHtml(c.id)}">${escapeHtml(courseTitle(c.title))}</option>`).join("");
   pageContent.innerHTML = `
     <a class="back-link" id="backToClasses">← Tilbake til klasser</a>
     <div class="page-header"><h1>Klasse</h1></div>

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -89,13 +89,6 @@ const envSchema = z.object({
     (value) => (typeof value === "string" && value.trim().length === 0 ? undefined : value),
     z.string().optional(),
   ),
-  // #684: public base URL of the participant app, used to build absolute course links in
-  // notification emails (e.g. class course-assignment). Optional — when unset, emails omit the
-  // clickable link and ask the participant to log in instead.
-  PUBLIC_APP_BASE_URL: z.preprocess(
-    (value) => (typeof value === "string" && value.trim().length === 0 ? undefined : value),
-    z.string().url().optional(),
-  ),
   ACS_EMAIL_SENDER_DISPLAY_NAME: z.string().default("A2 Assessment Platform"),
   PARTICIPANT_CONSOLE_CONFIG_FILE: z.string().default("config/participant-console.json"),
   PARTICIPANT_CONSOLE_DEBUG_MODE: z.enum(["auto", "true", "false"]).default("auto"),

--- a/src/modules/adminContent/llmContentGenerationService.ts
+++ b/src/modules/adminContent/llmContentGenerationService.ts
@@ -1537,8 +1537,18 @@ export async function reviseMcqQuestions(input: McqRevisionInput): Promise<McqGe
     correctAnswer: localizeForPrompt(question.correctAnswer, input.locale),
     rationale: localizeForPrompt(question.rationale, input.locale),
   }));
+  // #688: a TARGETED edit (e.g. "endre alternativ 1b") must edit one question in place and keep the
+  // rest — it must NOT change the question count. The LLM sometimes collapses to just the edited
+  // question (10 → 1, silent data loss). For instructions with an explicit target, require the count
+  // to be preserved; for open-ended instructions, allow the count to change.
+  const hasExplicitTarget = extractMcqRevisionTargets(input.instruction).length > 0;
+  const countPreserved = (revised: GeneratedMcqQuestion[]) =>
+    !hasExplicitTarget || revised.length === sourceQuestions.length;
+  const isAcceptable = (revised: GeneratedMcqQuestion[]) =>
+    hasMeaningfulMcqRevision(sourceQuestions, revised, input.instruction) && countPreserved(revised);
+
   const firstAttempt = await parseRevision(userPrompt);
-  if (hasMeaningfulMcqRevision(sourceQuestions, firstAttempt.questions, input.instruction)) {
+  if (isAcceptable(firstAttempt.questions)) {
     return firstAttempt;
   }
 
@@ -1548,13 +1558,21 @@ export async function reviseMcqQuestions(input: McqRevisionInput): Promise<McqGe
 
 Your previous attempt did not apply the requested change concretely enough.
 If the instruction names a specific question or option reference such as "question 3", "Q3", "3b", or "option B in question 3", you must change that exact target in a clearly visible way.
+You MUST return ALL ${sourceQuestions.length} questions — edit only the targeted one(s) and keep every other question unchanged. Do not drop, merge, or add questions.
 Return a revised question set where the requested change is concrete, visible, and materially different from the source questions.`;
   const secondAttempt = await parseRevision(retryPrompt);
 
-  // #682: the "meaningful revision" heuristic drives the RETRY, but it must not hard-fail the edit
-  // with a 500 on a false negative (e.g. the change landed but not on the exact parsed target). Only
-  // a genuine no-op — a revision byte-identical to the source — is worth surfacing as an error.
-  // Otherwise return the revision; the author reviews it and can re-instruct if it missed.
+  // A targeted edit that still dropped/changed the question count is wrong — reject rather than
+  // silently lose questions (#688).
+  if (!countPreserved(secondAttempt.questions)) {
+    throw new Error(
+      `MCQ revision unexpectedly changed the number of questions (${sourceQuestions.length} → ${secondAttempt.questions.length}). ` +
+        `Please make the instruction more specific (e.g. name the exact question and option) and try again.`,
+    );
+  }
+
+  // #682: the "meaningful revision" heuristic drives the RETRY, but must not hard-fail on a false
+  // negative. Only a genuine no-op — byte-identical to the source — is surfaced as an error.
   if (normalizeGeneratedMcqQuestions(sourceQuestions) === normalizeGeneratedMcqQuestions(secondAttempt.questions)) {
     throw new Error("MCQ revision produced no change. Please describe the change you want and try again.");
   }

--- a/src/modules/certification/participantNotificationService.ts
+++ b/src/modules/certification/participantNotificationService.ts
@@ -358,13 +358,15 @@ export async function notifyAppealStatusTransition(input: AppealNotificationInpu
 // #684: notify a participant that their class was assigned a course. Reuses the same channel
 // dispatch (disabled/log/acs_email) as other participant notifications. Webhook is treated as a
 // log for this notification type. Norwegian copy (primary locale).
+//
+// #688: the email contains NO link. Company policy forbids emails with links (phishing / spoofing
+// risk) — the participant is told to log in to the platform themselves.
 export interface CourseAssignmentNotificationInput {
   recipientEmail: string;
   recipientName?: string | null;
   courseTitle: string;
   className: string;
   dueAt?: Date | null;
-  courseUrl?: string | null;
 }
 
 export async function sendCourseAssignmentNotification(
@@ -372,10 +374,7 @@ export async function sendCourseAssignmentNotification(
 ): Promise<NotificationResult> {
   const subject = `Nytt kurs tildelt: ${input.courseTitle}`;
   const dueLine = input.dueAt ? `\nFrist: ${input.dueAt.toISOString().slice(0, 10)}.` : "";
-  const linkLine = input.courseUrl
-    ? `\n\nGå til kurset: ${input.courseUrl}`
-    : "\n\nLogg inn på plattformen for å starte.";
-  const body = `Hei!\n\nKlassen din «${input.className}» har blitt tildelt kurset «${input.courseTitle}».${dueLine}${linkLine}`;
+  const body = `Hei!\n\nKlassen din «${input.className}» har blitt tildelt kurset «${input.courseTitle}».${dueLine}\n\nLogg inn på plattformen for å starte.`;
 
   const payload = {
     notificationType: "class_course_assignment",

--- a/src/modules/course/classService.ts
+++ b/src/modules/course/classService.ts
@@ -2,7 +2,6 @@ import { prisma } from "../../db/prisma.js";
 import { NotFoundError, ValidationError } from "../../errors/AppError.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
-import { env } from "../../config/env.js";
 import { localizeContentText } from "../../i18n/content.js";
 import { sendCourseAssignmentNotification } from "../certification/participantNotificationService.js";
 import { classRepository, SYSTEM_ALL_PARTICIPANTS_CLASS_ID } from "./classRepository.js";
@@ -94,8 +93,10 @@ export async function listClassCourseAssignments(classId: string) {
 
 export async function assignCourseToClass(courseId: string, classId: string, dueAt: Date | null, actorId: string | null) {
   const klass = await requireClass(classId);
-  const course = await prisma.course.findUnique({ where: { id: courseId }, select: { id: true, title: true } });
+  const course = await prisma.course.findUnique({ where: { id: courseId }, select: { id: true, title: true, archivedAt: true } });
   if (!course) throw new NotFoundError("Course", "course_not_found", "Course not found.");
+  // #688: archived courses are retired and must not be assignable to a class.
+  if (course.archivedAt) throw new ValidationError("Cannot assign an archived course.");
   await classRepository.assignCourseToClass(courseId, classId, dueAt, actorId);
   await recordAuditEvent({
     entityType: auditEntityTypes.class,
@@ -121,7 +122,6 @@ async function notifyClassMembersOfCourseAssignment(
 ): Promise<void> {
   try {
     const courseTitle = localizeContentText("nb", courseTitleJson) ?? courseTitleJson;
-    const courseUrl = env.PUBLIC_APP_BASE_URL ? `${env.PUBLIC_APP_BASE_URL.replace(/\/+$/, "")}/participant` : null;
     const members = await classRepository.listMembers(classId);
     await Promise.allSettled(
       members
@@ -133,7 +133,6 @@ async function notifyClassMembersOfCourseAssignment(
             courseTitle,
             className,
             dueAt,
-            courseUrl,
           }),
         ),
     );

--- a/test/e2e/admin-content-classes.spec.ts
+++ b/test/e2e/admin-content-classes.spec.ts
@@ -67,7 +67,17 @@ test("classes admin: list, create, add a student via search, and assign a course
     route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ users: [{ id: "u1", name: "Kari Nordmann", email: "kari@x.no" }] }) }),
   );
   await page.route("**/api/admin/content/courses", (route: Route) =>
-    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ courses: [{ id: "course-1", title: JSON.stringify({ nb: "Arbeidsmiljø" }) }] }) }),
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        courses: [
+          { id: "course-1", title: JSON.stringify({ nb: "Arbeidsmiljø" }), archivedAt: null },
+          // #688: archived courses must NOT be offered for assignment.
+          { id: "course-arch", title: JSON.stringify({ nb: "Gammelt kurs" }), archivedAt: "2026-01-01T00:00:00.000Z" },
+        ],
+      }),
+    }),
   );
 
   await page.addInitScript(() => { try { localStorage.setItem("participant.locale", "nb"); } catch { /* ignore */ } });
@@ -92,6 +102,10 @@ test("classes admin: list, create, add a student via search, and assign a course
   await page.locator('[data-add-user="u1"]').click();
   await expect.poll(() => memberPosted).toBe(true);
   await expect(page.locator("#memberChips")).toContainText("Kari Nordmann");
+
+  // #688: the archived course must not be an assignable option; the active one must.
+  await expect(page.locator('#courseSelect option[value="course-arch"]')).toHaveCount(0);
+  await expect(page.locator('#courseSelect option[value="course-1"]')).toHaveCount(1);
 
   // Assign a course.
   await page.locator("#courseSelect").selectOption("course-1");

--- a/test/m2-classes.test.ts
+++ b/test/m2-classes.test.ts
@@ -106,4 +106,21 @@ describe("Class (cohort) management + dynamic assignment (#645/CL-2)", () => {
     expect((await request(app).delete(`/api/admin/content/classes/${SYSTEM_ALL_PARTICIPANTS_CLASS_ID}`).set(adminHeaders)).status).toBe(400);
     expect((await request(app).post("/api/admin/content/classes").set(participantHeaders(`cls-forbid-${Date.now()}`)).send({ name: "Nope" })).status).toBe(403);
   });
+
+  // #688: archived courses must not be assignable to a class.
+  it("refuses to assign an archived course to a class", async () => {
+    const courseId = await createRestrictedCourse();
+    await prisma.course.update({ where: { id: courseId }, data: { archivedAt: new Date() } });
+    const created = await request(app).post("/api/admin/content/classes").set(adminHeaders).send({ name: "Kull arch" });
+    const classId = created.body.class.id as string;
+
+    const res = await request(app)
+      .post(`/api/admin/content/classes/${classId}/courses`)
+      .set(adminHeaders)
+      .send({ courseId });
+    expect(res.status).toBe(400);
+
+    await prisma.class.delete({ where: { id: classId } });
+    await prisma.course.delete({ where: { id: courseId } });
+  });
 });

--- a/test/unit/course-assignment-notification.test.ts
+++ b/test/unit/course-assignment-notification.test.ts
@@ -1,19 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { sendCourseAssignmentNotification } from "../../src/modules/certification/participantNotificationService.js";
 
-// #684: class course-assignment email. In the default "log" channel (dev/test) it does not send a
-// real email — it returns a delivered result with the built subject/body. These tests pin the copy
-// and the link behaviour without touching ACS.
+// #684/#688: class course-assignment email. In the default "log" channel (dev/test) it does not send
+// a real email — it returns a delivered result with the built subject/body. The email contains NO
+// link (company policy: no links in email); it asks the participant to log in themselves.
 
-describe("sendCourseAssignmentNotification (#684)", () => {
-  it("builds a subject + body with the course title, class name, due date and link", async () => {
+describe("sendCourseAssignmentNotification (#684/#688)", () => {
+  it("builds a subject + body with the course title, class name and due date", async () => {
     const result = await sendCourseAssignmentNotification({
       recipientEmail: "kari@example.test",
       recipientName: "Kari",
       courseTitle: "Arbeidsmiljø",
       className: "Onboarding 2026",
       dueAt: new Date("2026-09-01T00:00:00.000Z"),
-      courseUrl: "https://app.example.test/participant",
     });
 
     expect(result.delivered).toBe(true);
@@ -22,16 +21,14 @@ describe("sendCourseAssignmentNotification (#684)", () => {
     expect(result.nextStepGuidance).toContain("Onboarding 2026");
     expect(result.nextStepGuidance).toContain("Arbeidsmiljø");
     expect(result.nextStepGuidance).toContain("2026-09-01");
-    expect(result.nextStepGuidance).toContain("https://app.example.test/participant");
   });
 
-  it("falls back to a login prompt when no course URL is configured", async () => {
+  it("contains NO link — asks the participant to log in (company policy, #688)", async () => {
     const result = await sendCourseAssignmentNotification({
       recipientEmail: "ola@example.test",
       courseTitle: "Brannvern",
       className: "Kull B",
       dueAt: null,
-      courseUrl: null,
     });
 
     expect(result.delivered).toBe(true);

--- a/test/unit/llm-content-generation-service.test.ts
+++ b/test/unit/llm-content-generation-service.test.ts
@@ -710,3 +710,15 @@ describe("clampMcqOptionCount (#682)", () => {
     expect(out.questions[0].options).toEqual(["a", "b", "c"]);
   });
 });
+
+// #688: a targeted edit like "endre alternativ 1b" must engage the question-count guard so the LLM
+// cannot collapse 10 questions to 1. The guard keys off extractMcqRevisionTargets being non-empty.
+describe("extractMcqRevisionTargets — count-guard trigger (#688)", () => {
+  it("finds an explicit target for a Norwegian 'alternativ 1b' instruction", () => {
+    expect(extractMcqRevisionTargets("Endre alternativ 1b").length).toBeGreaterThan(0);
+  });
+
+  it("returns no targets for an open-ended instruction (count may change)", () => {
+    expect(extractMcqRevisionTargets("Gjør spørsmålene vanskeligere")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Tre funn under stage-verifisering av v1.3.85. Closes #688.

1. **MCQ-revise datatap (#683-oppfølging):** «Endre alternativ 1b» reduserte 10 → 1 spørsmål — LLM-en kollapset til det redigerte spørsmålet, og heuristikken godtok det. Nå: for en **målrettet** endring (eksplisitt mål via `extractMcqRevisionTargets`) MÅ spørsmåls-antallet bevares; ellers retry med direktiv, så avvis med tydelig melding (ikke stille datatap). Åpne instruksjoner kan fortsatt endre antallet.
2. **Arkiverte kurs tildelbare:** klasse-UI-ets nedtrekksliste viste arkiverte kurs. Nå filtrert bort i UI ([admin-content-classes.js](public/static/admin-content-classes.js)) + backend-vakt ([classService.ts](src/modules/course/classService.ts) — `assignCourseToClass` avviser arkivert kurs med 400).
3. **E-post-lenke fjernet (firmapolicy):** policy forbyr e-post med lenker (spoofing/phishing). Varselet inneholder nå **ingen lenke** — ber bruker logge inn selv. `PUBLIC_APP_BASE_URL`-config fjernet; **#687 lukkes** (Bicep-oppfølging ikke lenger relevant).

**Test:** unit (count-guard-trigger + clamp + notification uten lenke), integrasjon (assign arkivert → 400), e2e (arkivert kurs ikke i nedtrekks). `tsc` rent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
