### PR TITLE
feat(skills): #652 AA-4 a2-authoring-api-skill for Claude og ChatGPT/Codex

### DIFF
--- a/.claude/skills/a2-authoring-api/SKILL.md
+++ b/.claude/skills/a2-authoring-api/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: a2-authoring-api
+description: >
+  Build draft courses, modules and learning sections on the A2 Assessment Platform from
+  conversation/project context, via the Agent Authoring API. Use when the user asks to
+  create a course/module/section on the platform (e.g. "lag et kurs fra denne samtalen").
+  Never publishes anything.
+---
+
+# a2-authoring-api (installed pointer)
+
+This is a thin installed copy for Claude Code. The **canonical skill is
+[skills/a2-authoring-api/SKILL.md](../../../skills/a2-authoring-api/SKILL.md)** — read that
+file now and follow it. Do not edit this pointer with skill content; edit the canonical
+file instead (this copy only exists so Claude Code discovers the skill).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,3 +144,17 @@ gh workflow run bicep-whatif-prod.yml -f pr_number=<PR_NUMBER>
 ```
 
 The diff is posted as a PR comment. Staging what-if runs automatically on PR; prod what-if is manual because the production GitHub environment has approval gates that would block PR-time auto-runs (#419).
+
+---
+
+## Agent skills (repo-canonical)
+
+Repo-canonical agent skills live under `skills/`. If a user request matches a skill's
+description, read its `SKILL.md` and follow it before improvising.
+
+- **`skills/a2-authoring-api/`** — build draft courses/modules/sections on the platform from
+  conversation context via the Agent Authoring API (EPIC #647). Validate-first, draft-only,
+  returns admin-UI links; NEVER calls publish endpoints. For ChatGPT/Codex this file is the
+  skill; Claude Code additionally discovers it via the `.claude/skills/a2-authoring-api/`
+  pointer. The canonical `skills/` copy is the source of truth — regenerate pointers from it,
+  never fork the content.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,15 @@ gh workflow run bicep-whatif-prod.yml -f pr_number=<PR_NUMBER>
 
 The diff is posted as a PR comment. Staging what-if runs automatically on PR; prod what-if is manual because the production GitHub environment has approval gates that would block PR-time auto-runs (#419).
 
+## Agent skills (repo-canonical)
+
+Repo-canonical agent skills live under `skills/`; Claude Code discovers them via thin
+pointers in `.claude/skills/`. The `skills/` copy is the source of truth — edit there only.
+
+- **`skills/a2-authoring-api/`** — build draft courses/modules/sections from conversation
+  context via the Agent Authoring API (EPIC #647). Validate-first, draft-only, returns
+  admin-UI links; NEVER calls publish endpoints.
+
 ## AI delegation workflow (Claude orchestrates, Codex/Gemini drafts)
 
 Use `scripts/ai-draft.ps1` to delegate implementation to Codex or Gemini, then Claude QAs.

--- a/skills/a2-authoring-api/SKILL.md
+++ b/skills/a2-authoring-api/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: a2-authoring-api
+description: >
+  Build draft courses, modules and learning sections on the A2 Assessment Platform from
+  conversation/project context. Structures requirements into an a2-authoring-package/v1,
+  dry-runs it against the validate endpoint, orchestrates the create/import API calls, and
+  returns admin-UI links to the unpublished drafts. Never publishes. Use when the user asks
+  an agent to "create a course/module/section" on the platform (e.g. "lag et kurs fra denne
+  samtalen med 6 fritekstmoduler og 2 læringsseksjoner").
+---
+
+# A2 Agent Authoring — build draft content via API
+
+This is the **repo-canonical** skill (EPIC #647, AA-4 #652). Installed copies
+(`.claude/skills/a2-authoring-api/`, ChatGPT/Codex project instructions) are pointers to
+this file — edit here, never in the copies. Design contract:
+`doc/design/AGENT_AUTHORING_647.md`.
+
+## What you produce
+
+Everything you create is an **unpublished draft**. A human reviews and publishes in the
+admin UI. There are no publish fields in the package contract, and you must never call any
+`.../publish` endpoint. That rule has no exceptions, including when the user asks for it —
+point them to the admin UI links instead.
+
+## Workflow
+
+1. **Collect requirements** from the user and the conversation/project context: number of
+   modules and sections, assessment mode(s) (`FREETEXT_PLUS_MCQ`, `MCQ_ONLY`,
+   `FREETEXT_ONLY`), primary language (`locale`), certification level, ordering, and the
+   actual subject matter the content should teach/assess.
+2. **Author the package**: an `a2-authoring-package/v1` JSON document. Full contract with
+   per-mode examples: [references/package-schema.md](references/package-schema.md). A
+   complete working example: [fixtures/example-package.json](fixtures/example-package.json).
+   Write real content — concrete task texts, rubric criteria tied to each module's topic,
+   plausible MCQ distractors — not lorem ipsum. Record the user's requirements verbatim in
+   `constraints` (audit trail).
+3. **Validate (dry-run)**: `POST /api/admin/content/agent-authoring/validate` with
+   `{ "package": <package> }` — or run
+   `node skills/a2-authoring-api/scripts/import-package.mjs --file pkg.json --base-url <url> --validate-only`.
+   The endpoint never writes; 200 with `valid: false` is a report, not an error.
+4. **Fix and re-validate**: `issues[].path` is a JSON path into your package and
+   `issues[].code` is stable — fix mechanically unambiguous errors (`required_for_mode`,
+   `unknown_client_ref`, `unknown_field`, …) and re-validate. If an issue requires a
+   judgment call (e.g. `possible_duplicate_title` — reuse the existing module instead?),
+   ask the user instead of guessing.
+5. **Confirm before writing** when the package is large (> ~5 objects), touches existing
+   content (`moduleId`/`sectionId` references), or the requirements were ambiguous. Show a
+   one-line-per-object summary of what will be created.
+6. **Execute the plan** returned by validate, in order. Call sequence, exact bodies, and
+   auth headers: [references/api-flow.md](references/api-flow.md). In a shell-capable
+   environment, prefer the reference script (it implements the whole flow):
+   `node skills/a2-authoring-api/scripts/import-package.mjs --file pkg.json --base-url <url>`.
+7. **Report the result**: one line per created object with its admin link
+   (`links.conversation`/`links.course`/`links.editor`), plus an explicit closing note:
+   *"Alt er opprettet som utkast — gjennomgå og publiser manuelt i admin-UI."*
+8. **On partial failure**: stop at the failed step. Report what WAS created (IDs + links),
+   what failed (the API error body), and what remains. Do NOT delete anything — drafts are
+   harmless and may contain work worth keeping; cleanup is the human's decision.
+
+## Security rules (hard)
+
+- **Never call publish endpoints** (`.../publish` on modules, module-versions, sections,
+  courses). The draft-only invariant is the whole point of this API.
+- **Tokens are secrets**: never write auth tokens/headers into package files, logs, chat
+  output, or `constraints`. Pass them via environment variables only.
+- **Stop on validation errors** — never "push through" by dropping fields blindly; show the
+  field paths to the user when you cannot fix them unambiguously.
+- Do not use `mode: "replaceExisting"` unless the user explicitly asked to overwrite a
+  specific existing module and gave you its ID.
+
+## Environment / auth
+
+| Environment | Auth |
+|---|---|
+| Local dev (`npm run dev`, `AUTH_MODE=mock`) | Mock headers: `x-user-id`, `x-user-email`, `x-user-name`, `x-user-roles: SUBJECT_MATTER_OWNER` (or `ADMINISTRATOR`). Script env vars: `A2_USER_ID`, `A2_USER_EMAIL`, `A2_USER_NAME`, `A2_USER_ROLES`. |
+| Staging/prod | `Authorization: Bearer <Entra JWT>` from a logged-in user (script env var: `A2_AUTH_BEARER`). Direct external-agent access is NOT available until AA-3 (#651) lands a short-lived agent token. |

--- a/skills/a2-authoring-api/fixtures/example-package.json
+++ b/skills/a2-authoring-api/fixtures/example-package.json
@@ -1,0 +1,142 @@
+{
+  "packageFormat": "a2-authoring-package/v1",
+  "locale": "nb",
+  "constraints": {
+    "source": "Eksempel-fixture for a2-authoring-api-skillen (AA-4, #652)",
+    "requirements": "1 kurs, 2 læringsseksjoner, 3 moduler (én per assessment mode), bokmål"
+  },
+  "objects": [
+    {
+      "clientRef": "intro",
+      "type": "section",
+      "payload": {
+        "title": "Introduksjon til personvern",
+        "bodyMarkdown": "## Hvorfor personvern\n\nDenne seksjonen gir oversikt over personvernprinsippene i GDPR artikkel 5 og hvorfor de gjelder alt arbeid med persondata.\n\n- Lovlighet, rettferdighet og åpenhet\n- Formålsbegrensning og dataminimering\n- Riktighet, lagringsbegrensning, integritet og konfidensialitet"
+      }
+    },
+    {
+      "clientRef": "oppsummering",
+      "type": "section",
+      "payload": {
+        "title": "Oppsummering og videre lesning",
+        "bodyMarkdown": "## Oppsummering\n\nDu har nå vært gjennom behandlingsgrunnlag, avviksmelding og personvernprinsippene.\n\nVidere lesning: Datatilsynets veiledere om internkontroll og informasjonssikkerhet."
+      }
+    },
+    {
+      "clientRef": "modul-behandlingsgrunnlag",
+      "type": "module",
+      "payload": {
+        "module": {
+          "title": "Behandlingsgrunnlag i praksis",
+          "description": "Fritekstvurdering: identifisere og begrunne riktig behandlingsgrunnlag.",
+          "certificationLevel": "basic"
+        },
+        "activeVersion": {
+          "assessmentMode": "FREETEXT_ONLY",
+          "taskText": "En kunde ber om å få slettet sine data, men avtalen løper fortsatt i 6 måneder. Beskriv hvilket behandlingsgrunnlag som gjelder for videre lagring, og hvordan du ville svart kunden.",
+          "assessorExpectedContent": "Identifiserer GDPR artikkel 6(1)(b) (avtale) som grunnlag for videre behandling i avtaleperioden, skiller mellom sletteplikt og lagringsplikt, og formulerer et korrekt og forståelig svar til kunden.",
+          "rubric": {
+            "criteria": {
+              "identifisering": "0-4: Identifiserer korrekt behandlingsgrunnlag (art. 6(1)(b)) og avgrenser mot samtykke.",
+              "begrunnelse": "0-4: Begrunner hvorfor sletting ikke kan skje før avtaleforholdet er avsluttet.",
+              "kommunikasjon": "0-4: Svaret til kunden er korrekt, klart og imøtekommende."
+            },
+            "scalingRule": { "practical_weight": 100, "max_total": 12 }
+          },
+          "promptTemplate": {
+            "systemPrompt": "Du er sensor for en personvernmodul. Vurder besvarelsen strengt mot rubrikken, på norsk.",
+            "userPromptTemplate": "Vurder følgende besvarelse mot rubrikken. Gi poeng per kriterium med kort begrunnelse."
+          }
+        }
+      }
+    },
+    {
+      "clientRef": "modul-prinsipper",
+      "type": "module",
+      "payload": {
+        "module": {
+          "title": "Personvernprinsippene",
+          "description": "Flervalgsprøve om GDPR artikkel 5.",
+          "certificationLevel": "basic"
+        },
+        "activeVersion": {
+          "assessmentMode": "MCQ_ONLY",
+          "mcqSet": {
+            "title": "Personvernprinsippene — kontrollspørsmål",
+            "questions": [
+              {
+                "stem": "Hvilket prinsipp krever at du ikke samler inn mer persondata enn nødvendig for formålet?",
+                "options": ["Dataminimering", "Formålsbegrensning", "Lagringsbegrensning", "Riktighet"],
+                "correctAnswer": "Dataminimering",
+                "rationale": "Dataminimering (art. 5(1)(c)) krever at opplysningene er adekvate, relevante og begrenset til det nødvendige."
+              },
+              {
+                "stem": "Data samlet inn for kundeservice brukes til markedsføring uten nytt grunnlag. Hvilket prinsipp brytes?",
+                "options": ["Formålsbegrensning", "Integritet og konfidensialitet", "Dataminimering", "Åpenhet"],
+                "correctAnswer": "Formålsbegrensning",
+                "rationale": "Formålsbegrensning (art. 5(1)(b)) forbyr viderebehandling som er uforenlig med innsamlingsformålet."
+              }
+            ]
+          },
+          "assessmentPolicy": { "passRules": { "mcqMinPercent": 70 } }
+        }
+      }
+    },
+    {
+      "clientRef": "modul-avvik",
+      "type": "module",
+      "payload": {
+        "module": {
+          "title": "Avvikshåndtering",
+          "description": "Kombinert fritekst + flervalg om brudd på personopplysningssikkerheten.",
+          "certificationLevel": "basic"
+        },
+        "activeVersion": {
+          "assessmentMode": "FREETEXT_PLUS_MCQ",
+          "taskText": "Du oppdager at en e-post med persondata er sendt til feil mottaker. Beskriv hva du gjør de første 24 timene.",
+          "assessorExpectedContent": "Varsler personvernombud/leder umiddelbart, dokumenterer hendelsen, vurderer risiko for de registrerte, og kjenner 72-timersfristen for melding til Datatilsynet.",
+          "rubric": {
+            "criteria": {
+              "varsling": "0-4: Varsler riktig rolle umiddelbart og kjenner 72-timersfristen.",
+              "risikovurdering": "0-4: Vurderer konsekvens for de registrerte og behovet for å varsle dem."
+            },
+            "scalingRule": { "practical_weight": 70, "max_total": 8 }
+          },
+          "promptTemplate": {
+            "systemPrompt": "Du er sensor for en avvikshåndteringsmodul. Vurder mot rubrikken, på norsk.",
+            "userPromptTemplate": "Vurder følgende besvarelse mot rubrikken. Gi poeng per kriterium med kort begrunnelse."
+          },
+          "mcqSet": {
+            "title": "Avvikshåndtering — kontrollspørsmål",
+            "questions": [
+              {
+                "stem": "Hva er fristen for å melde et meldepliktig brudd til Datatilsynet?",
+                "options": ["72 timer", "24 timer", "7 dager", "30 dager"],
+                "correctAnswer": "72 timer",
+                "rationale": "GDPR artikkel 33: uten ugrunnet opphold og senest innen 72 timer."
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "clientRef": "kurs-personvern",
+      "type": "course",
+      "payload": {
+        "course": {
+          "title": "Personvern for saksbehandlere",
+          "description": "Grunnkurs i personvern: prinsipper, behandlingsgrunnlag og avvikshåndtering.",
+          "certificationLevel": "basic"
+        },
+        "items": [
+          { "type": "SECTION", "ref": "intro" },
+          { "type": "MODULE", "ref": "modul-prinsipper" },
+          { "type": "MODULE", "ref": "modul-behandlingsgrunnlag" },
+          { "type": "MODULE", "ref": "modul-avvik" },
+          { "type": "SECTION", "ref": "oppsummering" }
+        ]
+      }
+    }
+  ]
+}

--- a/skills/a2-authoring-api/references/api-flow.md
+++ b/skills/a2-authoring-api/references/api-flow.md
@@ -1,0 +1,87 @@
+# API call flow — orchestrating an authoring package
+
+Reference implementation: [scripts/import-package.mjs](../scripts/import-package.mjs)
+(use it directly when you have a shell; follow the same sequence when calling the API
+through another mechanism). Endpoint catalog: `doc/API_REFERENCE.md` (Admin Content).
+
+All calls: `Content-Type: application/json`, auth per SKILL.md (mock headers locally,
+`Authorization: Bearer …` in shared environments). All routes require the `admin_content`
+capability (ADMINISTRATOR or SUBJECT_MATTER_OWNER).
+
+## Sequence
+
+Execute the `plan` from the validate report in order, maintaining a
+`clientRef → serverId` map. **Never call any `.../publish` endpoint.**
+
+### 1. `POST /api/admin/content/agent-authoring/validate`
+
+Body `{ "package": <pkg> }` → `200 { valid, summary, issues, plan }`. Abort (fix package)
+unless `valid: true`.
+
+### 2. `create_section` → `POST /api/admin/content/sections`
+
+```json
+{ "title": <payload.title>, "bodyMarkdown": <payload.bodyMarkdown>, "draft": true, "clientRef": "<ref>" }
+```
+
+`draft: true` is **mandatory** in agent flows (without it the section auto-publishes).
+→ `201 { section: { id, … }, links: { editor }, clientRef }` — store `section.id`.
+
+### 3. `create_module` → `POST /api/admin/content/modules/import`
+
+Wrap the module payload in a synthesized module-scoped `a2-content-export/v1` envelope
+with an **empty audit** (no publish history ⇒ can never auto-publish):
+
+```json
+{
+  "payload": {
+    "exportFormat": "a2-content-export/v1",
+    "exportedAt": "<now ISO>",
+    "scope": "module",
+    "module": { "module": <payload.module>, "activeVersion": { …<payload.activeVersion>, "audit": {} } }
+  },
+  "mode": "createNew",
+  "autoPublish": false,
+  "clientRef": "<ref>"
+}
+```
+
+`autoPublish: false` is **mandatory**. → `201 { moduleId, moduleVersionId, links: { conversation, advanced }, clientRef }`.
+
+### 4. `create_course` → `POST /api/admin/content/courses`
+
+```json
+{ "title": <payload.course.title>, "description": <…if set>, "certificationLevel": <…if set>, "clientRef": "<ref>" }
+```
+
+→ `201 { course: { id, publishedAt: null, … }, links: { course }, clientRef }`.
+
+### 5. `set_course_items` → `PUT /api/admin/content/courses/:courseId/items`
+
+Resolve each item: `ref` → mapped server ID; explicit `moduleId`/`sectionId` pass through.
+
+```json
+{ "items": [ { "type": "SECTION", "sectionId": "…" }, { "type": "MODULE", "moduleId": "…" } ] }
+```
+
+→ `204` (no body).
+
+## Error handling
+
+- Validation failures on create calls: `400 { error: "validation_error", issues: [...] }` —
+  same Zod-issue shape as the validate report; show field paths.
+- Other errors: `{ error: "<code>", message }` (e.g. `module_import_failed`, 403
+  `forbidden`, 404 `import_target_not_found`).
+- **Partial failure**: stop at the failed step; report created IDs + links, the error body,
+  and the remaining steps. Never auto-delete. Retries currently create duplicates
+  (Idempotency-Key is tracked in #726) — on a timeout, check with the user / the library
+  list before re-running a create step.
+
+## Admin links (for the final summary)
+
+| Object | Link |
+|---|---|
+| Module (conversational editor) | `/admin-content/module/:moduleId/conversation` |
+| Module (advanced editor) | `/admin-content/module/:moduleId/advanced` |
+| Course builder | `/admin-content/courses/:courseId` |
+| Section editor | `/admin-content/sections?id=:sectionId` |

--- a/skills/a2-authoring-api/references/package-schema.md
+++ b/skills/a2-authoring-api/references/package-schema.md
@@ -1,0 +1,132 @@
+# `a2-authoring-package/v1` — contract reference
+
+Authoritative Zod schema: `src/modules/adminContent/agentAuthoringSchemas.ts`.
+Design rationale: `doc/design/AGENT_AUTHORING_647.md` §2.
+
+## Top level
+
+```json
+{
+  "packageFormat": "a2-authoring-package/v1",
+  "locale": "nb",
+  "constraints": { "source": "…", "requirements": "…" },
+  "objects": [ { "clientRef": "…", "type": "module|section|course", "payload": { … } } ]
+}
+```
+
+- `packageFormat` — required literal.
+- `locale` — optional, informative only (the primary language you authored in).
+- `constraints` — optional free-form JSON; record the user's requirements verbatim for
+  audit/debug. The server never interprets it. **Never put secrets here.**
+- `objects` — 1+ entries. `clientRef` must match `[a-z0-9-]{1,64}` and be unique in the
+  package.
+- **All objects are strict**: unknown fields are rejected (`unknown_field`). There are no
+  publish/audit fields — do not invent `publishedAt`, `autoPublish`, `audit`, `status`, …
+
+## Localized text
+
+Every `title`/text field accepts either a **plain string** (recommended — applies to all
+locales) or a locale object. Module/course titles use the strict object form
+(`{"en-GB": "…", "nb": "…", "nn": "…"}` — all three required); section `title`/`bodyMarkdown`
+accept a partial object (e.g. only `nb`).
+
+## `type: "section"`
+
+```json
+{
+  "clientRef": "intro",
+  "type": "section",
+  "payload": {
+    "title": "Introduksjon til GDPR",
+    "bodyMarkdown": "## Hva er GDPR\n…markdown only, no assets…"
+  }
+}
+```
+
+## `type: "module"`
+
+`payload.module` = metadata; `payload.activeVersion` = the assessable content. Which
+`activeVersion` fields are required/forbidden depends on `assessmentMode`
+(`required_for_mode` / `forbidden_for_mode` in the validate report):
+
+| Field | FREETEXT_PLUS_MCQ (default) | FREETEXT_ONLY | MCQ_ONLY |
+|---|---|---|---|
+| `taskText` | required | required | forbidden |
+| `rubric` | required | required | forbidden |
+| `promptTemplate` | required | required | forbidden |
+| `mcqSet` | required | forbidden | required |
+| `assessorExpectedContent`, `candidateTaskConstraints`, `submissionSchema`, `assessmentPolicy`, `assessmentBlueprint` | optional | optional | optional (`assessmentPolicy.passRules.mcqMinPercent` recommended) |
+
+FREETEXT_ONLY example:
+
+```json
+{
+  "clientRef": "module-1",
+  "type": "module",
+  "payload": {
+    "module": {
+      "title": "Behandlingsgrunnlag",
+      "description": "Vurdering av behandlingsgrunnlag i praksis",
+      "certificationLevel": "basic"
+    },
+    "activeVersion": {
+      "assessmentMode": "FREETEXT_ONLY",
+      "taskText": "Beskriv hvilket behandlingsgrunnlag som gjelder når …",
+      "assessorExpectedContent": "Kandidaten identifiserer artikkel 6(1)(b) og begrunner …",
+      "rubric": {
+        "criteria": { "identifisering": "0-4: …", "begrunnelse": "0-4: …" },
+        "scalingRule": { "practical_weight": 100, "max_total": 8 }
+      },
+      "promptTemplate": {
+        "systemPrompt": "Du er sensor for …",
+        "userPromptTemplate": "Vurder besvarelsen mot rubrikken …"
+      }
+    }
+  }
+}
+```
+
+MCQ_ONLY: drop the three free-text fields, add
+`"mcqSet": { "title": "…", "questions": [{ "stem": "…", "options": ["…", "…"], "correctAnswer": "…", "rationale": "…" }] }`
+(`correctAnswer` must be one of `options`; 2–6 options; write plausible distractors).
+FREETEXT_PLUS_MCQ: include both the free-text triple and `mcqSet`.
+
+## `type: "course"`
+
+```json
+{
+  "clientRef": "course-main",
+  "type": "course",
+  "payload": {
+    "course": { "title": "GDPR for saksbehandlere", "description": "…", "certificationLevel": "basic" },
+    "items": [
+      { "type": "SECTION", "ref": "intro" },
+      { "type": "MODULE", "ref": "module-1" },
+      { "type": "MODULE", "moduleId": "cmr8…existing" }
+    ]
+  }
+}
+```
+
+- Each item has **exactly one** of `ref` (package object) or `moduleId`/`sectionId`
+  (existing content, checked against the DB). Array order = course order.
+- A course without any MODULE item validates but warns (`course_without_modules`) — it can
+  never be completed/published until a module is added.
+
+## Validate report
+
+`POST /api/admin/content/agent-authoring/validate` → `200`:
+
+```json
+{
+  "valid": false,
+  "summary": { "errors": 1, "warnings": 1, "objects": 3 },
+  "issues": [
+    { "severity": "error", "path": "objects[1].payload.activeVersion.mcqSet", "code": "required_for_mode", "message": "assessmentMode MCQ_ONLY requires mcqSet." }
+  ],
+  "plan": []
+}
+```
+
+`plan` (only when `errors == 0`) is the execution order:
+`create_section`* → `create_module`* → `create_course` → `set_course_items`.

--- a/skills/a2-authoring-api/scripts/import-package.d.mts
+++ b/skills/a2-authoring-api/scripts/import-package.d.mts
@@ -1,0 +1,35 @@
+// Type surface for import-package.mjs (consumed by the TypeScript integration test).
+
+export interface AuthoringCreatedObject {
+  clientRef: string;
+  type: "section" | "module" | "course";
+  id: string;
+  links: Record<string, string>;
+}
+
+export interface AuthoringValidationReport {
+  valid: boolean;
+  summary: { errors: number; warnings: number; objects: number };
+  issues: Array<{ severity: "error" | "warning"; path: string; code: string; message: string }>;
+  plan: Array<{ op: string; clientRef: string }>;
+}
+
+export interface AuthoringImportResult {
+  ok: boolean;
+  report: AuthoringValidationReport;
+  created: AuthoringCreatedObject[];
+  failedStep: { op: string; clientRef: string } | null;
+  error: string | null;
+}
+
+export interface AuthoringCallOptions {
+  baseUrl: string;
+  headers: Record<string, string>;
+  pkg: unknown;
+  fetchImpl?: typeof fetch;
+  log?: (line: string) => void;
+}
+
+export function synthesizeModuleEnvelope(modulePayload: unknown): Record<string, unknown>;
+export function validatePackage(options: AuthoringCallOptions): Promise<AuthoringValidationReport>;
+export function importPackage(options: AuthoringCallOptions): Promise<AuthoringImportResult>;

--- a/skills/a2-authoring-api/scripts/import-package.mjs
+++ b/skills/a2-authoring-api/scripts/import-package.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+// AA-4 (#652): reference implementation of the Agent Authoring orchestration.
+// Validates an a2-authoring-package/v1 against the dry-run endpoint, then executes
+// the returned plan (draft sections → draft module imports → draft course → items).
+// Never calls a publish endpoint; on failure it stops and reports partial progress.
+//
+// Library usage (also consumed by test/agent-authoring-skill-import.test.ts):
+//   import { importPackage, validatePackage } from ".../import-package.mjs";
+// CLI usage:
+//   node skills/a2-authoring-api/scripts/import-package.mjs --file pkg.json \
+//     --base-url http://localhost:3000 [--validate-only]
+// Auth (CLI): A2_AUTH_BEARER=<jwt>  — or mock headers via A2_USER_ID / A2_USER_EMAIL /
+// A2_USER_NAME / A2_USER_ROLES (default SUBJECT_MATTER_OWNER). Tokens stay in env —
+// they are never written to files or echoed in output.
+
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import process from "node:process";
+
+// The module payload is wrapped in a module-scoped a2-content-export/v1 envelope with an
+// EMPTY audit: no source publish history means the import can never auto-publish.
+export function synthesizeModuleEnvelope(modulePayload) {
+  return {
+    exportFormat: "a2-content-export/v1",
+    exportedAt: new Date().toISOString(),
+    scope: "module",
+    module: {
+      module: modulePayload.module,
+      activeVersion: { ...modulePayload.activeVersion, audit: {} },
+    },
+  };
+}
+
+async function requestJson(fetchImpl, method, url, headers, body) {
+  const response = await fetchImpl(url, {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  let json = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    // non-JSON error body — keep raw text for reporting
+  }
+  return { status: response.status, ok: response.ok, json, text };
+}
+
+export async function validatePackage({ baseUrl, headers, pkg, fetchImpl = fetch }) {
+  const result = await requestJson(
+    fetchImpl,
+    "POST",
+    `${baseUrl}/api/admin/content/agent-authoring/validate`,
+    headers,
+    { package: pkg },
+  );
+  if (result.status !== 200) {
+    throw new Error(`validate returned HTTP ${result.status}: ${result.text}`);
+  }
+  return result.json;
+}
+
+// Executes the validate plan. Returns:
+//   { ok, report, created: [{ clientRef, type, id, links }], failedStep, error }
+// Partial failure: `created` holds everything that succeeded before `failedStep`.
+export async function importPackage({ baseUrl, headers, pkg, fetchImpl = fetch, log = () => {} }) {
+  const report = await validatePackage({ baseUrl, headers, pkg, fetchImpl });
+  if (!report.valid) {
+    return { ok: false, report, created: [], failedStep: null, error: "validation_failed" };
+  }
+
+  const objectsByRef = new Map(pkg.objects.map((object) => [object.clientRef, object]));
+  const idsByRef = new Map();
+  const created = [];
+
+  for (const step of report.plan) {
+    const object = objectsByRef.get(step.clientRef);
+    let result;
+
+    if (step.op === "create_section") {
+      result = await requestJson(fetchImpl, "POST", `${baseUrl}/api/admin/content/sections`, headers, {
+        title: object.payload.title,
+        bodyMarkdown: object.payload.bodyMarkdown,
+        draft: true,
+        clientRef: step.clientRef,
+      });
+      if (result.ok) {
+        idsByRef.set(step.clientRef, result.json.section.id);
+        created.push({ clientRef: step.clientRef, type: "section", id: result.json.section.id, links: result.json.links });
+      }
+    } else if (step.op === "create_module") {
+      result = await requestJson(fetchImpl, "POST", `${baseUrl}/api/admin/content/modules/import`, headers, {
+        payload: synthesizeModuleEnvelope(object.payload),
+        mode: "createNew",
+        autoPublish: false,
+        clientRef: step.clientRef,
+      });
+      if (result.ok) {
+        idsByRef.set(step.clientRef, result.json.moduleId);
+        created.push({ clientRef: step.clientRef, type: "module", id: result.json.moduleId, links: result.json.links });
+      }
+    } else if (step.op === "create_course") {
+      const course = object.payload.course;
+      result = await requestJson(fetchImpl, "POST", `${baseUrl}/api/admin/content/courses`, headers, {
+        title: course.title,
+        ...(course.description ? { description: course.description } : {}),
+        ...(course.certificationLevel ? { certificationLevel: course.certificationLevel } : {}),
+        clientRef: step.clientRef,
+      });
+      if (result.ok) {
+        idsByRef.set(step.clientRef, result.json.course.id);
+        created.push({ clientRef: step.clientRef, type: "course", id: result.json.course.id, links: result.json.links });
+      }
+    } else if (step.op === "set_course_items") {
+      const items = object.payload.items.map((item) =>
+        item.type === "MODULE"
+          ? { type: "MODULE", moduleId: item.moduleId ?? idsByRef.get(item.ref) }
+          : { type: "SECTION", sectionId: item.sectionId ?? idsByRef.get(item.ref) },
+      );
+      result = await requestJson(
+        fetchImpl,
+        "PUT",
+        `${baseUrl}/api/admin/content/courses/${idsByRef.get(step.clientRef)}/items`,
+        headers,
+        { items },
+      );
+    } else {
+      return { ok: false, report, created, failedStep: step, error: `Unknown plan op: ${step.op}` };
+    }
+
+    if (!result.ok) {
+      return { ok: false, report, created, failedStep: step, error: `HTTP ${result.status}: ${result.text}` };
+    }
+    log(`${step.op} ${step.clientRef} ✓`);
+  }
+
+  return { ok: true, report, created, failedStep: null, error: null };
+}
+
+function headersFromEnv(env) {
+  if (env.A2_AUTH_BEARER) {
+    return { authorization: `Bearer ${env.A2_AUTH_BEARER}` };
+  }
+  if (!env.A2_USER_ID) {
+    throw new Error("Set A2_AUTH_BEARER (shared envs) or A2_USER_ID/A2_USER_EMAIL/A2_USER_NAME (local mock auth).");
+  }
+  return {
+    "x-user-id": env.A2_USER_ID,
+    "x-user-email": env.A2_USER_EMAIL ?? `${env.A2_USER_ID}@example.local`,
+    "x-user-name": env.A2_USER_NAME ?? env.A2_USER_ID,
+    "x-user-roles": env.A2_USER_ROLES ?? "SUBJECT_MATTER_OWNER",
+  };
+}
+
+function parseArgs(argv) {
+  const args = { file: undefined, baseUrl: undefined, validateOnly: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--file") args.file = argv[++i];
+    else if (argv[i] === "--base-url") args.baseUrl = argv[++i];
+    else if (argv[i] === "--validate-only") args.validateOnly = true;
+    else throw new Error(`Unknown argument: ${argv[i]}`);
+  }
+  if (!args.file || !args.baseUrl) {
+    throw new Error("Usage: import-package.mjs --file <package.json> --base-url <url> [--validate-only]");
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const pkg = JSON.parse(await readFile(args.file, "utf8"));
+  const headers = headersFromEnv(process.env);
+
+  if (args.validateOnly) {
+    const report = await validatePackage({ baseUrl: args.baseUrl, headers, pkg });
+    console.log(JSON.stringify(report, null, 2));
+    process.exitCode = report.valid ? 0 : 1;
+    return;
+  }
+
+  const result = await importPackage({
+    baseUrl: args.baseUrl,
+    headers,
+    pkg,
+    log: (line) => console.log(line),
+  });
+
+  if (!result.ok && result.error === "validation_failed") {
+    console.error("Package is invalid — nothing was created:");
+    for (const issue of result.report.issues) {
+      console.error(`  [${issue.severity}] ${issue.path} (${issue.code}): ${issue.message}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (result.created.length > 0) {
+    console.log("\nCreated drafts (review and publish manually in the admin UI):");
+    for (const entry of result.created) {
+      const link = entry.links?.conversation ?? entry.links?.course ?? entry.links?.editor ?? "";
+      console.log(`  ${entry.type} ${entry.clientRef} → ${entry.id}  ${link}`);
+    }
+  }
+
+  if (!result.ok) {
+    console.error(`\nFAILED at step ${result.failedStep?.op} ${result.failedStep?.clientRef}: ${result.error}`);
+    console.error("Objects listed above WERE created (drafts). Nothing has been deleted; remaining steps were skipped.");
+    process.exitCode = 2;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/test/agent-authoring-skill-import.test.ts
+++ b/test/agent-authoring-skill-import.test.ts
@@ -1,0 +1,147 @@
+// AA-4 (#652): happy-path test for the a2-authoring-api skill's reference
+// implementation. Boots the real app on an ephemeral port and runs the skill's
+// fixture package through skills/a2-authoring-api/scripts/import-package.mjs —
+// i.e. the exact HTTP flow an agent following the skill executes. Verifies the
+// acceptance criteria: all three assessment modes as drafts, a course with mixed
+// section/module order, admin links for every created object, and nothing published.
+
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { readFile } from "node:fs/promises";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+import {
+  importPackage,
+  validatePackage,
+} from "../skills/a2-authoring-api/scripts/import-package.mjs";
+
+const headers = {
+  "x-user-id": "admin-1",
+  "x-user-email": "admin@company.com",
+  "x-user-name": "Platform Admin",
+};
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  server = await new Promise<Server>((resolve) => {
+    const instance = app.listen(0, () => resolve(instance));
+  });
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+  await prisma.$disconnect();
+});
+
+async function loadFixture(suffix: string) {
+  const raw = await readFile("skills/a2-authoring-api/fixtures/example-package.json", "utf8");
+  // Unique titles per run so possible_duplicate_title warnings from earlier runs
+  // don't accumulate and the created rows are identifiable.
+  return JSON.parse(raw.replaceAll('"title": "', `"title": "[${suffix}] `));
+}
+
+describe("#652 a2-authoring-api skill happy path (fixture package → drafts via API)", () => {
+  it("imports the example package end-to-end: drafts, links and mixed course order", async () => {
+    const suffix = `skill-${Date.now()}`;
+    const pkg = await loadFixture(suffix);
+
+    const result = await importPackage({ baseUrl, headers, pkg });
+
+    expect(result.error).toBeNull();
+    expect(result.ok).toBe(true);
+    expect(result.report.valid).toBe(true);
+
+    // 2 sections + 3 modules + 1 course created, in plan order.
+    expect(result.created.map((entry) => `${entry.type}:${entry.clientRef}`)).toEqual([
+      "section:intro",
+      "section:oppsummering",
+      "module:modul-behandlingsgrunnlag",
+      "module:modul-prinsipper",
+      "module:modul-avvik",
+      "course:kurs-personvern",
+    ]);
+
+    // Every created object carries an admin link.
+    for (const entry of result.created) {
+      const link = entry.links.conversation ?? entry.links.course ?? entry.links.editor;
+      expect(link).toContain(entry.id);
+    }
+
+    // All three assessment-mode modules are drafts (never published).
+    const moduleEntries = result.created.filter((entry) => entry.type === "module");
+    expect(moduleEntries).toHaveLength(3);
+    for (const entry of moduleEntries) {
+      const row = await prisma.module.findUniqueOrThrow({
+        where: { id: entry.id },
+        select: { activeVersionId: true },
+      });
+      expect(row.activeVersionId).toBeNull();
+    }
+    const modes = await prisma.moduleVersion.findMany({
+      where: { moduleId: { in: moduleEntries.map((entry) => entry.id) } },
+      select: { assessmentMode: true },
+    });
+    expect(modes.map((version) => version.assessmentMode).sort()).toEqual([
+      "FREETEXT_ONLY",
+      "FREETEXT_PLUS_MCQ",
+      "MCQ_ONLY",
+    ]);
+
+    // Sections are drafts too (draft: true is part of the skill flow).
+    for (const entry of result.created.filter((item) => item.type === "section")) {
+      const row = await prisma.courseSection.findUniqueOrThrow({
+        where: { id: entry.id },
+        select: { activeVersionId: true },
+      });
+      expect(row.activeVersionId).toBeNull();
+    }
+
+    // The course is a draft with the fixture's mixed section/module order.
+    const courseEntry = result.created.find((entry) => entry.type === "course");
+    expect(courseEntry).toBeDefined();
+    const course = await prisma.course.findUniqueOrThrow({
+      where: { id: courseEntry!.id },
+      select: { publishedAt: true, items: { orderBy: { sortOrder: "asc" }, select: { moduleId: true, sectionId: true } } },
+    });
+    expect(course.publishedAt).toBeNull();
+    const byRef = new Map(result.created.map((entry) => [entry.clientRef, entry.id]));
+    expect(course.items.map((item) => item.moduleId ?? item.sectionId)).toEqual([
+      byRef.get("intro"),
+      byRef.get("modul-prinsipper"),
+      byRef.get("modul-behandlingsgrunnlag"),
+      byRef.get("modul-avvik"),
+      byRef.get("oppsummering"),
+    ]);
+  });
+
+  it("stops before any write when the package is invalid", async () => {
+    const suffix = `skill-invalid-${Date.now()}`;
+    const pkg = await loadFixture(suffix);
+    // Break the MCQ_ONLY module: forbidden free-text field.
+    const mcqModule = pkg.objects.find((object: { clientRef: string }) => object.clientRef === "modul-prinsipper");
+    mcqModule.payload.activeVersion.taskText = "Not allowed in MCQ_ONLY";
+
+    const result = await importPackage({ baseUrl, headers, pkg });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("validation_failed");
+    expect(result.created).toEqual([]);
+    expect(result.report.issues).toContainEqual(
+      expect.objectContaining({ code: "forbidden_for_mode" }),
+    );
+    const persisted = await prisma.module.count({ where: { title: { contains: suffix } } });
+    expect(persisted).toBe(0);
+  });
+
+  it("validate-only path returns the report without creating anything", async () => {
+    const suffix = `skill-dry-${Date.now()}`;
+    const report = await validatePackage({ baseUrl, headers, pkg: await loadFixture(suffix) });
+    expect(report.valid).toBe(true);
+    expect(report.plan).toHaveLength(7); // 2 sections + 3 modules + course + set_course_items
+    const persisted = await prisma.course.count({ where: { title: { contains: suffix } } });
+    expect(persisted).toBe(0);
+  });
+});


