### PR TITLE
ops(ci): widen post-deploy smoke window 4->6 for slow B1 worker

### DIFF
--- a/scripts/azure/post-deploy-smoke.sh
+++ b/scripts/azure/post-deploy-smoke.sh
@@ -49,7 +49,11 @@ echo "  parser: $PARSER"
 echo
 
 FAIL=0
-MAX_ATTEMPTS=4    # 4 attempts at ~30s timeout each, with 45s sleep between → ~3 min total budget
+# 6 attempts × (≤30s curl + 45s sleep) → ~6 min budget. Widened from 4 (#710 prod promote,
+# run 28431321940): the prod WORKER cold-started 7s AFTER the 4th attempt (B1 worker restart
+# took ~4 min), so a healthy deploy got a red smoke gate. Web/parser come up well within budget;
+# the worker is the slow one. 6 attempts comfortably covers the observed B1 worker cold-start.
+MAX_ATTEMPTS=6
 SLEEP_BETWEEN=45
 
 # An endpoint counts as healthy when curl returns the expected HTTP code. The deploy


### PR DESCRIPTION
Prod-promotering av v1.6.8 (kun CSS) fikk rod smoke-gate: worker /healthz ga 000 pa alle 4 forsok, sa kald-startet workeren 7s ETTER forsok 4 (B1-restart ~4 min). web=200 og parser=401 hele veien — kun workeren bommet pa vinduet. 6 forsok (~6 min budsjett) dekker observert kald-start.

Ingen app-endring; pavirker kun post-deploy-verifisering. Validert med `bash -n`.

Generated with Claude Code