### PR TITLE
feat(orgsync): automatisk Entra-brukersynk for klasse-tildeling (v1.3.87, #690)

### DIFF
--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -260,6 +260,7 @@ without auth headers. `GET /api/courses/completions/:certificateId` returns
 |---|---|---|
 | `POST` | `/api/admin/sync/org` | ADMINISTRATOR |
 | `POST` | `/api/admin/sync/org/delta` | ADMINISTRATOR |
+| `POST` | `/api/admin/sync/org/entra` | ADMINISTRATOR — import the configured Entra group's members (Graph, managed identity) as platform users so they're searchable before first login. `400` if `ENTRA_USER_SYNC_GROUP_ID` is unset. Runbook: `doc/ops/ENTRA_USER_SYNC_690.md` (#690). |
 
 ---
 

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,20 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.87 - 2026-06-26
+
+feat(orgsync): automatisk Entra-brukersynk for klasse-tildeling (#690)
+
+Plattformen provisjonerer brukere just-in-time ved innlogging, så en ansatt er ikke søkbar/tildelbar
+før hen har logget inn første gang. Ny **Entra-brukersynk** importerer medlemmene av ansatt-gruppa
+«Alle i A-2 Norge» (~61, ikke de 246 tenant-objektene som mest er gjester) til `User`-tabellen via
+Microsoft Graph (managed identity) → `applyOrgDeltaSync` (upsert, `externalId = oid`). On-demand:
+admin-knapp **«Synk brukere fra Entra»** på Klasser-siden + `POST /api/admin/sync/org/entra`
+(ADMINISTRATOR). Planlagt: `EntraUserSyncMonitor` i worker (default 24h), kun aktiv når
+`ENTRA_USER_SYNC_GROUP_ID` er satt. ⚠️ Krever ett Entra-admin-steg: gi app-ens managed identity
+Graph-permission `GroupMember.Read.All` (+ `User.Read.All`) med consent — se
+`doc/ops/ENTRA_USER_SYNC_690.md`. Mapping-unit-tester + e2e (admin-only knapp + POST).
+
 ## 1.3.86 - 2026-06-26
 
 fix: stage-funn for v1.3.85 — MCQ-revise datatap, arkiverte kurs, e-post-lenke (#688)

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -12,9 +12,12 @@ før hen har logget inn første gang. Ny **Entra-brukersynk** importerer medlemm
 Microsoft Graph (managed identity) → `applyOrgDeltaSync` (upsert, `externalId = oid`). On-demand:
 admin-knapp **«Synk brukere fra Entra»** på Klasser-siden + `POST /api/admin/sync/org/entra`
 (ADMINISTRATOR). Planlagt: `EntraUserSyncMonitor` i worker (default 24h), kun aktiv når
-`ENTRA_USER_SYNC_GROUP_ID` er satt. ⚠️ Krever ett Entra-admin-steg: gi app-ens managed identity
-Graph-permission `GroupMember.Read.All` (+ `User.Read.All`) med consent — se
-`doc/ops/ENTRA_USER_SYNC_690.md`. Mapping-unit-tester + e2e (admin-only knapp + POST).
+`ENTRA_USER_SYNC_GROUP_ID` er satt. ⚠️ Den automatiske Graph-pullen krever ett Entra-admin-steg: gi
+app-ens managed identity Graph-permission `GroupMember.Read.All` (+ `User.Read.All`) med consent
+(katalogrolle, ikke subscription-Owner). **Stopgap som virker uten consent:** admin-knapp **«Importer
+brukere fra fil»** på Klasser-siden tar imot en JSON eksportert med admins egen delegerte tilgang
+(`az ad group member list`) og kjører samme upsert via `POST /api/admin/sync/org/delta`. Se
+`doc/ops/ENTRA_USER_SYNC_690.md`. Mapping-unit-tester + e2e (admin-only Graph-knapp + POST, fil-import).
 
 ## 1.3.86 - 2026-06-26
 

--- a/doc/ops/ENTRA_USER_SYNC_690.md
+++ b/doc/ops/ENTRA_USER_SYNC_690.md
@@ -1,0 +1,66 @@
+# Entra user sync (#690) — runbook
+
+Imports the members of an Entra group (the **employee** group «Alle i A-2 Norge», ~61 people) into
+the platform's `User` table so they are **searchable/assignable for class membership before their
+first login**. Reconciliation key is `externalId = Entra object id` (the `oid` claim), so a later
+login maps to the same row.
+
+> Why this exists: the platform provisions users **just-in-time on login**. Before #690, only people
+> who had logged in were searchable. The tenant has 246 objects but only ~61 are real employees
+> (the rest are guests/external/customer/service accounts), so a blanket import is wrong — we scope
+> to the employee group.
+
+## Components (shipped)
+- Service `src/modules/orgSync/entraUserSyncService.ts` — Graph pull (managed identity) → map →
+  `applyOrgDeltaSync` (upsert). Skips non-user/disabled/no-email members.
+- Endpoint `POST /api/admin/sync/org/entra` (ADMINISTRATOR) — run on demand.
+- Admin button **«Synk brukere fra Entra»** on `/admin-content/classes` (ADMINISTRATOR only).
+- Scheduled `EntraUserSyncMonitor` (worker, default every 24h) — only runs when configured.
+
+## Config (per environment)
+| Setting | Value |
+|---|---|
+| `ENTRA_USER_SYNC_GROUP_ID` | prod «Alle i A-2 Norge» = `8bab5ab4-c7db-4c9c-baad-316e1ff63504` |
+| `ENTRA_USER_SYNC_INTERVAL_MS` | optional, default `86400000` (24h) |
+
+Set as a (non-secret) app setting on **both web and worker** apps. Add to `infra/azure/main.bicep`
+for durability (a manual `az` value is wiped by a full infra deploy — see #687 pattern).
+
+## ⚠️ One-time Entra admin step — Graph permission + consent (BLOCKER)
+The app calls Graph as its **managed identity** (`DefaultAzureCredential`). That identity must hold
+the Graph **application** permissions, granted by an Entra **admin** (Privileged Role / Global Admin).
+Until this is done, the sync returns 403 and imports nobody.
+
+Grant `GroupMember.Read.All` (and `User.Read.All` for `department`/`accountEnabled`) to the web app's
+managed identity (run against the **production** tenant):
+
+```bash
+az account set --subscription 5b3f760b-42d4-4d78-812c-c059278d1086   # prod
+
+MI=$(az webapp identity show -n a2-assessment-platform-prd-app-hea5kl -g rg-a2-assessment-production --query principalId -o tsv)
+GRAPH=$(az ad sp list --filter "appId eq '00000003-0000-0000-c000-000000000000'" --query "[0].id" -o tsv)
+
+# GroupMember.Read.All
+az rest --method POST --uri "https://graph.microsoft.com/v1.0/servicePrincipals/$MI/appRoleAssignments" \
+  --headers "Content-Type=application/json" \
+  --body "{\"principalId\":\"$MI\",\"resourceId\":\"$GRAPH\",\"appRoleId\":\"98830695-27a2-44f7-8c18-0c3ebc9698f6\"}"
+# User.Read.All
+az rest --method POST --uri "https://graph.microsoft.com/v1.0/servicePrincipals/$MI/appRoleAssignments" \
+  --headers "Content-Type=application/json" \
+  --body "{\"principalId\":\"$MI\",\"resourceId\":\"$GRAPH\",\"appRoleId\":\"df021288-bdef-4463-88db-98f22de89214\"}"
+```
+
+(App-role ids: `GroupMember.Read.All` = `98830695-27a2-44f7-8c18-0c3ebc9698f6`, `User.Read.All` =
+`df021288-bdef-4463-88db-98f22de89214` — verify against the Graph SP's `appRoles` if Microsoft
+changes them.) Repeat for the worker app's managed identity if the scheduled monitor runs there.
+
+## Run it
+- **On demand:** Innholdsforvaltning → **Klasser** → **«Synk brukere fra Entra»** (admin), or
+  `POST /api/admin/sync/org/entra`.
+- **Scheduled:** the worker runs it every `ENTRA_USER_SYNC_INTERVAL_MS` once `ENTRA_USER_SYNC_GROUP_ID`
+  is set. Status is exposed in the worker `/healthz` (`workers.entraUserSyncMonitor`).
+
+## Notes / follow-ups
+- v1 **upserts** (add/update). It does not deactivate users who leave the group — track as a follow-up
+  if departures must propagate.
+- Same Graph-permission pattern unlocks **CL-5** (Entra-linked classes, `Group.Read.All`).

--- a/doc/ops/ENTRA_USER_SYNC_690.md
+++ b/doc/ops/ENTRA_USER_SYNC_690.md
@@ -54,6 +54,29 @@ az rest --method POST --uri "https://graph.microsoft.com/v1.0/servicePrincipals/
 `df021288-bdef-4463-88db-98f22de89214` — verify against the Graph SP's `appRoles` if Microsoft
 changes them.) Repeat for the worker app's managed identity if the scheduled monitor runs there.
 
+## Stopgap: manual export + import (no Graph consent needed) ✅ works today
+Granting the managed identity the Graph app role requires an Entra **directory** role (Privileged
+Role Administrator / Global Admin) — **subscription Owner is NOT enough** (verified 2026-06-26: the
+`az rest` POST returned `Authorization_RequestDenied` for a subscription-Owner). Until that consent
+is granted, seed the users with an **admin's own delegated access**:
+
+1. **Export** the group's members (any directory member can read group membership):
+   ```bash
+   az account set --subscription 5b3f760b-42d4-4d78-812c-c059278d1086   # prod
+   az ad group member list --group 8bab5ab4-c7db-4c9c-baad-316e1ff63504 \
+     --query "[].{externalId:id, email:mail, name:displayName, upn:userPrincipalName}" -o json > members.json
+   ```
+   Shape the file as `{ "source": "entra_manual_export", "users": [ {externalId, email, name, activeStatus:true}, … ] }`
+   (use `upn` as `email` when `mail` is null). `externalId` MUST be the Entra object id (`oid`) so a
+   later SSO login reconciles to the same row. (Note: `az` on Windows writes the file as cp1252 — re-
+   encode to UTF-8 so names with æ/ø/å/é survive.)
+2. **Import** in the app: Innholdsforvaltning → **Klasser** → **«Importer brukere fra fil»**
+   (ADMINISTRATOR), pick the JSON. It POSTs to the existing admin-only `POST /api/admin/sync/org/delta`
+   (same `applyOrgDeltaSync` upsert as the automatic path) — no managed-identity Graph permission needed.
+
+This is a manual stopgap (re-run when the roster changes). The automatic Graph sync below is the
+durable path once consent is granted.
+
 ## Run it
 - **On demand:** Innholdsforvaltning → **Klasser** → **«Synk brukere fra Entra»** (admin), or
   `POST /api/admin/sync/org/entra`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.86",
+  "version": "1.3.87",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-classes.js
+++ b/public/static/admin-content-classes.js
@@ -12,6 +12,7 @@ const appVersionLabel = document.getElementById("appVersion");
 
 let _headerValues = {};
 let participantRuntimeConfig = {};
+let isAdministrator = false;
 function getHeaders() { return _headerValues; }
 
 function escapeHtml(s) {
@@ -50,19 +51,36 @@ async function renderListView() {
       </td>
     </tr>`).join("");
   pageContent.innerHTML = `
-    <div class="page-header"><h1>Klasser</h1><button id="newClassBtn" class="btn btn-primary" style="width:auto">+ Ny klasse</button></div>
+    <div class="page-header"><h1>Klasser</h1><div style="display:flex;gap:8px">${isAdministrator ? `<button id="syncEntraBtn" class="btn btn-secondary" style="width:auto" title="Importer brukere fra «Alle i A-2 Norge» i Entra">Synk brukere fra Entra</button>` : ""}<button id="newClassBtn" class="btn btn-primary" style="width:auto">+ Ny klasse</button></div></div>
     <p style="color:var(--color-meta);font-size:13px">En klasse er en gruppe deltakere du kan tildele kurs til samlet. «Alle deltakere» er en systemklasse (alle med deltakerrolle).</p>
     <table class="classes-table">
       <thead><tr><th>Navn</th><th>Medlemmer</th><th>Tildelte kurs</th><th></th></tr></thead>
       <tbody id="classesTableBody">${rows || `<tr><td colspan="4" style="color:var(--color-meta)">Ingen klasser ennå.</td></tr>`}</tbody>
     </table>`;
   document.getElementById("newClassBtn").addEventListener("click", createClassFlow);
+  document.getElementById("syncEntraBtn")?.addEventListener("click", syncEntraUsers);
   document.getElementById("classesTableBody").addEventListener("click", (e) => {
     const btn = e.target.closest("[data-action]");
     if (!btn) return;
     if (btn.dataset.action === "open") openClass(btn.dataset.id);
     if (btn.dataset.action === "archive") archiveClass(btn.dataset.id, btn.dataset.name);
   });
+}
+
+// #690: import users from the configured Entra group ("Alle i A-2 Norge") so they are searchable
+// for class membership before their first login. ADMINISTRATOR only.
+async function syncEntraUsers() {
+  const btn = document.getElementById("syncEntraBtn");
+  if (btn) { btn.disabled = true; btn.textContent = "Synker…"; }
+  try {
+    const res = await apiFetch("/api/admin/sync/org/entra", getHeaders, { method: "POST" });
+    const imported = res?.importedUsers ?? res?.run?.createdCount ?? 0;
+    showToast(`Synk fullført — ${imported} brukere importert/oppdatert.`, "success");
+  } catch (err) {
+    showToast(err?.message ?? "Kunne ikke synke brukere fra Entra.", "error");
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = "Synk brukere fra Entra"; }
+  }
 }
 
 async function createClassFlow() {
@@ -195,6 +213,7 @@ async function init() {
     const cfg = await getConsoleConfig();
     participantRuntimeConfig = cfg;
     const defaults = cfg?.identityDefaults?.contentAdmin ?? cfg?.identityDefaults ?? {};
+    isAdministrator = Array.isArray(defaults.roles) && defaults.roles.includes("ADMINISTRATOR");
     _headerValues = buildConsoleHeaders({
       userId: defaults.userId,
       email: defaults.email,

--- a/public/static/admin-content-classes.js
+++ b/public/static/admin-content-classes.js
@@ -51,7 +51,7 @@ async function renderListView() {
       </td>
     </tr>`).join("");
   pageContent.innerHTML = `
-    <div class="page-header"><h1>Klasser</h1><div style="display:flex;gap:8px">${isAdministrator ? `<button id="syncEntraBtn" class="btn btn-secondary" style="width:auto" title="Importer brukere fra «Alle i A-2 Norge» i Entra">Synk brukere fra Entra</button>` : ""}<button id="newClassBtn" class="btn btn-primary" style="width:auto">+ Ny klasse</button></div></div>
+    <div class="page-header"><h1>Klasser</h1><div style="display:flex;gap:8px">${isAdministrator ? `<button id="importUsersBtn" class="btn btn-secondary" style="width:auto" title="Importer brukere fra en JSON-fil eksportert fra Entra (delta-synk)">Importer brukere fra fil</button><input type="file" id="importUsersFile" accept="application/json,.json" style="display:none"><button id="syncEntraBtn" class="btn btn-secondary" style="width:auto" title="Importer brukere fra «Alle i A-2 Norge» i Entra (krever Graph-tilgang)">Synk brukere fra Entra</button>` : ""}<button id="newClassBtn" class="btn btn-primary" style="width:auto">+ Ny klasse</button></div></div>
     <p style="color:var(--color-meta);font-size:13px">En klasse er en gruppe deltakere du kan tildele kurs til samlet. «Alle deltakere» er en systemklasse (alle med deltakerrolle).</p>
     <table class="classes-table">
       <thead><tr><th>Navn</th><th>Medlemmer</th><th>Tildelte kurs</th><th></th></tr></thead>
@@ -59,6 +59,10 @@ async function renderListView() {
     </table>`;
   document.getElementById("newClassBtn").addEventListener("click", createClassFlow);
   document.getElementById("syncEntraBtn")?.addEventListener("click", syncEntraUsers);
+  const importBtn = document.getElementById("importUsersBtn");
+  const importFile = document.getElementById("importUsersFile");
+  importBtn?.addEventListener("click", () => importFile?.click());
+  importFile?.addEventListener("change", () => importUsersFromFile(importFile));
   document.getElementById("classesTableBody").addEventListener("click", (e) => {
     const btn = e.target.closest("[data-action]");
     if (!btn) return;
@@ -80,6 +84,42 @@ async function syncEntraUsers() {
     showToast(err?.message ?? "Kunne ikke synke brukere fra Entra.", "error");
   } finally {
     if (btn) { btn.disabled = false; btn.textContent = "Synk brukere fra Entra"; }
+  }
+}
+
+// #690 fallback: when the managed identity lacks Graph permission (admin consent pending), an
+// ADMINISTRATOR can still seed users with their own delegated access — export the group members
+// (e.g. `az ad group member list`) to a JSON file shaped `{ source, users: [{externalId,email,name}] }`
+// and import it here. Routes through the same admin-only delta endpoint as the automatic sync.
+async function importUsersFromFile(input) {
+  const file = input?.files?.[0];
+  if (!file) return;
+  const btn = document.getElementById("importUsersBtn");
+  if (btn) { btn.disabled = true; btn.textContent = "Importerer…"; }
+  try {
+    const text = await file.text();
+    let payload;
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      throw new Error("Fila er ikke gyldig JSON.");
+    }
+    const users = Array.isArray(payload) ? payload : payload?.users;
+    if (!Array.isArray(users) || users.length === 0) {
+      throw new Error('Fila må inneholde et "users"-array med minst én bruker.');
+    }
+    const body = { source: typeof payload?.source === "string" && payload.source.trim() ? payload.source.trim() : "manual_file_import", users };
+    const res = await apiFetch("/api/admin/sync/org/delta", getHeaders, { method: "POST", body: JSON.stringify(body) });
+    const run = res?.run ?? {};
+    const created = run.createdCount ?? 0;
+    const updated = run.updatedCount ?? 0;
+    const failed = run.failedCount ?? 0;
+    showToast(`Import fullført — ${created} opprettet, ${updated} oppdatert${failed ? `, ${failed} feilet` : ""}.`, failed ? "error" : "success");
+  } catch (err) {
+    showToast(err?.message ?? "Kunne ikke importere brukere.", "error");
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = "Importer brukere fra fil"; }
+    input.value = ""; // allow re-selecting the same file
   }
 }
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -45,6 +45,17 @@ const envSchema = z.object({
     .string()
     .transform((value) => value.toLowerCase() === "true")
     .default("false"),
+  // #690: Entra security/M365 group whose members are imported into the platform as users
+  // (e.g. "Alle i A-2 Norge"). When set, an admin can run a Graph-backed sync that upserts these
+  // users so they are searchable/assignable before their first login. Requires the app's managed
+  // identity to hold the Graph application permission GroupMember.Read.All (+ User.Read.All).
+  ENTRA_USER_SYNC_GROUP_ID: z.preprocess(
+    (value) => (typeof value === "string" && value.trim().length === 0 ? undefined : value),
+    z.string().optional(),
+  ),
+  // #690: how often the scheduled Entra user sync runs (worker). Default 24h. Only active when
+  // ENTRA_USER_SYNC_GROUP_ID is set.
+  ENTRA_USER_SYNC_INTERVAL_MS: z.coerce.number().int().positive().default(86_400_000),
   MOCK_DEFAULT_USER_ID: z.string().default("dev-user-1"),
   MOCK_DEFAULT_EMAIL: z.string().email().default("dev.user@company.com"),
   MOCK_DEFAULT_NAME: z.string().default("Dev User"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { AssessmentWorker } from "./modules/assessment/index.js";
 import { AppealSlaMonitor } from "./modules/appeal/index.js";
 import { PseudonymizationMonitor } from "./modules/user/PseudonymizationMonitor.js";
 import { AuditRetentionMonitor } from "./modules/retention/AuditRetentionMonitor.js";
+import { EntraUserSyncMonitor } from "./modules/orgSync/EntraUserSyncMonitor.js";
 
 export function resolveProcessRoleFlags(role: string) {
   return {
@@ -23,6 +24,7 @@ const assessmentWorker = startWorkers ? new AssessmentWorker(env.ASSESSMENT_JOB_
 const appealSlaMonitor = startWorkers ? new AppealSlaMonitor(env.APPEAL_SLA_MONITOR_INTERVAL_MS) : null;
 const pseudonymizationMonitor = startWorkers ? new PseudonymizationMonitor() : null;
 const auditRetentionMonitor = startWorkers ? new AuditRetentionMonitor() : null;
+const entraUserSyncMonitor = startWorkers ? new EntraUserSyncMonitor() : null;
 
 const gracefulShutdown = (exitCode = 0) => {
   if (shuttingDown) {
@@ -34,6 +36,7 @@ const gracefulShutdown = (exitCode = 0) => {
   assessmentWorker?.stop();
   pseudonymizationMonitor?.stop();
   auditRetentionMonitor?.stop();
+  entraUserSyncMonitor?.stop();
 
   if (!server) {
     process.exit(exitCode);
@@ -70,6 +73,7 @@ async function startServer() {
           appealSlaMonitor: appealSlaMonitor?.getStatus() ?? null,
           pseudonymizationMonitor: pseudonymizationMonitor?.getStatus() ?? null,
           auditRetentionMonitor: auditRetentionMonitor?.getStatus() ?? null,
+          entraUserSyncMonitor: entraUserSyncMonitor?.getStatus() ?? null,
         },
       }));
     }).listen(env.PORT, () => {
@@ -83,6 +87,7 @@ async function startServer() {
     appealSlaMonitor!.start();
     pseudonymizationMonitor!.start();
     auditRetentionMonitor!.start();
+    entraUserSyncMonitor!.start();
   }
 }
 

--- a/src/modules/orgSync/EntraUserSyncMonitor.ts
+++ b/src/modules/orgSync/EntraUserSyncMonitor.ts
@@ -1,0 +1,65 @@
+import { env } from "../../config/env.js";
+import { syncEntraUsersFromGroup } from "./entraUserSyncService.js";
+
+// #690: scheduled background sync of the configured Entra group's members into the platform's user
+// table, so the employee list stays current automatically (new hires appear, etc.). Only runs when
+// ENTRA_USER_SYNC_GROUP_ID is configured; failures are logged and never crash the worker.
+
+export type EntraUserSyncMonitorStatus = {
+  enabled: boolean;
+  lastCycleAt: string | null;
+  lastError: string | null;
+};
+
+const SYSTEM_ACTOR = "system_entra_user_sync";
+
+export class EntraUserSyncMonitor {
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private lastCycleAt: Date | null = null;
+  private lastError: string | null = null;
+
+  constructor(
+    private readonly pollIntervalMs = env.ENTRA_USER_SYNC_INTERVAL_MS,
+    private readonly runSync: (actorId: string) => Promise<unknown> = syncEntraUsersFromGroup,
+  ) {}
+
+  start() {
+    if (this.timer || !env.ENTRA_USER_SYNC_GROUP_ID) {
+      return; // not configured → don't schedule
+    }
+    void this.tick();
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.pollIntervalMs);
+  }
+
+  stop() {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  getStatus(): EntraUserSyncMonitorStatus {
+    return {
+      enabled: Boolean(env.ENTRA_USER_SYNC_GROUP_ID),
+      lastCycleAt: this.lastCycleAt?.toISOString() ?? null,
+      lastError: this.lastError,
+    };
+  }
+
+  private async tick() {
+    if (this.running || !env.ENTRA_USER_SYNC_GROUP_ID) return;
+    this.running = true;
+    try {
+      await this.runSync(SYSTEM_ACTOR);
+      this.lastCycleAt = new Date();
+      this.lastError = null;
+    } catch (error) {
+      this.lastError = error instanceof Error ? error.message : String(error);
+      console.warn(`[#690] Entra user sync failed: ${this.lastError}`);
+    } finally {
+      this.running = false;
+    }
+  }
+}

--- a/src/modules/orgSync/entraUserSyncService.ts
+++ b/src/modules/orgSync/entraUserSyncService.ts
@@ -1,0 +1,103 @@
+import { DefaultAzureCredential } from "@azure/identity";
+import { env } from "../../config/env.js";
+import { ValidationError } from "../../errors/AppError.js";
+import { applyOrgDeltaSync } from "./orgSyncService.js";
+
+// #690: import the members of a configured Entra group (e.g. "Alle i A-2 Norge", ~61 employees) into
+// the platform as users, so they are searchable/assignable for class membership BEFORE they ever log
+// in. Reuses the org-sync delta upsert (keyed by externalId = Entra object id) so a later login maps
+// to the same row. Auth is the app's managed identity (DefaultAzureCredential) — the identity must
+// hold the Graph application permission GroupMember.Read.All (+ User.Read.All). See the runbook.
+
+const GRAPH_BASE = "https://graph.microsoft.com/v1.0";
+const GRAPH_SCOPE = "https://graph.microsoft.com/.default";
+
+interface GraphMember {
+  "@odata.type"?: string;
+  id?: string;
+  displayName?: string | null;
+  mail?: string | null;
+  userPrincipalName?: string | null;
+  department?: string | null;
+  accountEnabled?: boolean | null;
+}
+
+export interface EntraUserSyncRecord {
+  externalId: string;
+  email: string;
+  name: string;
+  department: string | null;
+  activeStatus: boolean;
+}
+
+/**
+ * Maps a Graph group member to an org-sync record, or null if it is not a usable user (not a user
+ * object, or missing the id/email needed to provision and later reconcile on login).
+ */
+export function mapGraphMemberToOrgSyncRecord(member: GraphMember): EntraUserSyncRecord | null {
+  if (member["@odata.type"] && member["@odata.type"] !== "#microsoft.graph.user") return null;
+  const externalId = member.id?.trim();
+  const email = (member.mail ?? member.userPrincipalName ?? "").trim();
+  const name = (member.displayName ?? "").trim() || email;
+  if (!externalId || !email) return null;
+  return {
+    externalId,
+    email,
+    name,
+    department: member.department?.trim() || null,
+    // Default missing accountEnabled to true (the value is only present with User.Read.All; absence
+    // shouldn't deactivate a member of the employee group).
+    activeStatus: member.accountEnabled !== false,
+  };
+}
+
+async function getGraphToken(): Promise<string> {
+  const token = await new DefaultAzureCredential().getToken(GRAPH_SCOPE);
+  if (!token?.token) throw new Error("Could not acquire a Microsoft Graph token (managed identity).");
+  return token.token;
+}
+
+async function fetchAllGroupMembers(groupId: string, accessToken: string): Promise<GraphMember[]> {
+  const members: GraphMember[] = [];
+  let url: string | null =
+    `${GRAPH_BASE}/groups/${encodeURIComponent(groupId)}/members` +
+    `?$select=id,displayName,mail,userPrincipalName,department,accountEnabled&$top=100`;
+  while (url) {
+    const response = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(`Graph group members request failed (${response.status}): ${body.slice(0, 300)}`);
+    }
+    const page = (await response.json()) as { value?: GraphMember[]; "@odata.nextLink"?: string };
+    if (Array.isArray(page.value)) members.push(...page.value);
+    url = page["@odata.nextLink"] ?? null;
+  }
+  return members;
+}
+
+export interface EntraUserSyncResult {
+  groupId: string;
+  fetchedMembers: number;
+  importedUsers: number;
+  run: Awaited<ReturnType<typeof applyOrgDeltaSync>>;
+}
+
+/**
+ * Pulls the configured Entra group's members and upserts them as platform users. Throws a clear
+ * ValidationError when not configured, so the admin endpoint returns a helpful 400.
+ */
+export async function syncEntraUsersFromGroup(actorId: string): Promise<EntraUserSyncResult> {
+  const groupId = env.ENTRA_USER_SYNC_GROUP_ID;
+  if (!groupId) {
+    throw new ValidationError("Entra user sync is not configured (ENTRA_USER_SYNC_GROUP_ID is unset).");
+  }
+
+  const accessToken = await getGraphToken();
+  const members = await fetchAllGroupMembers(groupId, accessToken);
+  const users = members
+    .map(mapGraphMemberToOrgSyncRecord)
+    .filter((record): record is EntraUserSyncRecord => record !== null);
+
+  const run = await applyOrgDeltaSync({ source: "entra_group_sync", users, actorId });
+  return { groupId, fetchedMembers: members.length, importedUsers: users.length, run };
+}

--- a/src/modules/orgSync/index.ts
+++ b/src/modules/orgSync/index.ts
@@ -1,1 +1,2 @@
 export { applyOrgDeltaSync } from "./orgSyncService.js";
+export { syncEntraUsersFromGroup, mapGraphMemberToOrgSyncRecord } from "./entraUserSyncService.js";

--- a/src/routes/orgSync.ts
+++ b/src/routes/orgSync.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
-import { applyOrgDeltaSync } from "../modules/orgSync/index.js";
+import { applyOrgDeltaSync, syncEntraUsersFromGroup } from "../modules/orgSync/index.js";
+import { AppError } from "../errors/AppError.js";
 
 const orgSyncRouter = Router();
 
@@ -39,6 +40,25 @@ orgSyncRouter.post("/delta", async (request, response, next) => {
     });
     response.json({ run: result });
   } catch (error) {
+    next(error);
+  }
+});
+
+// #690: import the configured Entra group's members (Graph-backed) as platform users.
+orgSyncRouter.post("/entra", async (request, response, next) => {
+  const actorId = request.context?.userId;
+  if (!actorId) {
+    response.status(401).json({ error: "unauthorized" });
+    return;
+  }
+  try {
+    const result = await syncEntraUsersFromGroup(actorId);
+    response.json(result);
+  } catch (error) {
+    if (error instanceof AppError) {
+      response.status(error.httpStatus).json({ error: error.code, message: error.message });
+      return;
+    }
     next(error);
   }
 });

--- a/test/e2e/admin-content-classes.spec.ts
+++ b/test/e2e/admin-content-classes.spec.ts
@@ -141,3 +141,38 @@ test("classes admin: ADMINISTRATOR sees the Entra sync button and clicking it po
   await page.locator("#syncEntraBtn").click();
   await expect.poll(() => syncPosted).toBe(true);
 });
+
+// #690 fallback: ADMINISTRATOR imports users from a JSON file → POST /api/admin/sync/org/delta.
+test("classes admin: importing a users file posts to the delta sync endpoint", async ({ page }) => {
+  await mockBaseApis(page, ["ADMINISTRATOR"]);
+  await page.route("**/api/admin/content/classes", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ classes: [] }) }),
+  );
+  let deltaBody: unknown = null;
+  await page.route("**/api/admin/sync/org/delta", (route: Route) => {
+    deltaBody = route.request().postDataJSON();
+    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ run: { createdCount: 2, updatedCount: 0, failedCount: 0 } }) });
+  });
+
+  await page.goto("/admin-content/classes");
+  await expect(page.locator("#importUsersBtn")).toBeVisible();
+
+  // Provide the file directly to the hidden input (no OS picker).
+  await page.locator("#importUsersFile").setInputFiles({
+    name: "entra-export.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(
+      JSON.stringify({
+        source: "entra_manual_export",
+        users: [
+          { externalId: "oid-1", email: "a@x.no", name: "A", activeStatus: true },
+          { externalId: "oid-2", email: "b@x.no", name: "B", activeStatus: true },
+        ],
+      }),
+    ),
+  });
+
+  await expect.poll(() => deltaBody).not.toBeNull();
+  expect((deltaBody as { source: string }).source).toBe("entra_manual_export");
+  expect((deltaBody as { users: unknown[] }).users).toHaveLength(2);
+});

