### PR TITLE
fix(ux): width:auto pa teller-knapp - rot-arsak #710 (v1.6.8)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,22 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.8 - 2026-06-30
+
+fix(ux): ROT-ÅRSAK for «Brukt i kurs»-skjevhet — global `button { width: 100% }` (#710)
+
+Verifisert med headless-render (Playwright) av den faktisk deployede CSS-en: teller-**knappen**
+(`<button class="course-count-btn">`) arvet den globale skjema-regelen `button { width: 100% }`
+og ble dermed **cellebred (~169px)**, mens «0» (`<span>`) forble smal (~29px). Med
+`text-align: center` havnet «1» midt i den brede knappen → ~70px til høyre for «0».
+`min-width`/`text-align` fra 1.6.7 kunne aldri vinne mot `width: 100%`.
+
+Fiks: `width: auto` på `.course-count-btn`/`.course-count-zero` → shrink-to-fit, identisk
+29px-boks, sifrene perfekt over hverandre (målt glyf-senter-diff: 0.01px). Lærdom: CSS-fiks
+bør renderes og måles før deploy, ikke verifiseres manuelt på stage i flere runder.
+
+NB: foreløpig kun ment for **staging**-verifisering.
+
 ## 1.6.7 - 2026-06-30
 
 fix(ux): «Brukt i kurs»-tall sentreres i fast boks → robust linjering på tvers av rader (#710)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/shared.css
+++ b/public/static/shared.css
@@ -1130,11 +1130,12 @@ dialog::backdrop {
 
 /* #705-UX(G): «Brukt i kurs»-teller + popover, delt så seksjonslista matcher modul-biblioteket. */
 /* #710: «0» (span) og tall-knappen må ligge på nøyaktig samme sted på tvers av rader.
-   Begge får identisk boks (inline-block, lik min-bredde, midtstilt innhold), så sifferet
-   sentreres likt uansett element-type (button vs span), glyf-bredde eller button-quirks. */
+   ROT-ÅRSAK: global `button { width: 100% }` (skjema-knapper) gjorde teller-knappen
+   cellebred, så «1» (text-align center) havnet ~70px til høyre for span-«0». Fiks:
+   `width: auto` på begge → shrink-to-fit, identisk boks, sifferet sentrert likt. */
 .course-count-btn, .course-count-zero {
   display: inline-block; vertical-align: middle; box-sizing: border-box;
-  min-width: 2.25em; text-align: center; margin: 0;
+  width: auto; min-width: 2.25em; text-align: center; margin: 0;
   padding: 2px 6px; font-size: 13px; font-weight: 600; line-height: 1.5;
 }
 .course-count-btn {


### PR DESCRIPTION
ROT-ARSAK funnet via headless-render (Playwright) av deployet CSS: teller-knappen arvet global `button { width: 100% }` og ble cellebred (~169px), mens span-«0» forble ~29px. «1» sentrert i bred knapp havnet ~70px til hoyre.

Fiks: `width: auto` -> begge shrink-to-fit, identisk 29px-boks. Verifisert med render+maling for deploy (glyf-senter-diff 0.01px).

Kun for staging-verifisering forelopig.

Generated with Claude Code