### PR TITLE
fix(ux): harmoniser kurselement-lista + reell #710-fiks (v1.6.6)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,25 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.6 - 2026-06-30
+
+fix(ux): kurselement-lista harmonisert med admin-oversiktene + reell #710-fiks på modul-biblioteket
+
+Oppfølging etter stage-verifisering av 1.6.4/1.6.5 (#714/#710):
+
+- **#710 (egentlig fiks):** «Brukt i kurs»-linjeringen var fortsatt skjev på **Moduler**-siden.
+  Årsak: `admin-content-library.html` hadde en lokal `<style>`-override av
+  `.course-count-btn`/`.course-count-zero` som manglet `display:inline-block`/`vertical-align`/
+  `line-height` og dermed vant over shared.css (senere i dokumentet). Override fjernet → begge
+  sider styres nå av shared.css og «0»/tall ligger på samme linje. Seksjoner-siden var alt riktig.
+- **#714 (oppfølging, kosmetisk):** deltakerens oversikt over kurselementer er gjort lik
+  admin-oversiktene: hver tilstand er nå en **pille** (ikke bare «Bestått») — grå «ikke startet /
+  ikke lest», blå «påbegynt», grønn «bestått/lest», dempet «ikke tilgjengelig». Luftigere rader,
+  fet tittel, dempet handlingsverb som type-hint, status til høyre. Inline badge-stiler flyttet
+  til CSS (`.module-status-badge`).
+
+NB: foreløpig kun ment for **staging**-verifisering.
+
 ## 1.6.5 - 2026-06-29
 
 fix(security): re-implementer security-scan-funn på dagens main (#527/#528); #526 var alt fikset

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-library.html
+++ b/public/admin-content-library.html
@@ -149,20 +149,9 @@
         text-transform: capitalize;
       }
 
-      /* ── Course count clickable ──────────────────────────────────────────── */
-      .course-count-btn {
-        background: none;
-        border: none;
-        padding: 2px 6px;
-        font-size: 13px;
-        font-weight: 600;
-        cursor: pointer;
-        border-radius: 4px;
-        color: var(--color-link-active);
-        text-decoration: underline;
-      }
-      .course-count-btn:hover { background: var(--color-blue-light); }
-      .course-count-zero { color: var(--color-meta); font-size: 13px; }
+      /* #710: «Brukt i kurs»-teller styres nå utelukkende av shared.css
+         (.course-count-btn / .course-count-zero) — lokal override fjernet fordi
+         den manglet inline-block/vertical-align og brøt linjeringen mellom «0» og tall. */
 
       /* ── Row actions ─────────────────────────────────────────────────────── */
       .row-actions { display: flex; gap: 4px; align-items: center; flex-wrap: wrap; }

--- a/public/participant.html
+++ b/public/participant.html
@@ -28,9 +28,12 @@
       #moduleListSection.module-list-collapsed #moduleSelectionHint,
       #moduleListSection.module-list-collapsed [data-i18n="modules.summaryHint"] { display: none; }
       .module-badges { display: flex; flex-wrap: wrap; gap: 8px; margin-top: var(--space-1); }
-      .module-status-badge { display: inline-block; font-size: 11px; font-weight: 700; border-radius: 999px; padding: 4px 10px; }
+      /* #714-followup: hver tilstand er en pille (som status-merkene i admin-oversiktene),
+         ikke bare «bestått». Standard = grå «ikke startet / ikke lest». */
+      .module-status-badge { display: inline-flex; align-items: center; flex-shrink: 0; font-size: 11px; font-weight: 700; border-radius: 999px; padding: 3px 10px; background: #edf1f7; color: #42526b; white-space: nowrap; }
       .module-status-badge.completed { color: #1f7a4d; background: #e6f5ec; }
       .module-status-badge.retake { color: #0d3f9e; background: #e9f0ff; }
+      .module-status-badge.unavailable { color: #777; background: #f0f0f0; }
       .module-meta { font-size: 12px; color: var(--color-meta); margin-top: calc(var(--space-1) * 0.5); }
       .selected-badge { display: inline-block; margin-top: var(--space-1); font-size: 11px; font-weight: 600; color: var(--color-selected-badge); }
       .draft-badge { display: inline-block; margin-top: var(--space-1); margin-right: var(--space-1); font-size: 11px; font-weight: 700; color: #7a4b00; background: #fff3db; border-radius: 999px; padding: 4px 10px; }
@@ -75,16 +78,19 @@
       .course-progress-bar { height: 6px; background: var(--color-border-soft); border-radius: 999px; overflow: hidden; }
       .course-progress-fill { height: 100%; background: var(--color-blue); border-radius: 999px; transition: width 0.3s; }
       .course-progress-fill.completed { background: var(--color-success, #1f7a4d); }
-      .course-module-row { display: flex; align-items: center; gap: var(--space-1); padding: 4px 0; border-bottom: 1px solid var(--color-border-soft); }
+      /* #714-followup: kurselement-lista speiler admin-oversiktene — luftige rader, fet tittel,
+         dempet handlingsverb som type-hint, status som pille til høyre. */
+      .course-module-row { display: flex; align-items: center; gap: var(--space-2); padding: 10px 12px; border-bottom: 1px solid var(--color-border-soft); }
       .course-module-row:last-child { border-bottom: none; }
-      .course-module-row-title { flex: 1; font-size: 14px; color: var(--color-text); }
+      .course-module-row-title { flex: 1; font-size: 14px; font-weight: 600; color: var(--color-text); }
       .course-module-row-copy { display: grid; gap: 2px; flex: 1; min-width: 0; }
       .course-module-row-action { font-size: 12px; color: var(--color-meta); }
-      .course-module-button { width: 100%; border: none; background: transparent; text-align: left; color: inherit; cursor: pointer; border-radius: 8px; padding: 8px 0; }
-      .course-module-button:hover { background: var(--color-blue-light); }
+      .course-module-button { width: 100%; border: none; background: transparent; text-align: left; color: inherit; cursor: pointer; border-radius: 8px; padding: 10px 12px; }
+      .course-module-button:hover { background: var(--color-row-hover, var(--color-blue-light)); }
       .course-module-button:focus-visible { outline: 3px solid var(--color-focus); outline-offset: 2px; }
       .course-module-button.selected { background: var(--color-blue-light); }
-      .course-module-button[disabled] { cursor: wait; opacity: 0.8; }
+      .course-module-button[disabled] { cursor: default; opacity: 0.7; }
+      .course-module-button[disabled]:hover { background: transparent; }
       /* #492: «Fortsett der du slapp»-knapp + uthev neste uferdige element så lange lister blir lette å skanne. */
       .course-resume-btn { width: auto; margin: 0 0 var(--space-2); }
       .course-module-row--next { background: var(--color-blue-light); border-radius: 8px; box-shadow: inset 3px 0 0 var(--color-blue); }

--- a/public/participant.js
+++ b/public/participant.js
@@ -2977,7 +2977,7 @@ function renderCourseDetailModules(courseId, course) {
           <span class="course-module-row-title">${escapeHtmlP(localizePreviewText(entry.title))}</span>
           <span class="course-module-row-action">${escapeHtmlP(t("courses.section.read"))}</span>
         </span>
-        <span class="module-status-badge ${entry.read ? "completed" : ""}" style="font-size:11px;padding:2px 8px;flex-shrink:0">${escapeHtmlP(readBadge)}</span>
+        <span class="module-status-badge ${entry.read ? "completed" : ""}">${escapeHtmlP(readBadge)}</span>
       `;
       container.appendChild(sectionRow);
       continue;
@@ -2985,15 +2985,18 @@ function renderCourseDetailModules(courseId, course) {
     const m = entry;
     const passed = m.moduleStatus === "PASSED";
     const inProgress = m.moduleStatus === "IN_PROGRESS";
-    const badgeText = passed ? t("courses.module.passed") : inProgress ? t("courses.module.inProgress") : t("courses.module.notStarted");
-    const badgeClass = passed ? "completed" : inProgress ? "retake" : "";
     const selected = selectedModuleId === m.moduleId;
     // #502-followup: avpubliserte/utilgjengelige moduler vises som ikke-klikkbare (ingen blindvei).
     const available = m.available !== false;
-    // #495-follow-up UX: handlingsverb i stedet for «Velg modul» (begrepet «modul» fjernet i deltaker-UI).
-    const actionText = !available
+    // #714-followup: status ligger i pillen (som admin-oversiktene) — også «ikke tilgjengelig».
+    const badgeText = !available
       ? t("courses.module.unavailableShort")
-      : selected ? t("courses.module.selectedShort") : t("courses.module.go");
+      : passed ? t("courses.module.passed")
+      : inProgress ? t("courses.module.inProgress")
+      : t("courses.module.notStarted");
+    const badgeClass = !available ? "unavailable" : passed ? "completed" : inProgress ? "retake" : "";
+    // #495-follow-up UX: handlingsverb i stedet for «Velg modul» (begrepet «modul» fjernet i deltaker-UI).
+    const actionText = selected ? t("courses.module.selectedShort") : t("courses.module.go");
     const row = document.createElement("button");
     row.type = "button";
     row.className = selected ? "btn-secondary course-module-row course-module-button selected" : "btn-secondary course-module-row course-module-button";
@@ -3018,7 +3021,7 @@ function renderCourseDetailModules(courseId, course) {
         <span class="course-module-row-title">${escapeHtmlP(localizePreviewText(m.title))}</span>
         <span class="course-module-row-action">${escapeHtmlP(actionText)}</span>
       </span>
-      <span class="module-status-badge ${badgeClass}" style="font-size:11px;padding:2px 8px;flex-shrink:0">${escapeHtmlP(badgeText)}</span>
+      <span class="module-status-badge ${badgeClass}">${escapeHtmlP(badgeText)}</span>
     `;
     container.appendChild(row);
   }


### PR DESCRIPTION
Oppfolging etter stage-verifisering av 1.6.4/1.6.5.

## #710 (egentlig fiks)
«Brukt i kurs»-linjeringen var fortsatt skjev pa Moduler-siden. admin-content-library.html hadde en lokal style-override av .course-count-btn/.course-count-zero uten display:inline-block/vertical-align/line-height - den vant over shared.css. Override fjernet -> begge sider styres na av shared.css.

## #714 (kosmetisk oppfolging)
Deltakerens kurselement-liste harmonisert med admin-oversiktene: hver tilstand er na en pille (gra ikke-startet, bla pabegynt, gronn bestatt/lest, dempet ikke tilgjengelig), luftigere rader, fet tittel, status til hoyre. Inline badge-stiler -> CSS.

Klassenavn uendret (.course-module-row, .module-status-badge) - e2e participant-section-reader treffer fortsatt.

NB: kun for staging-verifisering forelopig.

Generated with Claude Code