### PR TITLE
feat(auth): #651 AA-3 kortlivede scopede agent-authoring-tokens (v1.6.13)

### DIFF
--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -216,6 +216,23 @@ Agent imports must pass `autoPublish: false` (and the authoring contract has no 
 source-publish auto-publication can never trigger). Retry-safe `Idempotency-Key` support is
 tracked separately in #726.
 
+**Agent authoring tokens (AA-3, #651):** short-lived, scoped tokens for direct agent calls.
+Issued by a logged-in ADMINISTRATOR/SMO with normal user auth (tokens can NOT mint tokens):
+
+| Method | Path | Notes |
+|--------|------|-------|
+| `POST` | `/api/admin/content/agent-authoring/tokens` | Body `{ label?, ttlMinutes? (5–60, default 60) }` → `201 { token: "aat_…", id, expiresAt }`. The secret is shown **once**; only its sha256 hash is stored. Issuance is audited. |
+| `GET` | `/api/admin/content/agent-authoring/tokens` | Own tokens (id, label, createdAt, expiresAt, revokedAt, lastUsedAt) — never the secret. |
+| `POST` | `/api/admin/content/agent-authoring/tokens/:tokenId/revoke` | Owner or ADMINISTRATOR. Immediate; audited. |
+
+Using `Authorization: Bearer aat_…` authenticates as the issuing user (works in both auth
+modes; identity/roles from the DB) but the request is **scope-limited** to the five draft
+authoring operations (validate, modules/import, sections, courses, courses/:id/items) —
+anything else returns `403 agent_token_scope`. Extra hardening on the allowlisted calls:
+import requires `mode: "createNew"` + `autoPublish: false`, section create requires
+`draft: true`, and items may only be set on unpublished courses. No publish code path is
+reachable with a token. Tokens are per installation (multitenant) and expire within the hour.
+
 **Audit trace (AA-5, #653):** the same calls (plus `PUT .../courses/:courseId/items`) accept
 an optional `agentRunId` (`[a-zA-Z0-9._-]{1,64}`, one ID per orchestration run). When
 `clientRef`/`agentRunId` is present, the write's audit event gets

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,33 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.13 - 2026-07-06
+
+feat(auth): #651 AA-3 — kortlivede, scopede agent-authoring-tokens (multitenant)
+
+Alternativ 2 fra designnotatet («Agent Authoring Session») implementert; åpner for trygg
+direkte agentbruk (ChatGPT/Claude) mot delte installasjoner:
+
+- **Ny tabell `AgentAuthoringToken`** (migrasjon 20260706100000): kun sha256-hash lagres,
+  hemmeligheten (`aat_<48 hex>`) vises én gang. TTL 5–60 min (default 60), revokerbar,
+  `lastUsedAt` spores. Per installasjon — tokens kan aldri brukes på tvers (multitenant).
+- **Endepunkter** under `/api/admin/content/agent-authoring/tokens`: utsted (POST), liste
+  (GET, aldri hemmeligheten), revokér (POST :id/revoke — eier eller ADMINISTRATOR).
+  Utstedelse/revokering audit-logges.
+- **Auth**: `Authorization: Bearer aat_...` virker i begge auth-moduser; identitet/roller
+  hentes fra utstederens brukerkonto — writes attribueres som brukeren og arver
+  eierskapsmodellen (#528). Mock-headere kan aldri overstyre token-identiteten.
+- **Scope-vakt** (`enforceAgentTokenScope`, montert rett etter authenticate): token-requests
+  kan kun kalle de fem draft-operasjonene (validate, modules/import, sections, courses,
+  courses/:id/items); alt annet → 403 `agent_token_scope`. Tokens kan ikke utstede/revokere
+  tokens. Rute-herding: import krever `createNew` + `autoPublish: false`, seksjoner krever
+  `draft: true`, items kun på upubliserte kurs — ingen publish-kodevei er nåbar med token.
+- Skillen er uendret i praksis (`A2_AUTH_BEARER` tar nå helst et `aat_`-token); SKILL.md,
+  api-flow og API_REFERENCE oppdatert; designnotatet §7 har beslutningen.
+- Tester: 6 nye integrasjonstester (utstedelse/liste uten hemmelighet, full orkestrering
+  med token + bruker-attribusjon, allowlist-avslag inkl. publish og self-mint, rute-herding,
+  expiry/revoke/ukjent token → 401, rollekrav for utstedelse).
+
 ## 1.6.12 - 2026-07-06
 
 feat(admin-content): #653 AA-5 — audit-spor og partial-failure-rapportering for agent authoring

--- a/doc/design/AGENT_AUTHORING_647.md
+++ b/doc/design/AGENT_AUTHORING_647.md
@@ -251,7 +251,7 @@ Vurderte alternativer:
 | # | Modell | Vurdering |
 |---|---|---|
 | 1 | Eksisterende app-auth (mock lokalt, Entra-JWT ellers) | Null ny angrepsflate; dekker repo-lokale agenter fullt ut i dag. **Valgt for MVP.** |
-| 2 | Kortlivet agent-authoring-token utstedt av innlogget bruker | Riktig modell for ekstern ChatGPT/Claude → staging/prod: scopet (kun authoring-endepunktene), kort TTL (≤ 60 min), bundet til utstedende bruker (arver eierskap + audit), revokerbar. **Designes/landes i AA-3 (#651) — obligatorisk før noen ekstern agent får kalle delte miljøer.** |
+| 2 | Kortlivet agent-authoring-token utstedt av innlogget bruker | Riktig modell for ekstern ChatGPT/Claude → staging/prod: scopet (kun authoring-endepunktene), kort TTL (≤ 60 min), bundet til utstedende bruker (arver eierskap + audit), revokerbar. **Implementert i AA-3 (#651)** — se «AA-3-beslutning» under. |
 | 3 | Statisk API-token/PAT | Ingen brukerbinding, lekkasje gir stående admin-innholdstilgang, ikke-revokerbar i praksis. **Avvist.** |
 | 4 | OAuth/device-flow | Best UX for tredjeparts-agenter på sikt, men uforholdsmessig tungt nå. **Senere**, bygger evt. oppå 2. |
 
@@ -259,6 +259,25 @@ MVP-konsekvens: en lokal agent kjører mot `npm run dev` med `AUTH_MODE=mock` og
 `x-user-roles: SUBJECT_MATTER_OWNER` (mock er allerede hard-blokkert i produksjon). Mot
 staging/prod i MVP går agentarbeid via en bruker som selv skaffer Entra-token — ingen ny
 mekanisme. Ekstern direktebruk er eksplisitt **utenfor MVP** til AA-3 er landet.
+
+### AA-3-beslutning (implementert, #651 / v1.6.13)
+
+Alternativ 2 er implementert som **Agent Authoring Session**, med multitenant som premiss
+(tokens utstedes og verifiseres kun mot installasjonens egen database — aldri på tvers):
+
+- **Utstedelse**: `POST /api/admin/content/agent-authoring/tokens` (`admin_content`-rolle,
+  vanlig bruker-auth) → `aat_<48 hex>`-hemmelighet vist **én gang**; kun sha256-hash lagres
+  (`AgentAuthoringToken`-tabellen). TTL 5–60 min (default 60). Liste/revokér via
+  `GET .../tokens` og `POST .../tokens/:id/revoke` (eier eller ADMINISTRATOR).
+- **Bruk**: `Authorization: Bearer aat_...` virker i begge auth-moduser; identitet/roller
+  hentes fra utstederens brukerkonto (writes attribueres som brukeren, eierskap #528 arves).
+- **Scope**: `enforceAgentTokenScope` (montert rett etter `authenticate`) tillater kun de
+  fem draft-operasjonene skillen orkestrerer; alt annet → 403 `agent_token_scope`. Tokens
+  kan ikke utstede/revokere tokens. Rutene herder i tillegg: import krever `createNew` +
+  `autoPublish: false`, seksjoner krever `draft: true`, items kun på upubliserte kurs —
+  ingen publish-kodevei er nåbar med token.
+- **Audit**: utstedelse/revokering audit-logges (`agent_authoring_token_issued`/`_revoked`);
+  selve writene bærer allerede `source: agent_authoring` + `agentRunId` (AA-5).
 
 ## 8. Rollback / partial failure (multi-call-orkestrering)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260706100000_add_agent_authoring_token/migration.sql
+++ b/prisma/migrations/20260706100000_add_agent_authoring_token/migration.sql
@@ -1,0 +1,23 @@
+-- AA-3 (#651): short-lived agent authoring tokens (hash only; the secret is never stored).
+-- CreateTable
+CREATE TABLE "AgentAuthoringToken" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "label" TEXT,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "lastUsedAt" TIMESTAMP(3),
+
+    CONSTRAINT "AgentAuthoringToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentAuthoringToken_tokenHash_key" ON "AgentAuthoringToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "AgentAuthoringToken_userId_idx" ON "AgentAuthoringToken"("userId");
+
+-- AddForeignKey
+ALTER TABLE "AgentAuthoringToken" ADD CONSTRAINT "AgentAuthoringToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,6 +102,25 @@ model User {
   discussionRepliesAuthored     DiscussionReply[]        @relation("DiscussionReplyAuthor")
   discussionRepliesDeleted      DiscussionReply[]        @relation("DiscussionReplyDeletedBy")
   discussionSubscriptions       DiscussionSubscription[]
+  agentAuthoringTokens          AgentAuthoringToken[]    @relation("AgentAuthoringTokens")
+}
+
+// AA-3 (#651): kortlivet, scopet token for agent-orkestrerte draft-operasjoner.
+// Kun sha256-hashen lagres — hemmeligheten (aat_...) vises én gang ved utstedelse.
+// Per installasjon (multitenant): tokens utstedes og verifiseres kun mot denne
+// installasjonens database og kan aldri brukes på tvers.
+model AgentAuthoringToken {
+  id         String    @id @default(cuid())
+  tokenHash  String    @unique
+  label      String?
+  userId     String
+  user       User      @relation("AgentAuthoringTokens", fields: [userId], references: [id], onDelete: Cascade)
+  createdAt  DateTime  @default(now())
+  expiresAt  DateTime
+  revokedAt  DateTime?
+  lastUsedAt DateTime?
+
+  @@index([userId])
 }
 
 model UserConsent {

--- a/skills/a2-authoring-api/SKILL.md
+++ b/skills/a2-authoring-api/SKILL.md
@@ -93,11 +93,11 @@ package are only valid within the target installation.
 | Installation type | Auth |
 |---|---|
 | Local dev (`npm run dev`, `AUTH_MODE=mock`) | Mock headers: `x-user-id`, `x-user-email`, `x-user-name`, `x-user-roles: SUBJECT_MATTER_OWNER` (or `ADMINISTRATOR`). Script env vars: `A2_USER_ID`, `A2_USER_EMAIL`, `A2_USER_NAME`, `A2_USER_ROLES`. |
-| Any shared installation (a tenant's staging/prod) | `Authorization: Bearer <JWT>` issued by **that installation's** identity provider (Entra tenant), from a user logged into that installation. Script env var: `A2_AUTH_BEARER`. A token from one tenant is useless in another — never reuse tokens across installations. |
+| Any shared installation (a tenant's staging/prod) — **preferred: agent authoring token** | A logged-in SMO/admin issues a short-lived token from **that installation**: `POST /api/admin/content/agent-authoring/tokens` (body `{ "label": "...", "ttlMinutes": 60 }`) → an `aat_...` secret shown once. The agent uses it as `Authorization: Bearer aat_...` (script env var: `A2_AUTH_BEARER`). It expires within the hour, can be revoked, and is scoped to draft authoring only — the API rejects any publish path, non-draft section create, `replaceExisting`/auto-publish import, and item changes on published courses. |
+| Any shared installation — fallback | A full `Authorization: Bearer <Entra JWT>` from a user logged into that installation (same env var). Unscoped — prefer the agent token. |
 
-Direct external-agent access (e.g. a ChatGPT Action calling an installation without a
-user-supplied token) is NOT available until AA-3 (#651) lands a short-lived, per-tenant
-agent authoring token.
+Tokens are per installation and useless anywhere else — never reuse them across
+installations, and never paste them into packages, chat output or files.
 
 ## Distribution
 

--- a/skills/a2-authoring-api/references/api-flow.md
+++ b/skills/a2-authoring-api/references/api-flow.md
@@ -5,8 +5,15 @@ Reference implementation: [scripts/import-package.mjs](../scripts/import-package
 through another mechanism). Endpoint catalog: `doc/API_REFERENCE.md` (Admin Content).
 
 All calls: `Content-Type: application/json`, auth per SKILL.md (mock headers locally,
-`Authorization: Bearer …` in shared environments). All routes require the `admin_content`
+`Authorization: Bearer …` in shared environments — preferably a short-lived `aat_...`
+agent authoring token issued by the user via
+`POST /api/admin/content/agent-authoring/tokens`). All routes require the `admin_content`
 capability (ADMINISTRATOR or SUBJECT_MATTER_OWNER).
+
+Note when running on an agent token: the API enforces the draft-only rules below
+(`draft: true`, `autoPublish: false`, `mode: "createNew"`, items only on draft courses) —
+deviating returns `403 agent_token_scope`. The token cannot call anything outside this
+flow, and cannot issue or revoke tokens.
 
 ## Sequence
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import { getParticipantConsoleRuntimeConfig } from "./config/participantConsole.
 import { SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES } from "./modules/adminContent/sourceMaterialExtractionService.js";
 import { rolesFor } from "./config/capabilities.js";
 import { authenticate } from "./auth/authenticate.js";
+import { enforceAgentTokenScope } from "./auth/agentTokenScope.js";
 import { requireAnyRole } from "./auth/authorization.js";
 import { attachCorrelationId, requestLoggingMiddleware } from "./middleware/requestObservability.js";
 import { securityHeadersMiddleware } from "./middleware/securityHeaders.js";
@@ -179,7 +180,9 @@ app.get("/admin-platform", (_request, response) => {
   response.sendFile(path.resolve(process.cwd(), "public", "admin-platform.html"));
 });
 
-app.use("/api", authenticate, generalApiLimiter, requireConsent);
+// AA-3 (#651): agent-token-autentiserte requests scopes til draft-authoring-
+// endepunktene rett etter autentisering — før noe annet får kjøre.
+app.use("/api", authenticate, enforceAgentTokenScope, generalApiLimiter, requireConsent);
 
 app.use("/api/me", meRouter);
 app.use("/api/courses", requireAnyRole(rolesFor("courses")), coursesRouter);

--- a/src/auth/agentAuthoringTokenService.ts
+++ b/src/auth/agentAuthoringTokenService.ts
@@ -1,0 +1,107 @@
+// AA-3 (#651): short-lived Agent Authoring Session tokens.
+//
+// A logged-in SMO/ADMINISTRATOR issues a token (secret `aat_<48 hex>`, shown ONCE),
+// hands it to an agent (env var A2_AUTH_BEARER), and the agent authenticates with
+// `Authorization: Bearer aat_...`. The request is then scoped by
+// enforceAgentTokenScope to draft-authoring operations only. Only the sha256 hash
+// is stored; expiry is short (5–60 min) and revocation is immediate. Multitenant:
+// tokens live in this installation's database and are meaningless anywhere else.
+
+import { randomBytes } from "node:crypto";
+import { prisma } from "../db/prisma.js";
+import { sha256 } from "../utils/hash.js";
+import { recordAuditEvent } from "../services/auditService.js";
+import { auditActions, auditEntityTypes } from "../observability/auditEvents.js";
+
+export const AGENT_TOKEN_PREFIX = "aat_";
+export const AGENT_TOKEN_DEFAULT_TTL_MINUTES = 60;
+export const AGENT_TOKEN_MAX_TTL_MINUTES = 60;
+export const AGENT_TOKEN_MIN_TTL_MINUTES = 5;
+
+export async function issueAgentAuthoringToken(input: {
+  userId: string;
+  label?: string;
+  ttlMinutes?: number;
+}) {
+  const ttl = Math.min(
+    AGENT_TOKEN_MAX_TTL_MINUTES,
+    Math.max(AGENT_TOKEN_MIN_TTL_MINUTES, input.ttlMinutes ?? AGENT_TOKEN_DEFAULT_TTL_MINUTES),
+  );
+  const secret = `${AGENT_TOKEN_PREFIX}${randomBytes(24).toString("hex")}`;
+  const record = await prisma.agentAuthoringToken.create({
+    data: {
+      tokenHash: sha256(secret),
+      label: input.label ?? null,
+      userId: input.userId,
+      expiresAt: new Date(Date.now() + ttl * 60_000),
+    },
+  });
+
+  await recordAuditEvent({
+    entityType: auditEntityTypes.agentAuthoringToken,
+    entityId: record.id,
+    action: auditActions.agentAuthoring.tokenIssued,
+    actorId: input.userId,
+    metadata: { tokenId: record.id, expiresAt: record.expiresAt.toISOString() },
+  });
+
+  // The secret exists only in this return value — it is never persisted or logged.
+  return { secret, record };
+}
+
+// Resolves a presented secret to its (active) token + user. Returns null for
+// unknown, expired or revoked tokens — the caller answers 401 without detail.
+export async function authenticateAgentToken(secret: string) {
+  if (!secret.startsWith(AGENT_TOKEN_PREFIX)) return null;
+  const token = await prisma.agentAuthoringToken.findUnique({
+    where: { tokenHash: sha256(secret) },
+    include: { user: true },
+  });
+  if (!token || token.revokedAt || token.expiresAt.getTime() <= Date.now()) return null;
+  await prisma.agentAuthoringToken.update({
+    where: { id: token.id },
+    data: { lastUsedAt: new Date() },
+  });
+  return token;
+}
+
+export function listAgentAuthoringTokens(userId: string) {
+  return prisma.agentAuthoringToken.findMany({
+    where: { userId },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      label: true,
+      createdAt: true,
+      expiresAt: true,
+      revokedAt: true,
+      lastUsedAt: true,
+    },
+  });
+}
+
+// Owner (or ADMINISTRATOR) revokes. Returns null when the token does not exist
+// or the actor is not allowed to touch it (both → 404 at the route layer).
+export async function revokeAgentAuthoringToken(input: {
+  tokenId: string;
+  actorUserId: string;
+  roles: string[];
+}) {
+  const token = await prisma.agentAuthoringToken.findUnique({ where: { id: input.tokenId } });
+  if (!token) return null;
+  if (token.userId !== input.actorUserId && !input.roles.includes("ADMINISTRATOR")) return null;
+  if (token.revokedAt) return token;
+
+  const revoked = await prisma.agentAuthoringToken.update({
+    where: { id: token.id },
+    data: { revokedAt: new Date() },
+  });
+  await recordAuditEvent({
+    entityType: auditEntityTypes.agentAuthoringToken,
+    entityId: token.id,
+    action: auditActions.agentAuthoring.tokenRevoked,
+    actorId: input.actorUserId,
+    metadata: { tokenId: token.id },
+  });
+  return revoked;
+}

--- a/src/auth/agentTokenScope.ts
+++ b/src/auth/agentTokenScope.ts
@@ -1,0 +1,36 @@
+// AA-3 (#651): scope enforcement for agent authoring tokens.
+//
+// A request authenticated with an agent token (request.context.agentToken) may
+// ONLY call the draft-authoring operations the skill orchestrates. Everything
+// else — publish/unpublish/archive/delete, token management (no self-minting),
+// the rest of the admin surface, participant APIs — is denied with 403.
+// Routes add per-call hardening on top (no replaceExisting/autoPublish on
+// import, draft-only sections, items only on unpublished courses).
+
+import type { NextFunction, Request, Response } from "express";
+
+const ALLOWED: Array<{ method: string; pattern: RegExp }> = [
+  { method: "POST", pattern: /^\/api\/admin\/content\/agent-authoring\/validate\/?$/ },
+  { method: "POST", pattern: /^\/api\/admin\/content\/modules\/import\/?$/ },
+  { method: "POST", pattern: /^\/api\/admin\/content\/sections\/?$/ },
+  { method: "POST", pattern: /^\/api\/admin\/content\/courses\/?$/ },
+  { method: "PUT", pattern: /^\/api\/admin\/content\/courses\/[^/]+\/items\/?$/ },
+];
+
+export function enforceAgentTokenScope(request: Request, response: Response, next: NextFunction) {
+  if (!request.context?.agentToken) {
+    next();
+    return;
+  }
+  const path = (request.originalUrl ?? request.url).split("?")[0];
+  if (ALLOWED.some((entry) => entry.method === request.method && entry.pattern.test(path))) {
+    next();
+    return;
+  }
+  response.status(403).json({
+    error: "agent_token_scope",
+    message:
+      "Agent authoring tokens may only call draft authoring endpoints " +
+      "(agent-authoring/validate, modules/import, sections, courses, courses/:id/items).",
+  });
+}

--- a/src/auth/authenticate.ts
+++ b/src/auth/authenticate.ts
@@ -5,6 +5,7 @@ import { env } from "../config/env.js";
 import { AppError } from "../errors/AppError.js";
 import type { AuthPrincipal } from "./principal.js";
 import { getActiveRoles, syncEntraGroupRoles, upsertUserFromPrincipal } from "../repositories/userRepository.js";
+import { AGENT_TOKEN_PREFIX, authenticateAgentToken } from "./agentAuthoringTokenService.js";
 import { resolveRequestLocale } from "../i18n/locale.js";
 import { t } from "../i18n/messages.js";
 
@@ -125,6 +126,35 @@ export async function authenticate(request: Request, response: Response, next: N
   if (env.AUTH_MODE === "mock" && process.env.NODE_ENV === "production") {
     console.error("CRITICAL SECURITY ERROR: Mock authentication is NOT allowed in production.");
     response.status(500).json({ error: "internal_error", message: "Security configuration error." });
+    return;
+  }
+
+  // AA-3 (#651): short-lived agent authoring tokens (Bearer aat_...) work in BOTH
+  // auth modes — they are resolved against this installation's database, not the
+  // IdP. Identity/roles come from the issuing user's DB record; the request is
+  // marked agentToken so enforceAgentTokenScope can restrict it to draft
+  // authoring endpoints. Handled before mode dispatch so mock headers can never
+  // override a token-authenticated identity.
+  const authorizationHeader = request.header("authorization");
+  if (authorizationHeader?.startsWith(`Bearer ${AGENT_TOKEN_PREFIX}`)) {
+    try {
+      const token = await authenticateAgentToken(authorizationHeader.slice("Bearer ".length));
+      if (!token || token.user.activeStatus === false) {
+        response.status(401).json({ error: "unauthorized", message: t(locale, "unauthorized") });
+        return;
+      }
+      request.context = {
+        correlationId: request.context?.correlationId,
+        userId: token.user.id,
+        roles: await getActiveRoles(token.user.id),
+        locale,
+        agentToken: { tokenId: token.id },
+      };
+      next();
+    } catch (error) {
+      console.error("Agent token authentication failed.", error);
+      next(new AppError("internal_error", 500, "Internal server error."));
+    }
     return;
   }
 

--- a/src/auth/principal.ts
+++ b/src/auth/principal.ts
@@ -16,4 +16,8 @@ export type RequestContext = {
   userId?: string;
   roles?: AppRole[];
   locale?: SupportedLocale;
+  // AA-3 (#651): set when the request authenticated with a short-lived agent
+  // authoring token — enforceAgentTokenScope then restricts it to draft
+  // authoring endpoints, and routes apply extra hardening (no publish paths).
+  agentToken?: { tokenId: string };
 };

--- a/src/modules/adminContent/adminContentSchemas.ts
+++ b/src/modules/adminContent/adminContentSchemas.ts
@@ -44,6 +44,13 @@ export const agentRunIdSchema = z
   .string()
   .regex(/^[a-zA-Z0-9._-]{1,64}$/, "agentRunId must match [a-zA-Z0-9._-]{1,64}.");
 
+// AA-3 (#651): utstedelse av kortlivet agent-authoring-token. TTL-grensene speiler
+// konstantene i agentAuthoringTokenService (5–60 min); tjenesten klamper uansett.
+export const agentTokenCreateBodySchema = z.object({
+  label: z.string().trim().min(1).max(100).optional(),
+  ttlMinutes: z.number().int().min(5).max(60).optional(),
+});
+
 export const moduleCreateBodySchema = z.object({
   title: localizedTextSchema,
   description: localizedTextSchema.optional(),

--- a/src/observability/auditEvents.ts
+++ b/src/observability/auditEvents.ts
@@ -3,6 +3,7 @@ type EventMetadata<T extends AdditionalMetadata> = T & AdditionalMetadata;
 type NestedValue<T> = T extends string ? T : { [K in keyof T]: NestedValue<T[K]> }[keyof T];
 
 export const auditEntityTypes = {
+  agentAuthoringToken: "agent_authoring_token",
   appeal: "appeal",
   assessmentDecision: "assessment_decision",
   assessmentJob: "assessment_job",
@@ -66,6 +67,11 @@ export const auditActions = {
   },
   calibration: {
     workspaceSessionStarted: "calibration_workspace_session_started",
+  },
+  // AA-3 (#651): utstedelse/revokering av kortlivede agent-authoring-tokens.
+  agentAuthoring: {
+    tokenIssued: "agent_authoring_token_issued",
+    tokenRevoked: "agent_authoring_token_revoked",
   },
   course: {
     created: "course_created",
@@ -286,6 +292,8 @@ export type AuditMetadataByAction = {
   [auditActions.certification.participantNotificationFailed]: EventMetadata<{
     channel: string;
   }>;
+  [auditActions.agentAuthoring.tokenIssued]: EventMetadata<{ tokenId: string; expiresAt: string }>;
+  [auditActions.agentAuthoring.tokenRevoked]: EventMetadata<{ tokenId: string }>;
   [auditActions.course.created]: EventMetadata<{ courseId: string }>;
   [auditActions.course.itemsUpdated]: EventMetadata<{ courseId: string; itemCount: number }>;
   [auditActions.course.published]: EventMetadata<{ courseId: string }>;

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -43,9 +43,15 @@ import {
   mcqRevisionBodySchema,
   sourceMaterialUploadBodySchema,
   importBodySchema,
+  agentTokenCreateBodySchema,
   parseRequest,
   parseOptionalDate,
 } from "../modules/adminContent/adminContentSchemas.js";
+import {
+  issueAgentAuthoringToken,
+  listAgentAuthoringTokens,
+  revokeAgentAuthoringToken,
+} from "../auth/agentAuthoringTokenService.js";
 import { importModuleFromEnvelope } from "../modules/adminContent/contentImportService.js";
 import { validateAuthoringPackage } from "../modules/adminContent/agentAuthoringValidationService.js";
 import { AUTHORING_PACKAGE_FORMAT } from "../modules/adminContent/agentAuthoringSchemas.js";
@@ -125,6 +131,74 @@ adminContentRouter.post("/agent-authoring/validate", async (request, response) =
       error: "agent_authoring_validate_failed",
       message: "Could not validate authoring package.",
     });
+  }
+});
+
+// AA-3 (#651): utstede/liste/revokere kortlivede agent-authoring-tokens.
+// Rutene er IKKE i agent-token-allowlisten (agentTokenScope.ts) — et token kan
+// aldri utstede eller revokere tokens. Hemmeligheten returneres én gang og kan
+// aldri hentes igjen (kun sha256-hash lagres).
+adminContentRouter.post("/agent-authoring/tokens", async (request, response) => {
+  const userId = request.context?.userId;
+  if (!userId) {
+    response.status(401).json({ error: "unauthorized" });
+    return;
+  }
+  const { data, error } = parseRequest(agentTokenCreateBodySchema, request.body ?? {});
+  if (error) {
+    response.status(400).json({ error: "validation_error", issues: error });
+    return;
+  }
+  try {
+    const { secret, record } = await issueAgentAuthoringToken({
+      userId,
+      label: data.label,
+      ttlMinutes: data.ttlMinutes,
+    });
+    response.status(201).json({
+      token: secret,
+      id: record.id,
+      label: record.label,
+      expiresAt: record.expiresAt.toISOString(),
+      note: "Store this token now — it is never shown again. It expires automatically and can be revoked.",
+    });
+  } catch {
+    response.status(500).json({ error: "agent_token_issue_failed", message: "Could not issue agent token." });
+  }
+});
+
+adminContentRouter.get("/agent-authoring/tokens", async (request, response) => {
+  const userId = request.context?.userId;
+  if (!userId) {
+    response.status(401).json({ error: "unauthorized" });
+    return;
+  }
+  try {
+    response.json({ tokens: await listAgentAuthoringTokens(userId) });
+  } catch {
+    response.status(500).json({ error: "agent_token_list_failed", message: "Could not list agent tokens." });
+  }
+});
+
+adminContentRouter.post("/agent-authoring/tokens/:tokenId/revoke", async (request, response) => {
+  const userId = request.context?.userId;
+  if (!userId) {
+    response.status(401).json({ error: "unauthorized" });
+    return;
+  }
+  try {
+    const token = await revokeAgentAuthoringToken({
+      tokenId: request.params.tokenId,
+      actorUserId: userId,
+      roles: request.context?.roles ?? [],
+    });
+    if (!token) {
+      response.status(404).json({ error: "agent_token_not_found", message: "Token not found." });
+      return;
+    }
+    response.json({ token: { id: token.id, revokedAt: token.revokedAt?.toISOString() ?? null } });
+  } catch {
+    response.status(500).json({ error: "agent_token_revoke_failed", message: "Could not revoke agent token." });
   }
 });
 
@@ -354,6 +428,16 @@ adminContentRouter.post("/modules/import", async (request, response) => {
   }
   if (data.payload.scope !== "module") {
     response.status(400).json({ error: "scope_mismatch", message: "Envelope scope must be 'module' for this endpoint." });
+    return;
+  }
+  // AA-3 (#651): agent-token-requests er create-draft-only. autoPublish default
+  // (true) ville publisert hvis kilde-audit har publishedAt — krev eksplisitt
+  // false, og forby replaceExisting (endrer eksisterende innhold).
+  if (request.context?.agentToken && (data.mode === "replaceExisting" || data.autoPublish !== false)) {
+    response.status(403).json({
+      error: "agent_token_scope",
+      message: "Agent tokens must import with mode 'createNew' and autoPublish: false.",
+    });
     return;
   }
   try {

--- a/src/routes/adminCourses.ts
+++ b/src/routes/adminCourses.ts
@@ -325,6 +325,18 @@ adminCoursesRouter.put("/:courseId/items", async (request, response, next) => {
     return;
   }
   try {
+    // AA-3 (#651): agent-token-requests kan kun endre item-sekvensen på UPUBLISERTE
+    // kurs — å endre et publisert kurs er en live-endring utenfor draft-scopet.
+    if (request.context?.agentToken) {
+      const course = await courseRepository.findCourseById(request.params.courseId);
+      if (course?.publishedAt) {
+        response.status(403).json({
+          error: "agent_token_scope",
+          message: "Agent tokens may only set items on unpublished (draft) courses.",
+        });
+        return;
+      }
+    }
     await setCourseItems(request.params.courseId, parsed.data.items, {
       actorId: request.context?.userId,
       agent: { agentRunId: parsed.data.agentRunId },

--- a/src/routes/adminSections.ts
+++ b/src/routes/adminSections.ts
@@ -90,6 +90,15 @@ adminSectionsRouter.post("/", async (request, response, next) => {
     response.status(400).json({ error: "validation_error", issues: parsed.error.issues });
     return;
   }
+  // AA-3 (#651): agent-token-requests er create-draft-only — default-adferden
+  // (auto-publiser ved lagring) er ikke tillatt for tokens.
+  if (request.context?.agentToken && parsed.data.draft !== true) {
+    response.status(403).json({
+      error: "agent_token_scope",
+      message: "Agent tokens must create sections with draft: true.",
+    });
+    return;
+  }
   try {
     const section = await createSection({
       title: localizedTextCodec.serialize(parsed.data.title),

--- a/test/agent-authoring-token.test.ts
+++ b/test/agent-authoring-token.test.ts
@@ -1,0 +1,239 @@
+// Integration tests for AA-3 (#651): short-lived agent authoring tokens.
+// Covers issuance/listing/revocation, full orchestration with a token (attributed
+// to the issuing user), scope enforcement (draft-authoring endpoints only, no
+// publish, no token self-minting), per-route hardening (autoPublish/replaceExisting,
+// draft-only sections, items only on draft courses), and expiry.
+
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import request from "supertest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+import { importPackage } from "../skills/a2-authoring-api/scripts/import-package.mjs";
+
+const adminHeaders = {
+  "x-user-id": "admin-1",
+  "x-user-email": "admin@company.com",
+  "x-user-name": "Platform Admin",
+};
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  server = await new Promise<Server>((resolve) => {
+    const instance = app.listen(0, () => resolve(instance));
+  });
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+  await prisma.$disconnect();
+});
+
+async function issueToken(ttlMinutes?: number) {
+  const response = await request(app)
+    .post("/api/admin/content/agent-authoring/tokens")
+    .set(adminHeaders)
+    .send({ label: "test-token", ...(ttlMinutes ? { ttlMinutes } : {}) });
+  expect(response.status).toBe(201);
+  expect(response.body.token).toMatch(/^aat_[0-9a-f]{48}$/);
+  return response.body as { token: string; id: string; expiresAt: string };
+}
+
+function tokenPackage(suffix: string) {
+  return {
+    packageFormat: "a2-authoring-package/v1",
+    objects: [
+      {
+        clientRef: "intro",
+        type: "section",
+        payload: { title: `AA3 section ${suffix}`, bodyMarkdown: "## Token" },
+      },
+      {
+        clientRef: "module-1",
+        type: "module",
+        payload: {
+          module: { title: `AA3 module ${suffix}` },
+          activeVersion: {
+            assessmentMode: "MCQ_ONLY",
+            mcqSet: { title: "Q", questions: [{ stem: "1+1?", options: ["2", "3"], correctAnswer: "2" }] },
+          },
+        },
+      },
+      {
+        clientRef: "course-main",
+        type: "course",
+        payload: {
+          course: { title: `AA3 course ${suffix}` },
+          items: [
+            { type: "SECTION", ref: "intro" },
+            { type: "MODULE", ref: "module-1" },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+describe("#651 agent authoring tokens", () => {
+  it("issues a token once, lists it without the secret, and audits the issuance", async () => {
+    const issued = await issueToken(30);
+
+    const list = await request(app)
+      .get("/api/admin/content/agent-authoring/tokens")
+      .set(adminHeaders);
+    expect(list.status).toBe(200);
+    const entry = list.body.tokens.find((token: { id: string }) => token.id === issued.id);
+    expect(entry).toMatchObject({ label: "test-token", revokedAt: null });
+    expect(JSON.stringify(entry)).not.toContain("aat_");
+
+    const audit = await prisma.auditEvent.findFirst({
+      where: { action: "agent_authoring_token_issued", entityId: issued.id },
+    });
+    expect(audit).not.toBeNull();
+  });
+
+  it("runs the full orchestration with a token, attributed to the issuing user", async () => {
+    const { token } = await issueToken();
+    const suffix = `aa3-ok-${Date.now()}`;
+
+    const result = await importPackage({
+      baseUrl,
+      headers: { authorization: `Bearer ${token}` },
+      pkg: tokenPackage(suffix),
+    });
+    expect(result.error).toBeNull();
+    expect(result.ok).toBe(true);
+
+    const moduleEntry = result.created.find((entry) => entry.type === "module")!;
+    const adminUser = await prisma.user.findUniqueOrThrow({
+      where: { externalId: "admin-1" },
+      select: { id: true },
+    });
+    const moduleRow = await prisma.module.findUniqueOrThrow({
+      where: { id: moduleEntry.id },
+      select: { activeVersionId: true, createdById: true },
+    });
+    expect(moduleRow.activeVersionId).toBeNull();
+    expect(moduleRow.createdById).toBe(adminUser.id);
+  });
+
+  it("denies everything outside the draft-authoring allowlist", async () => {
+    const { token, id } = await issueToken();
+    const bearer = { authorization: `Bearer ${token}` };
+
+    const denied = [
+      request(app).get("/api/admin/content/modules/library").set(bearer),
+      request(app).get("/api/me").set(bearer),
+      // No token self-minting or self-management:
+      request(app).post("/api/admin/content/agent-authoring/tokens").set(bearer).send({}),
+      request(app).post(`/api/admin/content/agent-authoring/tokens/${id}/revoke`).set(bearer),
+      // No publish paths (module/course/section publish are all outside the allowlist):
+      request(app).post("/api/admin/content/courses/some-id/publish").set(bearer),
+      request(app).post("/api/admin/content/sections/some-id/publish").set(bearer),
+    ];
+    for (const call of denied) {
+      const response = await call;
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe("agent_token_scope");
+    }
+  });
+
+  it("hardens the allowlisted writes: no auto-publish, no replaceExisting, draft-only sections, draft-only course items", async () => {
+    const { token } = await issueToken();
+    const bearer = { authorization: `Bearer ${token}` };
+    const envelope = {
+      exportFormat: "a2-content-export/v1",
+      exportedAt: new Date().toISOString(),
+      scope: "module",
+      module: {
+        module: { title: `AA3 hardening ${Date.now()}` },
+        activeVersion: {
+          assessmentMode: "MCQ_ONLY",
+          mcqSet: { title: "Q", questions: [{ stem: "1+1?", options: ["2", "3"], correctAnswer: "2" }] },
+          audit: { publishedAt: new Date().toISOString() },
+        },
+      },
+    };
+
+    // autoPublish omitted (default would publish because source audit has publishedAt):
+    const noAutoPublishFalse = await request(app)
+      .post("/api/admin/content/modules/import")
+      .set(bearer)
+      .send({ payload: envelope, mode: "createNew" });
+    expect(noAutoPublishFalse.status).toBe(403);
+
+    const replaceExisting = await request(app)
+      .post("/api/admin/content/modules/import")
+      .set(bearer)
+      .send({ payload: envelope, mode: "replaceExisting", targetId: "m-x", autoPublish: false });
+    expect(replaceExisting.status).toBe(403);
+
+    const publishedSection = await request(app)
+      .post("/api/admin/content/sections")
+      .set(bearer)
+      .send({ title: `AA3 live section ${Date.now()}`, bodyMarkdown: "## x" });
+    expect(publishedSection.status).toBe(403);
+
+    // Items on a published course: create as admin, force-publish via prisma.
+    const course = await request(app)
+      .post("/api/admin/content/courses")
+      .set(adminHeaders)
+      .send({ title: `AA3 published course ${Date.now()}` });
+    expect(course.status).toBe(201);
+    await prisma.course.update({ where: { id: course.body.course.id }, data: { publishedAt: new Date() } });
+    const items = await request(app)
+      .put(`/api/admin/content/courses/${course.body.course.id}/items`)
+      .set(bearer)
+      .send({ items: [] });
+    expect(items.status).toBe(403);
+    expect(items.body.error).toBe("agent_token_scope");
+  });
+
+  it("rejects expired and revoked tokens with 401", async () => {
+    const expired = await issueToken();
+    await prisma.agentAuthoringToken.update({
+      where: { id: expired.id },
+      data: { expiresAt: new Date(Date.now() - 1000) },
+    });
+    const expiredCall = await request(app)
+      .post("/api/admin/content/agent-authoring/validate")
+      .set({ authorization: `Bearer ${expired.token}` })
+      .send({ package: tokenPackage("x") });
+    expect(expiredCall.status).toBe(401);
+
+    const revokable = await issueToken();
+    const revoke = await request(app)
+      .post(`/api/admin/content/agent-authoring/tokens/${revokable.id}/revoke`)
+      .set(adminHeaders);
+    expect(revoke.status).toBe(200);
+    expect(revoke.body.token.revokedAt).not.toBeNull();
+
+    const revokedCall = await request(app)
+      .post("/api/admin/content/agent-authoring/validate")
+      .set({ authorization: `Bearer ${revokable.token}` })
+      .send({ package: tokenPackage("y") });
+    expect(revokedCall.status).toBe(401);
+
+    const audit = await prisma.auditEvent.findFirst({
+      where: { action: "agent_authoring_token_revoked", entityId: revokable.id },
+    });
+    expect(audit).not.toBeNull();
+
+    // Unknown token → 401 too.
+    const bogus = await request(app)
+      .get("/api/admin/content/agent-authoring/tokens")
+      .set({ authorization: `Bearer aat_${"0".repeat(48)}` });
+    expect(bogus.status).toBe(401);
+  });
+
+  it("requires admin_content roles to issue tokens", async () => {
+    const response = await request(app)
+      .post("/api/admin/content/agent-authoring/tokens")
+      .set({ ...adminHeaders, "x-user-roles": "PARTICIPANT" })
+      .send({});
+    expect(response.status).toBe(403);
+  });
+});


### PR DESCRIPTION
Del av EPIC #647; implementerer AA-3 (#651) — alternativ 2 («Kortlivet Agent Authoring Session») med multitenant-kravet fra produkteier som premiss. v1.6.13.

## Hva

- **`AgentAuthoringToken`** (ny Prisma-modell + migrasjon `20260706100000`): kun sha256-hashen lagres; hemmeligheten `aat_<48 hex>` genereres med `crypto.randomBytes(24)` og vises **én gang**. TTL klampes til 5–60 min (default 60). `revokedAt`/`lastUsedAt` spores. `onDelete: Cascade` mot bruker.
- **Endepunkter** (`admin_content`-guarded, krever ordinær bruker-auth): `POST /api/admin/content/agent-authoring/tokens` (utsted), `GET` (liste egne — aldri hemmeligheten), `POST .../:tokenId/revoke` (eier eller ADMINISTRATOR). Utstedelse/revokering audit-logges (`agent_authoring_token_issued`/`_revoked`).
- **Auth-integrasjon** ([authenticate.ts](../blob/main/src/auth/authenticate.ts)): `Bearer aat_...` håndteres FØR modus-dispatch — virker i både mock- og entra-modus, og mock-headere kan aldri overstyre token-identiteten. Identitet/roller hentes fra utstederens DB-konto → writes attribueres som brukeren og arver eierskapsmodellen (#528). Deaktivert bruker → 401.
- **Scope-vakt** (`enforceAgentTokenScope`, montert rett etter `authenticate` i app.ts): token-requests tillates kun mot de fem draft-operasjonene skillen orkestrerer; alt annet (inkl. alle publish/unpublish/archive/delete-stier, token-endepunktene selv, resten av API-flaten) → `403 agent_token_scope`.
- **Rute-herding på de tillatte kallene**: `modules/import` krever `mode: "createNew"` + eksplisitt `autoPublish: false` (default ville publisert ved kilde-audit med publishedAt), `sections` krever `draft: true`, `courses/:id/items` kun på upubliserte kurs.
- **Skill/docs**: `A2_AUTH_BEARER` tar nå helst et `aat_`-token (scriptet er uendret — samme header). SKILL.md, api-flow.md, API_REFERENCE og designnotatet (§7 «AA-3-beslutning») oppdatert. UI for utstedelse utskilt til **#731**.

## Security/privacy impact (akseptansekriterium)

- **Redusert risiko vs. status quo**: alternativet i dag er å gi agenten et fullt Entra-JWT (uscopet). `aat_`-tokenet er draft-only, ≤60 min, revokerbart og audit-sporbart — lekkasje gir ikke tilgang til publisering, sletting, deltakerdata eller admin-flater.
- **Ingen ny hemmelighetslagring**: kun hash; hemmeligheten kan ikke hentes ut igjen (heller ikke av ADMINISTRATOR).
- **Attribusjon**: alle writes står som utstederen i audit (pluss `source: agent_authoring` + `agentRunId` fra AA-5) — ingen anonyme maskinskriv.
- **Multitenant**: tabellen lever i installasjonens DB; et token er meningsløst i enhver annen installasjon. Ingen delt/vendor-global mekanisme.
- **Selvforsterkning umulig**: tokens kan ikke utstede/revokere tokens (utenfor allowlisten).
- Rate limiting og request-size caps gjelder uendret (samme `/api`-kjede).

## Akseptansekriterier (#651)

- [x] Designbeslutning dokumentert i #648-notatet (§7, «AA-3-beslutning»)
- [x] Integrationstester dekker scope, expiry/revoke og at publish ikke er tillatt (6 tester i `test/agent-authoring-token.test.ts`)
- [x] Security/privacy impact vurdert i PR (over)
- [x] Token kortlivet + revokerbart; bundet til bruker/rolle; kun draft-operasjoner; audit; hemmeligheten vises aldri igjen

## Test

- `npx tsc --noEmit` grønn; `npm run test:unit` 701 grønne
- `test/agent-authoring-token.test.ts` — 6/6 grønne (utstedelse/liste, full orkestrering med token, allowlist-avslag, rute-herding, expiry/revoke/ukjent → 401, rollekrav)
- Regresjon: alle 4 øvrige agent-authoring-suiter + `m1-core-flow` (auth-kjeden) — 16/16 grønne

🤖 Generated with [Claude Code](https://claude.com/claude-code)
