### PR TITLE
feat(admin-content): #653 AA-5 audit-spor + partial-failure for agent authoring (v1.6.12)

### DIFF
--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -216,6 +216,15 @@ Agent imports must pass `autoPublish: false` (and the authoring contract has no 
 source-publish auto-publication can never trigger). Retry-safe `Idempotency-Key` support is
 tracked separately in #726.
 
+**Audit trace (AA-5, #653):** the same calls (plus `PUT .../courses/:courseId/items`) accept
+an optional `agentRunId` (`[a-zA-Z0-9._-]{1,64}`, one ID per orchestration run). When
+`clientRef`/`agentRunId` is present, the write's audit event gets
+`source: "agent_authoring"` + `clientRef` + `agentRunId` in its metadata — query audit
+events by `agentRunId` to reconstruct exactly what a run created (partial or complete).
+Section/course creation and course-items updates are now always audited
+(`section_created` with a `draft` flag, `course_created`, `course_items_updated`) for both
+human and agent writes; the agent marker is only added for agent-orchestrated calls.
+
 ---
 
 ## Admin - Courses & Learning Sections

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,25 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.12 - 2026-07-06
+
+feat(admin-content): #653 AA-5 — audit-spor og partial-failure-rapportering for agent authoring
+
+- **`agentRunId`** (valgfri, `[a-zA-Z0-9._-]{1,64}`) på `POST /sections`, `POST /modules/import`,
+  `POST /courses` og `PUT /courses/:id/items`: én ID per orkestreringskjøring, stemples i
+  audit-metadata sammen med `source: "agent_authoring"` + `clientRef` — spør audit på
+  `agentRunId` for å rekonstruere nøyaktig hva en kjøring opprettet (også ved delvis feil).
+  Ingen server-side run-ledger (designbeslutning: audit-events + skillens klientlogg holder).
+- **Nye audit-hendelser**: `section_created` (med `draft`-flagg) og `course_items_updated` —
+  seksjonsoppretting og item-sekvens var uauditerte writes; nå logges de for både mennesker
+  og agenter (agent-markøren settes kun ved clientRef/agentRunId).
+- **Skill-scriptet** genererer runId automatisk, sender den på alle writes, og returnerer
+  standard partial-failure-rapport: `steps[]` med done/failed/skipped per plan-steg + `runId`.
+- Fix: fjernet shebang fra `import-package.mjs` — `#!` + CRLF (git-checkout på Windows) brakk
+  vite-nodes transform når tester importerer scriptet (CI på Linux/LF var upåvirket).
+- Tester: 3 nye integrasjonstester (audit-spor for vellykket kjøring, mid-flow-feil med
+  bevarte ID-er/links/steps, og at manuelle creates auditeres uten agent-markør).
+
 ## 1.6.11 - 2026-07-05
 
 feat(admin-content): #650 AA-2 — agentvennlige create/import-responser + draft-seksjoner

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/skills/a2-authoring-api/SKILL.md
+++ b/skills/a2-authoring-api/SKILL.md
@@ -52,11 +52,14 @@ point them to the admin UI links instead.
    environment, prefer the reference script (it implements the whole flow):
    `node skills/a2-authoring-api/scripts/import-package.mjs --file pkg.json --base-url <url>`.
 7. **Report the result**: one line per created object with its admin link
-   (`links.conversation`/`links.course`/`links.editor`), plus an explicit closing note:
+   (`links.conversation`/`links.course`/`links.editor`), the run's `agentRunId` (audit
+   trace), plus an explicit closing note:
    *"Alt er opprettet som utkast — gjennomgå og publiser manuelt i admin-UI."*
-8. **On partial failure**: stop at the failed step. Report what WAS created (IDs + links),
-   what failed (the API error body), and what remains. Do NOT delete anything — drafts are
-   harmless and may contain work worth keeping; cleanup is the human's decision.
+8. **On partial failure**: stop at the failed step. Report per plan step what happened
+   (done / failed / skipped), what WAS created (IDs + links), the API error body, and the
+   `agentRunId` (every completed write is audit-logged with it, so the run is
+   reconstructable). Do NOT delete anything — drafts are harmless and may contain work
+   worth keeping; cleanup is the human's decision.
 
 ## Security rules (hard)
 

--- a/skills/a2-authoring-api/references/api-flow.md
+++ b/skills/a2-authoring-api/references/api-flow.md
@@ -66,16 +66,29 @@ Resolve each item: `ref` → mapped server ID; explicit `moduleId`/`sectionId` p
 
 → `204` (no body).
 
