### PR TITLE
fix(ux): admin-liste-polish — Slett kun for arkiverte + felles knappestil (v1.6.1)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,19 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.1 - 2026-06-29
+
+fix(ux): admin-liste-polish fra staging-gjennomgang av v1.6.0 (#705-UX)
+
+- **Slett vises nå kun for arkiverte elementer** (kurs/modul/seksjon). Sletting er det terminale
+  steget *etter* arkivering — aktive rader viser Arkiver i stedet. Konsistent på tvers, og rydder
+  opp i de aktive radene. Moduler fikk dermed også en (vaktet) Slett — kun når arkivert.
+- **Felles knappestil:** `.row-action-btn` + `.row-actions` er nå kanonisk i `shared.css`. Seksjoner
+  og Klasser hadde egne, litt avvikende definisjoner (font/padding) — fjernet, arver nå felles.
+- **Seksjonslista layout:** tittel-kolonnen var `width:100%` og handlings-cellen var `display:flex`,
+  som klemte de andre kolonnene og stablet knappene vertikalt. Nå fleksibel tittel (min-width) +
+  vanlig handlings-celle → knappene ligger horisontalt og skjermbredden utnyttes som i Kurs/Moduler.
+
 ## 1.6.0 - 2026-06-29
 
 feat(ux): samkjørt innholdsforvaltning — Kurs/Moduler/Seksjoner/Klasser likere (#705-UX)

--- a/doc/design/CONTENT_LIFECYCLE.md
+++ b/doc/design/CONTENT_LIFECYCLE.md
@@ -74,7 +74,9 @@ arkivering peker derfor på Avpubliser som alternativet. (Aktivitets-signalet er
 ikke ved å trekke en påmelding — så en hard lås på avpublisering ville vært en blindvei.)
 
 ### G4 — Slett-vern (historikk)
-Kan ikke slette hvis det ødelegger bevarte registre — arkiver i stedet.
+**Slett vises kun for arkiverte elementer** (vedtatt v1.6.1): sletting er det terminale steget
+*etter* arkivering, likt for kurs/modul/seksjon. Aktive rader viser Arkiver i stedet. I tillegg
+kan man ikke slette hvis det ødelegger bevarte registre — arkiver i stedet.
 - **Kurs:** har `CourseCompletion` (utstedte sertifikat) → «Arkiver kurset i stedet».
 - **Modul:** har versjoner/forsøk/sertifiseringsstatus, eller er i et kurs (G2).
 - **Seksjon:** er i et kurs (G2) — dekker også leshistorikk (kun kurs-koblede seksjoner har lesinger).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-classes.html
+++ b/public/admin-content-classes.html
@@ -17,10 +17,8 @@
       .classes-table { width: 100%; border-collapse: collapse; font-size: 14px; }
       .classes-table th, .classes-table td { text-align: left; padding: 10px var(--space-2); border-bottom: 1px solid var(--color-border-soft); }
       .classes-table th { font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-meta); }
-      .classes-table .col-actions { text-align: right; white-space: nowrap; }
-      .row-action-btn { width: auto; background: none; border: 1px solid var(--color-border-soft); border-radius: var(--radius-btn); padding: 4px 8px; font-size: 13px; cursor: pointer; color: var(--color-text); }
-      .row-action-btn:hover { background: var(--color-row-hover); }
-      .row-action-btn.destructive { color: var(--color-error); border-color: #f5c0bb; }
+      .classes-table .col-actions { white-space: nowrap; }
+      /* #705-UX: .row-action-btn + .row-actions arves fra shared.css (felles utseende på tvers). */
       .system-badge { display: inline-block; margin-left: 6px; padding: 1px 8px; border-radius: 999px; background: var(--color-blue-light); color: var(--color-link-active); font-size: 11px; font-weight: 600; }
       .detail-section { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-2); margin-bottom: var(--space-3); }
       .detail-section h2 { font-size: 16px; margin: 0 0 var(--space-2); }

--- a/public/admin-content-sections.html
+++ b/public/admin-content-sections.html
@@ -47,14 +47,14 @@
 
       .sections-table-wrap { overflow-x: auto; border: 1px solid var(--color-table-wrap-border); border-radius: var(--radius-card); }
       .sections-table { width: 100%; border-collapse: collapse; font-size: 14px; }
-      .sections-table .col-title { width: 100%; }
-      .sections-table th, .sections-table td { text-align: left; padding: 10px var(--space-2); border-bottom: 1px solid var(--color-border-soft); }
+      /* #705-UX: tittel-kolonnen er den fleksible (min-width, ikke width:100% som klemte de andre
+         kolonnene + tvang handlingsknappene til å stable seg vertikalt). */
+      .sections-table .col-title { min-width: 220px; font-weight: 600; }
+      .sections-table th, .sections-table td { text-align: left; padding: 10px var(--space-2); border-bottom: 1px solid var(--color-border-soft); vertical-align: middle; }
       .sections-table th { font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-meta); }