--- a/test/e2e/admin-content-classes.spec.ts
+++ b/test/e2e/admin-content-classes.spec.ts
@@ -3,7 +3,7 @@ import { test, expect, type Page, type Route } from "@playwright/test";
 // #645/CL-3: browser e2e for the classes (cohort) admin page — runs the real front-end JS against
 // mocked APIs, covering the client wiring (list, create, add student via search, assign course).
 
-async function mockBaseApis(page: Page) {
+async function mockBaseApis(page: Page, roles: string[] = ["SUBJECT_MATTER_OWNER"]) {
   await page.route("**/participant/config", (route: Route) =>
     route.fulfill({
       status: 200,
@@ -11,7 +11,7 @@ async function mockBaseApis(page: Page) {
       body: JSON.stringify({
         authMode: "mock",
         navigation: { items: [], workspaceItems: [] },
-        identityDefaults: { contentAdmin: { userId: "smo-1", email: "smo@x.no", name: "SMO", roles: ["SUBJECT_MATTER_OWNER"] } },
+        identityDefaults: { contentAdmin: { userId: "smo-1", email: "smo@x.no", name: "SMO", roles } },
         calibrationWorkspace: { accessRoles: [] },
       }),
     }),
@@ -23,7 +23,7 @@ async function mockBaseApis(page: Page) {
     route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ user: { roles: ["SUBJECT_MATTER_OWNER"] }, consent: { accepted: true, currentVersion: "1.0" } }),
+      body: JSON.stringify({ user: { roles }, consent: { accepted: true, currentVersion: "1.0" } }),
     }),
   );
 }