+## Audit trace (agentRunId)
+
+Generate ONE `agentRunId` per orchestration run (pattern `[a-zA-Z0-9._-]{1,64}`, e.g.
+`aar-<timestamp>-<random>`; the reference script does this automatically) and send it in
+the body of every write (`POST /sections`, `POST /modules/import`, `POST /courses`,
+`PUT .../items`). Every write is then audit-logged with
+`source: "agent_authoring" + clientRef + agentRunId` — so a human can reconstruct exactly
+what a run created, even after a partial failure. Always include the `agentRunId` in your
+final summary to the user.
+
 ## Error handling
 
 - Validation failures on create calls: `400 { error: "validation_error", issues: [...] }` —
   same Zod-issue shape as the validate report; show field paths.
 - Other errors: `{ error: "<code>", message }` (e.g. `module_import_failed`, 403
   `forbidden`, 404 `import_target_not_found`).
-- **Partial failure**: stop at the failed step; report created IDs + links, the error body,
-  and the remaining steps. Never auto-delete. Retries currently create duplicates
-  (Idempotency-Key is tracked in #726) — on a timeout, check with the user / the library
-  list before re-running a create step.
+- **Partial failure**: stop at the failed step; report per step what happened
+  (done / failed / skipped — the reference script returns this as `steps[]`), the created
+  IDs + links, the error body, and the `agentRunId`. Never auto-delete — cleanup (archive +
+  delete in the admin UI) or completion is the human's decision; a retry of the remaining
+  steps can reuse the `clientRef → id` map you already have. Retries of CREATE steps
+  currently create duplicates (Idempotency-Key is tracked in #726) — on a timeout, check
+  with the user / the library list before re-running a create step.
 
 ## Admin links (for the final summary)
 

--- a/skills/a2-authoring-api/scripts/import-package.d.mts
+++ b/skills/a2-authoring-api/scripts/import-package.d.mts
@@ -14,10 +14,20 @@ export interface AuthoringValidationReport {
   plan: Array<{ op: string; clientRef: string }>;
 }
 
+export interface AuthoringStepStatus {
+  op: string;
+  clientRef: string;
+  status: "done" | "failed" | "skipped";
+  id?: string;
+  links?: Record<string, string>;
+}
+
 export interface AuthoringImportResult {
   ok: boolean;
+  runId: string;
   report: AuthoringValidationReport;
   created: AuthoringCreatedObject[];
+  steps: AuthoringStepStatus[];
   failedStep: { op: string; clientRef: string } | null;
   error: string | null;
 }
@@ -26,6 +36,7 @@ export interface AuthoringCallOptions {
   baseUrl: string;
   headers: Record<string, string>;
   pkg: unknown;
+  runId?: string;
   fetchImpl?: typeof fetch;
   log?: (line: string) => void;
 }

--- a/skills/a2-authoring-api/scripts/import-package.mjs
+++ b/skills/a2-authoring-api/scripts/import-package.mjs
@@ -1,7 +1,8 @@
-#!/usr/bin/env node
 // AA-4 (#652): reference implementation of the Agent Authoring orchestration.
+// (No shebang: vite-node evaluates this file when tests import it, and a shebang
+// line breaks its transform. Run it via `node <path>` instead of `./<path>`.)
 // Validates an a2-authoring-package/v1 against the dry-run endpoint, then executes
-// the returned plan (draft sections → draft module imports → draft course → items).
+// the returned plan (draft sections -> draft module imports -> draft course -> items).
 // Never calls a publish endpoint; on failure it stops and reports partial progress.
 //
 // Library usage (also consumed by test/agent-authoring-skill-import.test.ts):
@@ -62,19 +63,26 @@ export async function validatePackage({ baseUrl, headers, pkg, fetchImpl = fetch
 }
 
 // Executes the validate plan. Returns:
-//   { ok, report, created: [{ clientRef, type, id, links }], failedStep, error }
-// Partial failure: `created` holds everything that succeeded before `failedStep`.
-export async function importPackage({ baseUrl, headers, pkg, fetchImpl = fetch, log = () => {} }) {
+//   { ok, runId, report, created: [{ clientRef, type, id, links }],
+//     steps: [{ op, clientRef, status: "done"|"failed"|"skipped", id?, links? }],
+//     failedStep, error }
+// Partial failure: `created` holds everything that succeeded before `failedStep`;
+// `steps` is the standard per-operation status the skill shows the user (AA-5 #653).
+// Every write carries `agentRunId` (audit trace: source agent_authoring + runId).
+export async function importPackage({ baseUrl, headers, pkg, runId, fetchImpl = fetch, log = () => {} }) {
+  const agentRunId = runId ?? `aar-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
   const report = await validatePackage({ baseUrl, headers, pkg, fetchImpl });
   if (!report.valid) {
-    return { ok: false, report, created: [], failedStep: null, error: "validation_failed" };
+    return { ok: false, runId: agentRunId, report, created: [], steps: [], failedStep: null, error: "validation_failed" };
   }
 
   const objectsByRef = new Map(pkg.objects.map((object) => [object.clientRef, object]));
   const idsByRef = new Map();
   const created = [];
+  const steps = report.plan.map((step) => ({ ...step, status: "skipped" }));
 
-  for (const step of report.plan) {
+  for (const stepStatus of steps) {
+    const step = { op: stepStatus.op, clientRef: stepStatus.clientRef };
     const object = objectsByRef.get(step.clientRef);
     let result;
 
@@ -84,6 +92,7 @@ export async function importPackage({ baseUrl, headers, pkg, fetchImpl = fetch, 
         bodyMarkdown: object.payload.bodyMarkdown,
         draft: true,
         clientRef: step.clientRef,
+        agentRunId,
       });
       if (result.ok) {
         idsByRef.set(step.clientRef, result.json.section.id);
@@ -95,6 +104,7 @@ export async function importPackage({ baseUrl, headers, pkg, fetchImpl = fetch, 
         mode: "createNew",
         autoPublish: false,
         clientRef: step.clientRef,
+        agentRunId,
       });
       if (result.ok) {
         idsByRef.set(step.clientRef, result.json.moduleId);
@@ -107,6 +117,7 @@ export async function importPackage({ baseUrl, headers, pkg, fetchImpl = fetch, 
         ...(course.description ? { description: course.description } : {}),
         ...(course.certificationLevel ? { certificationLevel: course.certificationLevel } : {}),
         clientRef: step.clientRef,
+        agentRunId,
       });
       if (result.ok) {
         idsByRef.set(step.clientRef, result.json.course.id);
@@ -123,19 +134,27 @@ export async function importPackage({ baseUrl, headers, pkg, fetchImpl = fetch, 
         "PUT",
         `${baseUrl}/api/admin/content/courses/${idsByRef.get(step.clientRef)}/items`,
         headers,
-        { items },
+        { items, agentRunId },
       );
     } else {
-      return { ok: false, report, created, failedStep: step, error: `Unknown plan op: ${step.op}` };
+      stepStatus.status = "failed";
+      return { ok: false, runId: agentRunId, report, created, steps, failedStep: step, error: `Unknown plan op: ${step.op}` };
     }
 
     if (!result.ok) {
-      return { ok: false, report, created, failedStep: step, error: `HTTP ${result.status}: ${result.text}` };
+      stepStatus.status = "failed";
+      return { ok: false, runId: agentRunId, report, created, steps, failedStep: step, error: `HTTP ${result.status}: ${result.text}` };
     }
-    log(`${step.op} ${step.clientRef} ✓`);
+    stepStatus.status = "done";
+    const createdEntry = created.find((entry) => entry.clientRef === step.clientRef && step.op !== "set_course_items");
+    if (createdEntry) {
+      stepStatus.id = createdEntry.id;
+      stepStatus.links = createdEntry.links;
+    }
+    log(`${step.op} ${step.clientRef} ok`);
   }
 
-  return { ok: true, report, created, failedStep: null, error: null };
+  return { ok: true, runId: agentRunId, report, created, steps, failedStep: null, error: null };
 }
 
 function headersFromEnv(env) {
@@ -195,6 +214,7 @@ async function main() {
     return;
   }
 
+  console.log(`agentRunId: ${result.runId} (audit trace — all writes of this run carry it)`);
   if (result.created.length > 0) {
     console.log("\nCreated drafts (review and publish manually in the admin UI):");
     for (const entry of result.created) {

--- a/src/modules/adminContent/adminContentSchemas.ts
+++ b/src/modules/adminContent/adminContentSchemas.ts
@@ -38,6 +38,12 @@ export const clientRefSchema = z
   .string()
   .regex(/^[a-z0-9-]{1,64}$/, "clientRef must match [a-z0-9-]{1,64}.");
 
+// AA-5 (#653): one orchestration run's trace ID — stamped into the audit metadata
+// of every write the run performs, so partial success is reconstructable.
+export const agentRunIdSchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9._-]{1,64}$/, "agentRunId must match [a-zA-Z0-9._-]{1,64}.");
+
 export const moduleCreateBodySchema = z.object({
   title: localizedTextSchema,
   description: localizedTextSchema.optional(),
@@ -407,6 +413,8 @@ export const importBodySchema = z.object({
   autoPublish: z.boolean().optional(),
   // AA-2 (#650): echoed back in the response for agent plan→ID mapping; never persisted.
   clientRef: clientRefSchema.optional(),
+  // AA-5 (#653): stamped into the import's audit event (source: agent_authoring).
+  agentRunId: agentRunIdSchema.optional(),
 }).refine(
   (body) => body.mode !== "replaceExisting" || !!body.targetId,
   { message: "targetId is required when mode is replaceExisting", path: ["targetId"] },

--- a/src/modules/adminContent/contentImportService.ts
+++ b/src/modules/adminContent/contentImportService.ts
@@ -27,7 +27,12 @@ import { createCourse, setCourseModules, setCourseItems, publishCourse, type Cou
 import { createSection } from "../course/sectionCommands.js";
 import { localizedTextCodec, type LocalizedText } from "../../codecs/localizedTextCodec.js";
 import { recordAuditEvent } from "../../services/auditService.js";
-import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
+import {
+  auditActions,
+  auditEntityTypes,
+  agentAuthoringAuditMetadata,
+  type AgentAuthoringContext,
+} from "../../observability/auditEvents.js";
 import type {
   ExportEnvelope,
   ModuleExportPayload,
@@ -160,6 +165,8 @@ export async function importModuleFromEnvelope(
     mode: ImportMode;
     targetModuleId?: string;
     autoPublish?: boolean;
+    // AA-5 (#653): agent-orchestrated imports carry a trace in the audit metadata.
+    agent?: AgentAuthoringContext;
   },
 ): Promise<{ moduleId: string; moduleVersionId: string }> {
   if (envelope.scope !== "module" || !envelope.module) {
@@ -179,6 +186,7 @@ export async function importModuleFromEnvelope(
       sourcePublishedAt: envelope.module.activeVersion.audit.publishedAt ?? null,
       sourcePublishedBy: envelope.module.activeVersion.audit.publishedBy ?? null,
       sourceVersionNo: envelope.module.activeVersion.audit.sourceVersionNo ?? null,
+      ...agentAuthoringAuditMetadata(options.agent),
     },
   });
 

--- a/src/modules/course/courseCommands.ts
+++ b/src/modules/course/courseCommands.ts
@@ -2,7 +2,7 @@ import { prisma } from "../../db/prisma.js";
 import { runInTransaction } from "../../db/transaction.js";
 import { NotFoundError, ValidationError } from "../../errors/AppError.js";
 import { recordAuditEvent } from "../../services/auditService.js";
-import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
+import { auditActions, auditEntityTypes, agentAuthoringAuditMetadata, type AgentAuthoringContext } from "../../observability/auditEvents.js";
 import { assertCourseHasNoInProgressParticipants } from "./contentLifecycle.js";
 
 export async function createCourse(input: {
@@ -12,6 +12,8 @@ export async function createCourse(input: {
   enrollmentPolicy?: "OPEN" | "RESTRICTED";
   discussionsEnabled?: boolean;
   actorId?: string;
+  // AA-5 (#653): agent-orchestrated creates carry a trace in the audit metadata.
+  agent?: AgentAuthoringContext;
 }) {
   const course = await prisma.course.create({
     data: {
@@ -28,7 +30,7 @@ export async function createCourse(input: {
     entityId: course.id,
     action: auditActions.course.created,
     actorId: input.actorId,
-    metadata: { courseId: course.id },
+    metadata: { courseId: course.id, ...agentAuthoringAuditMetadata(input.agent) },
   });
 
   return course;
@@ -176,7 +178,12 @@ export type CourseItemInput =
 // sections interleaved (#486/B2). sortOrder follows array position. During the
 // expand-contract transition this also re-syncs CourseModule from the MODULE
 // items so the not-yet-cut-over read paths stay correct.
-export async function setCourseItems(courseId: string, items: CourseItemInput[]) {
+export async function setCourseItems(
+  courseId: string,
+  items: CourseItemInput[],
+  // AA-5 (#653): audited write; agent runs stamp source/agentRunId into the metadata.
+  options?: { actorId?: string; agent?: AgentAuthoringContext },
+) {
   const course = await prisma.course.findUnique({ where: { id: courseId }, select: { id: true } });
   if (!course) throw new NotFoundError("Course", "course_not_found", "Course not found.");
 
@@ -198,7 +205,7 @@ export async function setCourseItems(courseId: string, items: CourseItemInput[])
   }
 
   // #502: CourseItem er eneste sannhetskilde — ingen dual-write til CourseModule lenger.
-  return runInTransaction(async (tx) => {
+  const result = await runInTransaction(async (tx) => {
     await tx.courseItem.deleteMany({ where: { courseId } });
     if (items.length > 0) {
       await tx.courseItem.createMany({
@@ -216,6 +223,14 @@ export async function setCourseItems(courseId: string, items: CourseItemInput[])
     }
     await tx.course.update({ where: { id: courseId }, data: { updatedAt: new Date() } });
   });
+  await recordAuditEvent({
+    entityType: auditEntityTypes.course,
+    entityId: courseId,
+    action: auditActions.course.itemsUpdated,
+    actorId: options?.actorId,
+    metadata: { courseId, itemCount: items.length, ...agentAuthoringAuditMetadata(options?.agent) },
+  });
+  return result;
 }
 
 // Legacy modules-only setter (import + admin PUT /modules). #502: skriver nå CourseItem MODULE-

--- a/src/modules/course/sectionCommands.ts
+++ b/src/modules/course/sectionCommands.ts
@@ -2,7 +2,7 @@ import { prisma } from "../../db/prisma.js";
 import { runInTransaction } from "../../db/transaction.js";
 import { NotFoundError, ValidationError } from "../../errors/AppError.js";
 import { recordAuditEvent } from "../../services/auditService.js";
-import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
+import { auditActions, auditEntityTypes, agentAuthoringAuditMetadata, type AgentAuthoringContext } from "../../observability/auditEvents.js";
 import { assertSectionNotInAnyCourse } from "./contentLifecycle.js";
 
 // Section CRUD + versioning (#485/B1) for course learning sections (#476).
@@ -14,8 +14,16 @@ import { assertSectionNotInAnyCourse } from "./contentLifecycle.js";
 // AA-2 (#650): `draft: true` keeps the section in Utkast (activeVersionId stays
 // null) — same state a restored section lands in (I3). Content lives in version 1;
 // publishSection re-points to it. Default (false) preserves auto-publish-on-save.
-export async function createSection(input: { title: string; bodyMarkdown: string; actorId?: string; draft?: boolean }) {
-  return runInTransaction(async (tx) => {
+// AA-5 (#653): creation is audited; agent-orchestrated creates carry
+// source/clientRef/agentRunId in the metadata.
+export async function createSection(input: {
+  title: string;
+  bodyMarkdown: string;
+  actorId?: string;
+  draft?: boolean;
+  agent?: AgentAuthoringContext;
+}) {
+  const created = await runInTransaction(async (tx) => {
     const section = await tx.courseSection.create({ data: { title: input.title } });
     const version = await tx.courseSectionVersion.create({
       data: {
@@ -38,6 +46,18 @@ export async function createSection(input: { title: string; bodyMarkdown: string
       include: { activeVersion: true },
     });
   });
+  await recordAuditEvent({
+    entityType: auditEntityTypes.courseSection,
+    entityId: created.id,
+    action: auditActions.section.created,
+    actorId: input.actorId,
+    metadata: {
+      sectionId: created.id,
+      draft: Boolean(input.draft),
+      ...agentAuthoringAuditMetadata(input.agent),
+    },
+  });
+  return created;
 }
 
 export async function updateSectionTitle(sectionId: string, title: string) {

--- a/src/observability/auditEvents.ts
+++ b/src/observability/auditEvents.ts
@@ -69,6 +69,8 @@ export const auditActions = {
   },
   course: {
     created: "course_created",
+    // AA-5 (#653): item-sekvensen er en write i agent-orkestreringen og må være sporbar.
+    itemsUpdated: "course_items_updated",
     published: "course_published",
     unpublished: "course_unpublished",
     archived: "course_archived",
@@ -76,6 +78,7 @@ export const auditActions = {
     completionIssued: "course_completion_issued",
   },
   section: {
+    created: "section_created",
     published: "section_published",
     unpublished: "section_unpublished",
     archived: "section_archived",
@@ -284,10 +287,12 @@ export type AuditMetadataByAction = {
     channel: string;
   }>;
   [auditActions.course.created]: EventMetadata<{ courseId: string }>;
+  [auditActions.course.itemsUpdated]: EventMetadata<{ courseId: string; itemCount: number }>;
   [auditActions.course.published]: EventMetadata<{ courseId: string }>;
   [auditActions.course.unpublished]: EventMetadata<{ courseId: string }>;
   [auditActions.course.archived]: EventMetadata<{ courseId: string }>;
   [auditActions.course.restored]: EventMetadata<{ courseId: string }>;
+  [auditActions.section.created]: EventMetadata<{ sectionId: string; draft: boolean }>;
   [auditActions.section.published]: EventMetadata<{ sectionId: string }>;
   [auditActions.section.unpublished]: EventMetadata<{ sectionId: string }>;
   [auditActions.section.archived]: EventMetadata<{ sectionId: string }>;
@@ -391,3 +396,17 @@ export type AuditEventInput<TAction extends AuditAction = AuditAction> = {
   actorId?: string;
   metadata?: AuditMetadataByAction[TAction];
 };
+
+// AA-5 (#653): agent-orchestrated writes carry a trace (source + clientRef +
+// agentRunId) in the audit metadata so partial success is reconstructable —
+// query audit events by agentRunId to see exactly what a run created.
+export type AgentAuthoringContext = { clientRef?: string; agentRunId?: string };
+
+export function agentAuthoringAuditMetadata(agent?: AgentAuthoringContext) {
+  if (!agent || (!agent.clientRef && !agent.agentRunId)) return {};
+  return {
+    source: "agent_authoring" as const,
+    ...(agent.clientRef ? { clientRef: agent.clientRef } : {}),
+    ...(agent.agentRunId ? { agentRunId: agent.agentRunId } : {}),
+  };
+}

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -373,6 +373,7 @@ adminContentRouter.post("/modules/import", async (request, response) => {
       mode: data.mode ?? "createNew",
       targetModuleId: data.targetId,
       autoPublish: data.autoPublish,
+      agent: { clientRef: data.clientRef, agentRunId: data.agentRunId },
     });
     // AA-2 (#650): links + clientRef echo make the response agent-orchestrable.
     response.status(201).json({

--- a/src/routes/adminCourses.ts
+++ b/src/routes/adminCourses.ts
@@ -15,7 +15,7 @@ import {
   revokeEnrollment,
   listCourseEnrollments,
 } from "../modules/course/index.js";
-import { generationLocaleSchema, importBodySchema, localizedTextPatchSchema, parseRequest, clientRefSchema } from "../modules/adminContent/adminContentSchemas.js";
+import { generationLocaleSchema, importBodySchema, localizedTextPatchSchema, parseRequest, clientRefSchema, agentRunIdSchema } from "../modules/adminContent/adminContentSchemas.js";
 import { courseAdminLinks } from "../modules/adminContent/adminUiLinks.js";
 import { buildCourseExportEnvelope } from "../modules/adminContent/index.js";
 import { importCourseFromEnvelope } from "../modules/adminContent/contentImportService.js";
@@ -54,6 +54,8 @@ const setCourseItemsBodySchema = z.object({
       z.object({ type: z.literal("SECTION"), sectionId: z.string().min(1), discussionsEnabled: z.boolean().optional() }),
     ]),
   ),
+  // AA-5 (#653): stamped into the items-update's audit event (source: agent_authoring).
+  agentRunId: agentRunIdSchema.optional(),
 });
 
 const courseLocalizationBodySchema = z.object({
@@ -67,7 +69,11 @@ const courseLocalizationBodySchema = z.object({
 
 // AA-2 (#650): create accepts an optional clientRef (echoed back, never persisted)
 // and returns admin links so agent orchestration can hand humans review URLs.
-const courseCreateBodySchema = courseBodySchema.extend({ clientRef: clientRefSchema.optional() });
+// AA-5 (#653): agentRunId is stamped into the create's audit event.
+const courseCreateBodySchema = courseBodySchema.extend({
+  clientRef: clientRefSchema.optional(),
+  agentRunId: agentRunIdSchema.optional(),
+});
 
 adminCoursesRouter.post("/", async (request, response, next) => {
   const parsed = courseCreateBodySchema.safeParse(request.body);
@@ -84,6 +90,7 @@ adminCoursesRouter.post("/", async (request, response, next) => {
       enrollmentPolicy: parsed.data.enrollmentPolicy,
       discussionsEnabled: parsed.data.discussionsEnabled,
       actorId: request.context?.userId,
+      agent: { clientRef: parsed.data.clientRef, agentRunId: parsed.data.agentRunId },
     });
     response.status(201).json({
       course,
@@ -318,7 +325,10 @@ adminCoursesRouter.put("/:courseId/items", async (request, response, next) => {
     return;
   }
   try {
-    await setCourseItems(request.params.courseId, parsed.data.items);
+    await setCourseItems(request.params.courseId, parsed.data.items, {
+      actorId: request.context?.userId,
+      agent: { agentRunId: parsed.data.agentRunId },
+    });
     response.status(204).send();
   } catch (error) {
     next(error);

--- a/src/routes/adminSections.ts
+++ b/src/routes/adminSections.ts
@@ -18,7 +18,7 @@ import {
   MAX_ASSET_BYTES,
 } from "../modules/course/index.js";
 import { findCoursesForSections } from "../modules/course/contentLifecycle.js";
-import { localizedTextPatchSchema, generationLocaleSchema, clientRefSchema } from "../modules/adminContent/adminContentSchemas.js";
+import { localizedTextPatchSchema, generationLocaleSchema, clientRefSchema, agentRunIdSchema } from "../modules/adminContent/adminContentSchemas.js";
 import { sectionAdminLinks } from "../modules/adminContent/adminUiLinks.js";
 import { localizedTextCodec } from "../codecs/localizedTextCodec.js";
 import { NotFoundError } from "../errors/AppError.js";
@@ -50,6 +50,8 @@ const createSectionSchema = z.object({
   // and get their plan-ref echoed back. Default keeps auto-publish-on-save.
   draft: z.boolean().optional(),
   clientRef: clientRefSchema.optional(),
+  // AA-5 (#653): stamped into the create's audit event (source: agent_authoring).
+  agentRunId: agentRunIdSchema.optional(),
 });
 const titleSchema = z.object({ title: localizedTextPatchSchema });
 const contentSchema = z.object({ bodyMarkdown: localizedTextPatchSchema });
@@ -94,6 +96,7 @@ adminSectionsRouter.post("/", async (request, response, next) => {
       bodyMarkdown: localizedTextCodec.serialize(parsed.data.bodyMarkdown),
       actorId: request.context?.userId,
       draft: parsed.data.draft,
+      agent: { clientRef: parsed.data.clientRef, agentRunId: parsed.data.agentRunId },
     });
     response.status(201).json({
       section: toDetail(section),

--- a/test/agent-authoring-audit.test.ts
+++ b/test/agent-authoring-audit.test.ts
@@ -1,0 +1,174 @@
+// Integration tests for AA-5 (#653): audit/observability and partial-failure
+// handling for agent authoring. Boots the app on an ephemeral port and drives the
+// skill's reference implementation, then verifies (a) every agent write is audit-
+// logged with source: agent_authoring + clientRef + agentRunId, (b) a mid-flow
+// failure still reports everything created before the failure with IDs/links, and
+// (c) non-agent creates are audited WITHOUT the agent marker.
+
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import request from "supertest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+import { importPackage } from "../skills/a2-authoring-api/scripts/import-package.mjs";
+
+const headers = {
+  "x-user-id": "admin-1",
+  "x-user-email": "admin@company.com",
+  "x-user-name": "Platform Admin",
+};
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  server = await new Promise<Server>((resolve) => {
+    const instance = app.listen(0, () => resolve(instance));
+  });
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+  await prisma.$disconnect();
+});
+
+function smallPackage(suffix: string) {
+  return {
+    packageFormat: "a2-authoring-package/v1",
+    objects: [
+      {
+        clientRef: "intro",
+        type: "section",
+        payload: { title: `AA5 section ${suffix}`, bodyMarkdown: "## Audit" },
+      },
+      {
+        clientRef: "module-1",
+        type: "module",
+        payload: {
+          module: { title: `AA5 module ${suffix}` },
+          activeVersion: {
+            assessmentMode: "MCQ_ONLY",
+            mcqSet: { title: "Q", questions: [{ stem: "1+1?", options: ["2", "3"], correctAnswer: "2" }] },
+          },
+        },
+      },
+      {
+        clientRef: "course-main",
+        type: "course",
+        payload: {
+          course: { title: `AA5 course ${suffix}` },
+          items: [
+            { type: "SECTION", ref: "intro" },
+            { type: "MODULE", ref: "module-1" },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+async function auditEventsForRun(runId: string) {
+  const events = await prisma.auditEvent.findMany({
+    where: { metadataJson: { contains: runId } },
+    select: { action: true, metadataJson: true },
+  });
+  return events.map((event) => ({
+    action: event.action,
+    metadata: JSON.parse(event.metadataJson) as Record<string, unknown>,
+  }));
+}
+
+describe("#653 agent authoring audit & partial failure", () => {
+  it("audit-logs every write of a successful run with source, clientRef and agentRunId", async () => {
+    const suffix = `aa5-ok-${Date.now()}`;
+    const runId = `aar-test-${Date.now()}`;
+
+    const result = await importPackage({ baseUrl, headers, pkg: smallPackage(suffix), runId });
+    expect(result.ok).toBe(true);
+    expect(result.runId).toBe(runId);
+    expect(result.steps.map((step) => step.status)).toEqual(["done", "done", "done", "done"]);
+
+    const events = await auditEventsForRun(runId);
+    expect(events.map((event) => event.action).sort()).toEqual([
+      "course_created",
+      "course_items_updated",
+      "module_imported",
+      "section_created",
+    ]);
+    for (const event of events) {
+      expect(event.metadata.source).toBe("agent_authoring");
+      expect(event.metadata.agentRunId).toBe(runId);
+    }
+    const sectionEvent = events.find((event) => event.action === "section_created");
+    expect(sectionEvent?.metadata).toMatchObject({ clientRef: "intro", draft: true });
+    const itemsEvent = events.find((event) => event.action === "course_items_updated");
+    expect(itemsEvent?.metadata).toMatchObject({ itemCount: 2 });
+  });
+
+  it("reports partial success with created IDs/links when a later step fails mid-flow", async () => {
+    const suffix = `aa5-partial-${Date.now()}`;
+    const runId = `aar-partial-${Date.now()}`;
+
+    // Force the course create to fail — the section and module are already created.
+    const failingFetch: typeof fetch = async (url, init) => {
+      if (String(url).endsWith("/api/admin/content/courses") && init?.method === "POST") {
+        return new Response(JSON.stringify({ error: "simulated_outage" }), { status: 503 });
+      }
+      return fetch(url, init);
+    };
+
+    const result = await importPackage({
+      baseUrl,
+      headers,
+      pkg: smallPackage(suffix),
+      runId,
+      fetchImpl: failingFetch,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failedStep).toEqual({ op: "create_course", clientRef: "course-main" });
+    expect(result.error).toContain("503");
+
+    // Earlier objects are NOT hidden by the failure: both are reported with id + link.
+    expect(result.created.map((entry) => `${entry.type}:${entry.clientRef}`)).toEqual([
+      "section:intro",
+      "module:module-1",
+    ]);
+    for (const entry of result.created) {
+      expect(entry.id).toBeTruthy();
+      expect(Object.values(entry.links).join(" ")).toContain(entry.id);
+    }
+    expect(result.steps).toEqual([
+      expect.objectContaining({ op: "create_section", status: "done" }),
+      expect.objectContaining({ op: "create_module", status: "done" }),
+      expect.objectContaining({ op: "create_course", status: "failed" }),
+      expect.objectContaining({ op: "set_course_items", status: "skipped" }),
+    ]);
+
+    // The successful writes are audit-traceable even though the run failed —
+    // and nothing was deleted (drafts still exist).
+    const events = await auditEventsForRun(runId);
+    expect(events.map((event) => event.action).sort()).toEqual(["module_imported", "section_created"]);
+    const sectionId = result.created.find((entry) => entry.type === "section")!.id;
+    expect(await prisma.courseSection.count({ where: { id: sectionId } })).toBe(1);
+  });
+
+  it("audits non-agent creates without the agent_authoring marker", async () => {
+    const title = `AA5 manual section ${Date.now()}`;
+    const response = await request(app)
+      .post("/api/admin/content/sections")
+      .set(headers)
+      .send({ title, bodyMarkdown: "## Manuell" });
+    expect(response.status).toBe(201);
+
+    const event = await prisma.auditEvent.findFirst({
+      where: { action: "section_created", entityId: response.body.section.id },
+    });
+    expect(event).not.toBeNull();
+    const metadata = JSON.parse(event!.metadataJson) as Record<string, unknown>;
+    expect(metadata.source).toBeUndefined();
+    expect(metadata.agentRunId).toBeUndefined();
+    expect(metadata.draft).toBe(false);
+  });
+});


### PR DESCRIPTION
Del av EPIC #647; implementerer AA-5 (#653) etter designnotatet (`doc/design/AGENT_AUTHORING_647.md` §8). v1.6.12.

## Hva

- **Audit-spor per kjøring**: `agentRunId` (valgfri, `[a-zA-Z0-9._-]{1,64}`) aksepteres på `POST /sections`, `POST /modules/import`, `POST /courses` og `PUT /courses/:id/items`. Når `clientRef`/`agentRunId` er satt, stemples auditeventen med `source: "agent_authoring"` + `clientRef` + `agentRunId` (hjelper: `agentAuthoringAuditMetadata` i `auditEvents.ts`). En hel kjøring rekonstrueres med ett audit-oppslag på runId — også etter delvis feil.
- **Designbeslutning (fra issuet)**: ingen server-side run-ledger/`agentAuthoringRunId`-tabell i MVP — audit-events (spørbare på runId) + skillens klientlogg dekker behovet. Kan revurderes når #726 (Idempotency-Key) lander en tabell uansett.
- **Nye audit-hendelser**: `section_created` (med `draft`-flagg) og `course_items_updated` — seksjonsoppretting og item-sekvens var uauditerte writes. Logges nå for både mennesker og agenter; agent-markøren settes kun for agent-orkestrerte kall (verifisert i test).
- **Skill-standard for partial failure**: `import-package.mjs` genererer runId automatisk (eller tar imot en), sender den på alle writes, og returnerer `steps[]` med `done`/`failed`/`skipped` per plan-steg + `runId` + `created[]` med ID-er/links. CLI printer runId. SKILL.md/api-flow.md dokumenterer rapporterings- og cleanup/fortsett-flyten (aldri auto-sletting; retry gjenbruker clientRef→id-kartet).
- **Fix**: shebang fjernet fra `import-package.mjs` — `#!` + CRLF (etter git-checkout på Windows) knakk vite-nodes transform når tester importerer scriptet (`SyntaxError: Invalid or unexpected token`). CI på Linux (LF) var upåvirket, derfor grønt i #728.

## Akseptansekriterier (#653)

- [x] Agent-opprettede drafts kan spores i audit (`source: agent_authoring`, clientRef, agentRunId — testet for alle fire write-typene)
- [x] Skillen har standard partial-failure-respons (`steps[]` + `created[]` + `runId` + feilkropp)
- [x] Integrasjonstest dekker at mid-flow-feil rapporterer allerede opprettede ID-er/URL-er (simulert 503 på course-create; seksjon+modul beholdes og rapporteres, audit viser dem på runId)
- [x] Dokumentasjonen beskriver cleanup/fortsett-flyt (api-flow.md + SKILL.md; API_REFERENCE oppdatert)

## Test

- `npx tsc --noEmit` — grønn
- `npm run test:unit` — 701 grønne
- `npm run test:integration:native` (alle 4 agent-authoring-suiter) — 15/15 grønne
- Regresjon på berørte endepunkter (`m2-content-export-import`, `m2-admin-sections`, `m2-admin-courses`, `m2-course-items`, `m2-content-lifecycle`) — 21/21 grønne

🤖 Generated with [Claude Code](https://claude.com/claude-code)
