### PR TITLE
fix(ux): kompakte modul-filtre + sertifiseringsmerke som tag (v1.4.5)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,15 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.4.5 - 2026-06-28
+
+fix(ux): kompakte modul-filtre + sertifiseringsmerke ser ikke ut som knapp
+
+- **Modulbibliotek:** filter-fanene (Alle/Aktive/…) er nå kompakte piller på rad (`width:auto`
+  overstyrer global `button{width:100%}`), ikke fullbredde stablet.
+- **Kursliste:** sertifiseringsnivå-merket («Grunnleggende» o.l.) restylet til et flatt «tag»
+  (liten radius, ingen kant, svak blåtone) så det ikke forveksles med handlingsknappene.
+
 ## 1.4.4 - 2026-06-28
 
 fix(ux): bunt 2 — rapport-knapper, seksjoner ved opprettelse, avpublisert modul i kurs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a2-assessment-platform",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "dependencies": {
         "@azure/communication-email": "^1.1.0",
         "@azure/identity": "^4.13.1",
@@ -4984,7 +4984,7 @@
       }
     },
     "node_modules/once": {
-      "version": "1.4.4",
+      "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-courses.html
+++ b/public/admin-content-courses.html
@@ -88,16 +88,18 @@
       .col-actions { white-space: nowrap; }
 
       /* ── Cert badge ──────────────────────────────────────────────────────── */
+      /* Status-merke (sertifiseringsnivå) — flatt «tag», ikke pille m/kant, så det ikke forveksles
+         med handlingsknappene (Rediger/Eksporter/…). */
       .cert-badge {
         display: inline-block;
         padding: 2px 8px;
-        border-radius: 999px;
-        font-size: 12px;
+        border-radius: 4px;
+        font-size: 11px;
         font-weight: 600;
-        background: var(--color-module-summary-bg);
-        border: 1px solid var(--color-module-summary-border);
-        color: var(--color-meta);
+        background: var(--color-blue-light);
+        color: var(--color-link-active);
         text-transform: capitalize;
+        letter-spacing: 0.02em;
       }
 
       /* ── Row actions ─────────────────────────────────────────────────────── */

--- a/public/admin-content-library.html
+++ b/public/admin-content-library.html
@@ -62,6 +62,9 @@
 
       .library-filters { display: flex; flex-wrap: wrap; gap: 6px; }
       .library-filter-btn {
+        /* width:auto + min-height:0 overstyrer global button{width:100%} så filtrene blir kompakte piller på rad. */
+        width: auto;
+        min-height: 0;
         padding: 5px 14px;
         font-size: 13px;
         font-weight: 600;


### PR DESCRIPTION
Modul-filter-faner kompakte (ikke fullbredde); sertifiseringsnivå-merke restylet til flatt tag så det ikke forveksles med knapper. Ren CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)