### PR TITLE
feat: #405 production safeguards (guard + uptime ping; lock verified) v1.6.9

### DIFF
--- a/.github/workflows/activate-staging-app-layer.yml
+++ b/.github/workflows/activate-staging-app-layer.yml
@@ -57,6 +57,18 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      # #405 safeguard: this staging-only, Azure-mutating workflow must NEVER act against the
+      # production subscription. The May 2026 incident was a staging pause/resume that ran against
+      # prod and deleted most of it. Abort hard if the active context is the prod subscription.
+      - name: Assert staging subscription
+        shell: pwsh
+        run: |
+          $current = (az account show --query id -o tsv).Trim()
+          if ($current -eq '5b3f760b-42d4-4d78-812c-c059278d1086') {
+            throw "SAFETY ABORT: this workflow is authenticated against the PRODUCTION subscription (5b3f760b-...). It must only run against staging."
+          }
+          Write-Host "Subscription guard OK — active subscription $current is not production."
+
       - name: Start staging PostgreSQL compute
         shell: pwsh
         run: |

--- a/.github/workflows/bicep-whatif-prod.yml
+++ b/.github/workflows/bicep-whatif-prod.yml
@@ -79,6 +79,7 @@ jobs:
               parserWorkerAuthKey="whatif-only-placeholder-not-deployed" \
               deployPrincipalId="${{ vars.DEPLOY_PRINCIPAL_ID }}" \
               skipRoleAssignments="${{ vars.SKIP_ROLE_ASSIGNMENTS || 'false' }}" \
+              observabilityAlertEmail="${{ vars.OBSERVABILITY_ALERT_EMAIL }}" \
             2>&1 || true)
           # #472: large diffs (hundreds of KB) blow the E2BIG limit when passed via env to
           # github-script. Write to a file; the comment/log steps read it instead.

--- a/.github/workflows/deactivate-staging-app-layer.yml
+++ b/.github/workflows/deactivate-staging-app-layer.yml
@@ -35,6 +35,19 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      # #405 safeguard (defense in depth — the deactivate SCRIPT also has an env guard): this
+      # destructive, staging-only workflow tears down the App Service layer. The May 2026 incident
+      # was exactly this kind of operation running against prod. Abort hard if the active context
+      # is the production subscription, before any deletion happens.
+      - name: Assert staging subscription
+        shell: pwsh
+        run: |
+          $current = (az account show --query id -o tsv).Trim()
+          if ($current -eq '5b3f760b-42d4-4d78-812c-c059278d1086') {
+            throw "SAFETY ABORT: this workflow is authenticated against the PRODUCTION subscription (5b3f760b-...). It must only run against staging."
+          }
+          Write-Host "Subscription guard OK — active subscription $current is not production."
+
       - name: Deactivate staging app layer
         shell: pwsh
         run: |

