### PR TITLE
feat(ux): forenklet kurs-opprettelse — nivå-valg går rett til editoren (v1.4.6, #506)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,16 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.4.6 - 2026-06-28
+
+fix(ux): forenklet kurs-opprettelse — nivå-valg går rett til editoren (#506)
+
+- **Kurs-opprettelse (samtale):** det mellomliggende modul-søk-steget er fjernet. Etter at
+  forfatteren har skrevet tittel og valgt sertifiseringsnivå, opprettes kurset direkte (tittel +
+  nivå, ingen moduler) og **kurs-editoren** åpnes — der både moduler OG seksjoner legges til og
+  sekvensen redigeres. Færre steg, og moduler/seksjoner håndteres samme sted.
+- Tester: oppdaterte conv-create-e2e (nivå-valg → editor, intet modul-søk-steg).
+
 ## 1.4.5 - 2026-06-28
 
 fix(ux): kompakte modul-filtre + sertifiseringsmerke ser ikke ut som knapp

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -662,7 +662,10 @@ function showConvCertStep() {
     convCertLevel = btn.dataset.cert;
     document.querySelectorAll(".conv-choice-btn").forEach(b => b.disabled = true);
     appendConvCertBubble(btn.textContent.trim());
-    showConvModuleSearch();
+    // Forenklet flyt: etter nivå-valg opprettes kurset direkte og editoren åpnes, der moduler OG
+    // seksjoner legges til. (Det gamle modul-søk-steget i samtalen er fjernet.)
+    convModules = [];
+    convCreateCourse();
   });
 
   // Focus first cert-choice button so keyboard users land in the new step.

--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -945,7 +945,7 @@ test.describe("admin content browser coverage", () => {
     await expect(page.locator("#modeSwitchAdvanced")).toHaveAttribute("aria-pressed", "true");
   });
 
-  test("courses conversational flow goes straight to module selection and opens the editor after save (#673-followup)", async ({ page }) => {
+  test("courses conversational flow creates the course on certification choice and opens the editor (#506)", async ({ page }) => {
     const state = await mockCommonApis(page, {
       libraryModules: [
         { id: "module-1", title: "Trade unions" },
@@ -958,17 +958,14 @@ test.describe("admin content browser coverage", () => {
     const titleInput = page.locator("#convTitleInput");
     await titleInput.fill("Labour rights");
     await titleInput.press("Enter");
+    // #506: etter nivå-valg opprettes kurset direkte (tittel + nivå, ingen moduler) og editoren åpnes —
+    // moduler OG seksjoner legges til der. Det gamle modul-søk-steget i samtalen er fjernet.
     await clickEnabledButton(page, "Basic");
 
-    await page.locator("#convComboboxInput").fill("Trade");
-    await page.locator(".combobox-option").first().click();
-    await page.locator("#convAddModuleItemBtn").click();
-    await expect(page.locator("#convModuleListContainer")).toContainText("Trade unions");
-
-    await page.locator("#convCreateBtn").click();
-    // #673-followup: opprettelse lander i kurs-editoren (der seksjoner legges til), ikke lista.
     await expect(page).toHaveURL(/\/admin-content\/courses\/[^/]+$/);
-    await expect.poll(() => state.mutableCourses[0]?.modules?.length ?? 0).toBe(1);
+    await expect.poll(() => state.mutableCourses.length).toBe(1);
+    await expect.poll(() => state.mutableCourses[0]?.certificationLevel).toBe("basic");
+    await expect.poll(() => state.mutableCourses[0]?.modules?.length ?? 0).toBe(0);
   });
 
   test("course detail view renders when backend returns null description for an existing course", async ({ page }) => {
@@ -1166,8 +1163,8 @@ test.describe("admin content browser coverage", () => {
     await page.locator("#localeSelect").selectOption("nn");
     await page.locator("#convTitleInput").fill("Arbeidsmiljøkurs");
     await page.locator("#convTitleInput").press("Enter");
+    // #506: nivå-valget oppretter kurset direkte og åpner editoren.
     await page.locator('[data-cert="basic"]').click();
-    await page.locator("#convCreateBtn").click();
 
     // #673-followup: opprettelse går nå rett til kurs-editoren (der seksjoner legges til), ikke lista.
     await expect(page).toHaveURL(/\/admin-content\/courses\/[^/]+$/);
@@ -1211,8 +1208,8 @@ test.describe("admin content browser coverage", () => {
     await expect.poll(() => state.lastCourseLocalizationBodies.map((body) => body.targetLocale).slice(-2).sort()).toEqual(["en-GB", "nb"]);
   });
 
-  test("courses conversational flow goes directly from certification choice to module search", async ({ page }) => {
-    await mockCommonApis(page, {
+  test("courses conversational flow has no module-search step after certification choice (#506)", async ({ page }) => {
+    const state = await mockCommonApis(page, {
       libraryModules: [{ id: "module-1", title: "Trade unions" }],
     });
 
@@ -1220,11 +1217,11 @@ test.describe("admin content browser coverage", () => {
 
     await page.locator("#convTitleInput").fill("Labour rights");
     await page.locator("#convTitleInput").press("Enter");
+    // #506: ingen modul-søk-steg lenger — nivå-valget oppretter kurset og åpner editoren.
     await clickEnabledButton(page, "Basic");
 
-    await expect(page.locator("#convComboboxInput")).toBeVisible();
-    await expect(page.locator("#convCreateBtn")).toBeVisible();
-    await expect(page.getByText("Du kan opprette kurset direkte")).toBeVisible();
+    await expect(page).toHaveURL(/\/admin-content\/courses\/[^/]+$/);
+    await expect.poll(() => state.mutableCourses.length).toBe(1);
   });
 
   test("courses list refreshes 'Sist endret' after saving course changes", async ({ page }) => {


### PR DESCRIPTION
## Hva
Fjernet det mellomliggende modul-søk-steget i den samtale-baserte kurs-opprettelsen. Etter at forfatteren har skrevet tittel og valgt sertifiseringsnivå, opprettes kurset direkte (tittel + nivå, ingen moduler) og **kurs-editoren** åpnes — der både moduler OG seksjoner legges til og sekvensen redigeres.

## Hvorfor
Færre steg, og moduler/seksjoner håndteres på samme sted (editoren).

## Test
- Oppdaterte conv-create-e2e: nivå-valg → editor, intet modul-søk-steg. 6/6 grønt lokalt.
- tsc rent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)