### PR TITLE
feat(ux): samkjørt innholdsforvaltning (v1.6.0, #705-UX)

### DIFF
--- a/doc/FEATURE_SURFACE_MAP.md
+++ b/doc/FEATURE_SURFACE_MAP.md
@@ -220,3 +220,22 @@ fallback (that is only a safety net, #502-followup). Canonical model: `doc/desig
 | Shared badge style | `public/static/shared.css` → `.status-badge--{draft,published,archived}` | library has its own scoped `.status-badge` modifiers (richer module statuses) |
 
 **Guards:** `test/m2-content-lifecycle.test.ts` (G2/G3/I3 across all three); `test/m2-module-archive.test.ts` (archive auto-unpublishes); `test/e2e/admin-content-workspaces.spec.ts` "courses list can unpublish a published course (#705)" + "sections list shows status and runs the lifecycle actions (#705)".
+
+## 14. Admin-content list pages — shared shape across Kurs/Moduler/Seksjoner/Klasser (#705-UX)
+
+The four admin-content list pages are intentionally aligned so an author recognises the same shape
+everywhere. A change to any shared element (filter pills, status badge, action-button row, the
+"used in courses" popover, the top-nav i18n, the Kalibrering tab) should be applied to all relevant
+pages — they are separate static JS/HTML files, so consistency is by convention, not a component.
+
+| Shared element | Where | Notes |
+|----------------|-------|-------|
+| Filter pills | `.list-filters`/`.list-filter-btn` in `shared.css`; built per page (`courseFilterBar`/`sectionFilterBar`; modules uses its own `.library-filter-btn`) | Alle/Aktive/Publiserte/Arkiverte |
+| Status badge | `.status-badge--{draft,published,archived}` in `shared.css` (entry #13) | Utkast/Publisert/Arkivert |
+| Action row | `.row-actions` in `shared.css` | wraps `.row-action-btn` group |
+| "Used in courses" popover | `.course-count-btn`/`.courses-popover` in `shared.css`; `showCoursesPopover` (library), `showSectionCoursesPopover` (sections) | count + click popover |
+| Top workspace nav i18n | each page's `renderWorkspaceNavigation` `buildLabel: (item) => tNav/t(item.labelKey)` | **never** render `item.labelKey` raw (was the classes bug, D) |
+| Kalibrering tab + reveal | `#navKalibrering` in each `.html` + `renderContentAreaNav()` role-gate in each page JS | role-gated visibility |
+| Landing entry | capability `admin-content` path = `/admin-content/courses` (`src/config/capabilities.ts`) | «Innholdsforvaltning» opens on Kurs |
+
+**Guards:** `test/e2e/admin-content-classes.spec.ts` "admin buttons + top nav render in prod-shaped config" (asserts a REAL i18n key resolves, not raw); `test/e2e/admin-content-workspaces.spec.ts` course archive (filter pill), unpublish, sections lifecycle. When adding a column/filter to one list, mirror it where it applies and update this entry.

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,27 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.0 - 2026-06-29
+
+feat(ux): samkjørt innholdsforvaltning — Kurs/Moduler/Seksjoner/Klasser likere (#705-UX)
+
+UI-konsistens-runde etter staging-gjennomgang av de fire admin-listene:
+
+- **(D) Klasser-toppnav viste råe i18n-nøkler** («nav.participant» …) — klasser-siden manglet
+  i18n-oppslag. Lagt til oversettelse (tNav) + språkvelger. E2e-guard bruker nå en ekte nøkkel.
+- **(H) Kalibrering-fanen manglet** på Seksjoner og Klasser — lagt til (vises rollestyrt, likt
+  Kurs/Moduler).
+- **(E) «Innholdsforvaltning» åpner nå på Kurs** (ikke modul-biblioteket). Modul-biblioteket er
+  fortsatt på /admin-content via «Moduler»-fanen.
+- **(A) Filter-piller** (Alle/Aktive/Publiserte/Arkiverte) på Kurs og Seksjoner, samme uttrykk som
+  modul-biblioteket (erstatter «Vis arkiverte»-toggelen). Delt `.list-filter-btn` i shared.css.
+- **(B) Felles knapperad** (`.row-actions`) i alle listene.
+- **(F) Kurslista viser «Påbegynt»** — antall deltakere midt i kurset (samme signal som G3-vakta).
+- **(G) Seksjonslista viser «Brukt i kurs»** med popover (samme som modul-biblioteket).
+- **(C)** Kurslista viste allerede «Antall moduler» (uendret).
+- Småavvik: Klasser fikk språkvelger; delt status-/popover-CSS flyttet til shared.css.
+- Nye API-felt: `inProgressCount` på kurslista, `courseCount`/`courses` på seksjonslista.
+
 ## 1.5.1 - 2026-06-28
 
 fix: livssyklus-justeringer fra staging-gjennomgang av v1.5.0 (#705)

--- a/doc/route-map.md
+++ b/doc/route-map.md
@@ -6,7 +6,8 @@ This map covers all admin-content entry points and their status for pilot. Use i
 
 | Route | Workspace | HTML file | Status |
 |---|---|---|---|
-| `/admin-content` | Module library (root) | `admin-content-library.html` | **Canonical** |
+| `/admin-content` | Module library (the «Moduler» tab) | `admin-content-library.html` | **Canonical** |
+| `/admin-content/courses` (nav entry) | «Innholdsforvaltning» lander her by default (#705-UX/E) | `admin-content-courses.html` | **Canonical** |
 | `/admin-content/module/:moduleId/conversation` | Module — conversational editor | `admin-content.html` | **Canonical** |
 | `/admin-content/module/:moduleId/advanced` | Module — advanced editor | `admin-content-advanced.html` | **Canonical** |
 | `/admin-content/courses` | Course list | `admin-content-courses.html` | **Canonical** |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-classes.html
+++ b/public/admin-content-classes.html
@@ -43,6 +43,7 @@
         <nav id="workspaceNav" class="workspace-nav"></nav>
         <div class="locale-picker">
           <span id="appVersion" class="version-badge">…</span>
+          <select id="localeSelect" aria-label="Språk"></select>
         </div>
       </div>
 
@@ -51,6 +52,7 @@
         <a href="/admin-content" class="content-area-nav-link" id="navModuler">Moduler</a>
         <a href="/admin-content/sections" class="content-area-nav-link" id="navSeksjoner">Seksjoner</a>
         <a href="/admin-content/classes" class="content-area-nav-link active" id="navKlasser">Klasser</a>
+        <a href="/admin-content/calibration" class="content-area-nav-link" id="navKalibrering" hidden>Kalibrering</a>
       </nav>
 
       <div id="pageContent">

--- a/public/admin-content-sections.html
+++ b/public/admin-content-sections.html
@@ -98,6 +98,7 @@
         <a href="/admin-content" class="content-area-nav-link" id="navModuler">Moduler</a>
         <a href="/admin-content/sections" class="content-area-nav-link active" id="navSeksjoner">Seksjoner</a>
         <a href="/admin-content/classes" class="content-area-nav-link" id="navKlasser">Klasser</a>
+        <a href="/admin-content/calibration" class="content-area-nav-link" id="navKalibrering" hidden>Kalibrering</a>
       </nav>
 
       <div id="pageContent">

--- a/public/static/admin-content-classes.js
+++ b/public/static/admin-content-classes.js
@@ -3,12 +3,29 @@ import { initConsentGuard } from "/static/consent-guard.js";
 import { resolveWorkspaceNavigationItems } from "/static/participant-console-state.js";
 import { renderWorkspaceNavigationWithProfile } from "./workspace-nav.js";
 import { showToast } from "/static/toast.js";
+import { supportedLocales, localeLabels, translations as adminContentTranslations } from "/static/i18n/admin-content-translations.js";
 
 // #645/CL-3: admin UI for classes (cohorts) — list, create, manage members, assign courses.
 
 const pageContent = document.getElementById("pageContent");
 const workspaceNav = document.getElementById("workspaceNav");
+const localePicker = document.querySelector(".locale-picker");
+const localeSelect = document.getElementById("localeSelect");
+const navKalibrering = document.getElementById("navKalibrering");
 const appVersionLabel = document.getElementById("appVersion");
+
+// #705-UX(D): klasser-siden manglet i18n-oppslag, så topp-navet viste råe nøkler (nav.participant …).
+let currentLocale = (() => {
+  const stored = localStorage.getItem("participant.locale");
+  if (stored && supportedLocales.includes(stored)) return stored;
+  const b = navigator.language?.toLowerCase() ?? "";
+  if (b.startsWith("nb")) return "nb";
+  if (b.startsWith("nn")) return "nn";
+  return "en-GB";
+})();
+function tNav(key) {
+  return adminContentTranslations[currentLocale]?.[key] ?? adminContentTranslations["en-GB"]?.[key] ?? key;
+}
 
 let _headerValues = {};
 let participantRuntimeConfig = {};
@@ -55,8 +72,10 @@ async function renderListView() {
       <td>${c._count?.members ?? 0}</td>
       <td>${c._count?.courseAssignments ?? 0}</td>
       <td class="col-actions">
-        <button class="row-action-btn" data-action="open" data-id="${escapeHtml(c.id)}">Administrer</button>
-        ${c.isSystem ? "" : `<button class="row-action-btn destructive" data-action="archive" data-id="${escapeHtml(c.id)}" data-name="${escapeHtml(c.name)}">Arkiver</button>`}
+        <div class="row-actions">
+          <button class="row-action-btn" data-action="open" data-id="${escapeHtml(c.id)}">Administrer</button>
+          ${c.isSystem ? "" : `<button class="row-action-btn destructive" data-action="archive" data-id="${escapeHtml(c.id)}" data-name="${escapeHtml(c.name)}">Arkiver</button>`}
+        </div>
       </td>
     </tr>`).join("");
   pageContent.innerHTML = `
@@ -260,7 +279,27 @@ function renderWorkspaceNavigation() {
     resolveActiveWorkspaceRoles().join(","),
     window.location.pathname,
   );
-  renderWorkspaceNavigationWithProfile({ workspaceNav, localePicker: null, items, buildLabel: (item) => item.labelKey || item.id });
+  // #705-UX(D): resolver via tNav slik at etikettene oversettes i stedet for å vise råe nøkler.
+  renderWorkspaceNavigationWithProfile({ workspaceNav, localePicker, items, buildLabel: (item) => tNav(item.labelKey) || item.id });
+}
+
+// #705-UX(H): vis Kalibrering-fanen for brukere med kalibreringstilgang (likt kurs/modul-sidene).
+function renderContentAreaNav() {
+  const calibrationRoles = new Set(participantRuntimeConfig.calibrationWorkspace?.accessRoles ?? []);
+  const userRoles = new Set(resolveActiveWorkspaceRoles());
+  const hasCalibrationRole = [...calibrationRoles].some((r) => userRoles.has(r));
+  if (navKalibrering) navKalibrering.hidden = !hasCalibrationRole;
+}
+
+function buildLocaleSelector() {
+  if (!localeSelect) return;
+  localeSelect.innerHTML = supportedLocales.map((l) => `<option value="${l}"${l === currentLocale ? " selected" : ""}>${localeLabels[l] ?? l}</option>`).join("");
+  localeSelect.addEventListener("change", () => {
+    currentLocale = localeSelect.value;
+    localStorage.setItem("participant.locale", currentLocale);
+    renderWorkspaceNavigation();
+    renderListView();
+  });
 }
 
 async function init() {
@@ -288,8 +327,10 @@ async function init() {
   } catch {
     _headerValues = {};
   }
+  buildLocaleSelector();
   renderWorkspaceNavigation();
-  await initConsentGuard(getHeaders, "nb");
+  renderContentAreaNav();
+  await initConsentGuard(getHeaders, currentLocale);
   try {
     const body = await apiFetch("/version", { headers: {} });
     if (appVersionLabel) appVersionLabel.textContent = `v${body.version ?? "unknown"}`;

--- a/public/static/admin-content-courses-state.js
+++ b/public/static/admin-content-courses-state.js
@@ -24,5 +24,6 @@ export function deriveCourseListRows(courses, { localizeTitle, formatDate }) {
     updatedLabel: formatDate(course.updatedAt ?? course.publishedAt ?? null),
     publishedAt: course.publishedAt ?? null,
     archivedAt: course.archivedAt ?? null,
+    inProgressCount: course.inProgressCount ?? 0,
   }));
 }

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -315,6 +315,26 @@ function courseStatusBadge(status) {
   return `<span class="status-badge status-badge--${status}">${label}</span>`;
 }
 
+// #705-UX(A): filtrer kurslista likt modul-biblioteket. Bruker `course` slik den kommer fra API.
+function filterCourses(courses) {
+  if (coursesFilter === "all") return courses;
+  if (coursesFilter === "archived") return courses.filter((c) => c.archivedAt);
+  if (coursesFilter === "published") return courses.filter((c) => !c.archivedAt && c.publishedAt);
+  return courses.filter((c) => !c.archivedAt); // active
+}
+
+function courseFilterBar() {
+  const pills = [
+    ["all", "Alle"],
+    ["active", "Aktive"],
+    ["published", "Publiserte"],
+    ["archived", "Arkiverte"],
+  ];
+  return `<div class="list-filters" role="group" aria-label="Filtrer kurs">${pills
+    .map(([key, label]) => `<button type="button" class="list-filter-btn${coursesFilter === key ? " active" : ""}" data-filter="${key}">${label}</button>`)
+    .join("")}</div>`;
+}
+
 async function publishCourseInAdmin(courseId, triggerButton = null) {
   if (!courseId) return;
   if (triggerButton) triggerButton.disabled = true;
@@ -357,12 +377,10 @@ async function renderListView() {
     return;
   }
 
-  // #673: skjul arkiverte kurs fra standardlista; en toggle viser dem (med gjenopprett).
-  const archivedCount = allCourses.filter((c) => c.archivedAt).length;
-  const courses = showArchivedCourses ? allCourses : allCourses.filter((c) => !c.archivedAt);
-  const archiveToggle = archivedCount > 0
-    ? `<button type="button" id="toggleArchivedBtn" class="btn btn-secondary">${showArchivedCourses ? "Skjul arkiverte" : `Vis arkiverte (${archivedCount})`}</button>`
-    : "";
+  // #705-UX(A): filter-piller (Alle/Aktive/Publiserte/Arkiverte) likt modul-biblioteket, i stedet
+  // for den gamle «Vis arkiverte»-toggelen.
+  const courses = filterCourses(allCourses);
+  const archiveToggle = courseFilterBar(allCourses);
 
   if (allCourses.length === 0) {
     pageContent.innerHTML = `
@@ -407,6 +425,7 @@ async function renderListView() {
       <td class="col-status">${courseStatusBadge(status)}</td>
       <td class="col-level">${certBadge(course.certificationLevel)}</td>
       <td class="col-module-count">${course.moduleCount}</td>
+      <td class="col-inprogress">${course.inProgressCount > 0 ? course.inProgressCount : "–"}</td>
       <td class="col-updated">${escapeHtml(course.updatedLabel)}</td>
       <td class="col-actions">
         <div class="row-actions">
@@ -427,9 +446,9 @@ async function renderListView() {
         <a href="/admin-content/courses/new" class="btn btn-primary">Opprett nytt kurs</a>
         <button type="button" id="importCoursePackageBtn" class="btn btn-secondary">Importer kurs-pakke (.json)</button>
         <input id="importCoursePackageFile" type="file" accept="application/json,.json" hidden />
-        ${archiveToggle}
       </div>
     </div>
+    ${archiveToggle}
     <div class="courses-table-wrap">
       <table class="courses-table" aria-label="Kursliste">
         <thead>
@@ -438,6 +457,7 @@ async function renderListView() {
             <th scope="col">Status</th>
             <th scope="col">Sertifiseringsnivå</th>
             <th scope="col">Antall moduler</th>
+            <th scope="col" title="Deltakere som er midt i kurset (påbegynt, ikke fullført)">Påbegynt</th>
             <th scope="col">Sist endret</th>
             <th scope="col">Handlinger</th>
           </tr>
@@ -451,8 +471,10 @@ async function renderListView() {
   document.getElementById("importCoursePackageBtn")?.addEventListener("click", () => {
     document.getElementById("importCoursePackageFile")?.click();
   });
-  document.getElementById("toggleArchivedBtn")?.addEventListener("click", () => {
-    showArchivedCourses = !showArchivedCourses;
+  pageContent.querySelector(".list-filters")?.addEventListener("click", (event) => {
+    const btn = event.target.closest("[data-filter]");
+    if (!btn) return;
+    coursesFilter = btn.dataset.filter;
     renderListView();
   });
 }
@@ -1023,8 +1045,9 @@ let initialDetailLocaleValues = cloneCourseLocaleValues();
 // Course items being edited — modules and learning sections interleaved (#490/U3).
 // Each entry: { type: "MODULE" | "SECTION", refId, title }
 let courseModules = [];
-// #673: vis/skjul arkiverte kurs i lista (default skjult).
-let showArchivedCourses = false;
+// #705-UX(A): aktivt filter i kurslista (Alle/Aktive/Publiserte/Arkiverte). Default «Aktive»
+// (skjuler arkiverte), som den gamle default-visningen.
+let coursesFilter = "active";
 
 // All available library modules (for the combobox)
 let allLibraryModules = [];

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -23,6 +23,8 @@ const LABELS = {
     colStatus: "Status", statusDraft: "Draft", statusPublished: "Published", statusArchived: "Archived",
     publish: "Publish", unpublish: "Unpublish", archive: "Archive", restore: "Restore",
     showArchived: "Show archived", hideArchived: "Hide archived",
+    filterAll: "All", filterActive: "Active", filterPublished: "Published", filterArchived: "Archived",
+    colCourses: "Used in courses", coursesPopoverTitle: "Used in courses", noCourses: "Not used in any course.",
     published: "Section published.", unpublished: "Section unpublished.",
     archived: "Section archived.", restored: "Section restored.", confirmArchive: "Archive this section?",
     colUpdated: "Last changed", edit: "Edit", del: "Delete", empty: "No sections yet.",
@@ -39,6 +41,8 @@ const LABELS = {
     colStatus: "Status", statusDraft: "Utkast", statusPublished: "Publisert", statusArchived: "Arkivert",
     publish: "Publiser", unpublish: "Avpubliser", archive: "Arkiver", restore: "Gjenopprett",
     showArchived: "Vis arkiverte", hideArchived: "Skjul arkiverte",
+    filterAll: "Alle", filterActive: "Aktive", filterPublished: "Publiserte", filterArchived: "Arkiverte",
+    colCourses: "Brukt i kurs", coursesPopoverTitle: "Brukt i kurs", noCourses: "Ikke brukt i noe kurs.",
     published: "Seksjon publisert.", unpublished: "Seksjon avpublisert.",
     archived: "Seksjon arkivert.", restored: "Seksjon gjenopprettet.", confirmArchive: "Arkivere denne seksjonen?",
     colUpdated: "Sist endret", edit: "Rediger", del: "Slett", empty: "Ingen seksjoner ennå.",
@@ -55,6 +59,8 @@ const LABELS = {
     colStatus: "Status", statusDraft: "Utkast", statusPublished: "Publisert", statusArchived: "Arkivert",
     publish: "Publiser", unpublish: "Avpubliser", archive: "Arkiver", restore: "Gjenopprett",
     showArchived: "Vis arkiverte", hideArchived: "Skjul arkiverte",
+    filterAll: "Alle", filterActive: "Aktive", filterPublished: "Publiserte", filterArchived: "Arkiverte",
+    colCourses: "Brukt i kurs", coursesPopoverTitle: "Brukt i kurs", noCourses: "Ikke brukt i noe kurs.",
     published: "Seksjon publisert.", unpublished: "Seksjon avpublisert.",
     archived: "Seksjon arkivert.", restored: "Seksjon gjenoppretta.", confirmArchive: "Arkivere denne seksjonen?",
     colUpdated: "Sist endra", edit: "Rediger", del: "Slett", empty: "Ingen seksjonar enno.",
@@ -102,6 +108,7 @@ const pageContent = document.getElementById("pageContent");
 const workspaceNav = document.getElementById("workspaceNav");
 const localePicker = document.querySelector(".locale-picker");
 const localeSelect = document.getElementById("localeSelect");
+const navKalibrering = document.getElementById("navKalibrering");
 const appVersionLabel = document.getElementById("appVersion");
 
 function escapeHtml(value) {
@@ -168,21 +175,66 @@ function statusBadge(status) {
   return `<span class="status-badge status-badge--${status}">${escapeHtml(label)}</span>`;
 }
 
-// #705: vis/skjul arkiverte seksjoner (default skjult), likt kurslista.
-let showArchivedSections = false;
+// #705-UX(A): filter-piller (Alle/Aktive/Publiserte/Arkiverte) likt modul-biblioteket.
+let sectionsFilter = "active";
+let allSections = []; // siste hentede liste — slås opp av «Brukt i kurs»-popoveren.
+
+// #705-UX(G): popover som viser hvilke kurs en seksjon brukes i (likt modul-biblioteket).
+function showSectionCoursesPopover(anchor, sectionId) {
+  const section = allSections.find((s) => s.id === sectionId);
+  if (!section) return;
+  document.getElementById("sectionCoursesPopover")?.remove();
+  const pop = document.createElement("div");
+  pop.id = "sectionCoursesPopover";
+  pop.className = "courses-popover";
+  pop.setAttribute("role", "dialog");
+  const items = (section.courses ?? []).map((c) => `<li>${escapeHtml(c.title ?? c.id)}</li>`).join("")
+    || `<li><em>${escapeHtml(L("noCourses"))}</em></li>`;
+  pop.innerHTML = `<p class="courses-popover-title">${escapeHtml(L("coursesPopoverTitle"))}</p><ul class="courses-popover-list">${items}</ul>`;
+  document.body.appendChild(pop);
+  const rect = anchor.getBoundingClientRect();
+  pop.style.top = `${rect.bottom + window.scrollY + 6}px`;
+  pop.style.left = `${rect.left + window.scrollX}px`;
+  const close = (e) => {
+    if (!pop.contains(e.target) && e.target !== anchor) {
+      pop.remove();
+      document.removeEventListener("click", close, true);
+    }
+  };
+  setTimeout(() => document.addEventListener("click", close, true), 0);
+}
+
+function filterSections(sections) {
+  if (sectionsFilter === "all") return sections;
+  if (sectionsFilter === "archived") return sections.filter((s) => s.archivedAt);
+  if (sectionsFilter === "published") return sections.filter((s) => !s.archivedAt && s.activeVersionId);
+  return sections.filter((s) => !s.archivedAt); // active
+}
+
+function sectionFilterBar() {
+  const pills = [
+    ["all", L("filterAll")],
+    ["active", L("filterActive")],
+    ["published", L("filterPublished")],
+    ["archived", L("filterArchived")],
+  ];
+  return `<div class="list-filters" role="group" aria-label="Filtrer seksjoner">${pills
+    .map(([key, label]) => `<button type="button" class="list-filter-btn${sectionsFilter === key ? " active" : ""}" data-filter="${key}">${escapeHtml(label)}</button>`)
+    .join("")}</div>`;
+}
 
 async function renderListView() {
   let sections;
   try {
     const data = await apiFetch("/api/admin/content/sections", getHeaders);
     sections = data.sections ?? [];
+    allSections = sections;
   } catch (err) {
     pageContent.innerHTML = `<div class="empty-state"><p class="empty-state-title">${escapeHtml(L("loadError"))}</p><p class="empty-state-text">${escapeHtml(err?.message ?? "")}</p></div>`;
     return;
   }
 
-  const hasArchived = sections.some((s) => s.archivedAt);
-  const visible = showArchivedSections ? sections : sections.filter((s) => !s.archivedAt);
+  const visible = filterSections(sections);
 
   // #705: samme handlings-rekkefølge og status-vokabular som modul/kurs.
   const rows = visible.map((s) => {
@@ -195,15 +247,22 @@ async function renderListView() {
            <button class="row-action-btn" data-action="archive" data-id="${id}">${escapeHtml(L("archive"))}</button>`
         : `<button class="row-action-btn" data-action="publish" data-id="${id}">${escapeHtml(L("publish"))}</button>
            <button class="row-action-btn" data-action="archive" data-id="${id}">${escapeHtml(L("archive"))}</button>`;
+    const courseCount = Number(s.courseCount ?? 0);
+    const courseCell = courseCount > 0
+      ? `<button class="course-count-btn" data-id="${id}" aria-label="${courseCount}">${courseCount}</button>`
+      : `<span class="course-count-zero">0</span>`;
     return `<tr>
       <td class="col-title">${escapeHtml(displayTitle(s.title))}</td>
       <td>${statusBadge(status)}</td>
       <td>v${escapeHtml(s.versionNo ?? "1")}</td>
+      <td>${courseCell}</td>
       <td style="white-space:nowrap">${escapeHtml(new Date(s.updatedAt).toLocaleDateString(currentLocale))}</td>
       <td class="col-actions">
-        <button class="row-action-btn" data-action="edit" data-id="${id}">${escapeHtml(L("edit"))}</button>
-        ${lifecycle}
-        <button class="row-action-btn destructive" data-action="delete" data-id="${id}">${escapeHtml(L("del"))}</button>
+        <div class="row-actions">
+          <button class="row-action-btn" data-action="edit" data-id="${id}">${escapeHtml(L("edit"))}</button>
+          ${lifecycle}
+          <button class="row-action-btn destructive" data-action="delete" data-id="${id}">${escapeHtml(L("del"))}</button>
+        </div>
       </td>
     </tr>`;
   }).join("");
@@ -213,19 +272,23 @@ async function renderListView() {
       <h1>${escapeHtml(L("heading"))}</h1>
       <button type="button" id="newSectionBtn" class="btn btn-primary" style="width:auto">${escapeHtml(L("newSection"))}</button>
     </div>
-    ${hasArchived ? `<div style="margin-bottom:8px"><button type="button" id="toggleArchivedSectionsBtn" class="row-action-btn">${escapeHtml(showArchivedSections ? L("hideArchived") : L("showArchived"))}</button></div>` : ""}
+    ${sectionFilterBar()}
     ${visible.length === 0
       ? `<div class="empty-state"><p class="empty-state-text">${escapeHtml(L("empty"))}</p></div>`
       : `<div class="sections-table-wrap"><table class="sections-table">
-          <thead><tr><th>${escapeHtml(L("colTitle"))}</th><th>${escapeHtml(L("colStatus"))}</th><th>${escapeHtml(L("colVersion"))}</th><th>${escapeHtml(L("colUpdated"))}</th><th class="col-actions"></th></tr></thead>
+          <thead><tr><th>${escapeHtml(L("colTitle"))}</th><th>${escapeHtml(L("colStatus"))}</th><th>${escapeHtml(L("colVersion"))}</th><th>${escapeHtml(L("colCourses"))}</th><th>${escapeHtml(L("colUpdated"))}</th><th class="col-actions"></th></tr></thead>
           <tbody id="sectionsTableBody">${rows}</tbody></table></div>`}`;
 
   document.getElementById("newSectionBtn")?.addEventListener("click", () => goTo("editor", null));
-  document.getElementById("toggleArchivedSectionsBtn")?.addEventListener("click", () => {
-    showArchivedSections = !showArchivedSections;
+  pageContent.querySelector(".list-filters")?.addEventListener("click", (event) => {
+    const btn = event.target.closest("[data-filter]");
+    if (!btn) return;
+    sectionsFilter = btn.dataset.filter;
     renderListView();
   });
   document.getElementById("sectionsTableBody")?.addEventListener("click", (event) => {
+    const courseBtn = event.target.closest(".course-count-btn");
+    if (courseBtn) { showSectionCoursesPopover(courseBtn, courseBtn.dataset.id); return; }
     const btn = event.target.closest("[data-action]");
     if (!btn) return;
     const id = btn.dataset.id;
@@ -622,6 +685,14 @@ function renderWorkspaceNavigation() {
   renderWorkspaceNavigationWithProfile({ workspaceNav, localePicker, items, buildLabel: (item) => tNav(item.labelKey) || item.id });
 }
 
+// #705-UX(H): vis Kalibrering-fanen for brukere med kalibreringstilgang (likt kurs/modul-sidene).
+function renderContentAreaNav() {
+  const calibrationRoles = new Set(participantRuntimeConfig.calibrationWorkspace?.accessRoles ?? []);
+  const userRoles = new Set(resolveActiveWorkspaceRoles());
+  const hasCalibrationRole = [...calibrationRoles].some((r) => userRoles.has(r));
+  if (navKalibrering) navKalibrering.hidden = !hasCalibrationRole;
+}
+
 async function init() {
   try {
     const cfg = await getConsoleConfig();
@@ -648,6 +719,7 @@ async function init() {
 
   buildLocaleSelector();
   renderWorkspaceNavigation();
+  renderContentAreaNav();
 
   await initConsentGuard(getHeaders, currentLocale);
 

--- a/public/static/shared.css
+++ b/public/static/shared.css
@@ -1073,3 +1073,41 @@ dialog::backdrop {
 .status-badge--draft     { background: #edf1f7; color: #42526b; }  /* grå  — utkast (ikke synlig) */
 .status-badge--published { background: #e6f4ea; color: #12613a; }  /* grønn — live */
 .status-badge--archived  { background: #f0f0f0; color: #666; }     /* dempet — pensjonert */
+
+/* #705-UX(B): felles handlings-knapperad i admin-listene (seksjoner/klasser arvet ikke kurs/modul-
+   sidenes side-scopede .row-actions). Knapper grupperes og brytes pent på smale skjermer. */
+.row-actions { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+
+/* #705-UX(A): felles filter-piller (Alle/Aktive/Publiserte/Arkiverte) på tvers av admin-listene,
+   samme uttrykk som modul-bibliotekets .library-filter-btn. */
+.list-filters { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: var(--space-2); }
+.list-filter-btn {
+  width: auto;
+  min-height: 0;
+  padding: 5px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  border: 1px solid var(--color-border-soft);
+  border-radius: 999px;
+  background: var(--color-surface);
+  color: var(--color-meta);
+  cursor: pointer;
+}
+.list-filter-btn:hover { border-color: var(--color-link-hover-border); color: var(--color-text); }
+.list-filter-btn.active { background: var(--color-blue-light); border-color: var(--color-blue); color: var(--color-link-active); }
+
+/* #705-UX(G): «Brukt i kurs»-teller + popover, delt så seksjonslista matcher modul-biblioteket. */
+.course-count-btn {
+  background: none; border: none; padding: 2px 6px; font-size: 13px; font-weight: 600;
+  cursor: pointer; border-radius: 4px; color: var(--color-link-active); text-decoration: underline;
+}
+.course-count-btn:hover { background: var(--color-blue-light); }
+.course-count-zero { color: var(--color-meta); font-size: 13px; }
+.courses-popover {
+  position: fixed; z-index: 200; background: var(--color-surface);
+  border: 1px solid var(--color-border-soft); border-radius: var(--radius-card);
+  box-shadow: 0 4px 20px rgba(0,0,0,.12); padding: var(--space-1); min-width: 200px; max-width: 320px;
+}
+.courses-popover-title { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: var(--color-meta); margin: 0 0 6px; }
+.courses-popover-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
+.courses-popover-list li { font-size: 13px; color: var(--color-text); padding: 2px 0; }

--- a/src/config/capabilities.ts
+++ b/src/config/capabilities.ts
@@ -166,7 +166,9 @@ export function buildWorkspaceNavigationItems(calibrationAccessRoles: AppRoleTyp
     },
     {
       id: "admin-content",
-      path: "/admin-content",
+      // #705-UX(E): Innholdsforvaltning lander nå på Kurs (ikke modul-biblioteket). Modul-biblioteket
+      // er fortsatt på /admin-content via «Moduler»-fanen.
+      path: "/admin-content/courses",
       labelKey: "nav.adminContent",
       requiredRoles: [AppRole.SUBJECT_MATTER_OWNER, AppRole.ADMINISTRATOR],
     },

--- a/src/modules/course/contentLifecycle.ts
+++ b/src/modules/course/contentLifecycle.ts
@@ -32,6 +32,29 @@ export function findCoursesContainingSection(sectionId: string) {
   return coursesContaining({ sectionId });
 }
 
+// #705-UX(G): batch — hvilke kurs bruker hver av disse seksjonene (for «Brukt i kurs»-kolonnen i
+// seksjonslista, med samme popover som modul-biblioteket). Ett spørsmål for alle seksjonene.
+export async function findCoursesForSections(
+  sectionIds: string[],
+): Promise<Map<string, Array<{ id: string; title: string }>>> {
+  const result = new Map<string, Array<{ id: string; title: string }>>();
+  if (sectionIds.length === 0) return result;
+  const items = await prisma.courseItem.findMany({
+    where: { sectionId: { in: sectionIds }, itemType: "SECTION" },
+    select: { sectionId: true, course: { select: { id: true, title: true } } },
+  });
+  for (const item of items) {
+    if (!item.sectionId || !item.course) continue;
+    const list = result.get(item.sectionId) ?? [];
+    // Unngå duplikater hvis en seksjon skulle forekomme flere ganger.
+    if (!list.some((c) => c.id === item.course.id)) {
+      list.push({ id: item.course.id, title: courseDisplayTitle(item.course.title) });
+    }
+    result.set(item.sectionId, list);
+  }
+  return result;
+}
+
 function inUseMessage(
   subject: "Modulen" | "Seksjonen",
   verb: string,

--- a/src/modules/course/courseReadModels.ts
+++ b/src/modules/course/courseReadModels.ts
@@ -44,6 +44,8 @@ export interface AdminCourseListItem {
   updatedAt: string;
   publishedAt: string | null;
   archivedAt: string | null;
+  // #705-UX(F): antall deltakere som er midt i kurset (påbegynt, ikke fullført).
+  inProgressCount: number;
 }
 
 export interface AdminCourseDetail {

--- a/src/routes/adminCourses.ts
+++ b/src/routes/adminCourses.ts
@@ -22,6 +22,7 @@ import { localizedTextCodec } from "../codecs/localizedTextCodec.js";
 import { localizeCourseCopy } from "../modules/adminContent/llmContentGenerationService.js";
 import { NotFoundError, AppError } from "../errors/AppError.js";
 import type { AdminCourseListItem, AdminCourseDetail } from "../modules/course/index.js";
+import { countCourseInProgressParticipants } from "../modules/course/contentLifecycle.js";
 import { generateLimiter } from "../middleware/rateLimiting.js";
 
 const adminCoursesRouter = Router();
@@ -111,7 +112,11 @@ adminCoursesRouter.post("/localize-copy", generateLimiter, async (request, respo
 adminCoursesRouter.get("/", async (_request, response, next) => {
   try {
     const courses = await courseRepository.listCourses();
-    const items: AdminCourseListItem[] = courses.map((c) => ({
+    // #705-UX(F): vis antall påbegynte-ufullførte deltakere per kurs (samme signal som G3-vakta).
+    const inProgressCounts = await Promise.all(
+      courses.map((c) => countCourseInProgressParticipants(c.id)),
+    );
+    const items: AdminCourseListItem[] = courses.map((c, i) => ({
       id: c.id,
       title: c.title,
       description: c.description,
@@ -120,6 +125,7 @@ adminCoursesRouter.get("/", async (_request, response, next) => {
       updatedAt: c.updatedAt.toISOString(),
       publishedAt: c.publishedAt?.toISOString() ?? null,
       archivedAt: c.archivedAt?.toISOString() ?? null,
+      inProgressCount: inProgressCounts[i],
     }));
     response.json({ courses: items });
   } catch (error) {

--- a/src/routes/adminSections.ts
+++ b/src/routes/adminSections.ts
@@ -17,6 +17,7 @@ import {
   localizeSectionAssets,
   MAX_ASSET_BYTES,
 } from "../modules/course/index.js";
+import { findCoursesForSections } from "../modules/course/contentLifecycle.js";
 import { localizedTextPatchSchema, generationLocaleSchema } from "../modules/adminContent/adminContentSchemas.js";
 import { localizedTextCodec } from "../codecs/localizedTextCodec.js";
 import { NotFoundError } from "../errors/AppError.js";
@@ -132,16 +133,23 @@ adminSectionsRouter.post("/localize", generateLimiter, async (request, response,
 adminSectionsRouter.get("/", async (_request, response, next) => {
   try {
     const sections = await listSections();
+    // #705-UX(G): «Brukt i kurs»-kolonne med popover (likt modul-biblioteket).
+    const coursesBySection = await findCoursesForSections(sections.map((s) => s.id));
     response.json({
-      sections: sections.map((s) => ({
-        id: s.id,
-        title: s.title,
-        // #705: status-merkelappen i lista trenger activeVersionId (Publisert vs Utkast).
-        activeVersionId: s.activeVersionId,
-        versionNo: s.activeVersion?.versionNo ?? null,
-        updatedAt: s.updatedAt.toISOString(),
-        archivedAt: s.archivedAt?.toISOString() ?? null,
-      })),
+      sections: sections.map((s) => {
+        const courses = coursesBySection.get(s.id) ?? [];
+        return {
+          id: s.id,
+          title: s.title,
+          // #705: status-merkelappen i lista trenger activeVersionId (Publisert vs Utkast).
+          activeVersionId: s.activeVersionId,
+          versionNo: s.activeVersion?.versionNo ?? null,
+          updatedAt: s.updatedAt.toISOString(),
+          archivedAt: s.archivedAt?.toISOString() ?? null,
+          courseCount: courses.length,
+          courses,
+        };
+      }),
     });
   } catch (error) {
     next(error);

--- a/test/e2e/admin-content-classes.spec.ts
+++ b/test/e2e/admin-content-classes.spec.ts
@@ -159,6 +159,9 @@ test("classes admin: admin buttons + top nav render in prod-shaped config (role 
           items: [
             { id: "dashboard", path: "/dashboard", labelKey: "Oversikt", requiredRoles: [] },
             { id: "review", path: "/review", labelKey: "Vurdering", requiredRoles: ["SUBJECT_MATTER_OWNER"] },
+            // #705-UX(D): a REAL i18n key — the classes page must resolve it via tNav, not render
+            // the raw key. (The earlier mock used display strings as labelKeys, hiding the bug.)
+            { id: "adminContent", path: "/admin-content/courses", labelKey: "nav.adminContent", requiredRoles: [] },
           ],
           workspaceItems: [],
         },
@@ -182,6 +185,8 @@ test("classes admin: admin buttons + top nav render in prod-shaped config (role 
   await expect(page.locator("#workspaceNav")).toBeVisible();
   await expect(page.locator('#workspaceNav a', { hasText: "Oversikt" })).toBeVisible();
   await expect(page.locator('#workspaceNav a', { hasText: "Vurdering" })).toBeVisible();
+  // #705-UX(D): the real i18n key must be resolved (translated), never rendered raw.
+  await expect(page.locator("#workspaceNav")).not.toContainText("nav.adminContent");
 });
 
 // #690 fallback: ADMINISTRATOR imports users from a JSON file → POST /api/admin/sync/org/delta.

--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -1029,13 +1029,14 @@ test.describe("admin content browser coverage", () => {
     page.once("dialog", (dialog) => dialog.accept());
     await row.locator('[data-action="archive"]').click();
 
-    // #673: after archiving the course is hidden from the default list; a "Vis arkiverte" toggle appears.
+    // #673/#705-UX(A): after archiving the course is hidden from the default "Aktive" filter; the
+    // "Arkiverte" filter pill reveals it.
     await expect(page.locator("#coursesTableBody tr").filter({ hasText: "Labour rights" })).toHaveCount(0);
-    const toggle = page.locator("#toggleArchivedBtn");
-    await expect(toggle).toBeVisible();
-    await toggle.click();
+    const archivedFilter = page.locator('.list-filter-btn[data-filter="archived"]');
+    await expect(archivedFilter).toBeVisible();
+    await archivedFilter.click();
 
-    // Now visible under the toggle: carries the Arkivert badge, archive action gone, restore present.
+    // Now visible under the filter: carries the Arkivert badge, archive action gone, restore present.
     const archivedRow = page.locator("#coursesTableBody tr").filter({ hasText: "Labour rights" });
     await expect(archivedRow).toContainText("Arkivert");
     await expect(archivedRow.locator('[data-action="archive"]')).toHaveCount(0);

--- a/test/unit/admin-content-courses-state.test.js
+++ b/test/unit/admin-content-courses-state.test.js
@@ -55,6 +55,7 @@ describe("admin content courses state helpers", () => {
         updatedLabel: "formatted:2026-04-18T10:30:00.000Z",
         publishedAt: null,
         archivedAt: null,
+        inProgressCount: 0,
       },
       {
         courseId: "course-2",
@@ -64,6 +65,7 @@ describe("admin content courses state helpers", () => {
         updatedLabel: "formatted:2026-03-02T08:15:00.000Z",
         publishedAt: "2026-03-02T08:15:00.000Z",
         archivedAt: null,
+        inProgressCount: 0,
       },
     ]);
   });


### PR DESCRIPTION
UI-konsistens på tvers av de fire admin-listene (Kurs/Moduler/Seksjoner/Klasser), etter staging-gjennomgang. Adresserer punkt A–H.

| Punkt | Endring |
|---|---|
| A | Filter-piller (Alle/Aktive/Publiserte/Arkiverte) på Kurs + Seksjoner (som Moduler) |
| B | Felles `.row-actions`-knapperad i alle listene |
| C | Kurs viser allerede «Antall moduler» (uendret) |
| D | Klasser-toppnav viste **råe i18n-nøkler** → fikset (tNav) + språkvelger; e2e-guard m/ekte nøkkel |
| E | «Innholdsforvaltning» lander nå på **Kurs** (modulbibliotek fortsatt via «Moduler») |
| F | Kurslista viser **«Påbegynt»** (deltakere midt i kurset) |
| G | Seksjonslista viser **«Brukt i kurs»** med popover |
| H | **Kalibrering**-fanen lagt til på Seksjoner + Klasser |

Nye API-felt: `inProgressCount` (kursliste), `courseCount`/`courses` (seksjonsliste).

## Test
tsc rent · unit 689 · dom · integrasjon 315 · e2e 77 + ny Klasser-nav-guard — alt grønt lokalt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)