### PR DESCRIPTION
Del av EPIC #647; implementerer AA-4 (#652) oppå AA-1 (#649) og AA-2 (#650). Ingen app-runtime-endring → ingen versjonsbump (skill + referansescript + test + agent-docs).

## Hva

- **`skills/a2-authoring-api/`** (repo-canonical, source of truth):
  - `SKILL.md` — arbeidsflyten (samle krav → bygg pakke → validate → rett → bekreft ved store pakker → utfør plan → rapporter links → aldri publiser) + harde sikkerhetsregler (aldri publish-endepunkter, tokens kun via env, stopp på validation errors med feltstier, partial failure uten auto-sletting) + auth-tabell (mock lokalt, bearer i delte miljøer, ekstern agent-tilgang venter på AA-3).
  - `references/package-schema.md` — kontrakten med per-mode-krav-tabell og eksempler; `references/api-flow.md` — kallsekvens, eksakte bodies (`draft: true`, `autoPublish: false`, tom `audit`), feilhåndtering og link-tabell.
  - `fixtures/example-package.json` — komplett eksempel: 1 kurs, 2 seksjoner, 3 moduler (én per assessmentMode), blandet rekkefølge, bokmål.
  - `scripts/import-package.mjs` — referanseimplementasjon som både lib (brukes av testen) og CLI (`--file/--base-url/--validate-only`; auth via `A2_AUTH_BEARER` eller mock-env-vars). Aldri publish; exit 1 ved valideringsfeil, exit 2 ved partial failure med opprettede links i output.
