### PR TITLE
feat(skills): zip-pakketering + multitenant miljøoppløsning for a2-authoring-api (#652/#647)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,4 +157,5 @@ description, read its `SKILL.md` and follow it before improvising.
   returns admin-UI links; NEVER calls publish endpoints. For ChatGPT/Codex this file is the
   skill; Claude Code additionally discovers it via the `.claude/skills/a2-authoring-api/`
   pointer. The canonical `skills/` copy is the source of truth — regenerate pointers from it,
-  never fork the content.
+  never fork the content. Distributable zip (ChatGPT institution deploy / claude.ai upload):
+  `npm run skill:package` → `dist/skills/a2-authoring-api-v<version>.zip`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,8 @@ pointers in `.claude/skills/`. The `skills/` copy is the source of truth — edi
 
 - **`skills/a2-authoring-api/`** — build draft courses/modules/sections from conversation
   context via the Agent Authoring API (EPIC #647). Validate-first, draft-only, returns
-  admin-UI links; NEVER calls publish endpoints.
+  admin-UI links; NEVER calls publish endpoints. Distributable zip:
+  `npm run skill:package` → `dist/skills/a2-authoring-api-v<version>.zip`.
 
 ## AI delegation workflow (Claude orchestrates, Codex/Gemini drafts)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.4.5",
+  "version": "1.6.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a2-assessment-platform",
-      "version": "1.4.5",
+      "version": "1.6.12",
       "dependencies": {
         "@azure/communication-email": "^1.1.0",
         "@azure/identity": "^4.13.1",
@@ -43,6 +43,7 @@
         "@types/supertest": "^6.0.3",
         "@vitest/coverage-v8": "^2.1.9",
         "dotenv-cli": "^8.0.0",
+        "jszip": "^3.10.1",
         "playwright": "^1.59.1",
         "supertest": "^7.1.1",
         "tsx": "^4.19.3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "npm run postgres:setup && dotenv -e .env.postgres.local -- tsx watch src/index.ts",
     "dev:local": "dotenv -e .env.postgres.local -- tsx watch src/index.ts",
+    "skill:package": "node scripts/package-authoring-skill.mjs",
     "dev:seed:consent": "dotenv -e .env.postgres.local -- tsx scripts/dev/seed-mock-consent.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node scripts/runtime/startup.mjs",
@@ -97,6 +98,7 @@
     "@types/supertest": "^6.0.3",
     "@vitest/coverage-v8": "^2.1.9",
     "dotenv-cli": "^8.0.0",
+    "jszip": "^3.10.1",
     "playwright": "^1.59.1",
     "supertest": "^7.1.1",
     "tsx": "^4.19.3",

--- a/scripts/package-authoring-skill.mjs
+++ b/scripts/package-authoring-skill.mjs
@@ -1,0 +1,59 @@
+// AA-4/#652 follow-up: package the repo-canonical a2-authoring-api skill as a
+// distributable zip. The zip contains the skill FOLDER (a2-authoring-api/SKILL.md
+// at its root), which is the layout both ChatGPT (workspace/institution skill
+// deploy, per-user install) and claude.ai (capabilities upload) expect.
+//
+// Usage: npm run skill:package
+// Output: dist/skills/a2-authoring-api-v<package.json version>.zip
+//
+// jszip (devDependency) is used instead of PowerShell Compress-Archive because
+// PS 5.1 writes backslash entry names, which breaks unzip in other systems.
+
+import { readFile, readdir, mkdir, writeFile, stat } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import JSZip from "jszip";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SKILL_DIR = path.join(ROOT, "skills", "a2-authoring-api");
+const OUT_DIR = path.join(ROOT, "dist", "skills");
+
+async function addDirectory(zip, absoluteDir, zipPrefix) {
+  const entries = await readdir(absoluteDir, { withFileTypes: true });
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    const absolute = path.join(absoluteDir, entry.name);
+    const zipPath = `${zipPrefix}/${entry.name}`;
+    if (entry.isDirectory()) {
+      await addDirectory(zip, absolute, zipPath);
+    } else {
+      // Normalize to LF so the artifact is identical regardless of the
+      // packaging machine's git eol settings (see the #653 CRLF incident).
+      const raw = await readFile(absolute);
+      const isText = /\.(md|mjs|mts|json)$/.test(entry.name);
+      zip.file(zipPath, isText ? raw.toString("utf8").replaceAll("\r\n", "\n") : raw);
+    }
+  }
+}
+
+async function main() {
+  await stat(path.join(SKILL_DIR, "SKILL.md")); // fail fast if layout changed
+  const version = JSON.parse(await readFile(path.join(ROOT, "package.json"), "utf8")).version;
+
+  const zip = new JSZip();
+  await addDirectory(zip, SKILL_DIR, "a2-authoring-api");
+
+  await mkdir(OUT_DIR, { recursive: true });
+  const outFile = path.join(OUT_DIR, `a2-authoring-api-v${version}.zip`);
+  const buffer = await zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" });
+  await writeFile(outFile, buffer);
+
+  const fileCount = Object.keys(zip.files).filter((name) => !zip.files[name].dir).length;
+  console.log(`Wrote ${outFile} (${fileCount} files, ${buffer.length} bytes)`);
+  console.log("Deploy: ChatGPT admin (institusjons-skill) / claude.ai capabilities — same zip.");
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/skills/a2-authoring-api/SKILL.md
+++ b/skills/a2-authoring-api/SKILL.md
@@ -72,9 +72,37 @@ point them to the admin UI links instead.
 - Do not use `mode: "replaceExisting"` unless the user explicitly asked to overwrite a
   specific existing module and gave you its ID.
 
-## Environment / auth
+## Environment resolution (multitenant)
 
-| Environment | Auth |
+The platform is installed **per tenant** — each customer/organization runs its own
+installation with its own URL and its own identity provider. There is **no default or
+hardcoded environment**. Resolve the target installation for every run, in this order:
+
+1. A base URL the user gave you for this run ("kjør mot https://…").
+2. The `A2_BASE_URL` env var (set per machine/workspace to that tenant's installation).
+3. Otherwise: **ask the user** which installation to target. Never guess, never fall back
+   to localhost or to any vendor environment.
+
+Echo the resolved base URL back in the confirmation step (workflow step 5) so the user
+sees WHERE the drafts will be created before any write happens. Content created in one
+installation never references IDs from another — `moduleId`/`sectionId` references in a
+package are only valid within the target installation.
+
+### Auth (per installation)
+
+| Installation type | Auth |
 |---|---|
 | Local dev (`npm run dev`, `AUTH_MODE=mock`) | Mock headers: `x-user-id`, `x-user-email`, `x-user-name`, `x-user-roles: SUBJECT_MATTER_OWNER` (or `ADMINISTRATOR`). Script env vars: `A2_USER_ID`, `A2_USER_EMAIL`, `A2_USER_NAME`, `A2_USER_ROLES`. |
-| Staging/prod | `Authorization: Bearer <Entra JWT>` from a logged-in user (script env var: `A2_AUTH_BEARER`). Direct external-agent access is NOT available until AA-3 (#651) lands a short-lived agent token. |
+| Any shared installation (a tenant's staging/prod) | `Authorization: Bearer <JWT>` issued by **that installation's** identity provider (Entra tenant), from a user logged into that installation. Script env var: `A2_AUTH_BEARER`. A token from one tenant is useless in another — never reuse tokens across installations. |
+
+Direct external-agent access (e.g. a ChatGPT Action calling an installation without a
+user-supplied token) is NOT available until AA-3 (#651) lands a short-lived, per-tenant
+agent authoring token.
+
+## Distribution
+
+This folder is the deployable unit. `npm run skill:package` (in the platform repo) builds
+`dist/skills/a2-authoring-api-v<version>.zip` — a zip with the `a2-authoring-api/` folder
+at its root, which is the layout ChatGPT (institution-level skill deploy, per-user
+install) and claude.ai (capabilities upload) expect. The repo copy remains the source of
+truth; re-run the packaging after any skill change and redeploy the zip.

--- a/skills/a2-authoring-api/scripts/import-package.mjs
+++ b/skills/a2-authoring-api/scripts/import-package.mjs
@@ -172,8 +172,10 @@ function headersFromEnv(env) {
   };
 }
 
-function parseArgs(argv) {
-  const args = { file: undefined, baseUrl: undefined, validateOnly: false };
+function parseArgs(argv, env) {
+  // Multitenant: the platform is installed per tenant — there is NO default
+  // base URL. It must come from --base-url or the A2_BASE_URL env var.
+  const args = { file: undefined, baseUrl: env.A2_BASE_URL, validateOnly: false };
   for (let i = 0; i < argv.length; i += 1) {
     if (argv[i] === "--file") args.file = argv[++i];
     else if (argv[i] === "--base-url") args.baseUrl = argv[++i];
@@ -181,15 +183,19 @@ function parseArgs(argv) {
     else throw new Error(`Unknown argument: ${argv[i]}`);
   }
   if (!args.file || !args.baseUrl) {
-    throw new Error("Usage: import-package.mjs --file <package.json> --base-url <url> [--validate-only]");
+    throw new Error(
+      "Usage: import-package.mjs --file <package.json> --base-url <url> [--validate-only]\n" +
+        "(--base-url can be omitted when the A2_BASE_URL env var points at the target installation)",
+    );
   }
   return args;
 }
 
 async function main() {
-  const args = parseArgs(process.argv.slice(2));
+  const args = parseArgs(process.argv.slice(2), process.env);
   const pkg = JSON.parse(await readFile(args.file, "utf8"));
   const headers = headersFromEnv(process.env);
+  console.log(`Target installation: ${args.baseUrl}`);
 
   if (args.validateOnly) {
     const report = await validatePackage({ baseUrl: args.baseUrl, headers, pkg });


### PR DESCRIPTION
Oppfølging av #652 (EPIC #647) etter produkteier-avklaring: skillen skal distribueres som **zip** (deployes for institusjonen i ChatGPT, installeres av hver bruker — samme modell som claude.ai-upload), og miljøhåndteringen må være **multitenant**: plattformen installeres per kunde/organisasjon helt uavhengig av våre stage/prod-miljøer.

## Hva

- **`npm run skill:package`** → `dist/skills/a2-authoring-api-v<versjon>.zip` med `a2-authoring-api/`-mappen (SKILL.md i mapperoten) — layouten både ChatGPT-institusjonsdeploy og claude.ai forventer. Bygget med `jszip` (ny devDependency): PS 5.1 `Compress-Archive` skriver backslash-entry-navn som knekker unzip andre steder, og innholdet LF-normaliseres så artefakten er identisk uansett byggmaskin (jf. CRLF-hendelsen i #653).
- **Miljøoppløsning (multitenant) i SKILL.md**: ingen default eller hardkodet URL. Rekkefølge per kjøring: bruker-oppgitt URL → `A2_BASE_URL` → spør brukeren. Målinstallasjonens URL ekkoes i bekreftelsessteget før writes. `moduleId`/`sectionId`-referanser er kun gyldige i målinstallasjonen, og tokens gjenbrukes aldri på tvers av installasjoner.
- **`import-package.mjs`**: `--base-url` kan nå komme fra `A2_BASE_URL`; scriptet printer «Target installation: …» før kjøring.
- **AA-3 (#651)** har fått multitenant-kravet som kommentar: token må utstedes per installasjon (den tenantens IdP), aldri på tvers; det er forutsetningen for ChatGPT-Action-scenariet.
- AGENTS.md/CLAUDE.md peker på pakke-kommandoen.

Ingen app-runtime-endring → ingen versjonsbump (tooling + skill-docs + devDependency).

## Test

- `npx tsc --noEmit` grønn; skill-integrasjonstestene (6 tester) grønne.
- Zip bygget og innhold verifisert (`tar -tf`): 6 filer, forward-slash-paths, `a2-authoring-api/SKILL.md` i roten.
- CLI verifisert: uten base-URL → usage-feil; med `A2_BASE_URL` → brukes og printes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