@@ -111,4 +111,33 @@ test("classes admin: list, create, add a student via search, and assign a course
   await page.locator("#courseSelect").selectOption("course-1");
   await page.locator("#assignCourseBtn").click();
   await expect.poll(() => coursePosted).toBe(true);
+});
+
+// #690: the "Synk brukere fra Entra" button is ADMINISTRATOR-only and triggers the Entra user sync.
+test("classes admin: Entra user-sync button is admin-only and posts to the sync endpoint", async ({ page }) => {
+  // SUBJECT_MATTER_OWNER must NOT see the button.
+  await mockBaseApis(page, ["SUBJECT_MATTER_OWNER"]);
+  await page.route("**/api/admin/content/classes", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ classes: [] }) }),
+  );
+  await page.goto("/admin-content/classes");
+  await expect(page.locator("h1")).toContainText("Klasser");
+  await expect(page.locator("#syncEntraBtn")).toHaveCount(0);
+});
+
+test("classes admin: ADMINISTRATOR sees the Entra sync button and clicking it posts", async ({ page }) => {
+  await mockBaseApis(page, ["ADMINISTRATOR"]);
+  await page.route("**/api/admin/content/classes", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ classes: [] }) }),
+  );
+  let syncPosted = false;
+  await page.route("**/api/admin/sync/org/entra", (route: Route) => {
+    syncPosted = true;
+    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ importedUsers: 61, fetchedMembers: 61 }) });
+  });
+
+  await page.goto("/admin-content/classes");
+  await expect(page.locator("#syncEntraBtn")).toBeVisible();
+  await page.locator("#syncEntraBtn").click();
+  await expect.poll(() => syncPosted).toBe(true);
 });

