### PR TITLE
fix(discussions): helhetlig fargekoding av status-badges (v1.3.95, #495)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,20 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.3.95 - 2026-06-28
+
+fix(discussions): helhetlig fargekoding av status-badges (#495)
+
+Rettet semantikken i diskusjons-badgene og samlet paletten i CSS-klasser (.disc-badge--*)
+som gjenbruker app-ens etablerte badge-farger (jf. .sr-badge--*):
+
+- **Åpen → gul** (trenger svar), **Løst → grønn** (fullført), **Låst → rød** (lukket).
+  (Var tidligere semantisk bakvendt: Åpen=grønn, Løst=blå.)
+- **Spørsmål → blå** (informasjon), **Diskusjon → grå** (nøytral kategori).
+- **✓ Akseptert svar → grønn** (matcher Løst). **📌 Festet** = hvit m/gull kant (meta-markør).
+- Fargene flyttet fra inline-hex i `discussion-panel.js` til `shared.css` for et temabart,
+  helhetlig design.
+
 ## 1.3.94 - 2026-06-28
 
 fix(discussions): UX-polish av diskusjonspanelet (#495)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.94",
+  "version": "1.3.95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a2-assessment-platform",
-      "version": "1.3.94",
+      "version": "1.3.95",
       "dependencies": {
         "@azure/communication-email": "^1.1.0",
         "@azure/identity": "^4.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.94",
+  "version": "1.3.95",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/discussion-panel.js
+++ b/public/static/discussion-panel.js
@@ -46,17 +46,10 @@ export function mountDiscussionPanel(opts) {
     return `<button type="button" class="disc-btn ${extraClass}" data-disc-act="${action}">${escapeHtml(label)}</button>`;
   }
 
-  function badge(text, kind) {
-    const colors = {
-      open: "background:#e6f4ea;color:#137333;",
-      resolved: "background:#e8f0fe;color:#1a73e8;",
-      locked: "background:#fce8e6;color:#c5221f;",
-      question: "background:#fef7e0;color:#b06000;",
-      discussion: "background:#f1f3f4;color:#5f6368;",
-      pinned: "background:#fff;color:#b06000;border:1px solid #f0c36d;",
-      accepted: "background:#e6f4ea;color:#137333;",
-    };
-    return `<span class="disc-badge" style="${colors[kind] ?? colors.discussion}">${escapeHtml(text)}</span>`;
+  // Helhetlig badge-palett ligger i shared.css (.disc-badge--*). Semantikk: grønn=Løst/Akseptert,
+  // gul=Åpen (trenger svar), rød=Låst, blå=Spørsmål, grå=Diskusjon.
+  function badge(text, variant) {
+    return `<span class="disc-badge disc-badge--${variant}">${escapeHtml(text)}</span>`;
   }
 
   function authorName(author) {

--- a/public/static/shared.css
+++ b/public/static/shared.css
@@ -1032,7 +1032,23 @@ dialog::backdrop {
 }
 .discussion-panel .disc-thread-row:hover { background: var(--color-blue-light); }
 .disc-badges { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
-.disc-badge { font-size: 11px; padding: 2px 8px; border-radius: 10px; }
+.disc-badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+/* Helhetlig palett — gjenbruker app-ens badge-farger (jf. .sr-badge--*). Semantikk:
+   grønn = fullført (Løst/Akseptert), gul = trenger handling (Åpen), rød = lukket (Låst),
+   blå = informasjon (Spørsmål), grå = nøytral kategori (Diskusjon). */
+.disc-badge--open      { background: #fff3db; color: #7a4b00; }   /* gul  — trenger svar */
+.disc-badge--resolved  { background: #e6f4ea; color: #12613a; }   /* grønn — løst */
+.disc-badge--locked    { background: #fbe9e7; color: #b3261e; }   /* rød  — låst */
+.disc-badge--question  { background: #e8f0fe; color: #1a5276; }   /* blå  — spørsmål */
+.disc-badge--discussion{ background: #edf1f7; color: #42526b; }   /* grå  — diskusjon */
+.disc-badge--accepted  { background: #e6f4ea; color: #12613a; }   /* grønn — akseptert svar */
+.disc-badge--pinned    { background: var(--color-surface); color: #7a4b00; border-color: #e0c068; } /* festet */
 .disc-meta { color: var(--color-meta); font-size: 13px; }
 .disc-reply { border-top: 1px solid var(--color-border-soft); padding: 8px 0; }
 .disc-reply-actions { display: flex; gap: 6px; margin-top: 4px; flex-wrap: wrap; }


### PR DESCRIPTION
Åpen→gul, Løst→grønn, Låst→rød; Spørsmål→blå, Diskusjon→grå. Palett samlet i .disc-badge--* (gjenbruker app-ens badge-farger). e2e grønn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)