--- a/.github/workflows/stage-webapp-power.yml
+++ b/.github/workflows/stage-webapp-power.yml
@@ -1,0 +1,66 @@
+name: Stage web app power (stop/start)
+
+# Manual stop/start of the STAGING web app only. Added for #405 to drive the end-to-end
+# availability-alert test (stop → webtest goes red → alert fires → start) without needing
+# local az against the staging tenant (which is conditional-access blocked). Also useful for
+# ad-hoc staging cost control. Never touches production (subscription guard below).
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Power action for the staging web app"
+        required: true
+        type: choice
+        options:
+          - stop
+          - start
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  # Shared with deploy-azure / activate / deactivate so this Azure-mutating workflow cannot run
+  # in parallel with a deploy (consistent with the other staging app-layer workflows).
+  group: deploy-azure-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  power:
+    if: github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      # #405 safeguard: staging-only — abort if authenticated against the production subscription.
+      - name: Assert staging subscription
+        shell: pwsh
+        run: |
+          $current = (az account show --query id -o tsv).Trim()
+          if ($current -eq '5b3f760b-42d4-4d78-812c-c059278d1086') {
+            throw "SAFETY ABORT: authenticated against the PRODUCTION subscription (5b3f760b-...). This workflow is staging-only."
+          }
+          Write-Host "Subscription guard OK — $current is not production."
+
+      - name: Resolve and power the staging web app
+        shell: bash
+        run: |
+          set -euo pipefail
+          RG="${{ vars.AZURE_RESOURCE_GROUP }}"
+          WEB=$(az webapp list -g "$RG" --query "[?contains(name, '-app-')].name" -o tsv | head -1)
+          if [ -z "$WEB" ]; then
+            echo "::error::No web app (name contains '-app-') found in $RG."
+            exit 1
+          fi
+          echo "Web app: $WEB — action: ${{ inputs.action }}"
+          az webapp ${{ inputs.action }} --resource-group "$RG" --name "$WEB"
+          state=$(az webapp show --resource-group "$RG" --name "$WEB" --query state -o tsv)
+          echo "Result: $WEB is now '$state'."
+          echo "$WEB → ${{ inputs.action }} (state: $state)" >> "$GITHUB_STEP_SUMMARY"

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,26 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.9 - 2026-06-30
+
+fix(infra): #405 produksjonsvern — subscription-guard + ekstern oppetids-ping (lås verifisert)
+
+Tre vern mot May-2026-incidentklassen (staging-workflow traff prod og slettet det meste):
+
+- **Del 1 — CanNotDelete-lås (verifisert):** `rg-production-do-not-delete` er aktiv i prod (lå
+  allerede i Bicep; nå bekreftet live via `az lock list`). Blokkerer all sletting i prod-RG-en.
+- **Del 2 — subscription-guard:** `activate-`/`deactivate-staging-app-layer.yml` avbryter hardt
+  etter Azure-login hvis konteksten er prod-subscription (5b3f760b), før noen Azure-mutasjon.
+- **Del 3 — ekstern oppetids-ping:** Application Insights standard availability-test mot `/healthz`
+  fra West Europe + North Europe hvert 5. min, + `metricAlert` (begge lokasjoner nede) →
+  observability action group. Ekstern → fyrer **selv om** App Service slettes (ulikt dagens
+  HealthCheckStatus). Opprettes der det finnes en alarm-mottaker (`createObservabilityActionGroup`).
+
+NB: action group krever `OBSERVABILITY_ALERT_EMAIL` (GitHub-var) — settes for stage + prod. Det
+wirer samtidig dagens alarmer (latency/llmfail/health/runtime-errors) som i dag varsler ingen.
+Bicep validert: ren build + begge webtest-lokasjons-IDer bekreftet mot Azure. Deploy via
+`deploy-azure.yml` med prod what-if; stage først for å teste alarm-kjeden ende-til-ende.
+
 ## 1.6.8 - 2026-06-30
 
 fix(ux): ROT-ÅRSAK for «Brukt i kurs»-skjevhet — global `button { width: 100% }` (#710)

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -1662,6 +1662,82 @@ resource notificationFailureAlert 'Microsoft.Insights/scheduledQueryRules@2021-0
   }
 }
 
