### PR TITLE
feat: enhetlig innholds-livssyklus for kurs/modul/seksjon (v1.5.0, #705)

### DIFF
--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -210,7 +210,9 @@ fields (`title`, `bodyMarkdown`) accept a string or a partial `{en-GB,nb,nn}` ob
 | `GET` | `/api/admin/content/courses/:courseId/items` | Read the ordered mixed module/section sequence (#486/B2) |
 | `PUT` | `/api/admin/content/courses/:courseId/items` | Set the ordered sequence — body `{ items: [{type:"MODULE",moduleId} \| {type:"SECTION",sectionId}] }`. Re-syncs CourseModule (#486). |
 | `POST` | `/api/admin/content/courses/:courseId/publish` | Publish course |
-| `POST` | `/api/admin/content/courses/:courseId/archive` | Archive course |
+| `POST` | `/api/admin/content/courses/:courseId/unpublish` | Unpublish course. Blocked `400` if a participant has started-but-not-completed it (G3, #705) |
+| `POST` | `/api/admin/content/courses/:courseId/archive` | Archive course. Blocked `400` if a participant has started-but-not-completed it (G3); auto-unpublishes (I3, #705) |
+| `POST` | `/api/admin/content/courses/:courseId/restore` | Restore an archived course (lands in Utkast, #705) |
 | `GET` | `/api/admin/content/courses/:courseId/enrollments` | List active enrollments for a course, each with the participant + derived status (#496/EN-2) |
 | `POST` | `/api/admin/content/courses/:courseId/enrollments` | Assign — body `{ userIds?: string[], department?: string, dueAt?: string\|null }`. Individual list and/or department materialisation. Idempotent per user; audited (#496/EN-2) |
 | `DELETE` | `/api/admin/content/courses/:courseId/enrollments/:userId` | Revoke (soft) a participant's enrollment; audited (#496/EN-2) |
@@ -240,7 +242,11 @@ Classes (cohorts) assign a course to a group of participants dynamically: a part
 | `GET` | `/api/admin/content/sections/:sectionId` | Section detail (active version's `bodyMarkdown`) |
 | `PATCH` | `/api/admin/content/sections/:sectionId/title` | Update title |
 | `PUT` | `/api/admin/content/sections/:sectionId/content` | Publish a new immutable content version (latest-wins) |
-| `DELETE` | `/api/admin/content/sections/:sectionId` | Delete (blocked `400` if the section is used in a course) |
+| `POST` | `/api/admin/content/sections/:sectionId/publish` | Re-point active version to latest (G1 needs content, #705) |
+| `POST` | `/api/admin/content/sections/:sectionId/unpublish` | Unpublish. Blocked `400` if the section is used in any course (G2, #705) |
+| `POST` | `/api/admin/content/sections/:sectionId/archive` | Archive. Blocked `400` if used in any course (G2); auto-unpublishes (I3, #705) |
+| `POST` | `/api/admin/content/sections/:sectionId/restore` | Restore an archived section (lands in Utkast, #705) |
+| `DELETE` | `/api/admin/content/sections/:sectionId` | Delete (blocked `400` if the section is used in a course; names the courses, #705) |
 | `POST` | `/api/admin/content/sections/preview` | Render markdown → sanitised HTML (same F3/X1 policy as participant view) |
 | `POST` | `/api/admin/content/sections/localize` | LLM-translate title + bodyMarkdown to another locale (markdown-preserving). Rate-limited. |
 | `POST` | `/api/admin/content/sections/:sectionId/assets` | Upload a section image (multipart `file`). PNG/JPEG/GIF/WebP/SVG, max 5 MB. SVG is sanitised server-side before storage (scripts/handlers/`foreignObject`/`<a>` stripped, #657). Returns `asset` + `ref` (`asset:<id>`). |

--- a/doc/FEATURE_SURFACE_MAP.md
+++ b/doc/FEATURE_SURFACE_MAP.md
@@ -197,3 +197,26 @@ one page leaves siblings broken — this bit Klasser + Seksjoner together (v1.3.
 `test/e2e/admin-content-classes.spec.ts` "admin buttons + top nav render in prod-shaped config";
 `test/e2e/section-editor.spec.ts` "top workspace nav renders in prod-shaped config". A mock that sets
 **both** identityDefaults and `/api/me` hides this class of bug — always include a prod-shape case.
+
+## 13. Content lifecycle — publiser/avpubliser/arkiver/gjenopprett/slett on 3 entities (#705)
+
+Kurs, modul **and** seksjon share one lifecycle: states **Utkast/Publisert/Arkivert**, actions
+**Publiser⇄Avpubliser · Arkiver⇄Gjenopprett · Slett**, in that order, with the same four guards.
+A change to any rule (a new guard, a label, the auto-unpublish behaviour) must touch all three list
+UIs and the three command modules together. The integrity invariant (a published course never holds
+an unavailable module/section) is enforced by G2, **not** by the participant-side "Ikke tilgjengelig"
+fallback (that is only a safety net, #502-followup). Canonical model: `doc/design/CONTENT_LIFECYCLE.md`.
+
+| Surface | Where | Notes |
+|---------|-------|-------|
+| Shared guards (source of truth) | `src/modules/course/contentLifecycle.ts` | G2 `assertModuleNotInAnyCourse`/`assertSectionNotInAnyCourse`; G3 `assertCourseHasNoInProgressParticipants` |
+| Module commands | `src/modules/adminContent/adminContentCommands.ts` (`unpublishModule`, `archiveModule`) + repo `archiveModule` (auto-unpublish) | G2 on unpublish+archive; delete-in-course guard in `adminContent.ts` route |
+| Course commands | `src/modules/course/courseCommands.ts` (`unpublishCourse`, `archiveCourse`) | G3 on both; archive auto-unpublishes (I3); delete blocked by completions (G4) |
+| Section commands | `src/modules/course/sectionCommands.ts` (`publishSection`/`unpublishSection`/`archiveSection`/`restoreSection`/`deleteSection`) | G2 on unpublish/archive/delete; archive auto-unpublishes |
+| Routes | `adminContent.ts` (modules), `adminCourses.ts` (`/unpublish`), `adminSections.ts` (`/publish,/unpublish,/archive,/restore`) | `ValidationError` → 400 with named courses |
+| Module list UI | `public/static/admin-content-library.js` (`statusBadge`, row actions) | already had publish/unpublish/archive/restore + status column |
+| Course list UI | `public/static/admin-content-courses.js` (`courseStatus`/`courseStatusBadge`, `unpublishCourseInAdmin`, Status column) | added Avpubliser + status column |
+| Section list UI | `public/static/admin-content-sections.js` (`sectionStatus`/`statusBadge`/`sectionLifecycle`, archived toggle) | added status column + all lifecycle actions |
+| Shared badge style | `public/static/shared.css` → `.status-badge--{draft,published,archived}` | library has its own scoped `.status-badge` modifiers (richer module statuses) |
+
+**Guards:** `test/m2-content-lifecycle.test.ts` (G2/G3/I3 across all three); `test/m2-module-archive.test.ts` (archive auto-unpublishes); `test/e2e/admin-content-workspaces.spec.ts` "courses list can unpublish a published course (#705)" + "sections list shows status and runs the lifecycle actions (#705)".

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,33 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.5.0 - 2026-06-28
+
+feat: enhetlig innholds-livssyklus for kurs/modul/seksjon + tett integritets-hull (#705)
+
+Bakgrunn: en publisert modul kunne arkiveres ved å først avpublisere den (arkiv-vakta sjekket
+kun publiser-status, ikke kurs-referanser; avpubliser hadde ingen vakt) — slik kunne et publisert
+kurs ende med en arkivert/avpublisert modul. Livssyklusen var dessuten ujevnt implementert
+(seksjoner manglet arkiver/avpubliser helt, med et ubrukt `archivedAt`-felt).
+
+Én gjenkjennbar modell for alle tre innholdstyper (se `doc/design/CONTENT_LIFECYCLE.md`):
+
+- **Samme status overalt:** Utkast / Publisert / Arkivert, vist med felles `.status-badge`.
+- **Samme handlinger, samme rekkefølge:** Publiser⇄Avpubliser · Arkiver⇄Gjenopprett · Slett.
+- **G2 bruk-lås (alle kurs):** en modul/seksjon i ETHVERT kurs (publisert eller utkast) kan ikke
+  avpubliseres/arkiveres/slettes. Feilmeldingen navngir kursene. Tetter integritets-hullet.
+- **G3 aktivitets-lås:** et kurs med en påbegynt-men-ufullført deltaker kan ikke
+  avpubliseres/arkiveres.
+- **I3 arkiver auto-avpubliserer:** «arkivert men publisert» kan ikke oppstå; gjenopprett lander
+  i Utkast.
+- **Seksjoner:** ny publiser/avpubliser/arkiver/gjenopprett-symmetri (ruter + status-merkelapp +
+  Vis arkiverte-veksling i seksjonslista).
+- **Kurs:** ny Avpubliser (manglet) + status-kolonne i kurslista.
+- Nye endepunkt: `POST /api/admin/content/courses/:id/unpublish`,
+  `POST /api/admin/content/sections/:id/{publish,unpublish,archive,restore}`.
+- Tester: `m2-content-lifecycle` (G2/G3/I3) + oppdatert `m2-module-archive` (arkiver auto-avpub.)
+  + 2 nye e2e (kurs-avpubliser, seksjon-livssyklus).
+
 ## 1.4.6 - 2026-06-28
 
 fix(ux): forenklet kurs-opprettelse — nivå-valg går rett til editoren (#506)

--- a/doc/design/CONTENT_LIFECYCLE.md
+++ b/doc/design/CONTENT_LIFECYCLE.md
@@ -1,0 +1,125 @@
+# Enhetlig innholds-livssyklus — Kurs · Modul · Seksjon
+
+> Status: vedtatt 2026-06-28. Erstatter den ujevne, per-entitet-implementerte livssyklusen
+> som lot et publisert kurs ende opp med en arkivert/avpublisert modul (lappet i deltaker-UI
+> via #502-followup, «Ikke tilgjengelig»). Målet er **én gjenkjennbar modell** for alle tre
+> innholdstypene, slik at en forfatter lærer reglene én gang og kjenner dem igjen overalt.
+
+## 1. To akser, samme ord for alle tre
+
+Hvert innholdselement har **én status** sammensatt av to uavhengige akser:
+
+| Akse | Verdier | Betydning |
+|------|---------|-----------|
+| **Redaksjonell** | Utkast ⇄ Publisert | Er innholdet synlig/brukbart for deltakere? |
+| **Oppbevaring** | Aktiv ⇄ Arkivert | Er innholdet pensjonert (skjult i forfatter-lister, men bevart)? |
+
+Vist som **én status-merkelapp** med samme tre ord overalt:
+
+- **Utkast** — ikke publisert; usynlig for deltakere.
+- **Publisert** — live.
+- **Arkivert** — pensjonert; kan gjenopprettes. (Arkivert overstyrer; et arkivert element er
+  alltid også upublisert — se invariant I3.)
+
+### Hvordan akslene avbildes per entitet (datamodell)
+
+| | Utkast | Publisert | Arkivert |
+|---|---|---|---|
+| **Modul** | `activeVersionId = null`, `archivedAt = null` | `activeVersionId` satt | `archivedAt` satt |
+| **Kurs** | `publishedAt = null`, `archivedAt = null` | `publishedAt` satt | `archivedAt` satt |
+| **Seksjon** | `activeVersionId = null`, `archivedAt = null` | `activeVersionId` satt | `archivedAt` satt |
+
+Seksjoner **auto-publiseres ved lagring** (lavfriksjon — lagre = publiser), men eksponerer
+samme Avpubliser/Arkiver-handlinger som de to andre. Slik får forfatteren samme vokabular og
+samme knapper uten et ekstra obligatorisk publiser-klikk på den vanlige stien.
+
+## 2. Samme handlinger, samme rekkefølge, samme etiketter
+
+Alle tre entiteter viser nøyaktig samme handlingssett i samme rekkefølge:
+
+```
+Rediger/Åpne · Publiser ⇄ Avpubliser · Arkiver ⇄ Gjenopprett · Slett
+```
+
+Knappene veksler etter status: Publisert viser **Avpubliser**, Utkast viser **Publiser**;
+Aktiv viser **Arkiver**, Arkivert viser **Gjenopprett**. Slett er alltid synlig (men vaktet).
+
+## 3. Fire vakter (de gjenkjennbare reglene)
+
+### G1 — Fullstendighet ved publisering
+Kan ikke publisere ufullstendig innhold.
+- **Modul:** gyldig versjon (`validateModuleVersionForPublish` — blueprint/oppgave/innhold).
+- **Kurs:** minst én modul.
+- **Seksjon:** ikke-tomt innhold.
+
+### G2 — Bruk-lås (modul/seksjon i kurs)  ⟵ *vedtatt: ALLE kurs*
+En modul eller seksjon som ligger i **ethvert** kurs (publisert *eller* utkast) kan **ikke
+avpubliseres, arkiveres eller slettes**. Feilmeldingen navngir kursene:
+
+> «Modulen er i bruk i 2 kurs: «Arbeidsmiljø», «HMS-grunnkurs». Fjern den fra kursene
+> først (eller avpubliser kursene).»
+
+Dette gjør den eksisterende slett-vakta konsistent: alle tre tilbaketrekkende handlinger
+(avpubliser/arkiver/slett) er beskyttet likt, ikke bare slett.
+
+### G3 — Aktivitets-lås (kurs med påbegynt deltaker)  ⟵ *vedtatt: blokker hvis påbegynt*
+Et kurs som har minst én deltaker som har **påbegynt men ikke fullført** kan ikke
+**avpubliseres eller arkiveres**. «Påbegynt» = har lest minst én seksjon (`CourseSectionRead`)
+eller levert minst ett forsøk (`Submission`) på en modul i kurset, uten en `CourseCompletion`.
+
+### G4 — Slett-vern (historikk)
+Kan ikke slette hvis det ødelegger bevarte registre — arkiver i stedet.
+- **Kurs:** har `CourseCompletion` (utstedte sertifikat) → «Arkiver kurset i stedet».
+- **Modul:** har versjoner/forsøk/sertifiseringsstatus, eller er i et kurs (G2).
+- **Seksjon:** er i et kurs (G2) — dekker også leshistorikk (kun kurs-koblede seksjoner har lesinger).
+
+## 4. Invarianter
+
+- **I1 — Integritet:** Et publisert kurs inneholder aldri en modul/seksjon som ikke er
+  tilgjengelig. Håndheves av G2 (innhold kan ikke trekkes vekk under et kurs). «Ikke
+  tilgjengelig»-visningen i deltaker-UI (#502-followup) blir et rent sikkerhetsnett.
+- **I2 — Symmetri:** Hver tilstand er reversibel én tilbake: Publiser↔Avpubliser,
+  Arkiver↔Gjenopprett. Slett er den eneste terminale handlingen, og er vaktet (G4).
+- **I3 — Arkivert ⇒ Utkast:** Å arkivere **auto-avpubliserer** atomisk (fjerner
+  `activeVersionId`/`publishedAt` samtidig som `archivedAt` settes). Gjenopprett lander i
+  **Utkast** — forfatteren re-publiserer bevisst. Dermed finnes ikke tilstanden «arkivert men
+  fortsatt publisert».
+
+## 5. Tilstandsdiagram (likt for alle tre)
+
+```
+            publiser (G1)
+   Utkast ───────────────▶ Publisert
+     ▲   ◀───────────────     │
+     │      avpubliser         │
+     │      (G2/G3)            │ arkiver (G2/G3, auto-avpubliser → I3)
+     │                         │
+     │   arkiver (G2/G3)       ▼
+     └──────────────────▶ Arkivert
+          ◀───────────────
+            gjenopprett  (→ Utkast)
+
+   Slett (G4): terminal, fra hvilken som helst tilstand når vaktene tillater det.
+```
+
+## 6. Hva endres i koden (oppsummering)
+
+**Backend**
+- Modul: `unpublishModule` + `archiveModule` får G2-vakt (slett har den alt). Arkiver
+  auto-avpubliserer (I3).
+- Kurs: ny `unpublishCourse`; `archiveCourse` + `unpublishCourse` får G3-vakt; arkiver
+  auto-avpubliserer (I3). Slett beholder G4 (completions).
+- Seksjon: nye `publishSection`/`unpublishSection`/`archiveSection`/`restoreSection`; G2-vakt
+  på avpubliser/arkiver/slett.
+- Delt hjelper: `findCoursesContainingModule/Section` (id+tittel, alle publiseringstilstander)
+  for navngitte feilmeldinger; `countSectionCourses`.
+
+**Frontend (samkjør de tre listene)**
+- Felles status-merkelapp (Utkast/Publisert/Arkivert) med samme farger.
+- Seksjonsliste: legg til status-merkelapp + Publiser/Avpubliser/Arkiver/Gjenopprett (har i dag
+  bare Rediger/Slett).
+- Kursliste: legg til Avpubliser (mangler i dag).
+- Samme handlings-rekkefølge i alle tre lister.
+
+Se også `doc/FEATURE_SURFACE_MAP.md` (livssyklus-handlinger = distribuert oppførsel på tre
+flater) og `doc/API_REFERENCE.md` for endepunktene.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.4.6",
+  "version": "1.5.0",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -303,6 +303,18 @@ function canPublishCourse(course) {
   return !course?.publishedAt && !course?.archivedAt && moduleCount > 0;
 }
 
+// #705: samme to akser og status-vokabular som modul/seksjon — arkivert overstyrer.
+function courseStatus(course) {
+  if (course?.archivedAt) return "archived";
+  if (course?.publishedAt) return "published";
+  return "draft";
+}
+
+function courseStatusBadge(status) {
+  const label = status === "published" ? "Publisert" : status === "archived" ? "Arkivert" : "Utkast";
+  return `<span class="status-badge status-badge--${status}">${label}</span>`;
+}
+
 async function publishCourseInAdmin(courseId, triggerButton = null) {
   if (!courseId) return;
   if (triggerButton) triggerButton.disabled = true;
@@ -377,25 +389,36 @@ async function renderListView() {
   const rows = deriveCourseListRows(courses, {
     localizeTitle: localizedText,
     formatDate,
-  }).map((course) => `<tr>
-      <td class="col-title">${escapeHtml(course.title)}${course.archivedAt ? ` <span style="display:inline-block;margin-left:6px;padding:1px 8px;border-radius:999px;background:#f0f0f0;color:#666;font-size:11px;font-weight:600;vertical-align:middle;">Arkivert</span>` : ""}</td>
+  }).map((course) => {
+    const status = courseStatus(course);
+    const cid = escapeHtml(course.courseId);
+    const ctitle = escapeHtml(course.title);
+    // #705: samme handlings-rekkefølge som modul/seksjon — Publiser⇄Avpubliser, Arkiver⇄Gjenopprett.
+    const publishToggle = canPublishCourse(course)
+      ? `<button class="row-action-btn" data-action="publish" data-course-id="${cid}">Publiser</button>`
+      : status === "published"
+        ? `<button class="row-action-btn" data-action="unpublish" data-course-id="${cid}" data-course-title="${ctitle}">Avpubliser</button>`
+        : "";
+    const archiveToggleBtn = course.archivedAt
+      ? `<button class="row-action-btn" data-action="restore" data-course-id="${cid}" data-course-title="${ctitle}">Gjenopprett</button>`
+      : `<button class="row-action-btn" data-action="archive" data-course-id="${cid}" data-course-title="${ctitle}">Arkiver</button>`;
+    return `<tr>
+      <td class="col-title">${ctitle}</td>
+      <td class="col-status">${courseStatusBadge(status)}</td>
       <td class="col-level">${certBadge(course.certificationLevel)}</td>
       <td class="col-module-count">${course.moduleCount}</td>
       <td class="col-updated">${escapeHtml(course.updatedLabel)}</td>
       <td class="col-actions">
         <div class="row-actions">
           <a href="/admin-content/courses/${encodeURIComponent(course.courseId)}" class="row-action-btn">Rediger</a>
-          ${canPublishCourse(course)
-            ? `<button class="row-action-btn" data-action="publish" data-course-id="${escapeHtml(course.courseId)}">Publiser</button>`
-            : ""}
-          <button class="row-action-btn" data-action="export" data-course-id="${escapeHtml(course.courseId)}" data-course-title="${escapeHtml(course.title)}">Eksporter</button>
-          ${course.archivedAt
-            ? `<button class="row-action-btn" data-action="restore" data-course-id="${escapeHtml(course.courseId)}" data-course-title="${escapeHtml(course.title)}">Gjenopprett</button>`
-            : `<button class="row-action-btn" data-action="archive" data-course-id="${escapeHtml(course.courseId)}" data-course-title="${escapeHtml(course.title)}">Arkiver</button>`}
-          <button class="row-action-btn destructive" data-action="delete" data-course-id="${escapeHtml(course.courseId)}" data-course-title="${escapeHtml(course.title)}">Slett</button>
+          ${publishToggle}
+          ${archiveToggleBtn}
+          <button class="row-action-btn" data-action="export" data-course-id="${cid}" data-course-title="${ctitle}">Eksporter</button>
+          <button class="row-action-btn destructive" data-action="delete" data-course-id="${cid}" data-course-title="${ctitle}">Slett</button>
         </div>
       </td>
-    </tr>`).join("");
+    </tr>`;
+  }).join("");
 
   pageContent.innerHTML = `
     <div class="page-header">
@@ -412,6 +435,7 @@ async function renderListView() {
         <thead>
           <tr>
             <th scope="col">Tittel</th>
+            <th scope="col">Status</th>
             <th scope="col">Sertifiseringsnivå</th>
             <th scope="col">Antall moduler</th>
             <th scope="col">Sist endret</th>
@@ -496,6 +520,10 @@ function handleListTableClick(event) {
     exportCoursePackage(btn.dataset.courseId, btn.dataset.courseTitle);
     return;
   }
+  if (btn.dataset.action === "unpublish") {
+    unpublishCourseInAdmin(btn.dataset.courseId, btn.dataset.courseTitle, btn);
+    return;
+  }
   if (btn.dataset.action === "archive") {
     archiveCourseInAdmin(btn.dataset.courseId, btn.dataset.courseTitle, btn);
     return;
@@ -522,6 +550,23 @@ async function archiveCourseInAdmin(courseId, courseTitle, triggerButton = null)
     await renderListView();
   } catch (err) {
     showToast(err?.message ?? "Kunne ikke arkivere kurs.", "error");
+    if (triggerButton) triggerButton.disabled = false;
+  }
+}
+
+// #705: avpubliser et kurs (motstykke til Publiser). G3-vakta (påbegynt deltaker) i backend gir
+// en forklarende feilmelding hvis det ikke er lov.
+async function unpublishCourseInAdmin(courseId, courseTitle, triggerButton = null) {
+  if (!window.confirm(`Avpublisere kurset «${courseTitle}»? Det blir skjult for deltakere til du publiserer igjen.`)) {
+    return;
+  }
+  if (triggerButton) triggerButton.disabled = true;
+  try {
+    await apiFetch(`/api/admin/content/courses/${encodeURIComponent(courseId)}/unpublish`, getHeaders, { method: "POST" });
+    showToast("Kurset ble avpublisert.", "success");
+    await renderListView();
+  } catch (err) {
+    showToast(err?.message ?? "Kunne ikke avpublisere kurs.", "error");
     if (triggerButton) triggerButton.disabled = false;
   }
 }

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -20,6 +20,11 @@ const EDITOR_LOCALES = ["nb", "nn", "en-GB"];
 const LABELS = {
   "en-GB": {
     heading: "Sections", newSection: "+ New section", colTitle: "Title", colVersion: "Version",
+    colStatus: "Status", statusDraft: "Draft", statusPublished: "Published", statusArchived: "Archived",
+    publish: "Publish", unpublish: "Unpublish", archive: "Archive", restore: "Restore",
+    showArchived: "Show archived", hideArchived: "Hide archived",
+    published: "Section published.", unpublished: "Section unpublished.",
+    archived: "Section archived.", restored: "Section restored.", confirmArchive: "Archive this section?",
     colUpdated: "Last changed", edit: "Edit", del: "Delete", empty: "No sections yet.",
     back: "← Back", titleLabel: "Title", markdown: "Markdown", preview: "Preview",
     save: "Save new version", saved: "Section saved.", deleted: "Section deleted.",
@@ -31,6 +36,11 @@ const LABELS = {
   },
   nb: {
     heading: "Seksjoner", newSection: "+ Ny seksjon", colTitle: "Tittel", colVersion: "Versjon",
+    colStatus: "Status", statusDraft: "Utkast", statusPublished: "Publisert", statusArchived: "Arkivert",
+    publish: "Publiser", unpublish: "Avpubliser", archive: "Arkiver", restore: "Gjenopprett",
+    showArchived: "Vis arkiverte", hideArchived: "Skjul arkiverte",
+    published: "Seksjon publisert.", unpublished: "Seksjon avpublisert.",
+    archived: "Seksjon arkivert.", restored: "Seksjon gjenopprettet.", confirmArchive: "Arkivere denne seksjonen?",
     colUpdated: "Sist endret", edit: "Rediger", del: "Slett", empty: "Ingen seksjoner ennå.",
     back: "← Tilbake", titleLabel: "Tittel", markdown: "Markdown", preview: "Forhåndsvisning",
     save: "Lagre ny versjon", saved: "Seksjon lagret.", deleted: "Seksjon slettet.",
@@ -42,6 +52,11 @@ const LABELS = {
   },
   nn: {
     heading: "Seksjonar", newSection: "+ Ny seksjon", colTitle: "Tittel", colVersion: "Versjon",
+    colStatus: "Status", statusDraft: "Utkast", statusPublished: "Publisert", statusArchived: "Arkivert",
+    publish: "Publiser", unpublish: "Avpubliser", archive: "Arkiver", restore: "Gjenopprett",
+    showArchived: "Vis arkiverte", hideArchived: "Skjul arkiverte",
+    published: "Seksjon publisert.", unpublished: "Seksjon avpublisert.",
+    archived: "Seksjon arkivert.", restored: "Seksjon gjenoppretta.", confirmArchive: "Arkivere denne seksjonen?",
     colUpdated: "Sist endra", edit: "Rediger", del: "Slett", empty: "Ingen seksjonar enno.",
     back: "← Tilbake", titleLabel: "Tittel", markdown: "Markdown", preview: "Førehandsvising",
     save: "Lagre ny versjon", saved: "Seksjon lagra.", deleted: "Seksjon sletta.",
@@ -140,6 +155,22 @@ function goTo(view, sectionId) {
 // List view
 // ---------------------------------------------------------------------------
 
+// #705: status fra de samme to aksene som modul/kurs — arkivert overstyrer; ellers publisert hvis
+// en aktiv versjon er valgt, ellers utkast.
+function sectionStatus(s) {
+  if (s.archivedAt) return "archived";
+  if (s.activeVersionId) return "published";
+  return "draft";
+}
+
+function statusBadge(status) {
+  const label = status === "published" ? L("statusPublished") : status === "archived" ? L("statusArchived") : L("statusDraft");
+  return `<span class="status-badge status-badge--${status}">${escapeHtml(label)}</span>`;
+}
+
+// #705: vis/skjul arkiverte seksjoner (default skjult), likt kurslista.
+let showArchivedSections = false;
+
 async function renderListView() {
   let sections;
   try {
@@ -150,34 +181,73 @@ async function renderListView() {
     return;
   }
 
-  const rows = sections.map((s) => `<tr>
+  const hasArchived = sections.some((s) => s.archivedAt);
+  const visible = showArchivedSections ? sections : sections.filter((s) => !s.archivedAt);
+
+  // #705: samme handlings-rekkefølge og status-vokabular som modul/kurs.
+  const rows = visible.map((s) => {
+    const status = sectionStatus(s);
+    const id = escapeHtml(s.id);
+    const lifecycle = status === "archived"
+      ? `<button class="row-action-btn" data-action="restore" data-id="${id}">${escapeHtml(L("restore"))}</button>`
+      : status === "published"
+        ? `<button class="row-action-btn" data-action="unpublish" data-id="${id}">${escapeHtml(L("unpublish"))}</button>
+           <button class="row-action-btn" data-action="archive" data-id="${id}">${escapeHtml(L("archive"))}</button>`
+        : `<button class="row-action-btn" data-action="publish" data-id="${id}">${escapeHtml(L("publish"))}</button>
+           <button class="row-action-btn" data-action="archive" data-id="${id}">${escapeHtml(L("archive"))}</button>`;
+    return `<tr>
       <td class="col-title">${escapeHtml(displayTitle(s.title))}</td>
+      <td>${statusBadge(status)}</td>
       <td>v${escapeHtml(s.versionNo ?? "1")}</td>
       <td style="white-space:nowrap">${escapeHtml(new Date(s.updatedAt).toLocaleDateString(currentLocale))}</td>
       <td class="col-actions">
-        <button class="row-action-btn" data-action="edit" data-id="${escapeHtml(s.id)}">${escapeHtml(L("edit"))}</button>
-        <button class="row-action-btn destructive" data-action="delete" data-id="${escapeHtml(s.id)}">${escapeHtml(L("del"))}</button>
+        <button class="row-action-btn" data-action="edit" data-id="${id}">${escapeHtml(L("edit"))}</button>
+        ${lifecycle}
+        <button class="row-action-btn destructive" data-action="delete" data-id="${id}">${escapeHtml(L("del"))}</button>
       </td>
-    </tr>`).join("");
+    </tr>`;
+  }).join("");
 
   pageContent.innerHTML = `
     <div class="page-header">
       <h1>${escapeHtml(L("heading"))}</h1>
       <button type="button" id="newSectionBtn" class="btn btn-primary" style="width:auto">${escapeHtml(L("newSection"))}</button>
     </div>
-    ${sections.length === 0
+    ${hasArchived ? `<div style="margin-bottom:8px"><button type="button" id="toggleArchivedSectionsBtn" class="row-action-btn">${escapeHtml(showArchivedSections ? L("hideArchived") : L("showArchived"))}</button></div>` : ""}
+    ${visible.length === 0
       ? `<div class="empty-state"><p class="empty-state-text">${escapeHtml(L("empty"))}</p></div>`
       : `<div class="sections-table-wrap"><table class="sections-table">
-          <thead><tr><th>${escapeHtml(L("colTitle"))}</th><th>${escapeHtml(L("colVersion"))}</th><th>${escapeHtml(L("colUpdated"))}</th><th class="col-actions"></th></tr></thead>
+          <thead><tr><th>${escapeHtml(L("colTitle"))}</th><th>${escapeHtml(L("colStatus"))}</th><th>${escapeHtml(L("colVersion"))}</th><th>${escapeHtml(L("colUpdated"))}</th><th class="col-actions"></th></tr></thead>
           <tbody id="sectionsTableBody">${rows}</tbody></table></div>`}`;
 
   document.getElementById("newSectionBtn")?.addEventListener("click", () => goTo("editor", null));
+  document.getElementById("toggleArchivedSectionsBtn")?.addEventListener("click", () => {
+    showArchivedSections = !showArchivedSections;
+    renderListView();
+  });
   document.getElementById("sectionsTableBody")?.addEventListener("click", (event) => {
     const btn = event.target.closest("[data-action]");
     if (!btn) return;
-    if (btn.dataset.action === "edit") goTo("editor", btn.dataset.id);
-    else if (btn.dataset.action === "delete") deleteSection(btn.dataset.id);
+    const id = btn.dataset.id;
+    const action = btn.dataset.action;
+    if (action === "edit") goTo("editor", id);
+    else if (action === "delete") deleteSection(id);
+    else if (action === "publish") sectionLifecycle(id, "publish", "published");
+    else if (action === "unpublish") sectionLifecycle(id, "unpublish", "unpublished");
+    else if (action === "archive") { if (window.confirm(L("confirmArchive"))) sectionLifecycle(id, "archive", "archived"); }
+    else if (action === "restore") sectionLifecycle(id, "restore", "restored");
   });
+}
+
+// #705: én felles handler for de fire livssyklus-overgangene (POST .../{action}).
+async function sectionLifecycle(sectionId, action, toastKey) {
+  try {
+    await apiFetch(`/api/admin/content/sections/${encodeURIComponent(sectionId)}/${action}`, getHeaders, { method: "POST" });
+    showToast(L(toastKey));
+    renderListView();
+  } catch (err) {
+    showToast(err?.message ?? "Error", "error");
+  }
 }
 
 async function deleteSection(sectionId) {

--- a/public/static/shared.css
+++ b/public/static/shared.css
@@ -1057,3 +1057,19 @@ dialog::backdrop {
 .disc-compose-actions { display: flex; justify-content: flex-end; }
 .discussion-body { overflow-wrap: anywhere; }
 .discussion-body p { margin: 0 0 8px; }
+
+/* #705 Enhetlig innholds-livssyklus — felles status-merkelapp for kurs/modul/seksjon, slik at
+   de tre admin-listene gjenkjennes likt. Samme tre ord overalt: Utkast / Publisert / Arkivert. */
+.status-badge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.6;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.status-badge--draft     { background: #edf1f7; color: #42526b; }  /* grå  — utkast (ikke synlig) */
+.status-badge--published { background: #e6f4ea; color: #12613a; }  /* grønn — live */
+.status-badge--archived  { background: #f0f0f0; color: #666; }     /* dempet — pensjonert */

--- a/src/modules/adminContent/adminContentCommands.ts
+++ b/src/modules/adminContent/adminContentCommands.ts
@@ -7,6 +7,7 @@ import { assessmentPolicyCodec, type ModuleAssessmentPolicy } from "../../codecs
 import type { AssessmentMode } from "@prisma/client";
 import { localizedTextCodec, type LocalizedText, type LocalizedTextObject } from "../../codecs/localizedTextCodec.js";
 import { NotFoundError } from "../../errors/AppError.js";
+import { assertModuleNotInAnyCourse } from "../course/contentLifecycle.js";
 import {
   generateModuleRubric,
   type AssessmentBlueprint,
@@ -699,14 +700,17 @@ export async function archiveModule(moduleId: string, actorId: string) {
     throw new Error("Module not found.");
   }
 
-  if (module.activeVersionId) {
-    throw new Error("Module must be unpublished before it can be archived.");
-  }
-
   if (module.archivedAt) {
     throw new Error("Module is already archived.");
   }
 
+  // G2 (bruk-lås): en modul som ligger i ETHVERT kurs (publisert eller utkast) kan ikke
+  // arkiveres — den ville trekkes vekk under kurset. Dette tetter hullet der en publisert
+  // modul kunne avpubliseres og deretter arkiveres mens den fortsatt lå i et publisert kurs.
+  await assertModuleNotInAnyCourse(moduleId, "arkiveres");
+
+  // I3: arkivering auto-avpubliserer (rydder activeVersionId samtidig som archivedAt settes),
+  // så tilstanden «arkivert men fortsatt publisert» aldri oppstår. Gjenopprett lander i Utkast.
   const result = await adminContentRepository.archiveModule(moduleId, new Date());
 
   await recordAuditEvent({
@@ -746,6 +750,9 @@ export async function restoreModule(moduleId: string, actorId: string) {
 
 export async function unpublishModule(moduleId: string, actorId: string) {
   await ensureModuleExists(moduleId);
+  // G2 (bruk-lås): kan ikke avpublisere en modul som ligger i et kurs — det ville gi en
+  // blindvei i kurset. Fjern den fra kursene først.
+  await assertModuleNotInAnyCourse(moduleId, "avpubliseres");
   const result = await adminContentRepository.unpublishModule(moduleId);
 
   await recordAuditEvent({

--- a/src/modules/adminContent/adminContentRepository.ts
+++ b/src/modules/adminContent/adminContentRepository.ts
@@ -80,9 +80,11 @@ export function createAdminContentRepository(client: AdminContentRepositoryClien
     },
 
     archiveModule(moduleId: string, now: Date) {
+      // I3: arkivering auto-avpubliserer (activeVersionId nullstilles) så «arkivert men
+      // publisert» aldri oppstår. Gjenopprett (restoreModule) lander dermed i Utkast.
       return client.module.update({
         where: { id: moduleId },
-        data: { archivedAt: now },
+        data: { archivedAt: now, activeVersionId: null },
         select: { id: true, title: true, archivedAt: true },
       });
     },

--- a/src/modules/course/contentLifecycle.ts
+++ b/src/modules/course/contentLifecycle.ts
@@ -1,0 +1,104 @@
+import { prisma } from "../../db/prisma.js";
+import { ValidationError } from "../../errors/AppError.js";
+import { localizeContentText } from "../../i18n/content.js";
+
+// Enhetlig innholds-livssyklus — delte vakter for kurs/modul/seksjon.
+// Se doc/design/CONTENT_LIFECYCLE.md. G2 = bruk-lås (modul/seksjon i ETHVERT kurs kan ikke
+// avpubliseres/arkiveres/slettes). G3 = aktivitets-lås (kurs med påbegynt-ufullført deltaker
+// kan ikke avpubliseres/arkiveres). Feilmeldinger navngir kursene/teller deltakerne på norsk.
+
+const MSG_LOCALE = "nb" as const;
+
+function courseDisplayTitle(rawTitle: string): string {
+  return localizeContentText(MSG_LOCALE, rawTitle) ?? rawTitle;
+}
+
+async function coursesContaining(
+  itemWhere: { moduleId: string } | { sectionId: string },
+): Promise<Array<{ id: string; title: string }>> {
+  const rows = await prisma.course.findMany({
+    where: { items: { some: itemWhere } },
+    select: { id: true, title: true },
+    orderBy: { updatedAt: "desc" },
+  });
+  return rows.map((row) => ({ id: row.id, title: courseDisplayTitle(row.title) }));
+}
+
+export function findCoursesContainingModule(moduleId: string) {
+  return coursesContaining({ moduleId });
+}
+
+export function findCoursesContainingSection(sectionId: string) {
+  return coursesContaining({ sectionId });
+}
+
+function inUseMessage(
+  subject: "Modulen" | "Seksjonen",
+  verb: string,
+  courses: Array<{ title: string }>,
+): string {
+  const names = courses.map((c) => `«${c.title}»`).join(", ");
+  const plural = courses.length === 1 ? "kurs" : "kurs";
+  return (
+    `${subject} kan ikke ${verb} fordi den er i bruk i ${courses.length} ${plural}: ${names}. ` +
+    `Fjern den fra kursene først (eller avpubliser kursene).`
+  );
+}
+
+// G2: en modul som ligger i ethvert kurs (publisert eller utkast) kan ikke avpubliseres/
+// arkiveres/slettes. `verb` brukes i feilmeldingen, f.eks. "avpubliseres" | "arkiveres" | "slettes".
+export async function assertModuleNotInAnyCourse(moduleId: string, verb: string): Promise<void> {
+  const courses = await findCoursesContainingModule(moduleId);
+  if (courses.length > 0) {
+    throw new ValidationError(inUseMessage("Modulen", verb, courses));
+  }
+}
+
+// G2 for seksjoner — samme regel.
+export async function assertSectionNotInAnyCourse(sectionId: string, verb: string): Promise<void> {
+  const courses = await findCoursesContainingSection(sectionId);
+  if (courses.length > 0) {
+    throw new ValidationError(inUseMessage("Seksjonen", verb, courses));
+  }
+}
+
+// Antall deltakere som har PÅBEGYNT (lest en seksjon eller levert et forsøk på en kurs-modul)
+// men IKKE fullført (ingen CourseCompletion). Brukt av G3-vakta for kurs.
+export async function countCourseInProgressParticipants(courseId: string): Promise<number> {
+  const [reads, submissions, completions] = await Promise.all([
+    prisma.courseSectionRead.findMany({
+      where: { courseId },
+      select: { userId: true },
+      distinct: ["userId"],
+    }),
+    prisma.submission.findMany({
+      where: { module: { courseItems: { some: { courseId } } } },
+      select: { userId: true },
+      distinct: ["userId"],
+    }),
+    prisma.courseCompletion.findMany({ where: { courseId }, select: { userId: true } }),
+  ]);
+
+  const completed = new Set(completions.map((c) => c.userId));
+  const started = new Set<string>();
+  for (const r of reads) started.add(r.userId);
+  for (const s of submissions) started.add(s.userId);
+
+  let inProgress = 0;
+  for (const userId of started) {
+    if (!completed.has(userId)) inProgress += 1;
+  }
+  return inProgress;
+}
+
+// G3: et kurs med minst én påbegynt-ufullført deltaker kan ikke avpubliseres/arkiveres.
+export async function assertCourseHasNoInProgressParticipants(courseId: string, verb: string): Promise<void> {
+  const count = await countCourseInProgressParticipants(courseId);
+  if (count > 0) {
+    const deltaker = count === 1 ? "1 deltaker har" : `${count} deltakere har`;
+    throw new ValidationError(
+      `Kurset kan ikke ${verb} fordi ${deltaker} en påbegynt, ufullført gjennomføring. ` +
+        `Vent til de er ferdige, eller fjern påmeldingene først.`,
+    );
+  }
+}

--- a/src/modules/course/courseCommands.ts
+++ b/src/modules/course/courseCommands.ts
@@ -3,6 +3,7 @@ import { runInTransaction } from "../../db/transaction.js";
 import { NotFoundError, ValidationError } from "../../errors/AppError.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
+import { assertCourseHasNoInProgressParticipants } from "./contentLifecycle.js";
 
 export async function createCourse(input: {
   title: string;
@@ -72,10 +73,42 @@ export async function publishCourse(courseId: string, actorId?: string) {
   return updated;
 }
 
-export async function archiveCourse(courseId: string, actorId?: string) {
+// #705: avpubliser et kurs (motstykke til publishCourse). Symmetri med modul/seksjon.
+export async function unpublishCourse(courseId: string, actorId?: string) {
+  const course = await prisma.course.findUnique({ where: { id: courseId }, select: { id: true } });
+  if (!course) throw new NotFoundError("Course", "course_not_found", "Course not found.");
+
+  // G3 (aktivitets-lås): et kurs med påbegynt-ufullført deltaker kan ikke trekkes vekk.
+  await assertCourseHasNoInProgressParticipants(courseId, "avpubliseres");
+
   const updated = await prisma.course.update({
     where: { id: courseId },
-    data: { archivedAt: new Date() },
+    data: { publishedAt: null },
+  });
+
+  await recordAuditEvent({
+    entityType: auditEntityTypes.course,
+    entityId: courseId,
+    action: auditActions.course.unpublished,
+    actorId,
+    metadata: { courseId },
+  });
+
+  return updated;
+}
+
+export async function archiveCourse(courseId: string, actorId?: string) {
+  const course = await prisma.course.findUnique({ where: { id: courseId }, select: { id: true } });
+  if (!course) throw new NotFoundError("Course", "course_not_found", "Course not found.");
+
+  // G3 (aktivitets-lås): blokker arkivering så lenge noen har en påbegynt, ufullført gjennomføring.
+  await assertCourseHasNoInProgressParticipants(courseId, "arkiveres");
+
+  // I3: arkivering auto-avpubliserer (publishedAt nullstilles) så «arkivert men publisert» aldri
+  // oppstår. Gjenopprett (restoreCourse) lander dermed i Utkast.
+  const updated = await prisma.course.update({
+    where: { id: courseId },
+    data: { archivedAt: new Date(), publishedAt: null },
   });
 
   await recordAuditEvent({

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -1,6 +1,6 @@
 export { checkAndIssueCourseCompletions, checkCourseCompletionForCourse, reconcileCourseCompletionsForUser } from "./courseCompletionService.js";
 export { getCourseReport, getCourseLearnerReport } from "./courseReport.js";
-export { createCourse, updateCourse, publishCourse, archiveCourse, restoreCourse, setCourseModules, setCourseItems, deleteCourse } from "./courseCommands.js";
+export { createCourse, updateCourse, publishCourse, unpublishCourse, archiveCourse, restoreCourse, setCourseModules, setCourseItems, deleteCourse } from "./courseCommands.js";
 export type { CourseItemInput } from "./courseCommands.js";
 export {
   createSection,
@@ -8,6 +8,10 @@ export {
   updateSectionContent,
   getSection,
   listSections,
+  publishSection,
+  unpublishSection,
+  archiveSection,
+  restoreSection,
   deleteSection,
 } from "./sectionCommands.js";
 export {

--- a/src/modules/course/sectionCommands.ts
+++ b/src/modules/course/sectionCommands.ts
@@ -1,6 +1,9 @@
 import { prisma } from "../../db/prisma.js";
 import { runInTransaction } from "../../db/transaction.js";
 import { NotFoundError, ValidationError } from "../../errors/AppError.js";
+import { recordAuditEvent } from "../../services/auditService.js";
+import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
+import { assertSectionNotInAnyCourse } from "./contentLifecycle.js";
 
 // Section CRUD + versioning (#485/B1) for course learning sections (#476).
 // Mirrors Module/ModuleVersion: editing content publishes an immutable new
@@ -76,12 +79,122 @@ export function listSections() {
   });
 }
 
+// #705: enhetlig livssyklus for seksjoner (symmetri med modul/kurs). Seksjoner auto-publiseres
+// ved lagring; disse handlingene gir samme Publiser/Avpubliser/Arkiver/Gjenopprett-vokabular.
+
+// Publiser: re-pek activeVersionId til siste versjon (krever at det finnes en versjon med innhold).
+export async function publishSection(sectionId: string, actorId?: string) {
+  const section = await prisma.courseSection.findUnique({
+    where: { id: sectionId },
+    select: { id: true, archivedAt: true },
+  });
+  if (!section) {
+    throw new NotFoundError("CourseSection", "section_not_found", "Course section not found.");
+  }
+  if (section.archivedAt) {
+    throw new ValidationError("Gjenopprett seksjonen før du publiserer den.");
+  }
+  const latest = await prisma.courseSectionVersion.findFirst({
+    where: { sectionId },
+    orderBy: { versionNo: "desc" },
+    select: { id: true },
+  });
+  if (!latest) {
+    throw new ValidationError("Seksjonen har ikke noe innhold å publisere.");
+  }
+  const updated = await prisma.courseSection.update({
+    where: { id: sectionId },
+    data: { activeVersionId: latest.id },
+    include: { activeVersion: true },
+  });
+  await recordAuditEvent({
+    entityType: auditEntityTypes.courseSection,
+    entityId: sectionId,
+    action: auditActions.section.published,
+    actorId,
+    metadata: { sectionId },
+  });
+  return updated;
+}
+
+// Avpubliser: nullstill activeVersionId. G2 — kan ikke avpublisere en seksjon som ligger i et kurs.
+export async function unpublishSection(sectionId: string, actorId?: string) {
+  await assertSectionExists(sectionId);
+  await assertSectionNotInAnyCourse(sectionId, "avpubliseres");
+  const updated = await prisma.courseSection.update({
+    where: { id: sectionId },
+    data: { activeVersionId: null },
+    include: { activeVersion: true },
+  });
+  await recordAuditEvent({
+    entityType: auditEntityTypes.courseSection,
+    entityId: sectionId,
+    action: auditActions.section.unpublished,
+    actorId,
+    metadata: { sectionId },
+  });
+  return updated;
+}
+
+// Arkiver: G2-vakt + auto-avpubliser (I3). Gjenopprett lander i Utkast.
+export async function archiveSection(sectionId: string, actorId?: string) {
+  const section = await prisma.courseSection.findUnique({
+    where: { id: sectionId },
+    select: { id: true, archivedAt: true },
+  });
+  if (!section) {
+    throw new NotFoundError("CourseSection", "section_not_found", "Course section not found.");
+  }
+  if (section.archivedAt) {
+    throw new ValidationError("Seksjonen er allerede arkivert.");
+  }
+  await assertSectionNotInAnyCourse(sectionId, "arkiveres");
+  const updated = await prisma.courseSection.update({
+    where: { id: sectionId },
+    data: { archivedAt: new Date(), activeVersionId: null },
+    include: { activeVersion: true },
+  });
+  await recordAuditEvent({
+    entityType: auditEntityTypes.courseSection,
+    entityId: sectionId,
+    action: auditActions.section.archived,
+    actorId,
+    metadata: { sectionId },
+  });
+  return updated;
+}
+
+// Gjenopprett: nullstill archivedAt (lander i Utkast — forfatteren re-publiserer bevisst).
+export async function restoreSection(sectionId: string, actorId?: string) {
+  const section = await prisma.courseSection.findUnique({
+    where: { id: sectionId },
+    select: { id: true, archivedAt: true },
+  });
+  if (!section) {
+    throw new NotFoundError("CourseSection", "section_not_found", "Course section not found.");
+  }
+  if (!section.archivedAt) {
+    throw new ValidationError("Seksjonen er ikke arkivert.");
+  }
+  const updated = await prisma.courseSection.update({
+    where: { id: sectionId },
+    data: { archivedAt: null },
+    include: { activeVersion: true },
+  });
+  await recordAuditEvent({
+    entityType: auditEntityTypes.courseSection,
+    entityId: sectionId,
+    action: auditActions.section.restored,
+    actorId,
+    metadata: { sectionId },
+  });
+  return updated;
+}
+
 export async function deleteSection(sectionId: string) {
   await assertSectionExists(sectionId);
-  const references = await prisma.courseItem.count({ where: { sectionId } });
-  if (references > 0) {
-    throw new ValidationError("Cannot delete a section that is used in one or more courses.");
-  }
+  // G2: navngir kursene (konsistent med modul-sletting).
+  await assertSectionNotInAnyCourse(sectionId, "slettes");
   await runInTransaction(async (tx) => {
     // Detach activeVersion FK before deleting versions to avoid the self-reference.
     await tx.courseSection.update({ where: { id: sectionId }, data: { activeVersionId: null } });

--- a/src/observability/auditEvents.ts
+++ b/src/observability/auditEvents.ts
@@ -9,6 +9,7 @@ export const auditEntityTypes = {
   calibrationWorkspace: "calibration_workspace",
   certificationStatus: "certification_status",
   course: "course",
+  courseSection: "course_section",
   class: "class",
   discussionThread: "discussion_thread",
   discussionReply: "discussion_reply",
@@ -69,9 +70,16 @@ export const auditActions = {
   course: {
     created: "course_created",
     published: "course_published",
+    unpublished: "course_unpublished",
     archived: "course_archived",
     restored: "course_restored",
     completionIssued: "course_completion_issued",
+  },
+  section: {
+    published: "section_published",
+    unpublished: "section_unpublished",
+    archived: "section_archived",
+    restored: "section_restored",
   },
   enrollment: {
     assigned: "course_enrollment_assigned",
@@ -277,8 +285,13 @@ export type AuditMetadataByAction = {
   }>;
   [auditActions.course.created]: EventMetadata<{ courseId: string }>;
   [auditActions.course.published]: EventMetadata<{ courseId: string }>;
+  [auditActions.course.unpublished]: EventMetadata<{ courseId: string }>;
   [auditActions.course.archived]: EventMetadata<{ courseId: string }>;
   [auditActions.course.restored]: EventMetadata<{ courseId: string }>;
+  [auditActions.section.published]: EventMetadata<{ sectionId: string }>;
+  [auditActions.section.unpublished]: EventMetadata<{ sectionId: string }>;
+  [auditActions.section.archived]: EventMetadata<{ sectionId: string }>;
+  [auditActions.section.restored]: EventMetadata<{ sectionId: string }>;
   [auditActions.course.completionIssued]: EventMetadata<{
     userId: string;
     courseId: string;

--- a/src/routes/adminCourses.ts
+++ b/src/routes/adminCourses.ts
@@ -4,6 +4,7 @@ import {
   createCourse,
   updateCourse,
   publishCourse,
+  unpublishCourse,
   archiveCourse,
   restoreCourse,
   setCourseModules,
@@ -306,6 +307,16 @@ adminCoursesRouter.put("/:courseId/items", async (request, response, next) => {
 adminCoursesRouter.post("/:courseId/publish", async (request, response, next) => {
   try {
     const course = await publishCourse(request.params.courseId, request.context?.userId);
+    response.json({ course });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// #705: avpubliser et kurs (motstykke til publish). G3-vakt (påbegynt deltaker) i kommandolaget.
+adminCoursesRouter.post("/:courseId/unpublish", async (request, response, next) => {
+  try {
+    const course = await unpublishCourse(request.params.courseId, request.context?.userId);
     response.json({ course });
   } catch (error) {
     next(error);

--- a/src/routes/adminSections.ts
+++ b/src/routes/adminSections.ts
@@ -7,6 +7,10 @@ import {
   updateSectionContent,
   getSection,
   listSections,
+  publishSection,
+  unpublishSection,
+  archiveSection,
+  restoreSection,
   deleteSection,
   createSectionAsset,
   listSectionAssets,
@@ -230,6 +234,44 @@ adminSectionsRouter.post("/:sectionId/assets/localize", generateLimiter, async (
   try {
     const result = await localizeSectionAssets(request.params.sectionId, parsed.data.sourceLocale);
     response.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// #705: enhetlig livssyklus — seksjoner får samme Publiser/Avpubliser/Arkiver/Gjenopprett som
+// moduler/kurs. Bruk-lås (G2) håndheves i kommandolaget og gir 400 med navngitte kurs.
+adminSectionsRouter.post("/:sectionId/publish", async (request, response, next) => {
+  try {
+    const section = await publishSection(request.params.sectionId, request.context?.userId);
+    response.json({ section: toDetail(section) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminSectionsRouter.post("/:sectionId/unpublish", async (request, response, next) => {
+  try {
+    const section = await unpublishSection(request.params.sectionId, request.context?.userId);
+    response.json({ section: toDetail(section) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminSectionsRouter.post("/:sectionId/archive", async (request, response, next) => {
+  try {
+    const section = await archiveSection(request.params.sectionId, request.context?.userId);
+    response.json({ section: toDetail(section) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminSectionsRouter.post("/:sectionId/restore", async (request, response, next) => {
+  try {
+    const section = await restoreSection(request.params.sectionId, request.context?.userId);
+    response.json({ section: toDetail(section) });
   } catch (error) {
     next(error);
   }

--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -1304,6 +1304,75 @@ test.describe("admin content browser coverage", () => {
     await expect(page.locator("#deleteDialogText")).toContainText("Trade unions");
   });
 
+  // #705: enhetlig livssyklus — kurslista har nå Avpubliser (motstykke til Publiser) + status-merkelapp.
+  test("courses list can unpublish a published course (#705)", async ({ page }) => {
+    const state = await mockCommonApis(page, {
+      courses: [
+        {
+          id: "course-1",
+          title: { "en-GB": "Trade unions" },
+          certificationLevel: "basic",
+          moduleCount: 1,
+          updatedAt: "2026-04-18T10:30:00.000Z",
+          publishedAt: "2026-04-18T12:00:00.000Z",
+          modules: [{ moduleId: "module-1", sortOrder: 1, moduleTitle: { "en-GB": "Trade unions" } }],
+        },
+      ],
+    });
+    // The shared catch-all only matches single-segment courses/*; register the two-segment unpublish path.
+    await page.route("**/api/admin/content/courses/*/unpublish", async (route: Route) => {
+      const segments = new URL(route.request().url()).pathname.split("/");
+      const courseId = decodeURIComponent(segments[segments.length - 2] ?? "");
+      const course = state.mutableCourses.find((c) => c.id === courseId);
+      if (course) course.publishedAt = null;
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ course }) });
+    });
+
+    await page.goto("/admin-content/courses");
+    const row = page.locator("#coursesTableBody tr").filter({ hasText: "Trade unions" });
+    await expect(row.locator(".status-badge")).toHaveText("Publisert");
+    await expect(row.locator('[data-action="unpublish"]')).toBeVisible();
+
+    page.once("dialog", (dialog) => dialog.accept());
+    await row.locator('[data-action="unpublish"]').click();
+
+    await expect.poll(() => state.mutableCourses[0]?.publishedAt ?? null).toBeNull();
+    // Etter avpublisering: status → Utkast, og Publiser-knappen kommer tilbake.
+    await expect(page.locator("#coursesTableBody tr").filter({ hasText: "Trade unions" }).locator(".status-badge")).toHaveText("Utkast");
+    await expect(page.locator('[data-action="publish"][data-course-id="course-1"]')).toBeVisible();
+  });
+
+  // #705: seksjonslista fikk samme status-merkelapp + Publiser/Avpubliser/Arkiver/Gjenopprett.
+  test("sections list shows status and runs the lifecycle actions (#705)", async ({ page }) => {
+    await mockCommonApis(page);
+    const sections: Array<{ id: string; title: string; versionNo: number; activeVersionId: string | null; archivedAt: string | null; updatedAt: string }> = [
+      { id: "section-1", title: "Intro", versionNo: 2, activeVersionId: "v2", archivedAt: null, updatedAt: "2026-04-18T10:30:00.000Z" },
+    ];
+    await page.route("**/api/admin/content/sections", async (route: Route) => {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ sections }) });
+    });
+    await page.route("**/api/admin/content/sections/*/unpublish", async (route: Route) => {
+      sections[0].activeVersionId = null;
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ section: sections[0] }) });
+    });
+    await page.route("**/api/admin/content/sections/*/publish", async (route: Route) => {
+      sections[0].activeVersionId = "v2";
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ section: sections[0] }) });
+    });
+
+    // Seksjonssida er lokalisert; e2e booter på en-GB, så vi sjekker engelske etiketter her.
+    await page.goto("/admin-content/sections");
+    const row = page.locator("#sectionsTableBody tr").filter({ hasText: "Intro" });
+    await expect(row.locator(".status-badge")).toHaveText("Published");
+    await expect(row.locator('[data-action="unpublish"]')).toBeVisible();
+
+    await row.locator('[data-action="unpublish"]').click();
+    // Etter avpublisering: status → Draft, og Publish-knappen vises.
+    const row2 = page.locator("#sectionsTableBody tr").filter({ hasText: "Intro" });
+    await expect(row2.locator(".status-badge")).toHaveText("Draft");
+    await expect(row2.locator('[data-action="publish"]')).toBeVisible();
+  });
+
   test("shell and courses routes pass an accessibility smoke check", async ({ page }) => {
     await mockCommonApis(page, {
       courses: [],

--- a/test/m2-content-lifecycle.test.ts
+++ b/test/m2-content-lifecycle.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { prisma } from "../src/db/prisma.js";
+import { archiveModule, unpublishModule } from "../src/modules/adminContent/adminContentCommands.js";
+import { archiveCourse, unpublishCourse } from "../src/modules/course/courseCommands.js";
+import {
+  archiveSection,
+  unpublishSection,
+  restoreSection,
+  publishSection,
+  deleteSection,
+  createSection,
+} from "../src/modules/course/sectionCommands.js";
+
+// #705 — enhetlig innholds-livssyklus. Verifiserer de fire vaktene fra
+// doc/design/CONTENT_LIFECYCLE.md: G2 (bruk-lås på modul/seksjon i kurs), G3 (aktivitets-lås på
+// kurs med påbegynt deltaker), og I3 (arkivering auto-avpubliserer; gjenopprett → utkast).
+// Audit events FK actorId → User, so the actor must be a real user row (set in beforeAll).
+let ACTOR = "lifecycle-actor";
+
+const courseIds: string[] = [];
+const moduleIds: string[] = [];
+const sectionIds: string[] = [];
+const userIds: string[] = [];
+
+let seq = 0;
+const uniq = () => `lc-${Date.now()}-${seq++}`;
+
+async function makePublishedModule(): Promise<string> {
+  const module = await prisma.module.create({ data: { title: `LC Module ${uniq()}` }, select: { id: true } });
+  moduleIds.push(module.id);
+  const version = await prisma.moduleVersion.create({
+    data: { moduleId: module.id, versionNo: 1, publishedAt: new Date() },
+    select: { id: true },
+  });
+  await prisma.module.update({ where: { id: module.id }, data: { activeVersionId: version.id } });
+  return module.id;
+}
+
+async function makeSection(): Promise<string> {
+  const section = await createSection({ title: "LC Section", bodyMarkdown: "Body", actorId: ACTOR });
+  sectionIds.push(section.id);
+  return section.id;
+}
+
+async function makeCourse(opts: {
+  moduleId?: string;
+  sectionId?: string;
+  published?: boolean;
+}): Promise<string> {
+  const items: Array<{ itemType: "MODULE" | "SECTION"; moduleId?: string; sectionId?: string; sortOrder: number }> = [];
+  if (opts.moduleId) items.push({ itemType: "MODULE", moduleId: opts.moduleId, sortOrder: items.length });
+  if (opts.sectionId) items.push({ itemType: "SECTION", sectionId: opts.sectionId, sortOrder: items.length });
+  const course = await prisma.course.create({
+    data: {
+      title: JSON.stringify({ "en-GB": "LC Course", nb: "LC Kurs", nn: "LC Kurs" }),
+      publishedAt: opts.published ? new Date() : null,
+      items: { create: items },
+    },
+    select: { id: true },
+  });
+  courseIds.push(course.id);
+  return course.id;
+}
+
+async function makeUser(): Promise<string> {
+  const tag = uniq();
+  const user = await prisma.user.create({
+    data: { externalId: tag, email: `${tag}@example.com`, name: "LC Participant" },
+    select: { id: true },
+  });
+  userIds.push(user.id);
+  return user.id;
+}
+
+describe("Unified content lifecycle (#705)", () => {
+  beforeAll(async () => {
+    ACTOR = await makeUser();
+  });
+
+  afterAll(async () => {
+    await prisma.courseSectionRead.deleteMany({ where: { courseId: { in: courseIds } } });
+    await prisma.courseCompletion.deleteMany({ where: { courseId: { in: courseIds } } });
+    await prisma.courseItem.deleteMany({ where: { courseId: { in: courseIds } } });
+    await prisma.course.deleteMany({ where: { id: { in: courseIds } } });
+    await prisma.courseSection.updateMany({ where: { id: { in: sectionIds } }, data: { activeVersionId: null } });
+    await prisma.courseSectionVersion.deleteMany({ where: { sectionId: { in: sectionIds } } });
+    await prisma.courseSection.deleteMany({ where: { id: { in: sectionIds } } });
+    await prisma.module.updateMany({ where: { id: { in: moduleIds } }, data: { activeVersionId: null } });
+    await prisma.moduleVersion.deleteMany({ where: { moduleId: { in: moduleIds } } });
+    await prisma.module.deleteMany({ where: { id: { in: moduleIds } } });
+    await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+    await prisma.$disconnect();
+  });
+
+  // G2 — modul i kurs er bærende og kan ikke trekkes vekk.
+  it("blokkerer avpubliser OG arkiver av en modul som ligger i et kurs (G2)", async () => {
+    const moduleId = await makePublishedModule();
+    await makeCourse({ moduleId, published: false }); // også utkast-kurs låser (vedtatt: alle kurs)
+
+    await expect(unpublishModule(moduleId, ACTOR)).rejects.toThrow(/i bruk i 1 kurs/);
+    await expect(archiveModule(moduleId, ACTOR)).rejects.toThrow(/i bruk i 1 kurs/);
+
+    // Modulen er fortsatt publisert (ingen tilstandsendring skjedde).
+    const after = await prisma.module.findUnique({ where: { id: moduleId }, select: { activeVersionId: true, archivedAt: true } });
+    expect(after?.activeVersionId).not.toBeNull();
+    expect(after?.archivedAt).toBeNull();
+  });
+
+  // I3 — arkivering av en modul utenfor kurs auto-avpubliserer.
+  it("auto-avpubliserer en modul ved arkivering når den ikke er i noe kurs (I3)", async () => {
+    const moduleId = await makePublishedModule();
+
+    await archiveModule(moduleId, ACTOR);
+
+    const after = await prisma.module.findUnique({ where: { id: moduleId }, select: { activeVersionId: true, archivedAt: true } });
+    expect(after?.activeVersionId).toBeNull();
+    expect(after?.archivedAt).not.toBeNull();
+  });
+
+  // G2 — seksjon i kurs.
+  it("blokkerer avpubliser/arkiver/slett av en seksjon som ligger i et kurs (G2)", async () => {
+    const sectionId = await makeSection();
+    await makeCourse({ sectionId, published: false });
+
+    await expect(unpublishSection(sectionId, ACTOR)).rejects.toThrow(/i bruk i 1 kurs/);
+    await expect(archiveSection(sectionId, ACTOR)).rejects.toThrow(/i bruk i 1 kurs/);
+    await expect(deleteSection(sectionId)).rejects.toThrow(/i bruk i 1 kurs/);
+  });
+
+  // Seksjon-livssyklus utenfor kurs: full symmetri.
+  it("seksjon utenfor kurs: arkiver auto-avpubliserer, gjenopprett → utkast, publiser re-peker (I3)", async () => {
+    const sectionId = await makeSection();
+
+    // Auto-publisert ved opprettelse.
+    const created = await prisma.courseSection.findUnique({ where: { id: sectionId }, select: { activeVersionId: true } });
+    expect(created?.activeVersionId).not.toBeNull();
+
+    await archiveSection(sectionId, ACTOR);
+    const archived = await prisma.courseSection.findUnique({ where: { id: sectionId }, select: { activeVersionId: true, archivedAt: true } });
+    expect(archived?.activeVersionId).toBeNull();
+    expect(archived?.archivedAt).not.toBeNull();
+
+    await restoreSection(sectionId, ACTOR);
+    const restored = await prisma.courseSection.findUnique({ where: { id: sectionId }, select: { activeVersionId: true, archivedAt: true } });
+    expect(restored?.archivedAt).toBeNull();
+    expect(restored?.activeVersionId).toBeNull(); // gjenopprett lander i Utkast
+
+    await publishSection(sectionId, ACTOR);
+    const republished = await prisma.courseSection.findUnique({ where: { id: sectionId }, select: { activeVersionId: true } });
+    expect(republished?.activeVersionId).not.toBeNull();
+  });
+
+  // G3 — kurs med påbegynt-ufullført deltaker.
+  it("blokkerer avpubliser OG arkiver av et kurs med påbegynt deltaker; fullføring frigjør (G3, I3)", async () => {
+    const sectionId = await makeSection();
+    const courseId = await makeCourse({ sectionId, published: true });
+    const userId = await makeUser();
+
+    // Påbegynt: deltakeren har lest en seksjon, men ingen completion.
+    await prisma.courseSectionRead.create({ data: { userId, courseId, sectionId } });
+
+    await expect(unpublishCourse(courseId, ACTOR)).rejects.toThrow(/påbegynt/);
+    await expect(archiveCourse(courseId, ACTOR)).rejects.toThrow(/påbegynt/);
+
+    // Fullført: deltakeren har en completion → ikke lenger «påbegynt-ufullført».
+    await prisma.courseCompletion.create({
+      data: { userId, courseId, moduleSnapshotJson: "[]" },
+    });
+
+    const result = await archiveCourse(courseId, ACTOR);
+    expect(result.archivedAt).not.toBeNull();
+    expect(result.publishedAt).toBeNull(); // I3: arkivering auto-avpubliserer kurset
+  });
+});

--- a/test/m2-module-archive.test.ts
+++ b/test/m2-module-archive.test.ts
@@ -77,7 +77,10 @@ describe("Module archive and restore (#258)", () => {
     expect((archiveList.body.modules as Array<{ id: string }>).some((m) => m.id === moduleId)).toBe(false);
   });
 
-  it("blocks archiving a published (active) module", async () => {
+  // #705/I3: archiving a published module (not used in any course) now auto-unpublishes it
+  // atomically instead of erroring "must unpublish first". The course-use lock (G2) is covered
+  // separately in m2-content-lifecycle.test.ts.
+  it("auto-unpublishes a published module when archiving it (not in any course)", async () => {
     const moduleId = await createBareModule(`published-${Date.now()}`);
 
     // Create minimal content and publish
@@ -130,12 +133,19 @@ describe("Module archive and restore (#258)", () => {
       .set(adminHeaders);
     expect(pubRes.status).toBe(200);
 
-    // Archive should fail
+    // Archive now succeeds and auto-unpublishes (I3): the module ends up archived + unpublished.
     const archiveRes = await request(app)
       .post(`/api/admin/content/modules/${moduleId}/archive`)
       .set(adminHeaders);
-    expect(archiveRes.status).toBe(400);
-    expect(archiveRes.body.message).toMatch(/unpublished/);
+    expect(archiveRes.status).toBe(200);
+    expect(archiveRes.body.archivedAt).toBeTruthy();
+
+    const module = await prisma.module.findUnique({
+      where: { id: moduleId },
+      select: { activeVersionId: true, archivedAt: true },
+    });
+    expect(module?.activeVersionId).toBeNull();
+    expect(module?.archivedAt).toBeTruthy();
   });
 
   it("blocks archiving an already-archived module", async () => {


### PR DESCRIPTION
## Hva
Én gjenkjennbar livssyklus for **kurs, modul og seksjon**: samme status (Utkast/Publisert/Arkivert), samme handlinger (Publiser⇄Avpubliser · Arkiver⇄Gjenopprett · Slett), samme vakter. Se `doc/design/CONTENT_LIFECYCLE.md`.

## Hvorfor
En publisert modul kunne arkiveres ved å først avpublisere den (arkiv-vakta sjekket kun publiser-status, ikke kurs-referanser; avpubliser hadde ingen vakt) → et publisert kurs kunne ende med en arkivert/avpublisert modul. Seksjoner manglet arkiver/avpubliser helt.

## Endringer
- **G2 bruk-lås (alle kurs):** modul/seksjon i ethvert kurs kan ikke avpubliseres/arkiveres/slettes; feilmelding navngir kursene.
- **G3 aktivitets-lås:** kurs med påbegynt-ufullført deltaker kan ikke avpubliseres/arkiveres.
- **I3:** arkiver auto-avpubliserer; gjenopprett → Utkast.
- **Seksjoner:** nye `POST .../{publish,unpublish,archive,restore}` + status-merkelapp + Vis arkiverte.
- **Kurs:** ny `POST .../unpublish` + Avpubliser-knapp + status-kolonne.
- Delt vakt-modul `src/modules/course/contentLifecycle.ts`.

## Test
- `m2-content-lifecycle` (G2/G3/I3), oppdatert `m2-module-archive`, 2 nye e2e (kurs-avpubliser, seksjon-livssyklus).
- Lokalt: tsc rent · 314 integrasjon · unit+dom · 77 e2e grønt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)