### PR TITLE
feat(participant): deltakere kun via kurs — PARTICIPANT_COURSE_ONLY (v1.4.0)

### DIFF
--- a/doc/AZURE_ENVIRONMENTS.md
+++ b/doc/AZURE_ENVIRONMENTS.md
@@ -138,6 +138,7 @@ For each environment, define variables/secrets used by workflow:
 - `ACS_EMAIL_SENDER_DISPLAY_NAME` (optional, default `A2 Assessment Platform`; used when `PARTICIPANT_NOTIFICATION_CHANNEL=acs_email`)
 - `PARTICIPANT_CONSOLE_CONFIG_FILE` (optional, default `config/participant-console.json`)
 - `PARTICIPANT_CONSOLE_DEBUG_MODE` (optional, `auto` | `true` | `false`, default `auto`)
+- `PARTICIPANT_COURSE_ONLY` (optional, `true` | `false`, default `true`) — når `true` når deltakere moduler KUN gjennom kurs; den frittstående modul-lista og -innleveringen er gated av (SMO/ADMIN unntatt). Sett `false` for å gjenåpne frittstående modul-tilgang for deltakere.
 - `BUDGET_CONTACT_EMAIL`
 - `MONTHLY_BUDGET_AMOUNT`
 

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,25 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.4.0 - 2026-06-28
+
+feat(participant): deltakere når moduler kun via kurs (PARTICIPANT_COURSE_ONLY)
+
+Forenkling av deltaker-overflaten: én inngang (kurs) i stedet for både frittstående moduler og
+kurs. Modul forblir authoring-/vurderings-primitivet; kun deltaker-tilgangen begrenses.
+
+- Nytt flagg `PARTICIPANT_COURSE_ONLY` (env, **default `true`** — på i alle miljø). Eksponert i
+  `/participant/config` som `courseOnly`.
+- **Backend-gate:** `POST /api/submissions` krever at modulen ligger i et publisert kurs deltakeren
+  har tilgang til (`isModuleInAccessibleCourse`), ellers `403 course_required`. Modul åpnet via
+  course player passerer. SMO/ADMIN er unntatt. Hard grense — gjelder alle nye innleveringer; ingen
+  datamigrasjon, historikk bevares.
+- **Frontend:** den frittstående modul-seksjonen (`#moduleListSection`) skjules når `courseOnly`.
+- Tester: `test/m2-participant-course-only.test.ts` (gate) + `test/e2e/participant-course-only.spec.ts`
+  (UI skjuler/viser modul-lista). Escape-hatch: sett `PARTICIPANT_COURSE_ONLY=false`.
+
+Markerer overgangen til Tier-2-leveransen (diskusjon #495 + kurs-only) — minor-bump til 1.4.0.
+
 ## 1.3.95 - 2026-06-28
 
 fix(discussions): helhetlig fargekoding av status-badges (#495)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.95",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a2-assessment-platform",
-      "version": "1.3.95",
+      "version": "1.4.0",
       "dependencies": {
         "@azure/communication-email": "^1.1.0",
         "@azure/identity": "^4.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.3.95",
+  "version": "1.4.0",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/participant.js
+++ b/public/participant.js
@@ -1542,6 +1542,7 @@ async function loadParticipantConsoleConfig() {
   document.body.classList.toggle("auth-entra", roleSwitchState.authMode === "entra");
   applyOutputVisibility();
   applyIdentityDefaults();
+  applyCourseOnlyMode();
   renderRolePresetControl();
 
   if (roleSwitchState.authMode === "entra") {
@@ -1561,6 +1562,15 @@ async function loadParticipantConsoleConfig() {
 
   // Identity form is now populated — safe to allow course loading (#541).
   if (loadCoursesBtn) loadCoursesBtn.disabled = false;
+}
+
+// #495-follow-up: når PARTICIPANT_COURSE_ONLY er på, når deltakere moduler kun via kurs — skjul den
+// frittstående modul-seksjonen. Modul åpnet via course player bruker submission-/MCQ-seksjonene
+// (ikke denne lista), så den flyten er upåvirket.
+function applyCourseOnlyMode() {
+  if (participantRuntimeConfig?.courseOnly) {
+    setHidden(document.getElementById("moduleListSection"), true);
+  }
 }
 
 function applyIdentityDefaults() {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -45,6 +45,13 @@ const envSchema = z.object({
     .string()
     .transform((value) => value.toLowerCase() === "true")
     .default("false"),
+  // #495-follow-up: når true (default) når deltakere moduler KUN gjennom kurs — den frittstående
+  // modul-lista og -innleveringen er gated av. Modul forblir authoring/vurderings-primitivet; dette
+  // begrenser kun deltaker-overflaten. SMO/ADMIN er unntatt. Sett "false" for å gjenåpne frittstående.
+  PARTICIPANT_COURSE_ONLY: z
+    .string()
+    .transform((value) => value.toLowerCase() === "true")
+    .default("true"),
   // #690: Entra security/M365 group whose members are imported into the platform as users
   // (e.g. "Alle i A-2 Norge"). When set, an admin can run a Graph-backed sync that upserts these
   // users so they are searchable/assignable before their first login. Requires the app's managed

--- a/src/config/participantConsole.ts
+++ b/src/config/participantConsole.ts
@@ -84,6 +84,8 @@ type ParticipantConsoleConfig = z.infer<typeof participantConsoleConfigSchema>;
 export type ParticipantConsoleRuntimeConfig = {
   authMode: "mock" | "entra";
   debugMode: boolean;
+  // #495-follow-up: når true skjuler deltaker-UI den frittstående modul-lista (kun kurs).
+  courseOnly: boolean;
   mockRoleSwitchEnabled: boolean;
   mockRolePresets: ParticipantConsoleConfig["mockRolePresets"];
   navigation: { items: WorkspaceNavigationItem[] };
@@ -129,6 +131,7 @@ export function getParticipantConsoleRuntimeConfig(): ParticipantConsoleRuntimeC
   return {
     authMode: env.AUTH_MODE,
     debugMode: resolveParticipantConsoleDebugMode(),
+    courseOnly: env.PARTICIPANT_COURSE_ONLY,
     mockRoleSwitchEnabled,
     mockRolePresets: mockRoleSwitchEnabled ? config.mockRolePresets : [],
     navigation: {

--- a/src/modules/course/enrollmentService.ts
+++ b/src/modules/course/enrollmentService.ts
@@ -1,10 +1,11 @@
-import type { CourseEnrollmentSource } from "@prisma/client";
+import type { CourseEnrollmentSource, AppRole as AppRoleType } from "@prisma/client";
 import { prisma } from "../../db/prisma.js";
 import { NotFoundError, ValidationError } from "../../errors/AppError.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
 import { enrollmentRepository } from "./enrollmentRepository.js";
 import { deriveEnrollmentStatus, type EnrollmentStatus } from "./enrollmentStatus.js";
+import { getUserClassIds, getClassAssignedCourseDueDates } from "./classService.js";
 
 // #496/EN-2: enrollment service — assign/revoke/list + self-enroll + course visibility. Status is
 // always DERIVED here (never stored) from CourseCompletion + progress + dueAt, so it cannot drift.
@@ -227,4 +228,36 @@ export async function filterVisibleCourseIds(
     for (const row of enrolled) visible.add(row.courseId);
   }
   return visible;
+}
+
+// #495-follow-up (PARTICIPANT_COURSE_ONLY): er modulen del av et publisert kurs som brukeren har
+// tilgang til? Brukes til å gate frittstående modul-innlevering for deltakere — modul tatt via
+// course player passerer (modulen ligger jo i et tilgjengelig kurs).
+export async function isModuleInAccessibleCourse(input: {
+  moduleId: string;
+  userId: string;
+  roles: AppRoleType[];
+  groupIds?: string[];
+}): Promise<boolean> {
+  const links = await prisma.courseModule.findMany({
+    where: { moduleId: input.moduleId },
+    select: { courseId: true },
+  });
+  const courseIds = [...new Set(links.map((l) => l.courseId))];
+  if (courseIds.length === 0) return false;
+
+  const courses = await prisma.course.findMany({
+    where: { id: { in: courseIds }, publishedAt: { not: null }, archivedAt: null },
+    select: { id: true, enrollmentPolicy: true },
+  });
+  if (courses.length === 0) return false;
+
+  const classIds = await getUserClassIds({
+    userId: input.userId,
+    roles: input.roles,
+    groupIds: input.groupIds,
+  });
+  const classCourseDue = await getClassAssignedCourseDueDates(classIds);
+  const visible = await filterVisibleCourseIds(input.userId, courses, new Set(classCourseDue.keys()));
+  return courses.some((c) => visible.has(c.id));
 }

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -45,6 +45,7 @@ export {
   listUserEnrollments,
   listCourseEnrollments,
   filterVisibleCourseIds,
+  isModuleInAccessibleCourse,
   deriveStatus,
 } from "./enrollmentService.js";
 export type {

--- a/src/routes/submissions.ts
+++ b/src/routes/submissions.ts
@@ -7,7 +7,9 @@ import {
   getOwnedSubmissionResultView,
 } from "../modules/submission/index.js";
 import { createSubmissionAppeal } from "../modules/appeal/index.js";
+import { isModuleInAccessibleCourse } from "../modules/course/index.js";
 import { env } from "../config/env.js";
+import { AppRole } from "../db/prismaRuntime.js";
 import { submissionCreateLimiter } from "../middleware/rateLimiting.js";
 
 const createSubmissionSchema = z.object({
@@ -40,6 +42,27 @@ submissionsRouter.post("/", submissionCreateLimiter, async (request, response, n
   if (!userId) {
     response.status(401).json({ error: "unauthorized" });
     return;
+  }
+
+  // #495-follow-up (PARTICIPANT_COURSE_ONLY): deltakere kan kun levere på moduler som ligger i et
+  // publisert kurs de har tilgang til. Modul tatt via course player passerer (modulen er i kurset).
+  // SMO/ADMIN er unntatt (authoring/testing). Hard grense — gjelder alle nye innleveringer når på.
+  const roles = request.context?.roles ?? [];
+  const isContentRole = roles.includes(AppRole.SUBJECT_MATTER_OWNER) || roles.includes(AppRole.ADMINISTRATOR);
+  if (env.PARTICIPANT_COURSE_ONLY && !isContentRole) {
+    const allowed = await isModuleInAccessibleCourse({
+      moduleId: parsed.data.moduleId,
+      userId,
+      roles,
+      groupIds: request.context?.principal?.groupIds,
+    });
+    if (!allowed) {
+      response.status(403).json({
+        error: "course_required",
+        message: "This module is only available through a course.",
+      });
+      return;
+    }
   }
 
   try {

--- a/test/e2e/participant-course-only.spec.ts
+++ b/test/e2e/participant-course-only.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+// #495-follow-up: når config.courseOnly er på, skjuler deltaker-UI den frittstående modul-seksjonen
+// (#moduleListSection). Kurs-seksjonen forblir. Kjører ekte participant.js i mock-modus.
+
+async function mockBase(page: Page, courseOnly: boolean) {
+  await page.route("**/participant/config", (r: Route) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({
+    authMode: "mock", courseOnly, navigation: { items: [], workspaceItems: [] },
+    identityDefaults: { participant: { userId: "p1", email: "p@x.no", name: "P", department: "X", roles: ["PARTICIPANT"] } },
+    calibrationWorkspace: { accessRoles: [] }, flow: {}, output: {},
+  }) }));
+  await page.route("**/version", (r: Route) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "test" }) }));
+  await page.route("**/api/me", (r: Route) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ user: { roles: ["PARTICIPANT"] }, consent: { accepted: true, currentVersion: "1.0" } }) }));
+  await page.route("**/api/queue-counts", (r: Route) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ counts: {} }) }));
+  await page.route("**/api/courses/enrollments", (r: Route) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ enrollments: [] }) }));
+  await page.route("**/api/courses/completions", (r: Route) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ completions: [] }) }));
+  await page.route("**/api/courses", (r: Route) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ courses: [] }) }));
+}
+
+test("deltaker: modul-seksjonen skjules når courseOnly er på", async ({ page }) => {
+  await mockBase(page, true);
+  await page.addInitScript(() => { try { localStorage.setItem("participant.locale", "nb"); } catch { /* */ } });
+  await page.goto("/participant");
+  await expect(page.locator("#courseSection")).toBeVisible();
+  await expect(page.locator("#moduleListSection")).toBeHidden();
+});
+
+test("deltaker: modul-seksjonen vises når courseOnly er av", async ({ page }) => {
+  await mockBase(page, false);
+  await page.addInitScript(() => { try { localStorage.setItem("participant.locale", "nb"); } catch { /* */ } });
+  await page.goto("/participant");
+  await expect(page.locator("#moduleListSection")).toBeVisible();
+});

