### PR TITLE
fix(security): re-impl import-eierskap (#528) + rubrikk-skala (#527) (v1.6.5)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,24 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.5 - 2026-06-29
+
+fix(security): re-implementer security-scan-funn på dagens main (#527/#528); #526 var alt fikset
+
+Tre eldre codex-genererte security-PR-er (2026-06-17) ble vurdert. #526 (SSRF via redirect-kjeder)
+var allerede fikset i main (`urlFetchService` bruker `redirect:manual` + per-hop-validering) → lukket.
+De to andre stod fortsatt åpne og er re-implementert ferskt:
+
+- **#528 (autz):** `POST /api/admin/content/modules/import` med `mode=replaceExisting` sjekker nå
+  eierskap på `targetId` (`assertModuleOwnership`) før import. Tettet hull der en SMO kunne importere
+  (og auto-publisere) en ny versjon inn i en modul de ikke eier. Verken rute eller service sjekket
+  dette før. Regresjonsvakt i `m2-content-export-import`.
+- **#527 (vurderings-integritet):** generert rubrikk-skala låst — `maxScore` må være eksakt 4 (matcher
+  assessor-skalaen 0–4) og 3–6 kriterier, i både zod-skjema og generation-prompt. Hindrer LLM-styrt
+  nevner-drift i scoringen. (Manuelle slidere er fortsatt forfatter-kontroll, utenfor dette scope.)
+
+NB: ment for **staging**-verifisering foreløpig.
+
 ## 1.6.4 - 2026-06-29
 
 feat/ux: deltaker-kursspiller — «fortsett der du slapp», riktig telling, + småfiks (#492/#714/#710)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/llmContentGenerationService.ts
+++ b/src/modules/adminContent/llmContentGenerationService.ts
@@ -291,12 +291,14 @@ const moduleRubricResponseCodec = z.object({
         id: z.string().min(1),
         label: z.string().min(1),
         description: z.string().min(1),
-        maxScore: z.number().int().min(1).max(10),
+        // #527 (security/integritet): lås generert maxScore til 4 så den matcher assessor-kontrakten
+        // (rubric_scores 0..4 per kriterium). Tidligere 1..10 lot LLM-en styre nevneren i scoringen.
+        maxScore: z.literal(4),
         candidateVisible: z.boolean().default(true),
       }),
     )
-    .min(2)
-    .max(8),
+    .min(3)
+    .max(6),
   generatedFromTask: z.boolean().default(true),
   assessorNotes: z.string().default(""),
 });
@@ -1229,7 +1231,7 @@ ${blueprintSection}## Authoring rules
 
 - Produce 3-6 criteria. Each must name a specific dimension the task actually tests (e.g. "Trade-off between privacy and audit obligation", not "Quality of reasoning").
 - Each \`description\` must reference concrete content from the task or assessor expectations so a human assessor can apply it without guessing.
-- \`maxScore\` per criterion is an integer 1-10. Sum across all criteria should land in the range 10-30.
+- \`maxScore\` per criterion must be exactly 4, matching the assessor scale (0-4 per criterion). Produce 3-6 criteria.
 - \`id\` is short snake_case (e.g. "scenario_application", "priority_reasoning"). Stable across runs.
 - \`candidateVisible: true\` means the criterion text is appropriate to show the candidate before they submit. Set false only for criteria that would leak the expected answer.
 - \`assessorNotes\` is a short paragraph with one or two judgement calls the assessor should make consistently across submissions (e.g. don't penalise for missing X unless the task asked for it). Keep it under 60 words.
@@ -1244,7 +1246,7 @@ Return a single JSON object:
       "id": "snake_case_id",
       "label": "Short label in ${LOCALE_DISPLAY[input.locale]}",
       "description": "1-2 sentences that name what the assessor checks for, grounded in the task.",
-      "maxScore": integer 1-10,
+      "maxScore": 4,
       "candidateVisible": boolean
     }
   ],

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -321,6 +321,12 @@ adminContentRouter.post("/modules/import", async (request, response) => {
     return;
   }
   try {
+    // #528 (security): replaceExisting legger en ny aktiv versjon på targetId. Uten eierskaps-sjekk
+    // kunne en SMO importere (og auto-publisere) en versjon inn i en modul de ikke eier. Krev eierskap
+    // (eller ADMIN) på targetId før import — speiler vakta på publish/unpublish/archive-rutene.
+    if ((data.mode ?? "createNew") === "replaceExisting" && data.targetId) {
+      await assertModuleOwnership(data.targetId, actorId, request.context?.roles ?? []);
+    }
     // Cast through unknown: zod-inferred OUTPUT types from the import side and the
     // schema-builder side are structurally identical but nominally unrelated when
     // they cross module boundaries via different re-export chains. Runtime payload

--- a/test/m2-content-export-import.test.ts
+++ b/test/m2-content-export-import.test.ts
@@ -182,6 +182,35 @@ describe("#433 module export-import round-trip", () => {
     expect(importResponse.status).toBe(400);
     expect(importResponse.body.error).toBe("validation_error");
   });
+
+  // #528 (security): replaceExisting import into a module the actor does not own (and is not admin)
+  // must be blocked before any version is appended — closes an authz gap (combinable with auto-publish).
+  it("blocks replaceExisting import into a module the importer does not own (#528)", async () => {
+    const { moduleId } = await setupModule(`own-${Date.now()}`); // owned by admin-1
+    const envelope = (
+      await request(app).get(`/api/admin/content/modules/${moduleId}/export-package`).set(adminHeaders)
+    ).body.envelope;
+
+    const otherSmo = {
+      "x-user-id": `sec-import-${Date.now()}`,
+      "x-user-email": `imp-${Date.now()}@company.com`,
+      "x-user-name": "Other SMO",
+      "x-user-roles": "SUBJECT_MATTER_OWNER",
+    };
+    const res = await request(app)
+      .post("/api/admin/content/modules/import")
+      .set(otherSmo)
+      .send({ payload: envelope, mode: "replaceExisting", targetId: moduleId });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("module_ownership");
+
+    // Sanity: the owner (admin) can still replaceExisting into their own module.
+    const ownerRes = await request(app)
+      .post("/api/admin/content/modules/import")
+      .set(adminHeaders)
+      .send({ payload: envelope, mode: "replaceExisting", targetId: moduleId });
+    expect(ownerRes.status).toBe(201);
+  });
 });
 
 describe("#512 course export-import with learning sections", () => {


### PR DESCRIPTION
Re-implementering av to security-scan-funn på dagens main (codex-PR-ene var stale/konflikt). #526 (SSRF) var allerede fikset i main → lukket.

- **#528 (autz):** `POST /api/admin/content/modules/import` med `mode=replaceExisting` sjekker nå eierskap på `targetId` (`assertModuleOwnership`) før import. Tettet hull der en SMO kunne importere/auto-publisere en versjon inn i en modul de ikke eier (verken rute eller service sjekket det). Regresjonsvakt i `m2-content-export-import`.
- **#527 (vurderings-integritet):** generert rubrikk låst til `maxScore=4` + 3–6 kriterier (zod-skjema + prompt). Hindrer LLM-styrt nevner-drift i scoringen.

Foreløpig kun ment for **staging**. tsc rent · m2-content-export-import 8/8 (inkl. ny #528-vakt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)