### PR TITLE
perf(infra+auth): connection pool + strupet gruppe-synk (v1.6.2)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -15,6 +15,11 @@ holder når SPA-en fyrer flere parallelle `/api`-kall + auth kjører gruppe-synk
   = 3×10 = 30, godt under Postgres `max_connections=50`).
 - Prod ble hotfikset live ved å oppdatere KV-secret `DATABASE-URL` direkte + restart (ingen full
   deploy nødvendig); denne Bicep-endringen persisterer fiksen for fremtidige deploys.
+- **(A) Strupet Entra gruppe-synk:** `syncEntraGroupRoles` kjørte DB-arbeid (findMany + reconcile) på
+  HVERT autentisert request i Entra-modus, som la latens på alle API-kall (prod-vs-stage-deltaen,
+  siden stage har synk av). Nå strupet per bruker med 5-min in-memory TTL (web = én prosess).
+  `getActiveRoles` leser fortsatt DB hvert kall, så tildelte roller er alltid ferske; vi hopper kun
+  over den idempotente re-synkroniseringen innenfor vinduet. `resetGroupSyncThrottle()` for tester.
 
 ## 1.6.1 - 2026-06-29
 

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,20 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.2 - 2026-06-29
+
+fix(infra): øk Prisma connection pool (connection_limit=10) — fra prod-incident
+
+Første reelle samtidige deltaker-last i prod ga `PrismaClientKnownRequestError P2024` («Timed out
+fetching a connection from the connection pool», limit 3) → 500 på `/api/me`, `/api/courses` og
+manglende toppmeny. Prisma defaulter poolen til `cores*2+1` = **3** på 1-kjerne B1-appen, som ikke
+holder når SPA-en fyrer flere parallelle `/api`-kall + auth kjører gruppe-synk per request.
+
+- Bicep `postgresConnectionString` får nå `&connection_limit=10&pool_timeout=20` (web+worker+parser
+  = 3×10 = 30, godt under Postgres `max_connections=50`).
+- Prod ble hotfikset live ved å oppdatere KV-secret `DATABASE-URL` direkte + restart (ingen full
+  deploy nødvendig); denne Bicep-endringen persisterer fiksen for fremtidige deploys.
+
 ## 1.6.1 - 2026-06-29
 
 fix(ux): admin-liste-polish fra staging-gjennomgang av v1.6.0 (#705-UX)

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -250,7 +250,10 @@ var openAiModelDeploymentName = 'a2-assessment-${openAiEnvToken}-${azureOpenAiMo
 // 3-24 chars, lowercase alphanumeric only (no hyphens), globally unique.
 var courseAssetsStorageName = toLower('a2${envCode}assets${suffix}')
 var courseAssetsContainerName = 'course-assets'
-var postgresConnectionString = 'postgresql://${uriComponent(postgresAdministratorLogin)}:${uriComponent(postgresAdministratorPassword)}@${postgresHost}:5432/${postgresDatabaseName}?schema=public&sslmode=require'
+// connection_limit/pool_timeout: Prisma defaults the pool to (cores*2+1) = 3 on the 1-core B1 app,
+// which starved under real concurrent participant load (P2024 "Timed out fetching a connection").
+// Set explicitly so web+worker+parser stay well under Postgres max_connections (50): 3 apps × 10 = 30.
+var postgresConnectionString = 'postgresql://${uriComponent(postgresAdministratorLogin)}:${uriComponent(postgresAdministratorPassword)}@${postgresHost}:5432/${postgresDatabaseName}?schema=public&sslmode=require&connection_limit=10&pool_timeout=20'
 var llmFailureAlertQuery = '''
 union isfuzzy=true AppServiceConsoleLogs, AzureDiagnostics
 | where TimeGenerated > ago(5m)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -217,9 +217,28 @@ function parseRoleMap(): Record<string, AppRoleType> {
   return parseEntraGroupRoleMapJson(env.ENTRA_GROUP_ROLE_MAP_JSON);
 }
 
+// #705-perf(A): gruppe-synk kjørte på HVERT autentisert request (findMany + reconcile mot DB),
+// som la målbar latens på alle API-kall i Entra-modus på den Burstable-DB-en. Roller endres
+// sjelden, så vi struper synken per bruker med en in-memory TTL. Web-appen kjører som én
+// prosess (numberOfWorkers=1), så et modul-nivå cache er konsistent. getActiveRoles leser
+// fortsatt DB hvert kall, så allerede tildelte roller er alltid ferske — vi hopper kun over
+// den (idempotente) re-synkroniseringen innenfor vinduet.
+const groupSyncThrottleMs = 5 * 60 * 1000;
+const lastGroupSyncAtByUser = new Map<string, number>();
+
+// Eksponert for tester så throttle-tilstanden kan nullstilles mellom caser.
+export function resetGroupSyncThrottle() {
+  lastGroupSyncAtByUser.clear();
+}
+
 export async function syncEntraGroupRoles(userId: string, principal: AuthPrincipal, at = new Date()) {
   if (!env.ENTRA_SYNC_GROUP_ROLES) {
     return;
+  }
+
+  const lastSync = lastGroupSyncAtByUser.get(userId);
+  if (lastSync !== undefined && at.getTime() - lastSync < groupSyncThrottleMs) {
+    return; // synket nylig — hopp over DB-arbeidet for dette requestet
   }
 
   const map = parseRoleMap();
@@ -264,4 +283,7 @@ export async function syncEntraGroupRoles(userId: string, principal: AuthPrincip
       });
     }
   }
+
+  // Marker som synket først etter vellykket reconcile (så et kast → retry neste request).
+  lastGroupSyncAtByUser.set(userId, at.getTime());
 }


### PR DESCRIPTION
Prod-incident: første reelle samtidige last ga Prisma P2024 (pool limit 3) → 500 på /api/me + /api/courses + manglende toppmeny. Bicep-koblingsstrengen får connection_limit=10&pool_timeout=20 (3 apper × 10 = 30 < max_connections 50). Prod allerede hotfikset live via KV-secret + restart; denne PR-en persisterer fiksen for fremtidige deploys. **Rollback:** fjern query-paramene fra postgresConnectionString. Ingen umiddelbar deploy nødvendig (prod er allerede rettet).