### PR TITLE
feat(admin-content): #649 AA-1 agent-authoring/validate med detaljert rapport (v1.6.10)

### DIFF
--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -191,6 +191,16 @@ material for draft generation. All routes use the `admin_content` capability.
 | `POST` | `/api/admin/content/source-material/crawl-url` | **#479 Slice B.** Crawl a start URL: same-hostname only, ≤20 pages, ≤2 hops, honouring `robots.txt`, 300 ms politeness delay. Each page is independently SSRF-revalidated and byte-capped. **3/min per user.** Body `{ url }` → `{ startHostname, pages: [{ url, title, extractedText, fetchedBytes }], pagesCrawled, pagesSkipped, totalBytes, truncated }`. `422 crawl_empty` if nothing could be crawled. |
 | `POST` | `/api/admin/content/source-material/condense` | LLM-condense combined source material when it exceeds ~50K chars. |
 
+#### Agent Authoring (#647)
+
+Design: `doc/design/AGENT_AUTHORING_647.md`. Lets an agent dry-run an
+`a2-authoring-package/v1` (draft course/module/section plan) before orchestrating the
+ordinary create/import endpoints. Publishing is manual and is **not** part of the agent API.
+
+| Method | Path | Notes |
+|--------|------|-------|
+| `POST` | `/api/admin/content/agent-authoring/validate` | **AA-1 (#649).** Dry-run validation — **no DB writes**. Body `{ package: <a2-authoring-package/v1> }`. Returns `200 { valid, summary: { errors, warnings, objects }, issues: [{ severity: "error"\|"warning", path, code, message }], plan }` — 200 also for invalid packages (the report is the result). `plan` (topological execution order, ops `create_section`/`create_module`/`create_course`/`set_course_items`) is only populated when `errors == 0`. Covers all three `assessmentMode`s (`required_for_mode`/`forbidden_for_mode`), package rules (`duplicate_client_ref`, `unknown_client_ref`, `client_ref_type_mismatch`, `ref_or_id_required`, `ref_and_id_conflict`, `unknown_module_id`/`unknown_section_id`, `unknown_field` — publish/audit fields are rejected) and non-blocking warnings (`possible_duplicate_title`, `course_without_modules`). `400` only when the body isn't `{ package }` with the right `packageFormat`. |
+
 ---
 
 ## Admin - Courses & Learning Sections

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,25 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.10 - 2026-07-05
+
+feat(admin-content): #649 AA-1 — Agent Authoring validate-endepunkt med detaljert rapport
+
+Første API-steg i EPIC #647 (designnotat: `doc/design/AGENT_AUTHORING_647.md`, landet i #724):
+
+- **Ny kontrakt `a2-authoring-package/v1`** (`agentAuthoringSchemas.ts`): agentens plan for
+  drafts av seksjoner/moduler/kurs. Gjenbruker `a2-content-export/v1`-leaf-schemas uten
+  `audit`; alle objekter er strict, så publiserings-/audit-felt avvises som `unknown_field`
+  i stedet for å ignoreres stille (draft-only-invarianten håndheves strukturelt).
+- **`POST /api/admin/content/agent-authoring/validate`** (`admin_content`-beskyttet):
+  dry-run uten DB-writes. Returnerer 200 med `{ valid, summary, issues[{severity, path,
+  code, message}], plan }` også for ugyldige pakker; `plan` (topologisk rekkefølge) kun når
+  `errors == 0`. Dekker alle tre `assessmentMode` (`required_for_mode`/`forbidden_for_mode`),
+  clientRef-regler (duplikat/ukjent/type-mismatch), eksisterende-ID-sjekk mot DB, og
+  warnings for mulig duplikat-tittel og modul-løse kurs.
+- Tester: 12 unit (regelsettet, injiserbare lookups) + 5 integration (endepunktkontrakt,
+  ingen-writes-garanti, rollevern). API_REFERENCE oppdatert.
+
 ## 1.6.9 - 2026-06-30
 
 fix(infra): #405 produksjonsvern — subscription-guard + ekstern oppetids-ping (lås verifisert)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/agentAuthoringSchemas.ts
+++ b/src/modules/adminContent/agentAuthoringSchemas.ts
@@ -1,0 +1,124 @@
+// Agent Authoring package contract (`a2-authoring-package/v1`) — AA-1 (#649, EPIC #647).
+//
+// The package is the agent's *plan*: it is sent to the validate endpoint for a
+// dry-run and used by the authoring skill as the source for individual create
+// calls. It is never persisted as a whole. Leaf payloads reuse the
+// `a2-content-export/v1` schemas minus `audit` — agents have no publish history,
+// and the contract must not carry any field that could make content live.
+// All objects are `.strict()` so publish/audit fields fail loudly
+// (`unrecognized_keys` → reported as `unknown_field`) instead of being ignored.
+// See doc/design/AGENT_AUTHORING_647.md §2.
+
+import { z } from "zod";
+import {
+  localizedTextSchema,
+  localizedTextPatchSchema,
+  certificationLevelInputSchema,
+  assessmentModeSchema,
+  submissionSchemaBodySchema,
+  assessmentPolicyBodySchema,
+  rubricBodySchema,
+  promptTemplateBodySchema,
+  mcqSetBodySchema,
+} from "./adminContentSchemas.js";
+
+export const AUTHORING_PACKAGE_FORMAT = "a2-authoring-package/v1" as const;
+
+export const clientRefSchema = z
+  .string()
+  .regex(/^[a-z0-9-]{1,64}$/, "clientRef must match [a-z0-9-]{1,64}.");
+
+// Module payload = moduleExportPayloadSchema without `audit` (strict).
+export const authoringModulePayloadSchema = z
+  .object({
+    module: z
+      .object({
+        title: localizedTextSchema,
+        description: localizedTextSchema.nullable().optional(),
+        certificationLevel: certificationLevelInputSchema,
+      })
+      .strict(),
+    activeVersion: z
+      .object({
+        assessmentMode: assessmentModeSchema.optional(),
+        taskText: localizedTextSchema.nullable().optional(),
+        assessorExpectedContent: localizedTextSchema.nullable().optional(),
+        candidateTaskConstraints: localizedTextSchema.nullable().optional(),
+        assessmentBlueprint: z.string().nullable().optional(),
+        submissionSchema: submissionSchemaBodySchema.nullable().optional(),
+        assessmentPolicy: assessmentPolicyBodySchema.nullable().optional(),
+        rubric: rubricBodySchema.nullable().optional(),
+        promptTemplate: promptTemplateBodySchema.nullable().optional(),
+        mcqSet: mcqSetBodySchema.nullable().optional(),
+      })
+      .strict(),
+  })
+  .strict();
+
+// Section payload = sectionExportPayloadSchema without `audit` (strict).
+export const authoringSectionPayloadSchema = z
+  .object({
+    title: localizedTextPatchSchema,
+    bodyMarkdown: localizedTextPatchSchema,
+  })
+  .strict();
+
+// Course items reference other package objects by `clientRef` OR existing
+// content by server ID (mixing is allowed — an agent may reuse an existing
+// module in a new course). Exactly-one-of is enforced by the validation
+// service so it can report precise `ref_or_id_required` / `ref_and_id_conflict`
+// codes instead of a generic refine failure.
+export const authoringCourseItemSchema = z.discriminatedUnion("type", [
+  z
+    .object({
+      type: z.literal("MODULE"),
+      ref: clientRefSchema.optional(),
+      moduleId: z.string().min(1).optional(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("SECTION"),
+      ref: clientRefSchema.optional(),
+      sectionId: z.string().min(1).optional(),
+    })
+    .strict(),
+]);
+
+export const authoringCoursePayloadSchema = z
+  .object({
+    course: z
+      .object({
+        title: localizedTextSchema,
+        description: localizedTextSchema.nullable().optional(),
+        certificationLevel: certificationLevelInputSchema,
+      })
+      .strict(),
+    items: z.array(authoringCourseItemSchema),
+  })
+  .strict();
+
+export const authoringObjectSchema = z.discriminatedUnion("type", [
+  z.object({ clientRef: clientRefSchema, type: z.literal("module"), payload: authoringModulePayloadSchema }).strict(),
+  z.object({ clientRef: clientRefSchema, type: z.literal("section"), payload: authoringSectionPayloadSchema }).strict(),
+  z.object({ clientRef: clientRefSchema, type: z.literal("course"), payload: authoringCoursePayloadSchema }).strict(),
+]);
+
+export const authoringPackageSchema = z
+  .object({
+    packageFormat: z.literal(AUTHORING_PACKAGE_FORMAT),
+    // Informative only (the agent's primary language); leaf payloads follow the
+    // LocalizedText rules regardless.
+    locale: z.string().trim().min(1).max(16).optional(),
+    // Free-form audit/debug context (the requirements the agent worked from).
+    // Never interpreted by the server.
+    constraints: z.record(z.unknown()).optional(),
+    objects: z.array(authoringObjectSchema).min(1),
+  })
+  .strict();
+
+export type AuthoringPackage = z.infer<typeof authoringPackageSchema>;
+export type AuthoringObject = z.infer<typeof authoringObjectSchema>;
+export type AuthoringModulePayload = z.infer<typeof authoringModulePayloadSchema>;
+export type AuthoringSectionPayload = z.infer<typeof authoringSectionPayloadSchema>;
+export type AuthoringCoursePayload = z.infer<typeof authoringCoursePayloadSchema>;

--- a/src/modules/adminContent/agentAuthoringValidationService.ts
+++ b/src/modules/adminContent/agentAuthoringValidationService.ts
@@ -1,0 +1,382 @@
+// Agent Authoring validate (dry-run) — AA-1 (#649, EPIC #647).
+//
+// Takes an agent-generated `a2-authoring-package/v1`, returns a detailed,
+// actionable validation report and (when error-free) an execution plan in
+// topological order. Performs NO database writes — the only DB access is
+// read-only lookups for duplicate-title warnings and existing-ID checks.
+// Lookups are injectable so the rule set is unit-testable without a DB.
+// Report format: doc/design/AGENT_AUTHORING_647.md §5.
+
+import { z } from "zod";
+import { prisma } from "../../db/prisma.js";
+import { localizedTextCodec, type LocalizedText } from "../../codecs/localizedTextCodec.js";
+import {
+  AUTHORING_PACKAGE_FORMAT,
+  authoringPackageSchema,
+  type AuthoringPackage,
+  type AuthoringModulePayload,
+} from "./agentAuthoringSchemas.js";
+
+export type AuthoringIssueSeverity = "error" | "warning";
+
+export interface AuthoringIssue {
+  severity: AuthoringIssueSeverity;
+  path: string;
+  code: string;
+  message: string;
+}
+
+export type AuthoringPlanOp = "create_section" | "create_module" | "create_course" | "set_course_items";
+
+export interface AuthoringPlanStep {
+  op: AuthoringPlanOp;
+  clientRef: string;
+}
+
+export interface AuthoringValidationReport {
+  valid: boolean;
+  summary: { errors: number; warnings: number; objects: number };
+  issues: AuthoringIssue[];
+  plan: AuthoringPlanStep[];
+}
+
+// Read-only lookups. `listActive*Titles` return the raw stored title strings
+// (plain or serialized LocalizedText JSON); `findExisting*Ids` return the
+// subset of the given IDs that exist and are not archived.
+export interface AuthoringValidationLookups {
+  listActiveModuleTitles(): Promise<Array<{ id: string; title: string }>>;
+  listActiveCourseTitles(): Promise<Array<{ id: string; title: string }>>;
+  listActiveSectionTitles(): Promise<Array<{ id: string; title: string }>>;
+  findExistingModuleIds(ids: string[]): Promise<Set<string>>;
+  findExistingSectionIds(ids: string[]): Promise<Set<string>>;
+}
+
+const prismaLookups: AuthoringValidationLookups = {
+  async listActiveModuleTitles() {
+    return prisma.module.findMany({ where: { archivedAt: null }, select: { id: true, title: true } });
+  },
+  async listActiveCourseTitles() {
+    return prisma.course.findMany({ where: { archivedAt: null }, select: { id: true, title: true } });
+  },
+  async listActiveSectionTitles() {
+    return prisma.courseSection.findMany({ where: { archivedAt: null }, select: { id: true, title: true } });
+  },
+  async findExistingModuleIds(ids: string[]) {
+    if (ids.length === 0) return new Set();
+    const rows = await prisma.module.findMany({ where: { id: { in: ids }, archivedAt: null }, select: { id: true } });
+    return new Set(rows.map((row) => row.id));
+  },
+  async findExistingSectionIds(ids: string[]) {
+    if (ids.length === 0) return new Set();
+    const rows = await prisma.courseSection.findMany({ where: { id: { in: ids }, archivedAt: null }, select: { id: true } });
+    return new Set(rows.map((row) => row.id));
+  },
+};
+
+function formatIssuePath(path: Array<string | number>): string {
+  let out = "";
+  for (const segment of path) {
+    if (typeof segment === "number") {
+      out += `[${segment}]`;
+    } else {
+      out += out.length === 0 ? segment : `.${segment}`;
+    }
+  }
+  return out.length > 0 ? out : "package";
+}
+
+// Zod issues translate 1:1 to report issues with stable codes. The only
+// remap is `unrecognized_keys` → `unknown_field`, which is also how a
+// hallucinated publish/audit field surfaces (the schemas are strict).
+function zodIssueToAuthoringIssue(issue: z.ZodIssue): AuthoringIssue {
+  if (issue.code === "unrecognized_keys") {
+    return {
+      severity: "error",
+      path: formatIssuePath(issue.path),
+      code: "unknown_field",
+      message: `Unknown field(s): ${issue.keys.join(", ")}. Publish/audit fields are not allowed in authoring packages.`,
+    };
+  }
+  return {
+    severity: "error",
+    path: formatIssuePath(issue.path),
+    code: issue.code,
+    message: issue.message,
+  };
+}
+
+// Lower-cased, trimmed locale values of a title — used for duplicate matching.
+// A plain-string title matches a localized one when any locale value is equal.
+function titleValues(value: LocalizedText | null | undefined): string[] {
+  if (value === null || value === undefined) return [];
+  if (typeof value === "string") {
+    const trimmed = value.trim().toLowerCase();
+    return trimmed.length > 0 ? [trimmed] : [];
+  }
+  return Object.values(value)
+    .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    .map((entry) => entry.trim().toLowerCase());
+}
+
+function titlesOverlap(a: string[], b: string[]): boolean {
+  if (a.length === 0 || b.length === 0) return false;
+  const set = new Set(a);
+  return b.some((value) => set.has(value));
+}
+
+interface ModeFieldCheck {
+  field: "taskText" | "rubric" | "promptTemplate" | "mcqSet";
+  present: boolean;
+}
+
+// Mode rules mirror moduleVersionBodySchema/#525/#578: FREETEXT_* modes need the
+// free-text triple, *_MCQ modes need the MCQ set. Fields that the target mode
+// cannot use are rejected (not silently dropped) so the agent's package stays an
+// accurate description of what will be created.
+function checkAssessmentMode(payload: AuthoringModulePayload, basePath: string): AuthoringIssue[] {
+  const version = payload.activeVersion;
+  const mode = version.assessmentMode ?? "FREETEXT_PLUS_MCQ";
+  const fields: ModeFieldCheck[] = [
+    { field: "taskText", present: version.taskText !== null && version.taskText !== undefined },
+    { field: "rubric", present: version.rubric !== null && version.rubric !== undefined },
+    { field: "promptTemplate", present: version.promptTemplate !== null && version.promptTemplate !== undefined },
+    { field: "mcqSet", present: version.mcqSet !== null && version.mcqSet !== undefined },
+  ];
+  const required = new Set<ModeFieldCheck["field"]>(
+    mode === "MCQ_ONLY" ? ["mcqSet"]
+      : mode === "FREETEXT_ONLY" ? ["taskText", "rubric", "promptTemplate"]
+        : ["taskText", "rubric", "promptTemplate", "mcqSet"],
+  );
+
+  const issues: AuthoringIssue[] = [];
+  for (const { field, present } of fields) {
+    if (required.has(field) && !present) {
+      issues.push({
+        severity: "error",
+        path: `${basePath}.activeVersion.${field}`,
+        code: "required_for_mode",
+        message: `assessmentMode ${mode} requires ${field}.`,
+      });
+    }
+    if (!required.has(field) && present) {
+      issues.push({
+        severity: "error",
+        path: `${basePath}.activeVersion.${field}`,
+        code: "forbidden_for_mode",
+        message: `assessmentMode ${mode} does not use ${field} — remove it.`,
+      });
+    }
+  }
+  return issues;
+}
+
+function buildPlan(pkg: AuthoringPackage): AuthoringPlanStep[] {
+  const plan: AuthoringPlanStep[] = [];
+  for (const object of pkg.objects) {
+    if (object.type === "section") plan.push({ op: "create_section", clientRef: object.clientRef });
+  }
+  for (const object of pkg.objects) {
+    if (object.type === "module") plan.push({ op: "create_module", clientRef: object.clientRef });
+  }
+  for (const object of pkg.objects) {
+    if (object.type === "course") {
+      plan.push({ op: "create_course", clientRef: object.clientRef });
+      if (object.payload.items.length > 0) {
+        plan.push({ op: "set_course_items", clientRef: object.clientRef });
+      }
+    }
+  }
+  return plan;
+}
+
+export async function validateAuthoringPackage(
+  input: unknown,
+  lookups: AuthoringValidationLookups = prismaLookups,
+): Promise<AuthoringValidationReport> {
+  const parsed = authoringPackageSchema.safeParse(input);
+  const rawObjectCount = Array.isArray((input as { objects?: unknown } | null)?.objects)
+    ? ((input as { objects: unknown[] }).objects).length
+    : 0;
+
+  if (!parsed.success) {
+    const issues = parsed.error.issues.map(zodIssueToAuthoringIssue);
+    return {
+      valid: false,
+      summary: { errors: issues.length, warnings: 0, objects: rawObjectCount },
+      issues,
+      plan: [],
+    };
+  }
+
+  const pkg = parsed.data;
+  const issues: AuthoringIssue[] = [];
+
+  // Unique clientRef — flag every re-occurrence, keep the first.
+  const seenRefs = new Map<string, number>();
+  pkg.objects.forEach((object, index) => {
+    const firstIndex = seenRefs.get(object.clientRef);
+    if (firstIndex !== undefined) {
+      issues.push({
+        severity: "error",
+        path: `objects[${index}].clientRef`,
+        code: "duplicate_client_ref",
+        message: `clientRef '${object.clientRef}' is already used by objects[${firstIndex}].`,
+      });
+    } else {
+      seenRefs.set(object.clientRef, index);
+    }
+  });
+
+  const refTypes = new Map<string, "module" | "section" | "course">();
+  for (const object of pkg.objects) {
+    if (!refTypes.has(object.clientRef)) refTypes.set(object.clientRef, object.type);
+  }
+
+  // Per-module assessment-mode rules.
+  pkg.objects.forEach((object, index) => {
+    if (object.type === "module") {
+      issues.push(...checkAssessmentMode(object.payload, `objects[${index}].payload`));
+    }
+  });
+
+  // Course item references: exactly one of ref | server ID; refs must resolve
+  // to a package object of the matching type; server IDs must exist (checked
+  // against the DB below).
+  const referencedModuleIds = new Map<string, string[]>(); // id -> paths
+  const referencedSectionIds = new Map<string, string[]>();
+  pkg.objects.forEach((object, objectIndex) => {
+    if (object.type !== "course") return;
+    object.payload.items.forEach((item, itemIndex) => {
+      const itemPath = `objects[${objectIndex}].payload.items[${itemIndex}]`;
+      const serverId = item.type === "MODULE" ? item.moduleId : item.sectionId;
+      const idField = item.type === "MODULE" ? "moduleId" : "sectionId";
+      if (item.ref !== undefined && serverId !== undefined) {
+        issues.push({
+          severity: "error",
+          path: itemPath,
+          code: "ref_and_id_conflict",
+          message: `Provide either ref or ${idField}, not both.`,
+        });
+        return;
+      }
+      if (item.ref === undefined && serverId === undefined) {
+        issues.push({
+          severity: "error",
+          path: itemPath,
+          code: "ref_or_id_required",
+          message: `A ${item.type} item needs either ref (package object) or ${idField} (existing content).`,
+        });
+        return;
+      }
+      if (item.ref !== undefined) {
+        const targetType = refTypes.get(item.ref);
+        if (targetType === undefined) {
+          issues.push({
+            severity: "error",
+            path: `${itemPath}.ref`,
+            code: "unknown_client_ref",
+            message: `ref '${item.ref}' does not exist in the package.`,
+          });
+        } else {
+          const expected = item.type === "MODULE" ? "module" : "section";
+          if (targetType !== expected) {
+            issues.push({
+              severity: "error",
+              path: `${itemPath}.ref`,
+              code: "client_ref_type_mismatch",
+              message: `ref '${item.ref}' points to a ${targetType} object, but the item type is ${item.type}.`,
+            });
+          }
+        }
+        return;
+      }
+      const target = item.type === "MODULE" ? referencedModuleIds : referencedSectionIds;
+      const paths = target.get(serverId as string) ?? [];
+      paths.push(`${itemPath}.${idField}`);
+      target.set(serverId as string, paths);
+    });
+  });
+
+  // Existing-ID checks (read-only).
+  const [existingModuleIds, existingSectionIds] = await Promise.all([
+    lookups.findExistingModuleIds([...referencedModuleIds.keys()]),
+    lookups.findExistingSectionIds([...referencedSectionIds.keys()]),
+  ]);
+  for (const [moduleId, paths] of referencedModuleIds) {
+    if (!existingModuleIds.has(moduleId)) {
+      for (const path of paths) {
+        issues.push({
+          severity: "error",
+          path,
+          code: "unknown_module_id",
+          message: `Module '${moduleId}' does not exist (or is archived).`,
+        });
+      }
+    }
+  }
+  for (const [sectionId, paths] of referencedSectionIds) {
+    if (!existingSectionIds.has(sectionId)) {
+      for (const path of paths) {
+        issues.push({
+          severity: "error",
+          path,
+          code: "unknown_section_id",
+          message: `Section '${sectionId}' does not exist (or is archived).`,
+        });
+      }
+    }
+  }
+
+  // Warnings — never blockers.
+  pkg.objects.forEach((object, index) => {
+    if (object.type === "course") {
+      const hasModule = object.payload.items.some((item) => item.type === "MODULE");
+      if (!hasModule) {
+        issues.push({
+          severity: "warning",
+          path: `objects[${index}].payload.items`,
+          code: "course_without_modules",
+          message: "The course has no modules; it cannot be published or completed until at least one module is added.",
+        });
+      }
+    }
+  });
+
+  const [moduleTitles, courseTitles, sectionTitles] = await Promise.all([
+    lookups.listActiveModuleTitles(),
+    lookups.listActiveCourseTitles(),
+    lookups.listActiveSectionTitles(),
+  ]);
+  const existingTitles = {
+    module: moduleTitles,
+    course: courseTitles,
+    section: sectionTitles,
+  } as const;
+  pkg.objects.forEach((object, index) => {
+    const candidate =
+      object.type === "module" ? { label: "module" as const, path: `objects[${index}].payload.module.title`, title: object.payload.module.title }
+        : object.type === "course" ? { label: "course" as const, path: `objects[${index}].payload.course.title`, title: object.payload.course.title }
+          : { label: "section" as const, path: `objects[${index}].payload.title`, title: object.payload.title };
+    const candidateValues = titleValues(candidate.title as LocalizedText);
+    const duplicate = existingTitles[candidate.label].find((existing) =>
+      titlesOverlap(candidateValues, titleValues(localizedTextCodec.parse(existing.title))),
+    );
+    if (duplicate) {
+      issues.push({
+        severity: "warning",
+        path: candidate.path,
+        code: "possible_duplicate_title",
+        message: `A ${candidate.label} with this title already exists (id: ${duplicate.id}).`,
+      });
+    }
+  });
+
+  const errors = issues.filter((issue) => issue.severity === "error").length;
+  const warnings = issues.length - errors;
+  return {
+    valid: errors === 0,
+    summary: { errors, warnings, objects: pkg.objects.length },
+    issues,
+    plan: errors === 0 ? buildPlan(pkg) : [],
+  };
+}

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -47,6 +47,8 @@ import {
   parseOptionalDate,
 } from "../modules/adminContent/adminContentSchemas.js";
 import { importModuleFromEnvelope } from "../modules/adminContent/contentImportService.js";
+import { validateAuthoringPackage } from "../modules/adminContent/agentAuthoringValidationService.js";
+import { AUTHORING_PACKAGE_FORMAT } from "../modules/adminContent/agentAuthoringSchemas.js";
 import {
   condenseSourceMaterial,
   generateAssessmentBlueprint,
@@ -96,6 +98,34 @@ adminContentRouter.use("/courses", adminCoursesRouter);
 adminContentRouter.use("/classes", adminClassesRouter);
 adminContentRouter.use("/users", adminUsersRouter);
 adminContentRouter.use("/sections", adminSectionsRouter);
+
+// AA-1 (#649): dry-run validation of an agent-generated authoring package.
+// Read-only — never writes to the DB. Returns 200 with a report even when the
+// package is invalid (the report IS the result); 400 only when the request
+// isn't a recognizable validate call at all.
+adminContentRouter.post("/agent-authoring/validate", async (request, response) => {
+  const body = request.body as { package?: unknown } | undefined;
+  const pkg = body?.package;
+  const packageFormat =
+    pkg && typeof pkg === "object" ? (pkg as { packageFormat?: unknown }).packageFormat : undefined;
+  if (packageFormat !== AUTHORING_PACKAGE_FORMAT) {
+    response.status(400).json({
+      error: "validation_error",
+      message: `Request body must be { package } with packageFormat "${AUTHORING_PACKAGE_FORMAT}".`,
+    });
+    return;
+  }
+
+  try {
+    const report = await validateAuthoringPackage(pkg);
+    response.status(200).json(report);
+  } catch {
+    response.status(500).json({
+      error: "agent_authoring_validate_failed",
+      message: "Could not validate authoring package.",
+    });
+  }
+});
 
 adminContentRouter.post("/modules", async (request, response) => {
   const { data, error } = parseRequest(moduleCreateBodySchema, request.body);

--- a/test/agent-authoring-validate.test.ts
+++ b/test/agent-authoring-validate.test.ts
@@ -1,0 +1,171 @@
+// Integration tests for AA-1 (#649): POST /api/admin/content/agent-authoring/validate.
+// Verifies the endpoint contract (report shape, 400/403 behavior) and — critically —
+// that validate performs NO database writes, including for valid packages.
+//
+// Vitest integration profile (vitest.integration.config.ts) provides a real
+// Postgres test DB; assumes the seeded admin-1 user like the other admin tests.
+
+import request from "supertest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+
+const adminHeaders = {
+  "x-user-id": "admin-1",
+  "x-user-email": "admin@company.com",
+  "x-user-name": "Platform Admin",
+};
+
+function validPackage(suffix: string) {
+  return {
+    packageFormat: "a2-authoring-package/v1",
+    locale: "nb",
+    constraints: { source: "integration test" },
+    objects: [
+      {
+        clientRef: "intro",
+        type: "section",
+        payload: { title: `Authoring intro ${suffix}`, bodyMarkdown: "## Velkommen" },
+      },
+      {
+        clientRef: "module-1",
+        type: "module",
+        payload: {
+          module: { title: `Authoring module ${suffix}`, certificationLevel: "basic" },
+          activeVersion: {
+            assessmentMode: "FREETEXT_ONLY",
+            taskText: "Beskriv behandlingsgrunnlaget.",
+            assessorExpectedContent: "Nevner artikkel 6.",
+            rubric: { criteria: { relevance: "0-4" }, scalingRule: { max_total: 20 } },
+            promptTemplate: { systemPrompt: "Sys", userPromptTemplate: "Eval" },
+          },
+        },
+      },
+      {
+        clientRef: "course-main",
+        type: "course",
+        payload: {
+          course: { title: `Authoring course ${suffix}` },
+          items: [
+            { type: "SECTION", ref: "intro" },
+            { type: "MODULE", ref: "module-1" },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+async function contentCounts() {
+  const [modules, courses, sections] = await Promise.all([
+    prisma.module.count(),
+    prisma.course.count(),
+    prisma.courseSection.count(),
+  ]);
+  return { modules, courses, sections };
+}
+
+describe("#649 POST /api/admin/content/agent-authoring/validate", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("validates a well-formed package without writing to the database", async () => {
+    const before = await contentCounts();
+
+    const response = await request(app)
+      .post("/api/admin/content/agent-authoring/validate")
+      .set(adminHeaders)
+      .send({ package: validPackage(`ok-${Date.now()}`) });
+
+    expect(response.status).toBe(200);
+    expect(response.body.valid).toBe(true);
+    expect(response.body.summary).toEqual({ errors: 0, warnings: 0, objects: 3 });
+    expect(response.body.plan).toEqual([
+      { op: "create_section", clientRef: "intro" },
+      { op: "create_module", clientRef: "module-1" },
+      { op: "create_course", clientRef: "course-main" },
+      { op: "set_course_items", clientRef: "course-main" },
+    ]);
+
+    expect(await contentCounts()).toEqual(before);
+  });
+
+  it("returns a 200 report (not an error status) for an invalid package, still without writes", async () => {
+    const before = await contentCounts();
+    const pkg = validPackage(`bad-${Date.now()}`);
+    // Break it three ways: dangling ref, duplicate clientRef, mode violation.
+    (pkg.objects[2].payload as { items: unknown[] }).items = [{ type: "MODULE", ref: "does-not-exist" }];
+    pkg.objects[0].clientRef = "module-1";
+    (pkg.objects[1].payload as { activeVersion: Record<string, unknown> }).activeVersion.mcqSet = {
+      title: "Quiz",
+      questions: [{ stem: "1+1?", options: ["2", "3"], correctAnswer: "2" }],
+    };
+
+    const response = await request(app)
+      .post("/api/admin/content/agent-authoring/validate")
+      .set(adminHeaders)
+      .send({ package: pkg });
+
+    expect(response.status).toBe(200);
+    expect(response.body.valid).toBe(false);
+    expect(response.body.plan).toEqual([]);
+    const codes = (response.body.issues as Array<{ code: string }>).map((issue) => issue.code);
+    expect(codes).toContain("unknown_client_ref");
+    expect(codes).toContain("duplicate_client_ref");
+    expect(codes).toContain("forbidden_for_mode");
+
+    expect(await contentCounts()).toEqual(before);
+  });
+
+  it("warns about duplicate titles of existing modules", async () => {
+    const suffix = `dup-${Date.now()}`;
+    const created = await request(app)
+      .post("/api/admin/content/modules")
+      .set(adminHeaders)
+      .send({ title: `Authoring module ${suffix}` });
+    expect(created.status).toBe(201);
+
+    const response = await request(app)
+      .post("/api/admin/content/agent-authoring/validate")
+      .set(adminHeaders)
+      .send({ package: validPackage(suffix) });
+
+    expect(response.status).toBe(200);
+    expect(response.body.valid).toBe(true);
+    expect(response.body.issues).toContainEqual(
+      expect.objectContaining({
+        severity: "warning",
+        code: "possible_duplicate_title",
+        message: expect.stringContaining(created.body.module.id),
+      }),
+    );
+  });
+
+  it("rejects requests without a recognizable package with 400", async () => {
+    const missing = await request(app)
+      .post("/api/admin/content/agent-authoring/validate")
+      .set(adminHeaders)
+      .send({});
+    expect(missing.status).toBe(400);
+    expect(missing.body.error).toBe("validation_error");
+
+    const wrongFormat = await request(app)
+      .post("/api/admin/content/agent-authoring/validate")
+      .set(adminHeaders)
+      .send({ package: { packageFormat: "a2-content-export/v1" } });
+    expect(wrongFormat.status).toBe(400);
+  });
+
+  it("is admin_content-protected (participants get 403)", async () => {
+    const response = await request(app)
+      .post("/api/admin/content/agent-authoring/validate")
+      .set({
+        "x-user-id": "admin-1",
+        "x-user-email": "admin@company.com",
+        "x-user-name": "Platform Admin",
+        "x-user-roles": "PARTICIPANT",
+      })
+      .send({ package: validPackage("forbidden") });
+    expect(response.status).toBe(403);
+  });
+});

--- a/test/unit/agent-authoring-validation.test.ts
+++ b/test/unit/agent-authoring-validation.test.ts
@@ -1,0 +1,262 @@
+// AA-1 (#649): unit tests for the agent-authoring package validation rules.
+// DB lookups are stubbed via the injectable lookups parameter; prisma is mocked
+// so importing the service never touches a database.
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/db/prisma.js", () => ({ prisma: {} }));
+
+import {
+  validateAuthoringPackage,
+  type AuthoringValidationLookups,
+} from "../../src/modules/adminContent/agentAuthoringValidationService.js";
+
+function emptyLookups(overrides: Partial<AuthoringValidationLookups> = {}): AuthoringValidationLookups {
+  return {
+    listActiveModuleTitles: async () => [],
+    listActiveCourseTitles: async () => [],
+    listActiveSectionTitles: async () => [],
+    findExistingModuleIds: async () => new Set(),
+    findExistingSectionIds: async () => new Set(),
+    ...overrides,
+  };
+}
+
+const freetextVersion = {
+  assessmentMode: "FREETEXT_ONLY",
+  taskText: "Describe the processing basis.",
+  assessorExpectedContent: "Mentions article 6.",
+  rubric: { criteria: { relevance: "0-4" }, scalingRule: { max_total: 20 } },
+  promptTemplate: { systemPrompt: "Sys", userPromptTemplate: "Eval" },
+};
+
+const mcqSet = {
+  title: "Quiz",
+  questions: [
+    { stem: "1+1?", options: ["2", "3"], correctAnswer: "2" },
+  ],
+};
+
+function fullPackage() {
+  return {
+    packageFormat: "a2-authoring-package/v1",
+    locale: "nb",
+    constraints: { source: "unit test" },
+    objects: [
+      {
+        clientRef: "intro",
+        type: "section",
+        payload: { title: "Introduksjon", bodyMarkdown: "## Innhold" },
+      },
+      {
+        clientRef: "module-1",
+        type: "module",
+        payload: {
+          module: { title: "Behandlingsgrunnlag", certificationLevel: "basic" },
+          activeVersion: freetextVersion,
+        },
+      },
+      {
+        clientRef: "course-main",
+        type: "course",
+        payload: {
+          course: { title: "GDPR for saksbehandlere" },
+          items: [
+            { type: "SECTION", ref: "intro" },
+            { type: "MODULE", ref: "module-1" },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+describe("#649 agent authoring package validation", () => {
+  it("accepts a valid package and returns a topologically ordered plan", async () => {
+    const report = await validateAuthoringPackage(fullPackage(), emptyLookups());
+    expect(report.valid).toBe(true);
+    expect(report.summary).toEqual({ errors: 0, warnings: 0, objects: 3 });
+    expect(report.issues).toEqual([]);
+    expect(report.plan).toEqual([
+      { op: "create_section", clientRef: "intro" },
+      { op: "create_module", clientRef: "module-1" },
+      { op: "create_course", clientRef: "course-main" },
+      { op: "set_course_items", clientRef: "course-main" },
+    ]);
+  });
+
+  it("rejects duplicate clientRefs", async () => {
+    const pkg = fullPackage();
+    pkg.objects[1].clientRef = "intro";
+    const report = await validateAuthoringPackage(pkg, emptyLookups());
+    expect(report.valid).toBe(false);
+    expect(report.plan).toEqual([]);
+    const issue = report.issues.find((entry) => entry.code === "duplicate_client_ref");
+    expect(issue).toMatchObject({ severity: "error", path: "objects[1].clientRef" });
+    // The course's ref to 'module-1' now also dangles — both problems are reported.
+    expect(report.issues.some((entry) => entry.code === "unknown_client_ref")).toBe(true);
+  });
+
+  it("rejects course item refs that do not exist in the package", async () => {
+    const pkg = fullPackage();
+    (pkg.objects[2].payload as { items: unknown[] }).items = [{ type: "MODULE", ref: "module-7" }];
+    const report = await validateAuthoringPackage(pkg, emptyLookups());
+    expect(report.valid).toBe(false);
+    expect(report.issues).toContainEqual(
+      expect.objectContaining({
+        severity: "error",
+        code: "unknown_client_ref",
+        path: "objects[2].payload.items[0].ref",
+      }),
+    );
+  });
+
+  it("rejects refs pointing to an object of the wrong type", async () => {
+    const pkg = fullPackage();
+    (pkg.objects[2].payload as { items: unknown[] }).items = [{ type: "MODULE", ref: "intro" }];
+    const report = await validateAuthoringPackage(pkg, emptyLookups());
+    expect(report.issues).toContainEqual(
+      expect.objectContaining({ code: "client_ref_type_mismatch", path: "objects[2].payload.items[0].ref" }),
+    );
+  });
+
+  it("requires exactly one of ref and server ID on course items", async () => {
+    const pkg = fullPackage();
+    (pkg.objects[2].payload as { items: unknown[] }).items = [
+      { type: "MODULE", ref: "module-1", moduleId: "m_existing" },
+      { type: "SECTION" },
+    ];
+    const report = await validateAuthoringPackage(pkg, emptyLookups());
+    expect(report.issues).toContainEqual(expect.objectContaining({ code: "ref_and_id_conflict" }));
+    expect(report.issues).toContainEqual(expect.objectContaining({ code: "ref_or_id_required" }));
+  });
+
+  it("checks referenced server IDs against the database", async () => {
+    const pkg = fullPackage();
+    (pkg.objects[2].payload as { items: unknown[] }).items = [
+      { type: "MODULE", ref: "module-1" },
+      { type: "MODULE", moduleId: "m_known" },
+      { type: "SECTION", sectionId: "s_missing" },
+    ];
+    const report = await validateAuthoringPackage(
+      pkg,
+      emptyLookups({ findExistingModuleIds: async () => new Set(["m_known"]) }),
+    );
+    expect(report.issues).toContainEqual(
+      expect.objectContaining({ code: "unknown_section_id", path: "objects[2].payload.items[2].sectionId" }),
+    );
+    expect(report.issues.some((entry) => entry.code === "unknown_module_id")).toBe(false);
+  });
+
+  describe("assessment modes", () => {
+    function modulePackage(activeVersion: Record<string, unknown>) {
+      return {
+        packageFormat: "a2-authoring-package/v1",
+        objects: [
+          {
+            clientRef: "m1",
+            type: "module",
+            payload: { module: { title: "Mode test" }, activeVersion },
+          },
+        ],
+      };
+    }
+
+    it("MCQ_ONLY requires mcqSet and forbids free-text fields", async () => {
+      const missing = await validateAuthoringPackage(
+        modulePackage({ assessmentMode: "MCQ_ONLY" }),
+        emptyLookups(),
+      );
+      expect(missing.issues).toContainEqual(
+        expect.objectContaining({ code: "required_for_mode", path: "objects[0].payload.activeVersion.mcqSet" }),
+      );
+
+      const withFreetext = await validateAuthoringPackage(
+        modulePackage({ assessmentMode: "MCQ_ONLY", mcqSet, taskText: "Not allowed" }),
+        emptyLookups(),
+      );
+      expect(withFreetext.issues).toContainEqual(
+        expect.objectContaining({ code: "forbidden_for_mode", path: "objects[0].payload.activeVersion.taskText" }),
+      );
+    });
+
+    it("FREETEXT_ONLY requires the free-text triple and forbids mcqSet", async () => {
+      const report = await validateAuthoringPackage(
+        modulePackage({ assessmentMode: "FREETEXT_ONLY", taskText: "Task", mcqSet }),
+        emptyLookups(),
+      );
+      const codes = report.issues.map((entry) => `${entry.code}:${entry.path}`);
+      expect(codes).toContain("required_for_mode:objects[0].payload.activeVersion.rubric");
+      expect(codes).toContain("required_for_mode:objects[0].payload.activeVersion.promptTemplate");
+      expect(codes).toContain("forbidden_for_mode:objects[0].payload.activeVersion.mcqSet");
+    });
+
+    it("FREETEXT_PLUS_MCQ is the default mode and requires all four fields", async () => {
+      const report = await validateAuthoringPackage(modulePackage({}), emptyLookups());
+      const required = report.issues.filter((entry) => entry.code === "required_for_mode");
+      expect(required.map((entry) => entry.path).sort()).toEqual([
+        "objects[0].payload.activeVersion.mcqSet",
+        "objects[0].payload.activeVersion.promptTemplate",
+        "objects[0].payload.activeVersion.rubric",
+        "objects[0].payload.activeVersion.taskText",
+      ]);
+
+      const valid = await validateAuthoringPackage(
+        modulePackage({ taskText: "T", rubric: freetextVersion.rubric, promptTemplate: freetextVersion.promptTemplate, mcqSet }),
+        emptyLookups(),
+      );
+      expect(valid.valid).toBe(true);
+    });
+  });
+
+  it("rejects publish/audit fields as unknown_field", async () => {
+    const pkg = fullPackage();
+    (pkg.objects[1].payload as Record<string, unknown>).audit = { publishedAt: "2026-01-01T00:00:00Z" };
+    (pkg as Record<string, unknown>).autoPublish = true;
+    const report = await validateAuthoringPackage(pkg, emptyLookups());
+    expect(report.valid).toBe(false);
+    const unknownFieldIssues = report.issues.filter((entry) => entry.code === "unknown_field");
+    expect(unknownFieldIssues.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("warns (without blocking) on possible duplicate titles and module-less courses", async () => {
+    const pkg = fullPackage();
+    (pkg.objects[2].payload as { items: unknown[] }).items = [{ type: "SECTION", ref: "intro" }];
+    const report = await validateAuthoringPackage(
+      pkg,
+      emptyLookups({
+        listActiveModuleTitles: async () => [
+          { id: "m_abc123", title: JSON.stringify({ "en-GB": "Legal basis", nb: "Behandlingsgrunnlag" }) },
+        ],
+      }),
+    );
+    expect(report.valid).toBe(true);
+    expect(report.issues).toContainEqual(
+      expect.objectContaining({
+        severity: "warning",
+        code: "possible_duplicate_title",
+        path: "objects[1].payload.module.title",
+        message: expect.stringContaining("m_abc123"),
+      }),
+    );
+    expect(report.issues).toContainEqual(
+      expect.objectContaining({ severity: "warning", code: "course_without_modules" }),
+    );
+    expect(report.summary.warnings).toBe(2);
+  });
+
+  it("returns structural schema errors with paths and no plan", async () => {
+    const report = await validateAuthoringPackage(
+      {
+        packageFormat: "a2-authoring-package/v1",
+        objects: [{ clientRef: "Bad Ref!", type: "module", payload: { module: {}, activeVersion: {} } }],
+      },
+      emptyLookups(),
+    );
+    expect(report.valid).toBe(false);
+    expect(report.plan).toEqual([]);
+    expect(report.summary.objects).toBe(1);
+    expect(report.issues.some((entry) => entry.path === "objects[0].clientRef")).toBe(true);
+    expect(report.issues.some((entry) => entry.path === "objects[0].payload.module.title")).toBe(true);
+  });
+});


### PR DESCRIPTION
Del av EPIC #647; implementerer AA-1 (#649) etter designnotatet fra #648 (`doc/design/AGENT_AUTHORING_647.md`). v1.6.10.

## Hva

- **`src/modules/adminContent/agentAuthoringSchemas.ts`** — ny kontrakt `a2-authoring-package/v1`: `objects[]` med `clientRef` + `type` (`module`/`section`/`course`); kurs-items refererer per `clientRef` eller eksisterende `moduleId`/`sectionId`. Leaf-payloads gjenbruker `a2-content-export/v1`-schemas (modul/seksjon) minus `audit`. Alle objekter er `.strict()` → publiserings-/audit-felt gir `unknown_field`-feil i stedet for å ignoreres stille.
- **`src/modules/adminContent/agentAuthoringValidationService.ts`** — regelsettet: unike `clientRef`, ref-oppløsning (ukjent ref, type-mismatch, ref XOR server-ID), mode-krav for alle tre `assessmentMode` (`required_for_mode`/`forbidden_for_mode`), eksisterende-ID-sjekk mot DB (read-only), warnings (`possible_duplicate_title` mot eksisterende innhold, `course_without_modules`). Zod-issues oversettes 1:1 til stabile `{severity, path, code, message}` med JSON-stier (`objects[2].payload.activeVersion.mcqSet`). `plan` i topologisk rekkefølge (seksjoner → moduler → kurs → items), kun når `errors == 0`.
- **`src/routes/adminContent.ts`** — `POST /api/admin/content/agent-authoring/validate` under `admin_content`-kapabiliteten (ADMINISTRATOR + SUBJECT_MATTER_OWNER). 200 med rapport også for ugyldige pakker (rapporten er resultatet); 400 kun når requesten ikke er `{ package }` med riktig `packageFormat`.

## Akseptansekriterier (#649)

- [x] `admin_content`-beskyttet (integrasjonstest verifiserer 403 for PARTICIPANT)
- [x] Ingen DB-writes i validate (integrasjonstest sammenligner modul/kurs/seksjons-tellinger før/etter, både for gyldig og ugyldig pakke)
- [x] Zod-issues → stabile `path`, `code`, `message`, `severity`
- [x] Alle tre assessment modes dekket (krav + forbudte felt)
- [x] Unit/integrasjonstester: gyldig pakke, brutte refs, mode-krav, duplikat `clientRef`
- [x] API_REFERENCE oppdatert

## Test

- `npx tsc --noEmit` — grønn
- `npm run test:unit` — 83 filer / 701 tester grønne (12 nye i `test/unit/agent-authoring-validation.test.ts`)
- `npm run test:integration:native -- test/agent-authoring-validate.test.ts` — 5/5 grønne mot lokal Postgres

## Design-avvik

Ingen — følger §2 (kontrakt), §5 (rapportformat) og §3 (endepunkt) i designnotatet. Idempotency-Key/`adminUrl`/`draft:true` for seksjoner er bevisst utenfor scope her og kommer i AA-2 (#650).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
