### PR TITLE
fix(ux): sentrer «Brukt i kurs»-tall i fast boks (v1.6.7)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,19 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.7 - 2026-06-30
+
+fix(ux): «Brukt i kurs»-tall sentreres i fast boks → robust linjering på tvers av rader (#710)
+
+Etter 1.6.6 var «0» og tall-lenken fortsatt ikke på samme vertikale linje for noen brukere.
+Deployet 1.6.6-CSS var korrekt (lik padding/inline-block), så restproblemet var enten en
+`<button>` vs `<span>`-renderingsforskjell eller et cachet stilark. Robust fiks:
+`.course-count-btn`/`.course-count-zero` får nå `min-width: 2.25em` + `text-align: center` +
+`margin: 0`, slik at sifferet sentreres i en identisk boks uansett element-type, glyf-bredde
+eller button-quirks. Endringen gir også nytt ETag → tvinger frisk stilark-henting (cache-bust).
+
+NB: foreløpig kun ment for **staging**-verifisering.
+
 ## 1.6.6 - 2026-06-30
 
 fix(ux): kurselement-lista harmonisert med admin-oversiktene + reell #710-fiks på modul-biblioteket

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/shared.css
+++ b/public/static/shared.css
@@ -1129,10 +1129,12 @@ dialog::backdrop {
 .list-filter-btn.active { background: var(--color-blue-light); border-color: var(--color-blue); color: var(--color-link-active); }
 
 /* #705-UX(G): «Brukt i kurs»-teller + popover, delt så seksjonslista matcher modul-biblioteket. */
-/* #710: «0» (span) og tall-knappen må ha identisk boks-geometri så de ligger på samme linje
-   på tvers av rader. Begge: inline-block, samme padding/font/line-height, midtstilt vertikalt. */
+/* #710: «0» (span) og tall-knappen må ligge på nøyaktig samme sted på tvers av rader.
+   Begge får identisk boks (inline-block, lik min-bredde, midtstilt innhold), så sifferet
+   sentreres likt uansett element-type (button vs span), glyf-bredde eller button-quirks. */
 .course-count-btn, .course-count-zero {
   display: inline-block; vertical-align: middle; box-sizing: border-box;
+  min-width: 2.25em; text-align: center; margin: 0;
   padding: 2px 6px; font-size: 13px; font-weight: 600; line-height: 1.5;
 }
 .course-count-btn {


### PR DESCRIPTION
Etter 1.6.6 var «0» og tall-lenken fortsatt ikke pa samme vertikale linje. Deployet CSS var korrekt (verifisert mot stage), sa restproblemet var en button-vs-span renderingsforskjell eller cachet stilark.

Robust fiks: .course-count-btn/.course-count-zero far min-width 2.25em + text-align center + margin 0 -> sifferet sentreres likt i identisk boks uansett element-type/glyf. Nytt ETag tvinger frisk CSS-henting.

Kun for staging-verifisering forelopig.

Generated with Claude Code