+// #405 part 3 — external availability ping of /healthz. Unlike the internal HealthCheckStatus
+// metric alerts (which silence when the App Service resource disappears), this Application Insights
+// availability test runs from outside Azure and keeps reporting — so it fires even if the whole
+// App Service is deleted (the May 2026 incident scenario). Gated on createObservabilityActionGroup
+// so it lands in any environment that has an alert receiver wired (stage included → testable there).
+resource healthzAvailabilityTest 'Microsoft.Insights/webtests@2022-06-15' = if (createObservabilityActionGroup) {
+  name: toLower('${appNamePrefix}-${envCode}-healthz-ping')
+  location: location
+  kind: 'standard'
+  tags: {
+    // REQUIRED association with the App Insights component — without this the portal Availability
+    // blade and the metric alert cannot resolve the test.
+    'hidden-link:${appInsights.id}': 'Resource'
+    environment: environmentName
+    costCenter: costCenter
+    owner: owner
+  }
+  properties: {
+    SyntheticMonitorId: toLower('${appNamePrefix}-${envCode}-healthz-ping')
+    Name: '${appNamePrefix}-${envCode} /healthz availability'
+    Description: 'External ping of /healthz from EMEA — fires even if the App Service is deleted (#405).'
+    Enabled: true
+    Frequency: 300
+    Timeout: 30
+    Kind: 'standard'
+    RetryEnabled: true
+    Locations: [
+      { Id: 'emea-nl-ams-azr' }
+      { Id: 'emea-gb-db3-azr' }
+    ]
+    Request: {
+      RequestUrl: 'https://${webApp.properties.defaultHostName}/healthz'
+      HttpVerb: 'GET'
+    }
+    ValidationRules: {
+      ExpectedHttpStatusCode: 200
+      SSLCheck: true
+      SSLCertRemainingLifetimeCheck: 7
+    }
+  }
+}
+
+// Fires when both external test locations report /healthz unreachable. failedLocationCount=2 of 2
+// avoids single-location flapping while still catching a real outage (app down/deleted → all fail).
+resource healthzAvailabilityAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = if (createObservabilityActionGroup) {
+  name: toLower('${appNamePrefix}-${envCode}-healthz-availability')
+  location: 'global'
+  tags: {
+    environment: environmentName
+    costCenter: costCenter
+    owner: owner
+  }
+  properties: {
+    description: 'External /healthz availability test is failing — the app is unreachable from outside Azure (fires even if the App Service was deleted). See #405.'
+    severity: 1
+    enabled: true
+    scopes: [
+      healthzAvailabilityTest.id
+      appInsights.id
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT5M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria'
+      webTestId: healthzAvailabilityTest.id
+      componentId: appInsights.id
+      failedLocationCount: 2
+    }
+    actions: [
+      {
+        actionGroupId: observabilityActionGroup.id
+      }
+    ]
+  }
+}
+
 // Production resource group CanNotDelete lock (#405). Blocks all DELETE operations on
 // resources in the prod RG. The May 2026 incident where a staging deactivate workflow
 // targeted production resources would have been blocked here with a 409 Conflict before

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",


### PR DESCRIPTION
Lukker #405 — tre vern mot May-2026-incidentklassen (staging-workflow traff prod og slettet det meste).

## Del 1 — CanNotDelete-lås (verifisert)
`rg-production-do-not-delete` er aktiv i prod (bekreftet via `az lock list`). Lå allerede i Bicep.

## Del 2 — subscription-guard (CI)
`activate-`/`deactivate-staging-app-layer.yml` avbryter hardt etter Azure-login hvis konteksten er prod-subscription (5b3f760b), før noen Azure-mutasjon. Defense-in-depth ved siden av deactivate-scriptets egen env-guard.

## Del 3 — ekstern oppetids-ping (infra)
App Insights standard availability-test mot helsesjekk-endepunktet fra West + North Europe hvert 5. min + metricAlert (begge lokasjoner nede) → observability action group. Ekstern → fyrer selv om App Service slettes (ulikt dagens HealthCheckStatus). Gated på `createObservabilityActionGroup`.

Validert: ren `az bicep build`; begge webtest-lokasjons-IDer bekreftet mot Azure (emea-nl-ams-azr=West Europe, emea-gb-db3-azr=North Europe).

## Deploy / rollback
- `OBSERVABILITY_ALERT_EMAIL` satt: stage=gmail, prod=a-2 → action group opprettes (wirer også dagens alarmer som i dag varsler ingen).
- Prod what-if kjøres før merge. Stage først (test alarm-kjeden ende-til-ende), deretter prod.
- Rollback: webtest+alert er additive ressurser (kan fjernes); guard er ren YAML; låsen røres ikke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
