### PR TITLE
refactor(course): CourseItem eneste sannhetskilde — lese-cutover (v1.4.3, #502)

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -20,3 +20,6 @@ APPEAL_OVERDUE_ALERT_THRESHOLD=1
 PARTICIPANT_NOTIFICATION_CHANNEL=log
 PARTICIPANT_NOTIFICATION_WEBHOOK_URL=
 PARTICIPANT_NOTIFICATION_WEBHOOK_TIMEOUT_MS=5000
+
+# Gaten testes isolert i m2-participant-course-only; av som default her så modul-/submission-tester treffer modulene direkte.
+PARTICIPANT_COURSE_ONLY=false

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,26 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.4.3 - 2026-06-28
+
+refactor(course): CourseItem som eneste sannhetskilde — lese-cutover (#502, del 1)
+
+Contract-fasen av #480: alle lesninger av kursets moduler går nå mot `CourseItem` (MODULE-elementer)
+i stedet for `CourseModule`-join-en, og dual-write til `CourseModule` er fjernet.
+
+- Repository: `findCourseById`, `findPublishedCourses`, `findPublishedCoursesWithModuleDetails`,
+  `findPublishedCoursesContainingModule`, `listCourses` deriverer nå `modules`/`_count.modules` fra
+  CourseItem (retur-shape uendret → konsumenter urørt). publishCourse-gate teller MODULE-elementer.
+- `setCourseItems`/`setCourseModules` skriver kun CourseItem (ingen dual-write). adminContent
+  (modul-i-N-kurs-guard, purge-kandidater) + enrollment (`isModuleInAccessibleCourse`,
+  in-progress-probe) lest om til CourseItem.
+- **CourseModule-tabellen beholdes** (ingen migrasjon) — selve `DROP` er et eget steg etter
+  prod-soak (reverserbart; ingen data tapt siden CourseItem har alt).
+- **Fix:** `.env.test` setter nå `PARTICIPANT_COURSE_ONLY=false` — gaten (v1.4.0) defaultet true i
+  test og blokkerte frittstående-submission-tester, som gjorde **main-CI rød siden v1.4.0**. Gaten
+  dekkes fortsatt av `m2-participant-course-only`. Oppdaterte tester som lagde CourseModule direkte.
+- Verifisert: tsc + unit 689 + dom 5 + integrasjon 308 grønt.
+
 ## 1.4.2 - 2026-06-28
 
 fix(sections): sticky bilde-toolbar festes under tab-baren (#679 oppfølging)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a2-assessment-platform",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "dependencies": {
         "@azure/communication-email": "^1.1.0",
         "@azure/identity": "^4.13.1",
@@ -4984,7 +4984,7 @@
       }
     },
     "node_modules/once": {
-      "version": "1.4.2",
+      "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/adminContentCommands.ts
+++ b/src/modules/adminContent/adminContentCommands.ts
@@ -201,14 +201,14 @@ export async function listUnpublishedPurgeCandidates(): Promise<PurgeCandidate[]
   return candidates.map((m) => {
     const reasons: string[] = [];
     if (m._count.submissions > 0) reasons.push(`${m._count.submissions} submissions`);
-    if (m._count.courseModules > 0) reasons.push(`in ${m._count.courseModules} course(s)`);
+    if (m._count.courseItems > 0) reasons.push(`in ${m._count.courseItems} course(s)`);
     if (m._count.certificationStatuses > 0) reasons.push(`${m._count.certificationStatuses} certification statuses`);
     return {
       id: m.id,
       title: m.title,
       updatedAt: m.updatedAt,
       submissions: m._count.submissions,
-      courseModules: m._count.courseModules,
+      courseModules: m._count.courseItems,
       versions: m._count.versions,
       reasonSkipped: reasons.length > 0 ? reasons.join("; ") : null,
     };

--- a/src/modules/adminContent/adminContentQueries.ts
+++ b/src/modules/adminContent/adminContentQueries.ts
@@ -41,10 +41,10 @@ export async function listLibraryModules(locale: SupportedLocale = "en-GB") {
     activeVersionId: module.activeVersionId,
     activeVersionNo: module.activeVersion?.versionNo ?? null,
     latestVersionNo: module.versions[0]?.versionNo ?? null,
-    courseCount: module._count.courseModules,
-    courses: module.courseModules.map((cm) => ({
-      id: cm.course.id,
-      title: localizeContentText(locale, cm.course.title) ?? cm.course.title,
+    courseCount: module._count.courseItems,
+    courses: module.courseItems.map((ci) => ({
+      id: ci.course.id,
+      title: localizeContentText(locale, ci.course.title) ?? ci.course.title,
     })),
   }));
 }

--- a/src/modules/adminContent/adminContentRepository.ts
+++ b/src/modules/adminContent/adminContentRepository.ts
@@ -1,7 +1,7 @@
 import { prisma } from "../../db/prisma.js";
 import type { AssessmentMode } from "@prisma/client";
 
-type AdminContentRepositoryClient = Pick<typeof prisma, "module" | "moduleVersion" | "rubricVersion" | "promptTemplateVersion" | "mCQSetVersion" | "courseModule">;
+type AdminContentRepositoryClient = Pick<typeof prisma, "module" | "moduleVersion" | "rubricVersion" | "promptTemplateVersion" | "mCQSetVersion" | "courseItem">;
 
 export function createAdminContentRepository(client: AdminContentRepositoryClient = prisma) {
   return {
@@ -42,9 +42,9 @@ export function createAdminContentRepository(client: AdminContentRepositoryClien
             select: { id: true, versionNo: true, publishedAt: true },
           },
           _count: {
-            select: { courseModules: true },
+            select: { courseItems: true },
           },
-          courseModules: {
+          courseItems: {
             select: {
               course: {
                 select: { id: true, title: true },
@@ -153,7 +153,7 @@ export function createAdminContentRepository(client: AdminContentRepositoryClien
     },
 
     async countModuleCourses(moduleId: string) {
-      return client.courseModule.count({ where: { moduleId } });
+      return client.courseItem.count({ where: { moduleId } });
     },
 
     updateModuleTitle(moduleId: string, title: string) {
@@ -191,7 +191,7 @@ export function createAdminContentRepository(client: AdminContentRepositoryClien
           _count: {
             select: {
               submissions: true,
-              courseModules: true,
+              courseItems: true,
               versions: true,
               rubricVersions: true,
               promptTemplateVersions: true,

--- a/src/modules/course/courseCommands.ts
+++ b/src/modules/course/courseCommands.ts
@@ -49,10 +49,10 @@ export async function updateCourse(
 export async function publishCourse(courseId: string, actorId?: string) {
   const course = await prisma.course.findUnique({
     where: { id: courseId },
-    include: { _count: { select: { modules: true } } },
+    include: { _count: { select: { items: { where: { itemType: "MODULE" } } } } },
   });
   if (!course) throw new NotFoundError("Course", "course_not_found", "Course not found.");
-  if (course._count.modules === 0) {
+  if (course._count.items === 0) {
     throw new ValidationError("Cannot publish a course with no modules.");
   }
 
@@ -164,9 +164,9 @@ export async function setCourseItems(courseId: string, items: CourseItemInput[])
     if (found !== sectionIds.length) throw new ValidationError("One or more sections do not exist.");
   }
 
+  // #502: CourseItem er eneste sannhetskilde — ingen dual-write til CourseModule lenger.
   return runInTransaction(async (tx) => {
     await tx.courseItem.deleteMany({ where: { courseId } });
-    await tx.courseModule.deleteMany({ where: { courseId } });
     if (items.length > 0) {
       await tx.courseItem.createMany({
         data: items.map((item, index) => ({
@@ -180,39 +180,43 @@ export async function setCourseItems(courseId: string, items: CourseItemInput[])
           discussionsEnabled: item.discussionsEnabled ?? true,
         })),
       });
-      const moduleRows = items
-        .map((item, index) => ({ item, index }))
-        .filter((entry): entry is { item: { type: "MODULE"; moduleId: string }; index: number } => entry.item.type === "MODULE")
-        .map(({ item, index }) => ({ courseId, moduleId: item.moduleId, sortOrder: index }));
-      if (moduleRows.length > 0) {
-        await tx.courseModule.createMany({ data: moduleRows });
-      }
     }
     await tx.course.update({ where: { id: courseId }, data: { updatedAt: new Date() } });
   });
 }
 
+// Legacy modules-only setter (import + admin PUT /modules). #502: skriver nå CourseItem MODULE-
+// elementer i stedet for CourseModule. Erstatter modul-elementene; eventuelle SECTION-elementer
+// bevares (re-indekseres etter modulene for stabil sortOrder).
 export async function setCourseModules(
   courseId: string,
   modules: Array<{ moduleId: string; sortOrder: number }>,
 ) {
   return runInTransaction(async (tx) => {
-    await tx.courseModule.deleteMany({ where: { courseId } });
-    // Dual-write to CourseItem (#480 expand-contract). Only MODULE items are
-    // managed here so any future SECTION items survive a module re-order.
-    await tx.courseItem.deleteMany({ where: { courseId, itemType: "MODULE" } });
-    if (modules.length > 0) {
-      await tx.courseModule.createMany({
-        data: modules.map((m) => ({ courseId, moduleId: m.moduleId, sortOrder: m.sortOrder })),
-      });
-      await tx.courseItem.createMany({
-        data: modules.map((m) => ({
-          courseId,
-          itemType: "MODULE" as const,
-          moduleId: m.moduleId,
-          sortOrder: m.sortOrder,
-        })),
-      });
+    const sections = await tx.courseItem.findMany({
+      where: { courseId, itemType: "SECTION" },
+      orderBy: { sortOrder: "asc" },
+      select: { sectionId: true, discussionsEnabled: true },
+    });
+    await tx.courseItem.deleteMany({ where: { courseId } });
+    // Bevar den passerte sortOrder for moduler (uendret kontrakt fra før #502); seksjoner legges
+    // etter høyeste modul-sortOrder så de overlever en modul-re-set.
+    const moduleRows = modules.map((m) => ({
+      courseId,
+      itemType: "MODULE" as const,
+      moduleId: m.moduleId,
+      sortOrder: m.sortOrder,
+    }));
+    const maxModuleOrder = moduleRows.reduce((max, r) => Math.max(max, r.sortOrder), -1);
+    const sectionRows = sections.map((s, i) => ({
+      courseId,
+      itemType: "SECTION" as const,
+      sectionId: s.sectionId,
+      sortOrder: maxModuleOrder + 1 + i,
+      discussionsEnabled: s.discussionsEnabled,
+    }));
+    if (moduleRows.length + sectionRows.length > 0) {
+      await tx.courseItem.createMany({ data: [...moduleRows, ...sectionRows] });
     }
     await tx.course.update({
       where: { id: courseId },

--- a/src/modules/course/courseRepository.ts
+++ b/src/modules/course/courseRepository.ts
@@ -50,20 +50,25 @@ type CourseRepositoryClient = Pick<
 
 export function createCourseRepository(client: CourseRepositoryClient = prisma) {
   return {
-    findPublishedCoursesContainingModule(moduleId: string) {
-      return client.course.findMany({
+    async findPublishedCoursesContainingModule(moduleId: string) {
+      const courses = await client.course.findMany({
         where: {
           publishedAt: { not: null },
           archivedAt: null,
-          modules: { some: { moduleId } },
+          items: { some: { moduleId } },
         },
         include: {
-          modules: {
+          items: {
+            where: { itemType: "MODULE" },
             orderBy: { sortOrder: "asc" },
             select: { moduleId: true },
           },
         },
       });
+      return courses.map(({ items, ...rest }) => ({
+        ...rest,
+        modules: items.filter((i) => i.moduleId).map((i) => ({ moduleId: i.moduleId as string })),
+      }));
     },
 
     countPassedModulesForUser(userId: string, moduleIds: string[]) {
@@ -98,11 +103,13 @@ export function createCourseRepository(client: CourseRepositoryClient = prisma) 
       });
     },
 
-    listCourses() {
-      return client.course.findMany({
+    async listCourses() {
+      // #502: tell MODULE-elementer fra CourseItem i stedet for CourseModule; behold _count.modules-shapen.
+      const courses = await client.course.findMany({
         orderBy: { createdAt: "desc" },
-        include: { _count: { select: { modules: true } } },
+        include: { _count: { select: { items: { where: { itemType: "MODULE" } } } } },
       });
+      return courses.map(({ _count, ...rest }) => ({ ...rest, _count: { modules: _count.items } }));
     },
 
     markSectionRead(userId: string, courseId: string, sectionId: string) {
@@ -130,11 +137,15 @@ export function createCourseRepository(client: CourseRepositoryClient = prisma) 
       });
     },
 
-    findCourseById(courseId: string) {
-      return client.course.findUnique({
+    // #502 contract-fase: `modules` deriveres nå fra CourseItem (MODULE-elementer) i stedet for den
+    // gamle CourseModule-join-en, så CourseItem er eneste sannhetskilde. Retur-shapen beholdes
+    // ({ moduleId, sortOrder, module }) så konsumentene er uendret.
+    async findCourseById(courseId: string) {
+      const course = await client.course.findUnique({
         where: { id: courseId },
         include: {
-          modules: {
+          items: {
+            where: { itemType: "MODULE" },
             orderBy: { sortOrder: "asc" },
             include: {
               module: {
@@ -144,23 +155,36 @@ export function createCourseRepository(client: CourseRepositoryClient = prisma) 
           },
         },
       });
+      if (!course) return null;
+      const { items, ...rest } = course;
+      const modules = items
+        .filter((item) => item.moduleId && item.module)
+        .map((item) => ({ moduleId: item.moduleId as string, sortOrder: item.sortOrder, module: item.module! }));
+      return { ...rest, modules };
     },
 
-    findPublishedCourses() {
-      return client.course.findMany({
+    async findPublishedCourses() {
+      const courses = await client.course.findMany({
         where: { publishedAt: { not: null }, archivedAt: null },
         orderBy: { publishedAt: "asc" },
         include: {
-          modules: {
+          items: {
+            where: { itemType: "MODULE" },
             orderBy: { sortOrder: "asc" },
             select: { moduleId: true },
           },
         },
       });
+      return courses.map(({ items, ...rest }) => ({
+        ...rest,
+        modules: items
+          .filter((item) => item.moduleId)
+          .map((item) => ({ moduleId: item.moduleId as string })),
+      }));
     },
 
-    findPublishedCoursesWithModuleDetails(filters: Pick<ReportFilters, "courseId"> = {}) {
-      return client.course.findMany({
+    async findPublishedCoursesWithModuleDetails(filters: Pick<ReportFilters, "courseId"> = {}) {
+      const courses = await client.course.findMany({
         where: {
           publishedAt: { not: null },
           archivedAt: null,
@@ -168,14 +192,19 @@ export function createCourseRepository(client: CourseRepositoryClient = prisma) 
         },
         orderBy: { publishedAt: "asc" },
         include: {
-          modules: {
+          items: {
+            where: { itemType: "MODULE" },
             orderBy: { sortOrder: "asc" },
-            include: {
-              module: { select: { id: true, title: true } },
-            },
+            include: { module: { select: { id: true, title: true } } },
           },
         },
       });
+      return courses.map(({ items, ...rest }) => ({
+        ...rest,
+        modules: items
+          .filter((item) => item.moduleId && item.module)
+          .map((item) => ({ moduleId: item.moduleId as string, sortOrder: item.sortOrder, module: item.module! })),
+      }));
     },
 
     findUserCourseCompletions(userId: string) {

--- a/src/modules/course/enrollmentService.ts
+++ b/src/modules/course/enrollmentService.ts
@@ -139,7 +139,7 @@ async function hasUserStartedCourse(userId: string, courseId: string): Promise<b
   const reads = await prisma.courseSectionRead.count({ where: { userId, courseId } });
   if (reads > 0) return true;
   const submissions = await prisma.submission.count({
-    where: { userId, module: { courseModules: { some: { courseId } } } },
+    where: { userId, module: { courseItems: { some: { courseId } } } },
   });
   return submissions > 0;
 }
@@ -239,7 +239,7 @@ export async function isModuleInAccessibleCourse(input: {
   roles: AppRoleType[];
   groupIds?: string[];
 }): Promise<boolean> {
-  const links = await prisma.courseModule.findMany({
+  const links = await prisma.courseItem.findMany({
     where: { moduleId: input.moduleId },
     select: { courseId: true },
   });

--- a/test/m2-course-completions.test.ts
+++ b/test/m2-course-completions.test.ts
@@ -46,10 +46,10 @@ describe("Course completion issuance", () => {
           nn: "Test av kursbevis-utferding.",
         }),
         publishedAt: new Date(),
-        modules: {
+        items: {
           create: [
-            { moduleId: moduleA.module.id, sortOrder: 1 },
-            { moduleId: moduleB.module.id, sortOrder: 2 },
+            { itemType: "MODULE", moduleId: moduleA.module.id, sortOrder: 1 },
+            { itemType: "MODULE", moduleId: moduleB.module.id, sortOrder: 2 },
           ],
         },
       },
@@ -131,10 +131,10 @@ describe("Course completion issuance", () => {
         title: JSON.stringify({ "en-GB": `Reconcile Course ${suffix}`, nb: `Avstemmingskurs ${suffix}`, nn: `Avstemmingskurs ${suffix}` }),
         description: JSON.stringify({ "en-GB": "x", nb: "x", nn: "x" }),
         publishedAt: new Date(),
-        modules: {
+        items: {
           create: [
-            { moduleId: moduleA.module.id, sortOrder: 1 },
-            { moduleId: moduleB.module.id, sortOrder: 2 },
+            { itemType: "MODULE", moduleId: moduleA.module.id, sortOrder: 1 },
+            { itemType: "MODULE", moduleId: moduleB.module.id, sortOrder: 2 },
           ],
         },
       },
@@ -252,10 +252,10 @@ describe("Course completion issuance", () => {
         title: JSON.stringify({ "en-GB": `Cert Course ${suffix}`, nb: `Beviskurs ${suffix}`, nn: `Beviskurs ${suffix}` }),
         certificationLevel: "intermediate",
         publishedAt: new Date(),
-        modules: {
+        items: {
           create: [
-            { moduleId: moduleA.module.id, sortOrder: 1 },
-            { moduleId: moduleB.module.id, sortOrder: 2 },
+            { itemType: "MODULE", moduleId: moduleA.module.id, sortOrder: 1 },
+            { itemType: "MODULE", moduleId: moduleB.module.id, sortOrder: 2 },
           ],
         },
       },

--- a/test/m2-course-item-dual-write.test.ts
+++ b/test/m2-course-item-dual-write.test.ts
@@ -2,14 +2,14 @@ import { afterAll, describe, expect, it } from "vitest";
 import { setCourseModules } from "../src/modules/course/courseCommands.js";
 import { prisma } from "../src/db/prisma.js";
 
-// #480 expand-contract: setCourseModules dual-writes MODULE CourseItem rows in
-// parallel with CourseModule, while leaving any SECTION CourseItems intact.
-describe("CourseItem dual-write (#480)", () => {
+// #502 contract: setCourseModules skriver MODULE-elementer til CourseItem (eneste sannhetskilde —
+// ingen CourseModule-mirror lenger), og lar SECTION-elementer være i fred.
+describe("setCourseModules → CourseItem (#502 contract)", () => {
   afterAll(async () => {
     await prisma.$disconnect();
   });
 
-  it("mirrors modules into CourseItem with order preserved, and re-syncs on re-set", async () => {
+  it("writes modules to CourseItem with order preserved, and re-syncs on re-set", async () => {
     const course = await prisma.course.create({
       data: { title: `DualWrite ${Date.now()}` },
       select: { id: true },
@@ -28,16 +28,11 @@ describe("CourseItem dual-write (#480)", () => {
       { moduleId: moduleB.id, sortOrder: 1 },
     ]);
 
-    const courseModules = await prisma.courseModule.findMany({
-      where: { courseId: course.id },
-      orderBy: { sortOrder: "asc" },
-    });
     const courseItems = await prisma.courseItem.findMany({
       where: { courseId: course.id },
       orderBy: { sortOrder: "asc" },
     });
 
-    expect(courseModules.map((c) => c.moduleId)).toEqual([moduleB.id, moduleA.id]);
     expect(courseItems).toHaveLength(2);
     expect(courseItems.map((i) => i.moduleId)).toEqual([moduleB.id, moduleA.id]);
     expect(courseItems.every((i) => i.itemType === "MODULE")).toBe(true);

--- a/test/m2-course-items.test.ts
+++ b/test/m2-course-items.test.ts
@@ -15,7 +15,7 @@ describe("Admin course item ordering", () => {
     await prisma.$disconnect();
   });
 
-  it("sets and reads an interleaved module/section sequence and re-syncs CourseModule", async () => {
+  it("sets and reads an interleaved module/section sequence (CourseItem is the source)", async () => {
     const moduleA = await prisma.module.create({ data: { title: `Item Mod A ${Date.now()}` }, select: { id: true } });
     const moduleB = await prisma.module.create({ data: { title: `Item Mod B ${Date.now()}` }, select: { id: true } });
     const section = await prisma.courseSection.create({ data: { title: `Item Sec ${Date.now()}` }, select: { id: true } });
@@ -43,14 +43,6 @@ describe("Admin course item ordering", () => {
     expect(items[0].moduleId).toBe(moduleA.id);
     expect(items[1].sectionId).toBe(section.id);
     expect(items[2].moduleId).toBe(moduleB.id);
-
-    // CourseModule is re-synced from the MODULE items (read-path compatibility).
-    const courseModules = await prisma.courseModule.findMany({
-      where: { courseId: course.id },
-      orderBy: { sortOrder: "asc" },
-    });
-    expect(courseModules.map((c) => c.moduleId)).toEqual([moduleA.id, moduleB.id]);
-    expect(courseModules.map((c) => c.sortOrder)).toEqual([0, 2]);
 
     await prisma.course.delete({ where: { id: course.id } });
     await prisma.courseSection.delete({ where: { id: section.id } });

--- a/test/m2-courses-participant-flow.test.ts
+++ b/test/m2-courses-participant-flow.test.ts
@@ -137,10 +137,11 @@ describe("Participant courses API", () => {
       select: { id: true },
     });
 
-    await prisma.courseModule.create({
+    await prisma.courseItem.create({
       data: {
         courseId: startedOnlyCourse.id,
         moduleId: startedModule.module.id,
+        itemType: "MODULE",
         sortOrder: 1,
       },
     });
@@ -154,10 +155,10 @@ describe("Participant courses API", () => {
       select: { id: true },
     });
 
-    await prisma.courseModule.createMany({
+    await prisma.courseItem.createMany({
       data: [
-        { courseId: mixedCourse.id, moduleId: startedModule.module.id, sortOrder: 1 },
-        { courseId: mixedCourse.id, moduleId: passedModule.module.id, sortOrder: 2 },
+        { courseId: mixedCourse.id, moduleId: startedModule.module.id, itemType: "MODULE", sortOrder: 1 },
+        { courseId: mixedCourse.id, moduleId: passedModule.module.id, itemType: "MODULE", sortOrder: 2 },
       ],
     });
 

--- a/test/m2-participant-course-only.test.ts
+++ b/test/m2-participant-course-only.test.ts
@@ -32,7 +32,7 @@ describe("Participant course-only gate (#495-follow-up)", () => {
     env.PARTICIPANT_COURSE_ONLY = originalFlag;
   });
   afterAll(async () => {
-    await prisma.courseModule.deleteMany({ where: { courseId: { in: createdCourseIds } } });
+    await prisma.courseItem.deleteMany({ where: { courseId: { in: createdCourseIds } } });
     await prisma.course.deleteMany({ where: { id: { in: createdCourseIds } } });
     await prisma.module.deleteMany({ where: { id: { in: createdModuleIds } } });
     await prisma.user.deleteMany({ where: { externalId: { startsWith: idPrefix } } });
@@ -58,7 +58,7 @@ describe("Participant course-only gate (#495-follow-up)", () => {
       select: { id: true },
     });
     createdCourseIds.push(course.id);
-    await prisma.courseModule.create({ data: { courseId: course.id, moduleId: module.id, sortOrder: 0 } });
+    await prisma.courseItem.create({ data: { courseId: course.id, moduleId: module.id, itemType: "MODULE", sortOrder: 0 } });
 
     const res = await request(app)
       .post("/api/submissions")

--- a/test/m2-reporting.test.ts
+++ b/test/m2-reporting.test.ts
@@ -150,10 +150,11 @@ describe("MVP reporting endpoints", () => {
       select: { id: true },
     });
 
-    await prisma.courseModule.create({
+    await prisma.courseItem.create({
       data: {
         courseId: reportingCourse.id,
         moduleId,
+        itemType: "MODULE",
         sortOrder: 1,
       },
     });


### PR DESCRIPTION
Contract-fase av #480: lesninger → CourseItem, dual-write fjernet. CourseModule-tabell beholdt (DROP senere). Fikser også .env.test-flagget som gjorde main-CI rød siden v1.4.0. tsc + 689 unit + 5 dom + 308 integrasjon grønt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)