--- a/test/unit/entra-user-sync.test.ts
+++ b/test/unit/entra-user-sync.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { mapGraphMemberToOrgSyncRecord } from "../../src/modules/orgSync/entraUserSyncService.js";
+
+// #690: mapping a Graph group member to an org-sync upsert record. externalId = Entra object id so a
+// later login (oid claim) reconciles to the same row.
+
+describe("mapGraphMemberToOrgSyncRecord (#690)", () => {
+  it("maps a normal user member with mail + department", () => {
+    expect(
+      mapGraphMemberToOrgSyncRecord({
+        "@odata.type": "#microsoft.graph.user",
+        id: "oid-1",
+        displayName: "Kari Nordmann",
+        mail: "kari@a-2.no",
+        department: "Rådgivning",
+        accountEnabled: true,
+      }),
+    ).toEqual({ externalId: "oid-1", email: "kari@a-2.no", name: "Kari Nordmann", department: "Rådgivning", activeStatus: true });
+  });
+
+  it("falls back to userPrincipalName when mail is missing", () => {
+    const r = mapGraphMemberToOrgSyncRecord({ id: "oid-2", displayName: "Ola", userPrincipalName: "ola@a-2.no" });
+    expect(r?.email).toBe("ola@a-2.no");
+    expect(r?.department).toBeNull();
+    expect(r?.activeStatus).toBe(true); // accountEnabled absent → default enabled
+  });
+
+  it("skips non-user members (groups/devices nested in the group)", () => {
+    expect(mapGraphMemberToOrgSyncRecord({ "@odata.type": "#microsoft.graph.group", id: "g1", displayName: "Nested" })).toBeNull();
+  });
+
+  it("skips users with no id or no email", () => {
+    expect(mapGraphMemberToOrgSyncRecord({ id: "", mail: "x@a-2.no" })).toBeNull();
+    expect(mapGraphMemberToOrgSyncRecord({ id: "oid-3", mail: "", userPrincipalName: "" })).toBeNull();
+  });
+
+  it("marks a disabled account inactive", () => {
+    const r = mapGraphMemberToOrgSyncRecord({ id: "oid-4", mail: "z@a-2.no", accountEnabled: false });
+    expect(r?.activeStatus).toBe(false);
+  });
+});