--- a/test/m2-participant-course-only.test.ts
+++ b/test/m2-participant-course-only.test.ts
@@ -1,0 +1,89 @@
+import request from "supertest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+import { env } from "../src/config/env.js";
+
+// #495-follow-up (PARTICIPANT_COURSE_ONLY): deltakere kan kun levere på moduler som ligger i et
+// publisert kurs de har tilgang til. Modul via course player passerer; frittstående blokkeres.
+// SMO/ADMIN er unntatt. Gaten kjører FØR module-validering, så de fleste casene trenger ikke en
+// fullt publisert modul.
+
+const ts = Date.now();
+const idPrefix = `courseonly-${ts}`;
+const originalFlag = env.PARTICIPANT_COURSE_ONLY;
+
+function headers(suffix: string, roles: string) {
+  return {
+    "x-user-id": `${idPrefix}-${suffix}`,
+    "x-user-email": `${idPrefix}-${suffix}@example.com`,
+    "x-user-name": `User ${suffix}`,
+    "x-user-roles": roles,
+  };
+}
+const participant = headers("p", "PARTICIPANT");
+const smo = headers("smo", "SUBJECT_MATTER_OWNER");
+
+const createdCourseIds: string[] = [];
+const createdModuleIds: string[] = [];
+
+describe("Participant course-only gate (#495-follow-up)", () => {
+  afterEach(() => {
+    env.PARTICIPANT_COURSE_ONLY = originalFlag;
+  });
+  afterAll(async () => {
+    await prisma.courseModule.deleteMany({ where: { courseId: { in: createdCourseIds } } });
+    await prisma.course.deleteMany({ where: { id: { in: createdCourseIds } } });
+    await prisma.module.deleteMany({ where: { id: { in: createdModuleIds } } });
+    await prisma.user.deleteMany({ where: { externalId: { startsWith: idPrefix } } });
+    await prisma.$disconnect();
+  });
+
+  it("flagg på: deltaker blokkeres fra frittstående modul (403 course_required)", async () => {
+    env.PARTICIPANT_COURSE_ONLY = true;
+    const res = await request(app)
+      .post("/api/submissions")
+      .set(participant)
+      .send({ moduleId: `${idPrefix}-orphan-module`, deliveryType: "text", responseJson: {} });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("course_required");
+  });
+
+  it("flagg på: deltaker slipper gaten når modulen ligger i et tilgjengelig kurs", async () => {
+    env.PARTICIPANT_COURSE_ONLY = true;
+    const module = await prisma.module.create({ data: { title: "Gate-modul" }, select: { id: true } });
+    createdModuleIds.push(module.id);
+    const course = await prisma.course.create({
+      data: { title: JSON.stringify({ "en-GB": "C", nb: "C", nn: "C" }), publishedAt: new Date() },
+      select: { id: true },
+    });
+    createdCourseIds.push(course.id);
+    await prisma.courseModule.create({ data: { courseId: course.id, moduleId: module.id, sortOrder: 0 } });
+
+    const res = await request(app)
+      .post("/api/submissions")
+      .set(participant)
+      .send({ moduleId: module.id, deliveryType: "text", responseJson: {} });
+    // Gaten passerer; createSubmission feiler senere (ingen aktiv versjon) — men IKKE med 403/course_required.
+    expect(res.status).not.toBe(403);
+    expect(res.body.error).not.toBe("course_required");
+  });
+
+  it("flagg på: SMO er unntatt gaten (frittstående modul gir ikke course_required)", async () => {
+    env.PARTICIPANT_COURSE_ONLY = true;
+    const res = await request(app)
+      .post("/api/submissions")
+      .set(smo)
+      .send({ moduleId: `${idPrefix}-orphan-2`, deliveryType: "text", responseJson: {} });
+    expect(res.body.error).not.toBe("course_required");
+  });
+
+  it("flagg av: deltaker blokkeres ikke (frittstående tillatt igjen)", async () => {
+    env.PARTICIPANT_COURSE_ONLY = false;
+    const res = await request(app)
+      .post("/api/submissions")
+      .set(participant)
+      .send({ moduleId: `${idPrefix}-orphan-3`, deliveryType: "text", responseJson: {} });
+    expect(res.body.error).not.toBe("course_required");
+  });
+});


### PR DESCRIPTION
Forenkling: deltakere når moduler kun via kurs (flagg default på). Backend-gate på POST /api/submissions (403 course_required), frontend skjuler frittstående modul-liste. SMO/ADMIN unntatt. Tester + e2e grønne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)