-      .sections-table .col-actions { text-align: right; white-space: nowrap; }
-      .row-action-btn { width: auto; background: none; border: 1px solid var(--color-border-soft); border-radius: var(--radius-btn); padding: 4px 8px; font-size: 13px; cursor: pointer; color: var(--color-text); white-space: nowrap; }
-      .sections-table .col-actions { display: flex; gap: 6px; justify-content: flex-end; }
-      .row-action-btn:hover { background: var(--color-row-hover); }
-      .row-action-btn.destructive { color: var(--color-error); border-color: #f5c0bb; }
+      /* col-actions er en vanlig celle (ikke flex) så den vokser til knapperaden og holder den
+         horisontal. .row-action-btn + .row-actions arves nå fra shared.css (felles utseende). */
+      .sections-table .col-actions { white-space: nowrap; }
 
       /* Editor */
       .section-editor { max-width: 720px; }

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -417,8 +417,11 @@ async function renderListView() {
       : status === "published"
         ? `<button class="row-action-btn" data-action="unpublish" data-course-id="${cid}" data-course-title="${ctitle}">Avpubliser</button>`
         : "";
+    // #705-UX: Slett vises kun for arkiverte elementer (terminal steg etter arkivering). Aktive
+    // rader viser Arkiver i stedet — konsistent på tvers av kurs/modul/seksjon.
     const archiveToggleBtn = course.archivedAt
-      ? `<button class="row-action-btn" data-action="restore" data-course-id="${cid}" data-course-title="${ctitle}">Gjenopprett</button>`
+      ? `<button class="row-action-btn" data-action="restore" data-course-id="${cid}" data-course-title="${ctitle}">Gjenopprett</button>
+         <button class="row-action-btn destructive" data-action="delete" data-course-id="${cid}" data-course-title="${ctitle}">Slett</button>`
       : `<button class="row-action-btn" data-action="archive" data-course-id="${cid}" data-course-title="${ctitle}">Arkiver</button>`;
     return `<tr>
       <td class="col-title">${ctitle}</td>
@@ -431,9 +434,8 @@ async function renderListView() {
         <div class="row-actions">
           <a href="/admin-content/courses/${encodeURIComponent(course.courseId)}" class="row-action-btn">Rediger</a>
           ${publishToggle}
-          ${archiveToggleBtn}
           <button class="row-action-btn" data-action="export" data-course-id="${cid}" data-course-title="${ctitle}">Eksporter</button>
-          <button class="row-action-btn destructive" data-action="delete" data-course-id="${cid}" data-course-title="${ctitle}">Slett</button>
+          ${archiveToggleBtn}
         </div>
       </td>
     </tr>`;

--- a/public/static/admin-content-library.js
+++ b/public/static/admin-content-library.js
@@ -252,8 +252,11 @@ function renderLibrary() {
       ? `<button class="course-count-btn" data-module-id="${escapeHtml(m.id)}" aria-label="${m.courseCount} kurs">${m.courseCount}</button>`
       : `<span class="course-count-zero">0</span>`;
 
+    // #705-UX: Slett vises kun for arkiverte moduler (terminal steg etter arkivering) — konsistent
+    // med kurs/seksjon. Sletting er vaktet i backend (blokkeres ved avhengigheter/kursbruk).
     const archiveAction = isArchived
-      ? `<button class="row-action-btn" data-action="restore" data-module-id="${escapeHtml(m.id)}">Gjenopprett</button>`
+      ? `<button class="row-action-btn" data-action="restore" data-module-id="${escapeHtml(m.id)}">Gjenopprett</button>
+         <button class="row-action-btn destructive" data-action="delete" data-module-id="${escapeHtml(m.id)}" data-module-title="${escapeHtml(m.title ?? m.id)}">Slett</button>`
       : `<button class="row-action-btn" data-action="archive" data-module-id="${escapeHtml(m.id)}">Arkiver</button>`;
     // v1.2.20 (#459): Avpubliser-knapp synlig kun for moduler som er aktivt publisert
     // (published eller published_with_draft). Klikk → bekreftelses-prompt → POST /unpublish.
@@ -336,9 +339,25 @@ function handleTableClick(event) {
 
   if (action === "archive") archiveModule(moduleId, btn);
   else if (action === "restore") restoreModule(moduleId, btn);
+  else if (action === "delete") deleteModuleFromRow(moduleId, btn.dataset.moduleTitle ?? moduleId, btn);
   else if (action === "duplicate") duplicateModule(moduleId, btn);
   else if (action === "export") exportModulePackage(moduleId, btn.dataset.moduleTitle ?? moduleId, btn);
   else if (action === "unpublish") unpublishModuleFromRow(moduleId, btn.dataset.moduleTitle ?? moduleId, btn);
+}
+
+// #705-UX: slett en arkivert modul (terminal). Vaktet i backend — blokkeres med forklarende
+// melding hvis modulen har avhengigheter eller brukes i et kurs.
+async function deleteModuleFromRow(moduleId, moduleTitle, btn) {
+  if (!window.confirm(`Slette modulen «${moduleTitle}» permanent? Dette kan ikke angres.`)) return;
+  btn.disabled = true;
+  try {
+    await apiFetch(`/api/admin/content/modules/${encodeURIComponent(moduleId)}`, getHeaders, { method: "DELETE" });
+    showToast("Modul slettet.", "success");
+    await loadModules();
+  } catch (err) {
+    showToast(err?.message ?? "Kunne ikke slette modul.", "error");
+    btn.disabled = false;
+  }
 }
 
 // #433 — per-row module export. Calls the versioned /export-package endpoint

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -240,8 +240,10 @@ async function renderListView() {
   const rows = visible.map((s) => {
     const status = sectionStatus(s);
     const id = escapeHtml(s.id);
+    // #705-UX: Slett vises kun for arkiverte elementer (terminal steg etter arkivering).
     const lifecycle = status === "archived"
-      ? `<button class="row-action-btn" data-action="restore" data-id="${id}">${escapeHtml(L("restore"))}</button>`
+      ? `<button class="row-action-btn" data-action="restore" data-id="${id}">${escapeHtml(L("restore"))}</button>
+         <button class="row-action-btn destructive" data-action="delete" data-id="${id}">${escapeHtml(L("del"))}</button>`
       : status === "published"
         ? `<button class="row-action-btn" data-action="unpublish" data-id="${id}">${escapeHtml(L("unpublish"))}</button>
            <button class="row-action-btn" data-action="archive" data-id="${id}">${escapeHtml(L("archive"))}</button>`
@@ -261,7 +263,6 @@ async function renderListView() {
         <div class="row-actions">
           <button class="row-action-btn" data-action="edit" data-id="${id}">${escapeHtml(L("edit"))}</button>
           ${lifecycle}
-          <button class="row-action-btn destructive" data-action="delete" data-id="${id}">${escapeHtml(L("del"))}</button>
         </div>
       </td>
     </tr>`;

--- a/public/static/shared.css
+++ b/public/static/shared.css
@@ -1074,9 +1074,33 @@ dialog::backdrop {
 .status-badge--published { background: #e6f4ea; color: #12613a; }  /* grønn — live */
 .status-badge--archived  { background: #f0f0f0; color: #666; }     /* dempet — pensjonert */
 
-/* #705-UX(B): felles handlings-knapperad i admin-listene (seksjoner/klasser arvet ikke kurs/modul-
-   sidenes side-scopede .row-actions). Knapper grupperes og brytes pent på smale skjermer. */
-.row-actions { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+/* #705-UX(B): felles handlings-knapperad + knapp i admin-listene, så alle fire listene (kurs/
+   moduler/seksjoner/klasser) ser like ut. Tidligere definerte hver side sin egen .row-action-btn
+   med ulik font/padding. Kanonisk definisjon her; sidene kan fortsatt overstyre om nødvendig. */
+.row-actions { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
+.row-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: auto;
+  min-height: 0;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+  font-family: inherit;
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-button);
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+  white-space: nowrap;
+  text-decoration: none;
+  box-sizing: border-box;
+}
+.row-action-btn:hover { background: var(--color-row-hover); border-color: var(--color-link-hover-border); }
+.row-action-btn.destructive { color: var(--color-error); border-color: #f5c0bb; }
+.row-action-btn.destructive:hover { background: #fdf0ef; }
 
 /* #705-UX(A): felles filter-piller (Alle/Aktive/Publiserte/Arkiverte) på tvers av admin-listene,
    samme uttrykk som modul-bibliotekets .library-filter-btn. */

--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -1292,6 +1292,8 @@ test.describe("admin content browser coverage", () => {
           certificationLevel: "advanced",
           moduleCount: 3,
           updatedAt: "2026-04-18T10:30:00.000Z",
+          // #705-UX: Slett vises kun for arkiverte kurs, så denne må være arkivert.
+          archivedAt: "2026-04-18T12:00:00.000Z",
         },
       ],
     });
@@ -1299,6 +1301,8 @@ test.describe("admin content browser coverage", () => {
     await page.goto("/admin-content/courses");
 
     await expect(page.getByRole("table", { name: "Kursliste" })).toBeVisible();
+    // Arkiverte er skjult under default «Aktive»-filter — bytt til «Arkiverte».
+    await page.locator('.list-filter-btn[data-filter="archived"]').click();
     await page.locator('[data-action="delete"]').first().click();
 
     await expect(page.locator("#deleteDialog")).toHaveAttribute("open", "");


### PR DESCRIPTION
Polish fra din v1.6.0-gjennomgang:

1. **Slett vises kun for arkiverte elementer** (din forslag) — terminalt steg etter arkivering, likt for kurs/modul/seksjon. Aktive rader viser Arkiver. Svarer også på «hvorfor har ikke moduler Slett»: moduler fikk (vaktet) Slett, kun når arkivert.
2. **Felles knappestil** — `.row-action-btn`/`.row-actions` kanonisk i `shared.css`; seksjoner/klasser hadde egne avvikende definisjoner → fjernet.
3. **Seksjonslista layout** — fikset `width:100%`-tittel + `display:flex`-handlingscelle som stablet knappene vertikalt og utnyttet skjermen dårlig; nå horisontale knapper som Kurs/Moduler.

## Test
tsc rent · e2e 77 grønt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)