### PR TITLE
feat(admin-content): #650 AA-2 agentvennlige create/import-responser + draft-seksjoner (v1.6.11)

### DIFF
--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -201,6 +201,21 @@ ordinary create/import endpoints. Publishing is manual and is **not** part of th
 |--------|------|-------|
 | `POST` | `/api/admin/content/agent-authoring/validate` | **AA-1 (#649).** Dry-run validation — **no DB writes**. Body `{ package: <a2-authoring-package/v1> }`. Returns `200 { valid, summary: { errors, warnings, objects }, issues: [{ severity: "error"\|"warning", path, code, message }], plan }` — 200 also for invalid packages (the report is the result). `plan` (topological execution order, ops `create_section`/`create_module`/`create_course`/`set_course_items`) is only populated when `errors == 0`. Covers all three `assessmentMode`s (`required_for_mode`/`forbidden_for_mode`), package rules (`duplicate_client_ref`, `unknown_client_ref`, `client_ref_type_mismatch`, `ref_or_id_required`, `ref_and_id_conflict`, `unknown_module_id`/`unknown_section_id`, `unknown_field` — publish/audit fields are rejected) and non-blocking warnings (`possible_duplicate_title`, `course_without_modules`). `400` only when the body isn't `{ package }` with the right `packageFormat`. |
 
+**Agent-friendly create/import responses (AA-2, #650):** the create/import calls the skill
+orchestrates accept an optional `clientRef` (pattern `[a-z0-9-]{1,64}`, echoed back in the
+201-response, never persisted) and return admin-UI deep links in `links`:
+
+- `POST /modules` and `POST /modules/import` → `links: { conversation: "/admin-content/module/:id/conversation", advanced: "/admin-content/module/:id/advanced" }`
+- `POST /courses` and `POST /courses/import` → `links: { course: "/admin-content/courses/:id" }`
+- `POST /sections` → `links: { editor: "/admin-content/sections?id=:id" }`. Also accepts
+  `draft: true` — the section is created in Utkast (`activeVersionId` stays `null`; content is
+  preserved as version 1, published later via `POST /sections/:id/publish`). Default (omitted)
+  keeps auto-publish-on-save.
+
+Agent imports must pass `autoPublish: false` (and the authoring contract has no `audit`, so
+source-publish auto-publication can never trigger). Retry-safe `Idempotency-Key` support is
+tracked separately in #726.
+
 ---
 
 ## Admin - Courses & Learning Sections

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,26 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.11 - 2026-07-05
+
+feat(admin-content): #650 AA-2 — agentvennlige create/import-responser + draft-seksjoner
+
+Andre API-steg i EPIC #647 (design: `doc/design/AGENT_AUTHORING_647.md` §3–§4):
+
+- **`links` i 201-responser**: `POST /modules`, `POST /modules/import` (conversation/advanced),
+  `POST /courses`, `POST /courses/import` (kursbygger) og `POST /sections` (editor) returnerer
+  admin-UI-deep-links (`adminUiLinks.ts`, kanoniske ruter fra `doc/route-map.md`) slik at
+  skillen kan gi brukeren gjennomgangs-URL-er.
+- **`clientRef`-ekko**: samme kall aksepterer valgfri `clientRef` (`[a-z0-9-]{1,64}`) som
+  ekkoes i responsen (aldri persistert) — skillen mapper plan → server-ID-er uten egen bokføring.
+- **`draft: true` på `POST /sections`**: tetter seksjonshullet i draft-only-invarianten —
+  seksjonen opprettes i Utkast (`activeVersionId` forblir null; innholdet ligger som versjon 1
+  og publiseres via eksisterende `publish`). Default-adferd (auto-publiser ved lagring) uendret.
+- Idempotency-Key (krever ny tabell) utskilt til #726 slik #650 åpner for.
+- Tester: ny integrasjonssuite kjører hele skill-sekvensen (import i alle tre assessmentMode →
+  draft-seksjon → kurs → mixed items) som både ADMINISTRATOR og SUBJECT_MATTER_OWNER og
+  verifiserer at ingenting blir live underveis. API_REFERENCE oppdatert.
+
 ## 1.6.10 - 2026-07-05
 
 feat(admin-content): #649 AA-1 — Agent Authoring validate-endepunkt med detaljert rapport

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/adminContent/adminContentSchemas.ts
+++ b/src/modules/adminContent/adminContentSchemas.ts
@@ -31,12 +31,20 @@ export const certificationLevelInputSchema = z.union([
   z.record(z.string(), safeShortString),
 ]).optional();
 
+// AA-2 (#650): agent-orchestrated create/import calls may carry a clientRef
+// (the object's identity within an a2-authoring-package/v1 plan). The server
+// never persists it — it is echoed back so the skill can map plan → server IDs.
+export const clientRefSchema = z
+  .string()
+  .regex(/^[a-z0-9-]{1,64}$/, "clientRef must match [a-z0-9-]{1,64}.");
+
 export const moduleCreateBodySchema = z.object({
   title: localizedTextSchema,
   description: localizedTextSchema.optional(),
   certificationLevel: certificationLevelInputSchema,
   validFrom: z.string().trim().optional(),
   validTo: z.string().trim().optional(),
+  clientRef: clientRefSchema.optional(),
 });
 
 export const moduleTitleUpdateBodySchema = z.object({
@@ -397,6 +405,8 @@ export const importBodySchema = z.object({
   // v1.2.14 (#456): når false, auto-publiser ikke selv om kildens audit.publishedAt er
   // satt. In-app duplisering sender false; fil-import lar default (true) stå.
   autoPublish: z.boolean().optional(),
+  // AA-2 (#650): echoed back in the response for agent plan→ID mapping; never persisted.
+  clientRef: clientRefSchema.optional(),
 }).refine(
   (body) => body.mode !== "replaceExisting" || !!body.targetId,
   { message: "targetId is required when mode is replaceExisting", path: ["targetId"] },

--- a/src/modules/adminContent/adminUiLinks.ts
+++ b/src/modules/adminContent/adminUiLinks.ts
@@ -1,0 +1,23 @@
+// Admin-UI deep links returned by agent-friendly create/import responses —
+// AA-2 (#650, EPIC #647). URL patterns are the canonical routes from
+// doc/route-map.md; a skill shows these to the user so a human can review and
+// publish the drafts the agent created.
+
+export function moduleAdminLinks(moduleId: string) {
+  return {
+    conversation: `/admin-content/module/${moduleId}/conversation`,
+    advanced: `/admin-content/module/${moduleId}/advanced`,
+  };
+}
+
+export function courseAdminLinks(courseId: string) {
+  return {
+    course: `/admin-content/courses/${courseId}`,
+  };
+}
+
+export function sectionAdminLinks(sectionId: string) {
+  return {
+    editor: `/admin-content/sections?id=${sectionId}`,
+  };
+}

--- a/src/modules/adminContent/agentAuthoringSchemas.ts
+++ b/src/modules/adminContent/agentAuthoringSchemas.ts
@@ -20,13 +20,12 @@ import {
   rubricBodySchema,
   promptTemplateBodySchema,
   mcqSetBodySchema,
+  clientRefSchema,
 } from "./adminContentSchemas.js";
 
 export const AUTHORING_PACKAGE_FORMAT = "a2-authoring-package/v1" as const;
 
-export const clientRefSchema = z
-  .string()
-  .regex(/^[a-z0-9-]{1,64}$/, "clientRef must match [a-z0-9-]{1,64}.");
+export { clientRefSchema };
 
 // Module payload = moduleExportPayloadSchema without `audit` (strict).
 export const authoringModulePayloadSchema = z

--- a/src/modules/course/sectionCommands.ts
+++ b/src/modules/course/sectionCommands.ts
@@ -11,7 +11,10 @@ import { assertSectionNotInAnyCourse } from "./contentLifecycle.js";
 // fields (title, bodyMarkdown) arrive already serialized to JSON strings by the
 // route layer, exactly like createCourse.
 
-export async function createSection(input: { title: string; bodyMarkdown: string; actorId?: string }) {
+// AA-2 (#650): `draft: true` keeps the section in Utkast (activeVersionId stays
+// null) — same state a restored section lands in (I3). Content lives in version 1;
+// publishSection re-points to it. Default (false) preserves auto-publish-on-save.
+export async function createSection(input: { title: string; bodyMarkdown: string; actorId?: string; draft?: boolean }) {
   return runInTransaction(async (tx) => {
     const section = await tx.courseSection.create({ data: { title: input.title } });
     const version = await tx.courseSectionVersion.create({
@@ -19,10 +22,16 @@ export async function createSection(input: { title: string; bodyMarkdown: string
         sectionId: section.id,
         versionNo: 1,
         bodyMarkdown: input.bodyMarkdown,
-        publishedBy: input.actorId ?? null,
-        publishedAt: new Date(),
+        publishedBy: input.draft ? null : input.actorId ?? null,
+        publishedAt: input.draft ? null : new Date(),
       },
     });
+    if (input.draft) {
+      return tx.courseSection.findUniqueOrThrow({
+        where: { id: section.id },
+        include: { activeVersion: true },
+      });
+    }
     return tx.courseSection.update({
       where: { id: section.id },
       data: { activeVersionId: version.id },

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -49,6 +49,7 @@ import {
 import { importModuleFromEnvelope } from "../modules/adminContent/contentImportService.js";
 import { validateAuthoringPackage } from "../modules/adminContent/agentAuthoringValidationService.js";
 import { AUTHORING_PACKAGE_FORMAT } from "../modules/adminContent/agentAuthoringSchemas.js";
+import { moduleAdminLinks } from "../modules/adminContent/adminUiLinks.js";
 import {
   condenseSourceMaterial,
   generateAssessmentBlueprint,
@@ -148,7 +149,12 @@ adminContentRouter.post("/modules", async (request, response) => {
     const module = await createModule(
       toCreateModuleInput(data, validFrom ?? undefined, validTo ?? undefined, request.context?.userId),
     );
-    response.status(201).json({ module });
+    // AA-2 (#650): links + clientRef echo make the response agent-orchestrable.
+    response.status(201).json({
+      module,
+      links: moduleAdminLinks(module.id),
+      ...(data.clientRef !== undefined ? { clientRef: data.clientRef } : {}),
+    });
   } catch (error) {
     response.status(400).json({ error: "create_module_failed", message: "Could not create module." });
   }
@@ -368,7 +374,13 @@ adminContentRouter.post("/modules/import", async (request, response) => {
       targetModuleId: data.targetId,
       autoPublish: data.autoPublish,
     });
-    response.status(201).json({ moduleId: result.moduleId, moduleVersionId: result.moduleVersionId });
+    // AA-2 (#650): links + clientRef echo make the response agent-orchestrable.
+    response.status(201).json({
+      moduleId: result.moduleId,
+      moduleVersionId: result.moduleVersionId,
+      links: moduleAdminLinks(result.moduleId),
+      ...(data.clientRef !== undefined ? { clientRef: data.clientRef } : {}),
+    });
   } catch (err) {
     if (err instanceof AppError) {
       response.status(err.httpStatus).json({ error: err.code, message: err.message });

--- a/src/routes/adminCourses.ts
+++ b/src/routes/adminCourses.ts
@@ -15,7 +15,8 @@ import {
   revokeEnrollment,
   listCourseEnrollments,
 } from "../modules/course/index.js";
-import { generationLocaleSchema, importBodySchema, localizedTextPatchSchema, parseRequest } from "../modules/adminContent/adminContentSchemas.js";
+import { generationLocaleSchema, importBodySchema, localizedTextPatchSchema, parseRequest, clientRefSchema } from "../modules/adminContent/adminContentSchemas.js";
+import { courseAdminLinks } from "../modules/adminContent/adminUiLinks.js";
 import { buildCourseExportEnvelope } from "../modules/adminContent/index.js";
 import { importCourseFromEnvelope } from "../modules/adminContent/contentImportService.js";
 import { localizedTextCodec } from "../codecs/localizedTextCodec.js";
@@ -64,8 +65,12 @@ const courseLocalizationBodySchema = z.object({
   message: "At least one field is required.",
 });
 
+// AA-2 (#650): create accepts an optional clientRef (echoed back, never persisted)
+// and returns admin links so agent orchestration can hand humans review URLs.
+const courseCreateBodySchema = courseBodySchema.extend({ clientRef: clientRefSchema.optional() });
+
 adminCoursesRouter.post("/", async (request, response, next) => {
-  const parsed = courseBodySchema.safeParse(request.body);
+  const parsed = courseCreateBodySchema.safeParse(request.body);
   if (!parsed.success) {
     response.status(400).json({ error: "validation_error", issues: parsed.error.issues });
     return;
@@ -80,7 +85,11 @@ adminCoursesRouter.post("/", async (request, response, next) => {
       discussionsEnabled: parsed.data.discussionsEnabled,
       actorId: request.context?.userId,
     });
-    response.status(201).json({ course });
+    response.status(201).json({
+      course,
+      links: courseAdminLinks(course.id),
+      ...(parsed.data.clientRef !== undefined ? { clientRef: parsed.data.clientRef } : {}),
+    });
   } catch (error) {
     next(error);
   }
@@ -159,7 +168,13 @@ adminCoursesRouter.post("/import", async (request, response, next) => {
       mode: data.mode ?? "createNew",
       targetCourseId: data.targetId,
     });
-    response.status(201).json({ courseId: result.courseId, moduleIds: result.moduleIds });
+    // AA-2 (#650): links + clientRef echo make the response agent-orchestrable.
+    response.status(201).json({
+      courseId: result.courseId,
+      moduleIds: result.moduleIds,
+      links: courseAdminLinks(result.courseId),
+      ...(data.clientRef !== undefined ? { clientRef: data.clientRef } : {}),
+    });
   } catch (err) {
     if (err instanceof AppError) {
       response.status(err.httpStatus).json({ error: err.code, message: err.message });

--- a/src/routes/adminSections.ts
+++ b/src/routes/adminSections.ts
@@ -18,7 +18,8 @@ import {
   MAX_ASSET_BYTES,
 } from "../modules/course/index.js";
 import { findCoursesForSections } from "../modules/course/contentLifecycle.js";
-import { localizedTextPatchSchema, generationLocaleSchema } from "../modules/adminContent/adminContentSchemas.js";
+import { localizedTextPatchSchema, generationLocaleSchema, clientRefSchema } from "../modules/adminContent/adminContentSchemas.js";
+import { sectionAdminLinks } from "../modules/adminContent/adminUiLinks.js";
 import { localizedTextCodec } from "../codecs/localizedTextCodec.js";
 import { NotFoundError } from "../errors/AppError.js";
 import { renderSectionMarkdown } from "../modules/course/sectionContent.js";
@@ -45,6 +46,10 @@ const uploadAsset: RequestHandler = (request, response, next) => {
 const createSectionSchema = z.object({
   title: localizedTextPatchSchema,
   bodyMarkdown: localizedTextPatchSchema,
+  // AA-2 (#650): agents create sections as drafts (activeVersionId stays null)
+  // and get their plan-ref echoed back. Default keeps auto-publish-on-save.
+  draft: z.boolean().optional(),
+  clientRef: clientRefSchema.optional(),
 });
 const titleSchema = z.object({ title: localizedTextPatchSchema });
 const contentSchema = z.object({ bodyMarkdown: localizedTextPatchSchema });
@@ -88,8 +93,13 @@ adminSectionsRouter.post("/", async (request, response, next) => {
       title: localizedTextCodec.serialize(parsed.data.title),
       bodyMarkdown: localizedTextCodec.serialize(parsed.data.bodyMarkdown),
       actorId: request.context?.userId,
+      draft: parsed.data.draft,
     });
-    response.status(201).json({ section: toDetail(section) });
+    response.status(201).json({
+      section: toDetail(section),
+      links: sectionAdminLinks(section.id),
+      ...(parsed.data.clientRef !== undefined ? { clientRef: parsed.data.clientRef } : {}),
+    });
   } catch (error) {
     next(error);
   }

--- a/test/agent-authoring-orchestration.test.ts
+++ b/test/agent-authoring-orchestration.test.ts
@@ -1,0 +1,221 @@
+// Integration tests for AA-2 (#650): agent-friendly create/import responses.
+// Exercises the exact orchestration sequence the authoring skill will run
+// (validate → import modules → create draft section → create course → set items)
+// and verifies the AA-2 guarantees: everything stays draft, responses carry
+// admin links + clientRef echo, and both ADMINISTRATOR and SUBJECT_MATTER_OWNER
+// can run the flow.
+
+import request from "supertest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+
+const adminHeaders = {
+  "x-user-id": "admin-1",
+  "x-user-email": "admin@company.com",
+  "x-user-name": "Platform Admin",
+};
+
+// Mock-auth auto-provisions the user; the roles header defines the effective role set.
+const smoHeaders = {
+  "x-user-id": "smo-agent-650",
+  "x-user-email": "smo.agent650@company.com",
+  "x-user-name": "SMO Agent",
+  "x-user-roles": "SUBJECT_MATTER_OWNER",
+};
+
+const freetextOnlyVersion = {
+  assessmentMode: "FREETEXT_ONLY",
+  taskText: "Beskriv behandlingsgrunnlaget.",
+  assessorExpectedContent: "Nevner artikkel 6.",
+  rubric: { criteria: { relevance: "0-4" }, scalingRule: { max_total: 20 } },
+  promptTemplate: { systemPrompt: "Sys", userPromptTemplate: "Eval" },
+};
+
+const mcqSet = {
+  title: "Quiz",
+  questions: [{ stem: "1+1?", options: ["2", "3"], correctAnswer: "2" }],
+};
+
+// The skill synthesizes a module-scoped a2-content-export/v1 envelope per module
+// object (empty audit → no publish history → can never auto-publish).
+function moduleEnvelope(title: string, activeVersion: Record<string, unknown>) {
+  return {
+    exportFormat: "a2-content-export/v1",
+    exportedAt: new Date().toISOString(),
+    scope: "module",
+    module: {
+      module: { title, certificationLevel: "basic" },
+      activeVersion: { ...activeVersion, audit: {} },
+    },
+  };
+}
+
+async function importDraftModule(
+  headers: Record<string, string>,
+  title: string,
+  activeVersion: Record<string, unknown>,
+  clientRef?: string,
+) {
+  const response = await request(app)
+    .post("/api/admin/content/modules/import")
+    .set(headers)
+    .send({
+      payload: moduleEnvelope(title, activeVersion),
+      mode: "createNew",
+      autoPublish: false,
+      ...(clientRef ? { clientRef } : {}),
+    });
+  expect(response.status).toBe(201);
+  return response.body as {
+    moduleId: string;
+    moduleVersionId: string;
+    links: { conversation: string; advanced: string };
+    clientRef?: string;
+  };
+}
+
+describe("#650 agent-friendly authoring orchestration", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("runs the full skill sequence as ADMINISTRATOR: drafts only, links and clientRef echo everywhere", async () => {
+    const suffix = `aa2-admin-${Date.now()}`;
+
+    // 1. Module import (FREETEXT_ONLY) — draft + agent-friendly response.
+    const module1 = await importDraftModule(adminHeaders, `AA2 module ${suffix}`, freetextOnlyVersion, "module-1");
+    expect(module1.clientRef).toBe("module-1");
+    expect(module1.links).toEqual({
+      conversation: `/admin-content/module/${module1.moduleId}/conversation`,
+      advanced: `/admin-content/module/${module1.moduleId}/advanced`,
+    });
+    const moduleRow = await prisma.module.findUniqueOrThrow({
+      where: { id: module1.moduleId },
+      select: { activeVersionId: true, createdById: true },
+    });
+    expect(moduleRow.activeVersionId).toBeNull(); // draft
+    expect(moduleRow.createdById).not.toBeNull(); // ownership tracked
+
+    // 2. Draft section — activeVersionId stays null, content preserved in v1.
+    const sectionResponse = await request(app)
+      .post("/api/admin/content/sections")
+      .set(adminHeaders)
+      .send({ title: `AA2 section ${suffix}`, bodyMarkdown: "## Innhold", draft: true, clientRef: "intro" });
+    expect(sectionResponse.status).toBe(201);
+    expect(sectionResponse.body.clientRef).toBe("intro");
+    const sectionId = sectionResponse.body.section.id as string;
+    expect(sectionResponse.body.links).toEqual({ editor: `/admin-content/sections?id=${sectionId}` });
+    expect(sectionResponse.body.section.activeVersionId).toBeNull();
+    const versionCount = await prisma.courseSectionVersion.count({ where: { sectionId } });
+    expect(versionCount).toBe(1);
+
+    // 3. Course create — draft + links + echo.
+    const courseResponse = await request(app)
+      .post("/api/admin/content/courses")
+      .set(adminHeaders)
+      .send({ title: `AA2 course ${suffix}`, clientRef: "course-main" });
+    expect(courseResponse.status).toBe(201);
+    const courseId = courseResponse.body.course.id as string;
+    expect(courseResponse.body.clientRef).toBe("course-main");
+    expect(courseResponse.body.links).toEqual({ course: `/admin-content/courses/${courseId}` });
+    expect(courseResponse.body.course.publishedAt).toBeNull();
+
+    // 4. Mixed item sequence.
+    const itemsResponse = await request(app)
+      .put(`/api/admin/content/courses/${courseId}/items`)
+      .set(adminHeaders)
+      .send({
+        items: [
+          { type: "SECTION", sectionId },
+          { type: "MODULE", moduleId: module1.moduleId },
+        ],
+      });
+    expect(itemsResponse.status).toBe(204);
+
+    const itemsRead = await request(app)
+      .get(`/api/admin/content/courses/${courseId}/items`)
+      .set(adminHeaders);
+    expect(itemsRead.status).toBe(200);
+    expect(
+      itemsRead.body.items.map((item: { type: string; moduleId: string | null; sectionId: string | null }) => ({
+        type: item.type,
+        id: item.moduleId ?? item.sectionId,
+      })),
+    ).toEqual([
+      { type: "SECTION", id: sectionId },
+      { type: "MODULE", id: module1.moduleId },
+    ]);
+
+    // Nothing became live along the way.
+    const courseRow = await prisma.course.findUniqueOrThrow({ where: { id: courseId }, select: { publishedAt: true } });
+    expect(courseRow.publishedAt).toBeNull();
+  });
+
+  it("imports draft modules in all three assessment modes (never published)", async () => {
+    const suffix = Date.now();
+    const variants: Array<[string, Record<string, unknown>]> = [
+      [`AA2 freetext-only ${suffix}`, freetextOnlyVersion],
+      [`AA2 mcq-only ${suffix}`, { assessmentMode: "MCQ_ONLY", mcqSet }],
+      [`AA2 freetext-plus-mcq ${suffix}`, { ...freetextOnlyVersion, assessmentMode: "FREETEXT_PLUS_MCQ", mcqSet }],
+    ];
+    for (const [title, activeVersion] of variants) {
+      const imported = await importDraftModule(adminHeaders, title, activeVersion);
+      const row = await prisma.module.findUniqueOrThrow({
+        where: { id: imported.moduleId },
+        select: { activeVersionId: true },
+      });
+      expect(row.activeVersionId).toBeNull();
+    }
+  });
+
+  it("lets a SUBJECT_MATTER_OWNER run the same flow and records ownership", async () => {
+    const suffix = `aa2-smo-${Date.now()}`;
+
+    const imported = await importDraftModule(smoHeaders, `AA2 SMO module ${suffix}`, freetextOnlyVersion, "smo-module");
+    expect(imported.clientRef).toBe("smo-module");
+    const smoUser = await prisma.user.findUniqueOrThrow({
+      where: { externalId: "smo-agent-650" },
+      select: { id: true },
+    });
+    const moduleRow = await prisma.module.findUniqueOrThrow({
+      where: { id: imported.moduleId },
+      select: { activeVersionId: true, createdById: true },
+    });
+    expect(moduleRow.activeVersionId).toBeNull();
+    expect(moduleRow.createdById).toBe(smoUser.id);
+
+    const sectionResponse = await request(app)
+      .post("/api/admin/content/sections")
+      .set(smoHeaders)
+      .send({ title: `AA2 SMO section ${suffix}`, bodyMarkdown: "## SMO", draft: true });
+    expect(sectionResponse.status).toBe(201);
+    expect(sectionResponse.body.section.activeVersionId).toBeNull();
+
+    const courseResponse = await request(app)
+      .post("/api/admin/content/courses")
+      .set(smoHeaders)
+      .send({ title: `AA2 SMO course ${suffix}` });
+    expect(courseResponse.status).toBe(201);
+
+    const itemsResponse = await request(app)
+      .put(`/api/admin/content/courses/${courseResponse.body.course.id}/items`)
+      .set(smoHeaders)
+      .send({
+        items: [
+          { type: "SECTION", sectionId: sectionResponse.body.section.id },
+          { type: "MODULE", moduleId: imported.moduleId },
+        ],
+      });
+    expect(itemsResponse.status).toBe(204);
+  });
+
+  it("keeps the default section-create behavior (auto-publish) when draft is not set", async () => {
+    const response = await request(app)
+      .post("/api/admin/content/sections")
+      .set(adminHeaders)
+      .send({ title: `AA2 default section ${Date.now()}`, bodyMarkdown: "## Publisert" });
+    expect(response.status).toBe(201);
+    expect(response.body.section.activeVersionId).not.toBeNull();
+    expect(response.body.section.bodyMarkdown).toBe("## Publisert");
+  });
+});

--- a/test/agent-authoring-validate.test.ts
+++ b/test/agent-authoring-validate.test.ts
@@ -55,13 +55,16 @@ function validPackage(suffix: string) {
   };
 }
 
-async function contentCounts() {
+// Parallel-safe no-writes check: other integration files create content
+// concurrently, so global counts are racy. Instead we assert that nothing
+// with THIS test's unique title suffix was persisted.
+async function rowsWithSuffix(suffix: string) {
   const [modules, courses, sections] = await Promise.all([
-    prisma.module.count(),
-    prisma.course.count(),
-    prisma.courseSection.count(),
+    prisma.module.count({ where: { title: { contains: suffix } } }),
+    prisma.course.count({ where: { title: { contains: suffix } } }),
+    prisma.courseSection.count({ where: { title: { contains: suffix } } }),
   ]);
-  return { modules, courses, sections };
+  return modules + courses + sections;
 }
 
 describe("#649 POST /api/admin/content/agent-authoring/validate", () => {
@@ -70,12 +73,12 @@ describe("#649 POST /api/admin/content/agent-authoring/validate", () => {
   });
 
   it("validates a well-formed package without writing to the database", async () => {
-    const before = await contentCounts();
+    const suffix = `ok-${Date.now()}`;
 
     const response = await request(app)
       .post("/api/admin/content/agent-authoring/validate")
       .set(adminHeaders)
-      .send({ package: validPackage(`ok-${Date.now()}`) });
+      .send({ package: validPackage(suffix) });
 
     expect(response.status).toBe(200);
     expect(response.body.valid).toBe(true);
@@ -87,12 +90,12 @@ describe("#649 POST /api/admin/content/agent-authoring/validate", () => {
       { op: "set_course_items", clientRef: "course-main" },
     ]);
 
-    expect(await contentCounts()).toEqual(before);
+    expect(await rowsWithSuffix(suffix)).toBe(0);
   });
 
   it("returns a 200 report (not an error status) for an invalid package, still without writes", async () => {
-    const before = await contentCounts();
-    const pkg = validPackage(`bad-${Date.now()}`);
+    const suffix = `bad-${Date.now()}`;
+    const pkg = validPackage(suffix);
     // Break it three ways: dangling ref, duplicate clientRef, mode violation.
     (pkg.objects[2].payload as { items: unknown[] }).items = [{ type: "MODULE", ref: "does-not-exist" }];
     pkg.objects[0].clientRef = "module-1";
@@ -114,7 +117,7 @@ describe("#649 POST /api/admin/content/agent-authoring/validate", () => {
     expect(codes).toContain("duplicate_client_ref");
     expect(codes).toContain("forbidden_for_mode");
 
-    expect(await contentCounts()).toEqual(before);
+    expect(await rowsWithSuffix(suffix)).toBe(0);
   });
 
   it("warns about duplicate titles of existing modules", async () => {


### PR DESCRIPTION
Del av EPIC #647; implementerer AA-2 (#650) etter designnotatet (`doc/design/AGENT_AUTHORING_647.md` §3–§4, §6). v1.6.11.

## Hva

- **`links` i 201-responser** (`src/modules/adminContent/adminUiLinks.ts`, kanoniske ruter fra `doc/route-map.md`): `POST /modules` og `POST /modules/import` → `{ conversation, advanced }`; `POST /courses` og `POST /courses/import` → `{ course }`; `POST /sections` → `{ editor }`.
- **`clientRef`-ekko**: samme kall aksepterer valgfri `clientRef` (`[a-z0-9-]{1,64}`, `clientRefSchema` flyttet til `adminContentSchemas.ts` og gjenbrukt av authoring-pakken). Ekkoes i responsen, persisteres aldri.
- **`draft: true` på `POST /sections`**: seksjonen opprettes i Utkast (`activeVersionId` forblir `null`; innholdet ligger som versjon 1 med `publishedAt: null`, publiseres via eksisterende `POST /sections/:id/publish`). Samme tilstand som restore-lander-i-Utkast (I3). Default-adferd (auto-publiser ved lagring) er uendret — regressjonsguardet i testen.
- **Idempotency-Key utskilt til #726** (issuet åpner eksplisitt for det siden det krever ny tabell + migrasjon). Akseptert midlertidig risiko er dokumentert i #726.

## Akseptansekriterier (#650)

- [x] Skillen kan opprette modul i alle tre assessment modes via API uten å publisere (integrasjonstest: `activeVersionId` er `null` etter import med `autoPublish: false` + tom `audit` for FREETEXT_ONLY, MCQ_ONLY, FREETEXT_PLUS_MCQ)
- [x] Skillen kan opprette seksjon og kurs og sette mixed `CourseItem`-rekkefølge (verifisert via `GET .../items`)
- [x] Alle relevante create/import-kall returnerer admin-URL-er
- [x] Integrasjonstester dekker ADMINISTRATOR og SUBJECT_MATTER_OWNER (inkl. at SMO-eierskap (`createdById`) settes riktig)
- [x] API_REFERENCE oppdatert
- [x] Alt agent-opprettet forblir draft — testen asserterer at verken modul, seksjon eller kurs er live etter hele sekvensen

## Test

- `npx tsc --noEmit` — grønn
- `npm run test:unit` — 701 tester grønne
- `npm run test:integration:native -- test/agent-authoring-orchestration.test.ts test/agent-authoring-validate.test.ts` — 9/9 grønne
- `npm run test:integration:native -- test/m2-content-export-import.test.ts test/m2-admin-sections.test.ts test/m2-admin-courses.test.ts test/m2-course-items.test.ts test/m2-content-lifecycle.test.ts` — 21/21 grønne (ingen regresjon på berørte endepunkter; `links`/`clientRef` er additive felt)
- Fikset også en parallellkjørings-rase i AA-1-testens «ingen writes»-sjekk (global telling → suffiks-scopet telling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