- **Installert for begge agentmiljøer**: `.claude/skills/a2-authoring-api/SKILL.md` (tynn peker → Claude Code-oppdagelse) og ny «Agent skills»-seksjon i `AGENTS.md` (Codex/ChatGPT) + `CLAUDE.md`. Kanonisk kopi er source of truth; pekere inneholder ikke innhold som kan divergere.

## Akseptansekriterier (#652)

- [x] Pakke for alle tre assessment modes (fixture + test verifiserer FREETEXT_ONLY, MCQ_ONLY, FREETEXT_PLUS_MCQ)
- [x] Oppretter kurs med blandet seksjon/modul-rekkefølge via API i lokal mock-auth full-stack (testen booter appen på efemer port og kjører skill-scriptet mot ekte HTTP)
- [x] Returnerer admin-URL-er for alle drafts (asserted per objekt)
- [x] Dokumentert i repo + installert for begge agentmiljøer
- [x] Happy-path-test: `test/agent-authoring-skill-import.test.ts` (3 tester: full import, valideringsstopp uten writes, validate-only)

## Test

- `npx tsc --noEmit` — grønn (typet `.d.mts` for scriptet)
- `npm run test:integration:native -- test/agent-authoring-skill-import.test.ts` — 3/3 grønne
- CLI manuelt verifisert: usage-feil (exit 1) og nettverksfeil (exit 1) gir rene meldinger

## Sikkerhet

Scriptet og skillen har ingen publish-kodevei i det hele tatt; draft-garantien er strukturell (`draft: true`, `autoPublish: false`, tom `audit`). Tokens leses kun fra env og skrives aldri til filer/output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
