### PR TITLE
fix(sections): sticky bilde-toolbar under tab-baren (v1.4.2, #679)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,14 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.4.2 - 2026-06-28
+
+fix(sections): sticky bilde-toolbar festes under tab-baren (#679 oppfølging)
+
+Den sticky pane-toolbaren (`.editor-pane-label`) lå bak den sticky workspace-tab-baren
+(`.content-area-nav`, `top:0`), så «Last opp bilde» bare så vidt stakk fram. Forskjøvet til
+`top: 46px` (under tab-baren) + høyere z-index, så hele toolbaren er synlig i høy editor.
+
 ## 1.4.1 - 2026-06-28
 
 fix(ux): bunt med små deltaker-/forfatter-forbedringer (lav risiko)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a2-assessment-platform",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "@azure/communication-email": "^1.1.0",
         "@azure/identity": "^4.13.1",
@@ -4984,7 +4984,7 @@
       }
     },
     "node_modules/once": {
-      "version": "1.4.1",
+      "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-sections.html
+++ b/public/admin-content-sections.html
@@ -71,8 +71,9 @@
          the preview's height instead of staying pinned at its 320px minimum. */
       .editor-cols > div { display: flex; flex-direction: column; min-width: 0; }
       .editor-cols textarea { width: 100%; min-height: 320px; flex: 1 1 auto; padding: var(--space-2); border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); font-family: var(--font-mono, monospace); font-size: 13px; resize: vertical; }
-      /* #679: hold pane-toolbaren (inkl. «Last opp bilde») synlig i høy editor. */
-      .editor-pane-label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-meta); margin-bottom: 4px; position: sticky; top: 0; z-index: 2; background: var(--color-surface); padding: 6px 0; }
+      /* #679: hold pane-toolbaren (inkl. «Last opp bilde») synlig i høy editor. Festes UNDER den
+         sticky workspace-tab-baren (.content-area-nav: top:0, ~44px) så den ikke havner bak den. */
+      .editor-pane-label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-meta); margin-bottom: 4px; position: sticky; top: 46px; z-index: 5; background: var(--color-surface); padding: 6px 0; }
       .preview-pane { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-2); min-height: 320px; flex: 1 1 auto; overflow-y: auto; }
       .preview-pane img { max-width: 100%; height: auto; }
       .preview-pane iframe { max-width: 100%; }


### PR DESCRIPTION
Oppfølging av #679: toolbaren lå bak den sticky tab-baren; forskjøvet til top:46px. CSS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)