### PR TITLE
fix: livssyklus-justeringer fra staging-gjennomgang (v1.5.1, #705)

### DIFF
--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -210,8 +210,8 @@ fields (`title`, `bodyMarkdown`) accept a string or a partial `{en-GB,nb,nn}` ob
 | `GET` | `/api/admin/content/courses/:courseId/items` | Read the ordered mixed module/section sequence (#486/B2) |
 | `PUT` | `/api/admin/content/courses/:courseId/items` | Set the ordered sequence — body `{ items: [{type:"MODULE",moduleId} \| {type:"SECTION",sectionId}] }`. Re-syncs CourseModule (#486). |
 | `POST` | `/api/admin/content/courses/:courseId/publish` | Publish course |
-| `POST` | `/api/admin/content/courses/:courseId/unpublish` | Unpublish course. Blocked `400` if a participant has started-but-not-completed it (G3, #705) |
-| `POST` | `/api/admin/content/courses/:courseId/archive` | Archive course. Blocked `400` if a participant has started-but-not-completed it (G3); auto-unpublishes (I3, #705) |
+| `POST` | `/api/admin/content/courses/:courseId/unpublish` | Unpublish course (reversible soft take-down; no G3 lock, #705) |
+| `POST` | `/api/admin/content/courses/:courseId/archive` | Archive course. Blocked `400` if a participant is mid-course (G3 — suggests unpublish instead); auto-unpublishes (I3, #705) |
 | `POST` | `/api/admin/content/courses/:courseId/restore` | Restore an archived course (lands in Utkast, #705) |
 | `GET` | `/api/admin/content/courses/:courseId/enrollments` | List active enrollments for a course, each with the participant + derived status (#496/EN-2) |
 | `POST` | `/api/admin/content/courses/:courseId/enrollments` | Assign — body `{ userIds?: string[], department?: string, dueAt?: string\|null }`. Individual list and/or department materialisation. Idempotent per user; audited (#496/EN-2) |

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,20 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.5.1 - 2026-06-28
+
+fix: livssyklus-justeringer fra staging-gjennomgang av v1.5.0 (#705)
+
+- **Seksjon-status viste alltid «Utkast» + Publiser-knapp uten effekt:** list-endepunktet
+  `GET /api/admin/content/sections` utelot `activeVersionId`, så klienten kunne ikke utlede status.
+  Nå inkludert. Regresjonsvakt i `m2-content-lifecycle`.
+- **Seksjonseditoren manglet Publiser-knapp (slik moduler har):** lagt til status-merkelapp +
+  Publiser/Avpubliser i editor-verktøylinja; status holdes i synk etter lagring.
+- **Kurs-avpublisering er ikke lenger G3-låst:** avpublisering er reversibel «myk» nedtaking og
+  tillates alltid; den harde G3-låsen gjelder kun **arkivering** (pensjonering). Feilmeldingen ved
+  blokkert arkivering peker nå på Avpubliser som alternativ. (Aktivitets-signalet er varig, så en
+  hard lås på avpublisering ville vært en blindvei.)
+
 ## 1.5.0 - 2026-06-28
 
 feat: enhetlig innholds-livssyklus for kurs/modul/seksjon + tett integritets-hull (#705)

--- a/doc/design/CONTENT_LIFECYCLE.md
+++ b/doc/design/CONTENT_LIFECYCLE.md
@@ -63,9 +63,15 @@ Dette gjør den eksisterende slett-vakta konsistent: alle tre tilbaketrekkende h
 (avpubliser/arkiver/slett) er beskyttet likt, ikke bare slett.
 
 ### G3 — Aktivitets-lås (kurs med påbegynt deltaker)  ⟵ *vedtatt: blokker hvis påbegynt*
-Et kurs som har minst én deltaker som har **påbegynt men ikke fullført** kan ikke
-**avpubliseres eller arkiveres**. «Påbegynt» = har lest minst én seksjon (`CourseSectionRead`)
-eller levert minst ett forsøk (`Submission`) på en modul i kurset, uten en `CourseCompletion`.
+Et kurs som har minst én deltaker som har **påbegynt men ikke fullført** kan ikke **arkiveres**
+(pensjoneres). «Påbegynt» = har lest minst én seksjon (`CourseSectionRead`) eller levert minst
+ett forsøk (`Submission`) på en modul i kurset, uten en `CourseCompletion`.
+
+**Avpublisering er bevisst unntatt fra G3** (justert etter staging-gjennomgang v1.5.1):
+avpublisering er reversibel (republiser når som helst) og er den «myke» måten å ta et kurs ned på
+mens noen er midt i det. Arkivering er pensjonering og forblir låst. Feilmeldingen ved blokkert
+arkivering peker derfor på Avpubliser som alternativet. (Aktivitets-signalet er varig — det fjernes
+ikke ved å trekke en påmelding — så en hard lås på avpublisering ville vært en blindvei.)
 
 ### G4 — Slett-vern (historikk)
 Kan ikke slette hvis det ødelegger bevarte registre — arkiver i stedet.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -269,13 +269,15 @@ let editing = null; // { id, title:{}, body:{}, editLocale }
 let previewTimer = null;
 
 async function renderEditorView(sectionId) {
-  editing = { id: sectionId, title: { nb: "", nn: "", "en-GB": "" }, body: { nb: "", nn: "", "en-GB": "" }, editLocale: currentLocale };
+  editing = { id: sectionId, title: { nb: "", nn: "", "en-GB": "" }, body: { nb: "", nn: "", "en-GB": "" }, editLocale: currentLocale, activeVersionId: null, archivedAt: null };
 
   if (sectionId) {
     try {
       const data = await apiFetch(`/api/admin/content/sections/${encodeURIComponent(sectionId)}`, getHeaders);
       editing.title = parseLocalized(data.section.title);
       editing.body = parseLocalized(data.section.bodyMarkdown);
+      editing.activeVersionId = data.section.activeVersionId ?? null;
+      editing.archivedAt = data.section.archivedAt ?? null;
     } catch (err) {
       pageContent.innerHTML = `<div class="empty-state"><p class="empty-state-title">${escapeHtml(err?.message ?? "Error")}</p></div>`;
       return;
@@ -283,7 +285,10 @@ async function renderEditorView(sectionId) {
   }
 
   pageContent.innerHTML = `
-    <div class="page-header-back"><a href="#" class="back-link" id="backLink">${escapeHtml(L("back"))}</a></div>
+    <div class="page-header-back" style="display:flex;align-items:center;gap:10px">
+      <a href="#" class="back-link" id="backLink">${escapeHtml(L("back"))}</a>
+      <span id="sectionStatusBadge"></span>
+    </div>
     <div class="section-editor">
       <div class="lang-tabs" id="langTabs">
         ${EDITOR_LOCALES.map((loc) => `<button type="button" class="lang-tab${loc === editing.editLocale ? " active" : ""}" data-locale="${loc}">${escapeHtml(localeLabels[loc] ?? loc)}</button>`).join("")}
@@ -309,6 +314,7 @@ async function renderEditorView(sectionId) {
       <div class="editor-actions">
         <button type="button" id="saveBtn" class="btn btn-primary">${escapeHtml(L("save"))}</button>
         <button type="button" id="translateBtn" class="btn btn-secondary" style="width:auto">${escapeHtml(L("translate"))}</button>
+        <button type="button" id="sectionLifecycleBtn" class="btn btn-secondary" style="width:auto;display:none"></button>
         <span class="editor-status" id="editorStatus"></span>
       </div>
     </div>`;
@@ -333,7 +339,57 @@ async function renderEditorView(sectionId) {
     event.target.value = "";
     if (file) uploadImage(file);
   });
+  document.getElementById("sectionLifecycleBtn")?.addEventListener("click", toggleSectionLifecycle);
+  refreshSectionLifecycleUI();
   refreshPreview();
+}
+
+// #705: status i editoren (samme vokabular som modul) + Publiser/Avpubliser-knapp. Seksjoner
+// auto-publiseres ved lagring, så knappen er først og fremst for å avpublisere en live seksjon,
+// eller publisere en som er tatt ned igjen — uten å redigere innholdet.
+function editorSectionStatus() {
+  if (!editing?.id) return null;
+  if (editing.archivedAt) return "archived";
+  if (editing.activeVersionId) return "published";
+  return "draft";
+}
+
+function refreshSectionLifecycleUI() {
+  const badge = document.getElementById("sectionStatusBadge");
+  const btn = document.getElementById("sectionLifecycleBtn");
+  const status = editorSectionStatus();
+  if (badge) badge.innerHTML = status ? statusBadge(status) : "";
+  if (!btn) return;
+  if (!status || status === "archived") {
+    btn.style.display = "none";
+    return;
+  }
+  btn.style.display = "";
+  if (status === "published") {
+    btn.textContent = L("unpublish");
+    btn.dataset.action = "unpublish";
+  } else {
+    btn.textContent = L("publish");
+    btn.dataset.action = "publish";
+  }
+}
+
+async function toggleSectionLifecycle() {
+  const btn = document.getElementById("sectionLifecycleBtn");
+  if (!editing?.id || !btn) return;
+  const action = btn.dataset.action;
+  btn.disabled = true;
+  try {
+    const data = await apiFetch(`/api/admin/content/sections/${encodeURIComponent(editing.id)}/${action}`, getHeaders, { method: "POST" });
+    editing.activeVersionId = data.section?.activeVersionId ?? null;
+    editing.archivedAt = data.section?.archivedAt ?? null;
+    showToast(L(action === "publish" ? "published" : "unpublished"));
+    refreshSectionLifecycleUI();
+  } catch (err) {
+    showToast(err?.message ?? "Error", "error");
+  } finally {
+    btn.disabled = false;
+  }
 }
 
 function captureInputs() {
@@ -402,17 +458,23 @@ async function persistSection({ silent } = {}) {
         body: JSON.stringify({ title, bodyMarkdown }),
       });
       editing.id = data.section.id;
+      editing.activeVersionId = data.section.activeVersionId ?? editing.activeVersionId;
+      editing.archivedAt = data.section.archivedAt ?? null;
       history.replaceState({}, "", `/admin-content/sections?id=${encodeURIComponent(editing.id)}`);
     } else {
       await apiFetch(`/api/admin/content/sections/${encodeURIComponent(editing.id)}/title`, getHeaders, {
         method: "PATCH",
         body: JSON.stringify({ title }),
       });
-      await apiFetch(`/api/admin/content/sections/${encodeURIComponent(editing.id)}/content`, getHeaders, {
+      const contentRes = await apiFetch(`/api/admin/content/sections/${encodeURIComponent(editing.id)}/content`, getHeaders, {
         method: "PUT",
         body: JSON.stringify({ bodyMarkdown }),
       });
+      // Lagring publiserer (latest-wins) — oppdater status så merkelappen blir riktig.
+      editing.activeVersionId = contentRes.section?.activeVersionId ?? editing.activeVersionId;
     }
+    // #705: hold status-merkelappen + Publiser/Avpubliser-knappen i editoren i synk etter lagring.
+    refreshSectionLifecycleUI();
     if (!silent) {
       showToast(L("saved"));
       if (status) status.textContent = L("saved");

--- a/src/modules/course/contentLifecycle.ts
+++ b/src/modules/course/contentLifecycle.ts
@@ -91,14 +91,15 @@ export async function countCourseInProgressParticipants(courseId: string): Promi
   return inProgress;
 }
 
-// G3: et kurs med minst én påbegynt-ufullført deltaker kan ikke avpubliseres/arkiveres.
+// G3: et kurs med minst én påbegynt-ufullført deltaker kan ikke arkiveres (pensjoneres). Avpublisering
+// er bevisst unntatt (reversibel «myk» nedtaking) — derfor peker meldingen på Avpubliser som alternativ.
 export async function assertCourseHasNoInProgressParticipants(courseId: string, verb: string): Promise<void> {
   const count = await countCourseInProgressParticipants(courseId);
   if (count > 0) {
-    const deltaker = count === 1 ? "1 deltaker har" : `${count} deltakere har`;
+    const deltaker = count === 1 ? "1 deltaker er" : `${count} deltakere er`;
     throw new ValidationError(
-      `Kurset kan ikke ${verb} fordi ${deltaker} en påbegynt, ufullført gjennomføring. ` +
-        `Vent til de er ferdige, eller fjern påmeldingene først.`,
+      `Kurset kan ikke ${verb} fordi ${deltaker} midt i en gjennomføring. ` +
+        `Avpubliser kurset i stedet (skjuler det uten å pensjonere det), eller vent til de er ferdige.`,
     );
   }
 }

--- a/src/modules/course/courseCommands.ts
+++ b/src/modules/course/courseCommands.ts
@@ -74,12 +74,12 @@ export async function publishCourse(courseId: string, actorId?: string) {
 }
 
 // #705: avpubliser et kurs (motstykke til publishCourse). Symmetri med modul/seksjon.
+// Bevisst UTEN G3-lås: avpublisering er reversibel (republiser når som helst) og er den «myke»
+// måten å ta et kurs ned på mens noen er midt i det. Den harde G3-låsen gjelder kun arkivering
+// (som er pensjonering). Frontend bekrefter avpublisering med en advarsel.
 export async function unpublishCourse(courseId: string, actorId?: string) {
   const course = await prisma.course.findUnique({ where: { id: courseId }, select: { id: true } });
   if (!course) throw new NotFoundError("Course", "course_not_found", "Course not found.");
-
-  // G3 (aktivitets-lås): et kurs med påbegynt-ufullført deltaker kan ikke trekkes vekk.
-  await assertCourseHasNoInProgressParticipants(courseId, "avpubliseres");
 
   const updated = await prisma.course.update({
     where: { id: courseId },

--- a/src/routes/adminSections.ts
+++ b/src/routes/adminSections.ts
@@ -136,6 +136,8 @@ adminSectionsRouter.get("/", async (_request, response, next) => {
       sections: sections.map((s) => ({
         id: s.id,
         title: s.title,
+        // #705: status-merkelappen i lista trenger activeVersionId (Publisert vs Utkast).
+        activeVersionId: s.activeVersionId,
         versionNo: s.activeVersion?.versionNo ?? null,
         updatedAt: s.updatedAt.toISOString(),
         archivedAt: s.archivedAt?.toISOString() ?? null,

--- a/test/m2-content-lifecycle.test.ts
+++ b/test/m2-content-lifecycle.test.ts
@@ -1,4 +1,6 @@
+import request from "supertest";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { app } from "../src/app.js";
 import { prisma } from "../src/db/prisma.js";
 import { archiveModule, unpublishModule } from "../src/modules/adminContent/adminContentCommands.js";
 import { archiveCourse, unpublishCourse } from "../src/modules/course/courseCommands.js";
@@ -150,25 +152,42 @@ describe("Unified content lifecycle (#705)", () => {
     expect(republished?.activeVersionId).not.toBeNull();
   });
 
-  // G3 — kurs med påbegynt-ufullført deltaker.
-  it("blokkerer avpubliser OG arkiver av et kurs med påbegynt deltaker; fullføring frigjør (G3, I3)", async () => {
+  // G3 — kurs med påbegynt-ufullført deltaker. Arkiver blokkeres; avpubliser er bevisst tillatt
+  // (reversibel «myk» nedtaking).
+  it("blokkerer ARKIVER (ikke avpubliser) av et kurs med påbegynt deltaker; fullføring frigjør (G3, I3)", async () => {
     const sectionId = await makeSection();
-    const courseId = await makeCourse({ sectionId, published: true });
     const userId = await makeUser();
 
-    // Påbegynt: deltakeren har lest en seksjon, men ingen completion.
-    await prisma.courseSectionRead.create({ data: { userId, courseId, sectionId } });
+    // Eget kurs for avpubliser-delen (slik at vi kan republisere uten å påvirke arkiver-delen).
+    const unpubCourseId = await makeCourse({ sectionId, published: true });
+    await prisma.courseSectionRead.create({ data: { userId, courseId: unpubCourseId, sectionId } });
+    // Avpubliser er IKKE G3-låst — skal lykkes selv med påbegynt deltaker.
+    const unpubResult = await unpublishCourse(unpubCourseId, ACTOR);
+    expect(unpubResult.publishedAt).toBeNull();
 
-    await expect(unpublishCourse(courseId, ACTOR)).rejects.toThrow(/påbegynt/);
-    await expect(archiveCourse(courseId, ACTOR)).rejects.toThrow(/påbegynt/);
+    // Arkiver ER G3-låst.
+    const archCourseId = await makeCourse({ sectionId, published: true });
+    await prisma.courseSectionRead.create({ data: { userId, courseId: archCourseId, sectionId } });
+    await expect(archiveCourse(archCourseId, ACTOR)).rejects.toThrow(/midt i en gjennomføring/);
 
-    // Fullført: deltakeren har en completion → ikke lenger «påbegynt-ufullført».
-    await prisma.courseCompletion.create({
-      data: { userId, courseId, moduleSnapshotJson: "[]" },
-    });
+    // Fullført: deltakeren har en completion → ikke lenger «midt i».
+    await prisma.courseCompletion.create({ data: { userId, courseId: archCourseId, moduleSnapshotJson: "[]" } });
 
-    const result = await archiveCourse(courseId, ACTOR);
+    const result = await archiveCourse(archCourseId, ACTOR);
     expect(result.archivedAt).not.toBeNull();
     expect(result.publishedAt).toBeNull(); // I3: arkivering auto-avpubliserer kurset
+  });
+
+  // Regresjonsvakt: seksjonslistas status-merkelapp trenger activeVersionId i list-responsen.
+  // (Tidligere utelatt → alle seksjoner viste «Utkast» og Publiser-knappen så ingen effekt.)
+  it("GET /sections returnerer activeVersionId så status kan utledes", async () => {
+    const sectionId = await makeSection(); // createSection auto-publiserer
+    const res = await request(app)
+      .get("/api/admin/content/sections")
+      .set({ "x-user-id": "admin-1", "x-user-email": "admin@company.com", "x-user-name": "Admin" });
+    expect(res.status).toBe(200);
+    const row = (res.body.sections as Array<{ id: string; activeVersionId: string | null }>).find((s) => s.id === sectionId);
+    expect(row).toBeTruthy();
+    expect(row?.activeVersionId).toBeTruthy(); // publisert → status «Publisert», ikke «Utkast»
   });
 });


### PR DESCRIPTION
Justeringer etter din staging-gjennomgang av v1.5.0:

1. **Seksjon-status viste alltid «Utkast» + Publiser uten effekt** — `GET /api/admin/content/sections` utelot `activeVersionId`, så klienten kunne ikke utlede status. Nå inkludert + regresjonsvakt.
2. **Seksjonseditoren manglet Publiser-knapp** (slik moduler har) — lagt til status-merkelapp + Publiser/Avpubliser i editor-verktøylinja.
3. **Kurs-avpublisering ikke lenger G3-låst** — avpublisering er reversibel «myk» nedtaking og tillates alltid; den harde G3-låsen gjelder kun **arkivering**, med melding som peker på Avpubliser som alternativ.

## Test
- tsc rent · `m2-content-lifecycle` 6/6 (inkl. ny serialiserings-vakt) · e2e 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)