### PR TITLE
fix(admin-content): prod-gating på Klasser/Seksjoner — admin-knapper + topp-nav (v1.3.88, #690)

### DIFF
--- a/doc/FEATURE_SURFACE_MAP.md
+++ b/doc/FEATURE_SURFACE_MAP.md
@@ -173,3 +173,27 @@ that never reaches the viewer because the locale isn't threaded).
 | Client upload + translate trigger | `public/static/admin-content-sections.js` (`accept` incl. svg; translate loop calls `/assets/localize`; preview sends `locale`) | `hydrateContentAssetImages` preserves the `?locale=` query |
 
 **Guards:** `test/unit/svg-sanitizer.test.ts` (XSS vectors + text round-trip), `test/unit/svg-text-localization.test.ts` (stub + order/count), `test/m2-section-assets.test.ts` (upload sanitised + serve headers + localise→variant).
+
+## 12. Admin-content client gating — roles & identity from /api/me, NOT identityDefaults (#690)
+
+Every admin-content page (`/admin-content/*`) decides what to show based on the signed-in user's
+**roles**: admin-only buttons, and the top **workspace nav** (items are filtered by `requiredRoles`).
+The trap: `participantRuntimeConfig.identityDefaults` is populated **only in mock-role mode** —
+`participantConsole.ts` sends it as `undefined` in prod/Entra. So any page that reads roles/identity
+from `identityDefaults` works locally and silently shows **nothing** (hidden admin controls, empty
+top nav) in prod. The live roles come from `GET /api/me` (`user.roles`, the token's roles). A fix on
+one page leaves siblings broken — this bit Klasser + Seksjoner together (v1.3.87→1.3.88).
+
+| Surface | Where | Notes |
+|---------|-------|-------|
+| Live roles source | `GET /api/me` → `user.roles` (`src/routes/me.ts`) | token roles via `request.context.roles` |
+| Roles helper (per page) | `resolveActiveWorkspaceRoles()` in each `admin-content-*.js` | live `/api/me` → identityDefaults → `["SUBJECT_MATTER_OWNER"]` |
+| Admin-button gating | `admin-content-classes.js` `isAdministrator` (from `/api/me`) | gates import/sync buttons |
+| Workspace nav filter | `resolveWorkspaceNavigationItems(navigation.items, rolesCsv, path)` | empty `navItems` OR empty roles ⇒ `workspaceNav.hidden` |
+| Correct reference impls | `admin-content-courses.js`, `-library.js`, `-calibration.js` | already fetch `/api/me` into `activeUserRoles` |
+| Was broken (now fixed) | `admin-content-classes.js`, `admin-content-sections.js` | classes passed whole config as navItems; sections passed `roles=""` |
+
+**Guards (must mock the PROD shape — no identityDefaults, roles only via `/api/me`):**
+`test/e2e/admin-content-classes.spec.ts` "admin buttons + top nav render in prod-shaped config";
+`test/e2e/section-editor.spec.ts` "top workspace nav renders in prod-shaped config". A mock that sets
+**both** identityDefaults and `/api/me` hides this class of bug — always include a prod-shape case.

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,28 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.88 - 2026-06-26
+
+fix(admin-content): prod-bugs på Klasser/Seksjoner — admin-knapper skjult + topp-nav borte (#690)
+
+To prod-bugs oppdaget rett etter v1.3.87, begge fordi klient-koden leste roller/identitet fra
+`identityDefaults` som KUN finnes i mock-rolle-modus (`participantConsole.ts` sender `undefined` i
+prod/Entra):
+
+1. **Admin-knapper skjult i prod** (Klasser): «Importer brukere fra fil» og «Synk brukere fra Entra»
+   gates på `isAdministrator`, utledet fra `identityDefaults.contentAdmin.roles` → alltid `false` i
+   prod. Nå hentes rollen fra `/api/me` (tokenets `user.roles`).
+2. **Topp-menyen (workspace-nav) borte på Klasser OG Seksjoner**: nav-items filtreres på brukerroller.
+   Klasser sendte feil argument (hele config-objektet som `navItems` → sanitert til `[]`); Seksjoner
+   sendte `roles=""` (fra fraværende identityDefaults) → alle rolle-gatede nav-items skjult →
+   `workspaceNav.hidden`. Begge henter nå roller fra `/api/me` og sender riktig `navigation.items`,
+   som courses/library/calibration allerede gjorde.
+
+**Hvorfor lokal test ikke fanget #1:** e2e-mock satte BÅDE identityDefaults OG /api/me, så prod-formen
+(uten identityDefaults) ble aldri kjørt — testen tok den bekvemme stien, ikke den ekte brukerreisen.
+Nye regresjonstester pinner prod-formen (identityDefaults fraværende, roller fra /api/me) for både
+admin-knappene og topp-nav (classes + section-editor e2e).
+
 ## 1.3.87 - 2026-06-26
 
 feat(orgsync): automatisk Entra-brukersynk for klasse-tildeling (#690)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.87",
+  "version": "1.3.88",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-classes.js
+++ b/public/static/admin-content-classes.js
@@ -13,7 +13,16 @@ const appVersionLabel = document.getElementById("appVersion");
 let _headerValues = {};
 let participantRuntimeConfig = {};
 let isAdministrator = false;
+let activeUserRoles = [];
 function getHeaders() { return _headerValues; }
+
+// Workspace nav items are filtered by the signed-in user's roles. Prefer the live /api/me roles;
+// fall back to mock identityDefaults; finally to SUBJECT_MATTER_OWNER so the nav is never empty.
+function resolveActiveWorkspaceRoles() {
+  if (Array.isArray(activeUserRoles) && activeUserRoles.length > 0) return activeUserRoles;
+  const defaults = participantRuntimeConfig?.identityDefaults?.contentAdmin ?? participantRuntimeConfig?.identityDefaults ?? {};
+  return Array.isArray(defaults.roles) && defaults.roles.length > 0 ? defaults.roles : ["SUBJECT_MATTER_OWNER"];
+}
 
 function escapeHtml(s) {
   return String(s ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
@@ -244,7 +253,13 @@ async function openClass(id) {
 
 function renderWorkspaceNavigation() {
   if (!workspaceNav) return;
-  const items = resolveWorkspaceNavigationItems(participantRuntimeConfig);
+  // resolveWorkspaceNavigationItems(navItems, rolesCsv, currentPath) — previously the whole config
+  // object was passed as navItems, so it sanitized to [] and the top nav never rendered.
+  const items = resolveWorkspaceNavigationItems(
+    participantRuntimeConfig?.navigation?.items,
+    resolveActiveWorkspaceRoles().join(","),
+    window.location.pathname,
+  );
   renderWorkspaceNavigationWithProfile({ workspaceNav, localePicker: null, items, buildLabel: (item) => item.labelKey || item.id });
 }
 
@@ -253,13 +268,23 @@ async function init() {
     const cfg = await getConsoleConfig();
     participantRuntimeConfig = cfg;
     const defaults = cfg?.identityDefaults?.contentAdmin ?? cfg?.identityDefaults ?? {};
-    isAdministrator = Array.isArray(defaults.roles) && defaults.roles.includes("ADMINISTRATOR");
     _headerValues = buildConsoleHeaders({
       userId: defaults.userId,
       email: defaults.email,
       name: defaults.name,
       roles: Array.isArray(defaults.roles) ? defaults.roles.join(",") : defaults.roles,
     });
+    // Admin gating must use the *live* signed-in user's roles. identityDefaults is only populated
+    // in mock-role mode (undefined in prod/Entra — see participantConsole.ts), so reading roles
+    // from it hides admin controls for real admins in prod. /api/me returns the token's roles.
+    try {
+      const me = await apiFetch("/api/me", getHeaders);
+      activeUserRoles = Array.isArray(me?.user?.roles) ? me.user.roles : [];
+      isAdministrator = activeUserRoles.includes("ADMINISTRATOR") ||
+        (Array.isArray(defaults.roles) && defaults.roles.includes("ADMINISTRATOR"));
+    } catch {
+      isAdministrator = Array.isArray(defaults.roles) && defaults.roles.includes("ADMINISTRATOR");
+    }
   } catch {
     _headerValues = {};
   }

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -71,6 +71,16 @@ function tNav(key) {
 
 let participantRuntimeConfig = {};
 let _headerValues = {};
+let activeUserRoles = [];
+
+// Workspace nav items are filtered by the signed-in user's roles. Prefer live /api/me roles; fall
+// back to mock identityDefaults; finally SUBJECT_MATTER_OWNER so the top nav is never empty (in prod
+// identityDefaults is undefined, so passing "" hid every role-gated nav item).
+function resolveActiveWorkspaceRoles() {
+  if (Array.isArray(activeUserRoles) && activeUserRoles.length > 0) return activeUserRoles;
+  const defaults = participantRuntimeConfig?.identityDefaults?.contentAdmin ?? participantRuntimeConfig?.identityDefaults ?? {};
+  return Array.isArray(defaults.roles) && defaults.roles.length > 0 ? defaults.roles : ["SUBJECT_MATTER_OWNER"];
+}
 function getHeaders() { return _headerValues; }
 
 const pageContent = document.getElementById("pageContent");
@@ -474,7 +484,7 @@ function renderWorkspaceNavigation() {
   if (!workspaceNav) return;
   const items = resolveWorkspaceNavigationItems(
     participantRuntimeConfig?.navigation?.items,
-    "",
+    resolveActiveWorkspaceRoles().join(","),
     window.location.pathname,
   );
   renderWorkspaceNavigationWithProfile({ workspaceNav, localePicker, items, buildLabel: (item) => tNav(item.labelKey) || item.id });
@@ -493,6 +503,13 @@ async function init() {
       roles: Array.isArray(defaults.roles) ? defaults.roles.join(",") : defaults.roles,
       locale: currentLocale,
     });
+    // Live roles drive the workspace nav filter (identityDefaults is undefined in prod).
+    try {
+      const me = await apiFetch("/api/me", getHeaders);
+      activeUserRoles = Array.isArray(me?.user?.roles) ? me.user.roles : [];
+    } catch {
+      activeUserRoles = [];
+    }
   } catch {
     _headerValues = {};
   }

--- a/test/e2e/admin-content-classes.spec.ts
+++ b/test/e2e/admin-content-classes.spec.ts
@@ -142,6 +142,48 @@ test("classes admin: ADMINISTRATOR sees the Entra sync button and clicking it po
   await expect.poll(() => syncPosted).toBe(true);
 });
 
+// #690 regression: in prod (Entra auth) `identityDefaults` is undefined — admin gating AND the
+// workspace nav role filter MUST come from /api/me's live roles. Guards two prod bugs: (1) import/sync
+// buttons hidden because isAdministrator read absent identityDefaults; (2) the top workspace nav never
+// rendered because the whole config object was passed as navItems (→ sanitized to []) and roles were "".
+test("classes admin: admin buttons + top nav render in prod-shaped config (role from /api/me)", async ({ page }) => {
+  await page.route("**/participant/config", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      // Prod shape: mockRoleSwitch disabled → identityDefaults omitted entirely. Two nav items: one
+      // open, one role-gated (only visible if the live roles include SUBJECT_MATTER_OWNER).
+      body: JSON.stringify({
+        authMode: "mock",
+        navigation: {
+          items: [
+            { id: "dashboard", path: "/dashboard", labelKey: "Oversikt", requiredRoles: [] },
+            { id: "review", path: "/review", labelKey: "Vurdering", requiredRoles: ["SUBJECT_MATTER_OWNER"] },
+          ],
+          workspaceItems: [],
+        },
+        calibrationWorkspace: { accessRoles: [] },
+      }),
+    }),
+  );
+  await page.route("**/version", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "test" }) }),
+  );
+  await page.route("**/api/me", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ user: { roles: ["ADMINISTRATOR", "SUBJECT_MATTER_OWNER"] }, consent: { accepted: true, currentVersion: "1.0" } }) }),
+  );
+  await page.route("**/api/admin/content/classes", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ classes: [] }) }),
+  );
+  await page.goto("/admin-content/classes");
+  await expect(page.locator("#importUsersBtn")).toBeVisible();
+  await expect(page.locator("#syncEntraBtn")).toBeVisible();
+  // Top workspace nav renders both the open item and the role-gated one (live roles applied).
+  await expect(page.locator("#workspaceNav")).toBeVisible();
+  await expect(page.locator('#workspaceNav a', { hasText: "Oversikt" })).toBeVisible();
+  await expect(page.locator('#workspaceNav a', { hasText: "Vurdering" })).toBeVisible();
+});
+
 // #690 fallback: ADMINISTRATOR imports users from a JSON file → POST /api/admin/sync/org/delta.
 test("classes admin: importing a users file posts to the delta sync endpoint", async ({ page }) => {
   await mockBaseApis(page, ["ADMINISTRATOR"]);

--- a/test/e2e/section-editor.spec.ts
+++ b/test/e2e/section-editor.spec.ts
@@ -217,3 +217,39 @@ test("participant: course load sends x-user-* identity headers in mock mode", as
   await expect.poll(() => coursesUserId).toBe("participant-1");
   expect(coursesRoles).toContain("PARTICIPANT");
 });
+
+// #690 regression: the Sections page top workspace nav was empty in prod because role filtering used
+// identityDefaults (undefined in prod) → roles "" hid every role-gated nav item. The fix reads live
+// roles from /api/me. Guards the prod shape: no identityDefaults, role-gated nav item, role via /api/me.
+test("section editor: top workspace nav renders in prod-shaped config (roles from /api/me)", async ({ page }) => {
+  await page.route("**/participant/config", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        authMode: "mock",
+        navigation: {
+          items: [
+            { id: "dashboard", path: "/dashboard", labelKey: "Oversikt", requiredRoles: [] },
+            { id: "review", path: "/review", labelKey: "Vurdering", requiredRoles: ["SUBJECT_MATTER_OWNER"] },
+          ],
+          workspaceItems: [],
+        },
+        calibrationWorkspace: { accessRoles: [] },
+      }),
+    }),
+  );
+  await page.route("**/version", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "test" }) }),
+  );
+  await page.route("**/api/me", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ user: { roles: ["SUBJECT_MATTER_OWNER"] }, consent: { accepted: true, currentVersion: "1.0" } }) }),
+  );
+  await page.route("**/api/admin/content/sections**", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ sections: [] }) }),
+  );
+  await page.goto("/admin-content/sections");
+  await expect(page.locator("#workspaceNav")).toBeVisible();
+  await expect(page.locator('#workspaceNav a', { hasText: "Oversikt" })).toBeVisible();
+  await expect(page.locator('#workspaceNav a', { hasText: "Vurdering" })).toBeVisible();
+});


