### PR TITLE
fix(ux): skjul dev mock-identity-kort til auth-modus er kjent (v1.6.3)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,22 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.3 - 2026-06-29
+
+fix(ux): skjul dev-only «mock-identity»-kort til auth-modus er kjent (ingen flash i prod)
+
+Det dev-only «Testbruker / Dev only»-kortet (mock-identitet + rolle-velger) blinket i et par
+sekunder før den normale siden i prod/stage (entra), fordi sidene starter med standard `authMode:
+"mock"` og først skjuler kortet etter at `/participant/config` er lastet — synlig når DB/last er treg.
+
+- Ikke en sikkerhetssvakhet: i entra-modus ignorerer `authenticate()` mock-headerne fullstendig
+  (roller kommer fra Entra-tokenet), så rolle-velgeren kan ikke endre tilgang server-side. Men dev-UI
+  skal ikke vises for ekte brukere.
+- Fiks: sidene starter med `<body class="auth-resolving">` + `shared.css` skjuler
+  `.mock-identity-card` mens den klassen er på. JS fjerner `auth-resolving` etter at config er lastet,
+  så kortet vises kun i ekte mock-modus (lokal dev), aldri som et blink i prod/stage.
+- Berørte sider: participant, admin-content (+ advanced), admin-platform, calibration.
+
 ## 1.6.2 - 2026-06-29
 
 fix(infra): øk Prisma connection pool (connection_limit=10) — fra prod-incident

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-advanced.html
+++ b/public/admin-content-advanced.html
@@ -206,7 +206,7 @@
       }
     </style>
   </head>
-  <body>
+  <body class="auth-resolving">
     <a href="#main-content" class="skip-nav" data-i18n="nav.skipToContent">Skip to main content</a>
     <main id="main-content" class="layout-container">
     <div class="page-top-bar">

--- a/public/admin-content.html
+++ b/public/admin-content.html
@@ -341,7 +341,7 @@
       }
     </style>
   </head>
-  <body>
+  <body class="auth-resolving">
     <a href="#main-content" class="skip-nav" data-i18n="nav.skipToContent">Skip to main content</a>
     <main id="main-content" class="layout-container">
 

--- a/public/admin-content.js
+++ b/public/admin-content.js
@@ -1791,6 +1791,7 @@ async function loadParticipantConsoleConfig() {
   }
 
   document.body.classList.toggle("auth-entra", roleSwitchState.authMode === "entra");
+  document.body.classList.remove("auth-resolving"); // auth-modus kjent → ikke vis dev-kort i prod/stage
   applyOutputVisibility();
   applyIdentityDefaults();
   if (calibrationLimitInput) {

--- a/public/admin-platform.html
+++ b/public/admin-platform.html
@@ -20,7 +20,7 @@
       .save-bar { display: flex; align-items: center; gap: var(--space-1); margin-top: var(--space-2); }
     </style>
   </head>
-  <body>
+  <body class="auth-resolving">
     <a href="#main-content" class="skip-nav" data-i18n="nav.skipToContent">Skip to main content</a>
 
     <main id="main-content" class="layout-container">

--- a/public/admin-platform.js
+++ b/public/admin-platform.js
@@ -304,6 +304,7 @@ async function loadConsoleConfig() {
   }
 
   document.body.classList.toggle("auth-entra", roleSwitchState.authMode === "entra");
+  document.body.classList.remove("auth-resolving"); // auth-modus kjent → ikke vis dev-kort i prod/stage
 
   const identityDefaults = participantRuntimeConfig?.identityDefaults?.administrator;
   if (identityDefaults) {

--- a/public/calibration.html
+++ b/public/calibration.html
@@ -13,7 +13,7 @@
       tr:hover { background: var(--color-row-hover); }
     </style>
   </head>
-  <body>
+  <body class="auth-resolving">
     <a href="#main-content" class="skip-nav" data-i18n="nav.skipToContent">Skip to main content</a>
     <main id="main-content" class="layout-container">
     <div class="page-top-bar">

--- a/public/calibration.js
+++ b/public/calibration.js
@@ -541,6 +541,7 @@ async function loadParticipantConsoleConfig() {
   }
 
   document.body.classList.toggle("auth-entra", roleSwitchState.authMode === "entra");
+  document.body.classList.remove("auth-resolving"); // auth-modus kjent → ikke vis dev-kort i prod/stage
   applyOutputVisibility();
   applyIdentityDefaults();
   const maxRows = participantRuntimeConfig?.calibrationWorkspace?.defaults?.maxRows ?? 120;

--- a/public/participant.html
+++ b/public/participant.html
@@ -94,7 +94,7 @@
       .reset-flow-discreet:hover { color: var(--color-text, #1e293b); background: transparent; }
     </style>
   </head>
-  <body>
+  <body class="auth-resolving">
     <a href="#main-content" class="skip-nav" data-i18n="nav.skipToContent">Skip to main content</a>
     <main id="main-content" class="layout-container">
     <div class="page-top-bar">

--- a/public/participant.js
+++ b/public/participant.js
@@ -1540,6 +1540,9 @@ async function loadParticipantConsoleConfig() {
   }
 
   document.body.classList.toggle("auth-entra", roleSwitchState.authMode === "entra");
+  // Auth-modus er nå kjent → fjern «resolving»-tilstanden (dev-kortet vises kun i ekte mock-modus,
+  // aldri som et blink i prod/stage). Se shared.css `body.auth-resolving .mock-identity-card`.
+  document.body.classList.remove("auth-resolving");
   applyOutputVisibility();
   applyIdentityDefaults();
   applyCourseOnlyMode();

--- a/public/static/shared.css
+++ b/public/static/shared.css
@@ -525,6 +525,14 @@ body.auth-entra .mock-identity-card {
   display: none;
 }
 
+/* Skjul dev-only mock-identity-/rollevelger-kortet til runtime auth-modus er kjent, så det aldri
+   blinker i prod/stage (entra) før config er lastet. Sidene starter med <body class="auth-resolving">
+   og JS fjerner klassen etter at /participant/config er hentet. (Ingen sikkerhetsrisiko — mock-
+   headerne ignoreres server-side i entra-modus — men dev-UI skal ikke vises for ekte brukere.) */
+body.auth-resolving .mock-identity-card {
+  display: none !important;
+}
+
 .mock-identity-dev-badge {
   display: inline-block;
   font-size: 10px;


### PR DESCRIPTION
Dev-only «Testbruker / Dev only»-kortet blinket i prod/stage (entra) før /participant/config var lastet (sidene starter med default authMode=mock).

**Ikke en sikkerhetssvakhet** — i entra-modus ignorerer authenticate() mock-headerne (roller kommer fra Entra-tokenet), så rolle-velgeren kan ikke endre tilgang server-side. Men dev-UI skal ikke vises for ekte brukere.

**Fiks:** sidene starter med body-klassen auth-resolving + shared.css skjuler .mock-identity-card mens den er på; JS fjerner klassen etter at config er lastet. Kortet vises dermed kun i ekte mock-modus (lokal dev). Sider: participant, admin-content (+advanced), admin-platform, calibration.

Full e2e (som bruker mock-kortet på admin-sidene) er regresjonsvakt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)