### PR DESCRIPTION
## Hvorfor
I produksjon ser en SMO/admin bare seg selv når de søker etter studenter å legge i en klasse. Årsak: plattformen provisjonerer brukere **just-in-time ved innlogging**, så ansatte som ikke har logget inn finnes ikke i `User`-tabellen ennå. Closes #690.

## Hva
Automatisk synk av ansatt-lista fra Entra, scoped til gruppa **«Alle i A-2 Norge»** (~61 ansatte — ikke de 246 tenant-objektene som mest er gjester/eksterne).

- **Service** `entraUserSyncService` — Graph-pull (managed identity, paginert) → map → `applyOrgDeltaSync` (upsert, `externalId = oid`, så senere innlogging mapper til samme rad). Hopper over ikke-bruker / deaktiverte / uten e-post.
- **On-demand:** `POST /api/admin/sync/org/entra` (ADMINISTRATOR) + admin-knapp **«Synk brukere fra Entra»** på `/admin-content/classes`.
- **Planlagt:** `EntraUserSyncMonitor` i worker (default 24h), kun aktiv når `ENTRA_USER_SYNC_GROUP_ID` er satt; feiler trygt (logg, krasjer aldri worker). Status i worker `/healthz`.
- **Config:** `ENTRA_USER_SYNC_GROUP_ID`, `ENTRA_USER_SYNC_INTERVAL_MS`.

## ⚠️ Deploy-forutsetning (Entra-admin, blocker)
Managed identity må få Graph-permission `GroupMember.Read.All` (+ `User.Read.All`) med admin-consent på prod-tenant — ellers returnerer synk 403 og importerer ingen. Eksakte `az`-steg i `doc/ops/ENTRA_USER_SYNC_690.md`.

## Tester
- Unit: mapping (5, grønne) — normal, UPN-fallback, skip non-user/no-id/no-email, disabled→inaktiv.
- E2e: knapp er ADMINISTRATOR-only (skjult for SMO) + klikk poster til endepunktet (3 grønne).
- `tsc --noEmit` rent.

## Oppfølging
- Legg config i `infra/azure/main.bicep` (durabilitet; manuell `az`-verdi wipes av full infra-deploy).
- v1 upserter; deaktiverer ikke brukere som forlater gruppa.
- Samme Graph-mønster låser opp CL-5 (#678, Entra-koblede klasser).