### PR DESCRIPTION
## Hvorfor
To prod-bugs oppdaget rett etter v1.3.87-deploy, begge med **samme rotårsak**: klient-koden leste roller/identitet fra `participantRuntimeConfig.identityDefaults`, som **kun populeres i mock-rolle-modus** — `participantConsole.ts` sender `undefined` i prod/Entra. Alt som gates på det fungerer lokalt og viser **ingenting** i prod.

1. **Admin-knapper skjult i prod** (Klasser): «Importer brukere fra fil» + «Synk brukere fra Entra» gates på `isAdministrator`, utledet fra `identityDefaults.contentAdmin.roles` → alltid `false` i prod. → henter nå rollen fra `/api/me`.
2. **Topp-menyen (workspace-nav) borte på Klasser OG Seksjoner**: nav-items filtreres på brukerroller. Klasser sendte feil argument (hele config-objektet som `navItems` → sanitert til `[]`); Seksjoner sendte `roles=""` → alle rolle-gatede items skjult → `workspaceNav.hidden`. → begge henter roller fra `/api/me` og sender riktig `navigation.items`, slik courses/library/calibration allerede gjorde.

## Hvorfor lokal test ikke fanget det
e2e-mock-en satte **både** `identityDefaults` OG `/api/me`, så `isAdministrator` ble sann via identityDefaults og **prod-formen ble aldri kjørt** — testen tok den bekvemme stien, ikke den ekte brukerreisen (akkurat det stående ordre advarer mot).

## Tester (alle grønne)
- `admin-content-classes.spec.ts`: «admin buttons + top nav render in prod-shaped config» (identityDefaults fraværende, roller fra `/api/me`) — feilet før fixen.
- `section-editor.spec.ts`: «top workspace nav renders in prod-shaped config».
- `tsc --noEmit` rent.

## Surface map
Lagt til **#12** i `doc/FEATURE_SURFACE_MAP.md`: admin-content-gating skal lese roller fra `/api/me`, ikke identityDefaults; guards må mocke prod-formen. Verifisert at courses/library/calibration allerede er korrekte; bare classes + sections var brutt.

## Rollback
Ren klient-/test-endring (ingen infra). Revert commit gjenoppretter forrige oppførsel.
