### PR TITLE
fix(auth): #651 agent-token 403 på stage — frys utstederens roller på tokenet (v1.6.15)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,24 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.15 - 2026-07-07
+
+fix(auth): #651 agent-token 403 på stage — frys utstederens roller på tokenet
+
+Stage-test av agent-tokenet ga `403 forbidden` («Requires one of roles: ADMINISTRATOR,
+SUBJECT_MATTER_OWNER») selv om tokenet ble utstedt av en admin/SMO. Rotårsak: i Entra-modus
+er de effektive rollene DB-roller ∪ JWT-app-rollekrav, men JWT-kravrollene persisteres ikke
+som `RoleAssignment`. Token-auth utledet rollene på nytt med `getActiveRoles` (kun
+persisterte) → SMO/admin-rollen forsvant → 403. (Lokale/seedede brukere har persisterte
+roller, derfor grønt i test og lokalt.)
+
+Fiks: utstederens effektive roller (fra det autentiserte request-et som allerede passerte
+`admin_content`-vakta) fryses på tokenet ved utstedelse (`AgentAuthoringToken.rolesJson`,
+migrasjon 20260707100000) og gjenbrukes ved token-auth. Deterministisk, uavhengig av
+rollekilde, og hindrer at tokenet eskalerer roller senere. Eldre tokens uten snapshot
+faller tilbake til persisterte roller. Ny regresjonstest: bruker med rolle kun i
+request-konteksten (0 persisterte roller) utsteder token → validate gir 200, ikke 403.
+
 ## 1.6.14 - 2026-07-06
 
 feat(ux): #731 «Agent-tilgang» på profilsiden — utsted/vis én gang/liste/revokér agent-tokens

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260707100000_add_agent_token_roles/migration.sql
+++ b/prisma/migrations/20260707100000_add_agent_token_roles/migration.sql
@@ -1,0 +1,3 @@
+-- AA-3 fix (#651): freeze the issuer's effective roles on the token so token-auth
+-- doesn't depend on re-deriving Entra JWT-claim roles (which aren't persisted).
+ALTER TABLE "AgentAuthoringToken" ADD COLUMN "rolesJson" TEXT NOT NULL DEFAULT '[]';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -115,6 +115,11 @@ model AgentAuthoringToken {
   label      String?
   userId     String
   user       User      @relation("AgentAuthoringTokens", fields: [userId], references: [id], onDelete: Cascade)
+  // Snapshot of the issuer's effective roles at issuance (JSON array of AppRole).
+  // Entra app-role-claim roles are NOT persisted as RoleAssignments, so re-deriving
+  // them at token-auth time would drop them (→ 403). Freezing them here binds the
+  // token to exactly the roles the user was authorized with when they created it.
+  rolesJson  String    @default("[]")
   createdAt  DateTime  @default(now())
   expiresAt  DateTime
   revokedAt  DateTime?

--- a/src/auth/agentAuthoringTokenService.ts
+++ b/src/auth/agentAuthoringTokenService.ts
@@ -22,6 +22,9 @@ export async function issueAgentAuthoringToken(input: {
   userId: string;
   label?: string;
   ttlMinutes?: number;
+  // The issuer's effective roles for THIS request (DB ∪ Entra-claim). Frozen onto
+  // the token so token-auth doesn't have to re-derive non-persisted claim roles.
+  roles: string[];
 }) {
   const ttl = Math.min(
     AGENT_TOKEN_MAX_TTL_MINUTES,
@@ -33,6 +36,7 @@ export async function issueAgentAuthoringToken(input: {
       tokenHash: sha256(secret),
       label: input.label ?? null,
       userId: input.userId,
+      rolesJson: JSON.stringify(input.roles ?? []),
       expiresAt: new Date(Date.now() + ttl * 60_000),
     },
   });

--- a/src/auth/authenticate.ts
+++ b/src/auth/authenticate.ts
@@ -41,6 +41,18 @@ function parseRoleNames(input: string[] | undefined): AppRole[] {
     .filter((role) => valid.has(role)) as AppRole[];
 }
 
+// AA-3 (#651): parse the token's frozen role snapshot (JSON array). Never throws —
+// a corrupt value yields [] so auth falls back to persisted roles.
+function parseStoredRoles(rolesJson: string | null | undefined): string[] {
+  if (!rolesJson) return [];
+  try {
+    const parsed = JSON.parse(rolesJson);
+    return Array.isArray(parsed) ? parsed.filter((role): role is string => typeof role === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
 function isIdentityReconciliationError(error: unknown): error is { code: string } {
   return (
     typeof error === "object" &&
@@ -131,10 +143,12 @@ export async function authenticate(request: Request, response: Response, next: N
 
   // AA-3 (#651): short-lived agent authoring tokens (Bearer aat_...) work in BOTH
   // auth modes — they are resolved against this installation's database, not the
-  // IdP. Identity/roles come from the issuing user's DB record; the request is
-  // marked agentToken so enforceAgentTokenScope can restrict it to draft
-  // authoring endpoints. Handled before mode dispatch so mock headers can never
-  // override a token-authenticated identity.
+  // IdP. The roles were frozen onto the token at issuance (the issuer's effective
+  // roles, incl. Entra JWT-claim roles that are never persisted as RoleAssignments
+  // and so can't be re-derived here). Legacy tokens with no snapshot fall back to
+  // persisted roles. The request is marked agentToken so enforceAgentTokenScope can
+  // restrict it to draft authoring endpoints. Handled before mode dispatch so mock
+  // headers can never override a token-authenticated identity.
   const authorizationHeader = request.header("authorization");
   if (authorizationHeader?.startsWith(`Bearer ${AGENT_TOKEN_PREFIX}`)) {
     try {
@@ -143,10 +157,11 @@ export async function authenticate(request: Request, response: Response, next: N
         response.status(401).json({ error: "unauthorized", message: t(locale, "unauthorized") });
         return;
       }
+      const frozenRoles = parseRoleNames(parseStoredRoles(token.rolesJson));
       request.context = {
         correlationId: request.context?.correlationId,
         userId: token.user.id,
-        roles: await getActiveRoles(token.user.id),
+        roles: frozenRoles.length > 0 ? frozenRoles : await getActiveRoles(token.user.id),
         locale,
         agentToken: { tokenId: token.id },
       };

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -154,6 +154,10 @@ adminContentRouter.post("/agent-authoring/tokens", async (request, response) => 
       userId,
       label: data.label,
       ttlMinutes: data.ttlMinutes,
+      // Freeze the issuer's effective roles (this request passed the admin_content
+      // guard, so they include ADMINISTRATOR/SMO even when sourced from an Entra
+      // claim that isn't persisted). #651 stage 403 fix.
+      roles: request.context?.roles ?? [],
     });
     response.status(201).json({
       token: secret,

--- a/test/agent-authoring-token.test.ts
+++ b/test/agent-authoring-token.test.ts
@@ -120,6 +120,39 @@ describe("#651 agent authoring tokens", () => {
     expect(moduleRow.createdById).toBe(adminUser.id);
   });
 
+  it("works when the issuer's role is not persisted (Entra claim / mock hint) — #651 stage 403 regression", async () => {
+    // A user whose SMO role comes ONLY from the request (x-user-roles hint in mock,
+    // a JWT app-role claim on stage) and has NO persisted RoleAssignment. Before the
+    // role-snapshot fix, getActiveRoles() returned [] at token-auth time → 403.
+    const claimOnlyHeaders = {
+      "x-user-id": "smo-claim-only-651",
+      "x-user-email": "smo.claim651@company.com",
+      "x-user-name": "Claim-only SMO",
+      "x-user-roles": "SUBJECT_MATTER_OWNER",
+    };
+    const issued = await request(app)
+      .post("/api/admin/content/agent-authoring/tokens")
+      .set(claimOnlyHeaders)
+      .send({ label: "claim-only" });
+    expect(issued.status).toBe(201);
+
+    // Sanity: this user genuinely has no persisted roles.
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { externalId: "smo-claim-only-651" },
+      select: { id: true },
+    });
+    const persisted = await prisma.roleAssignment.count({ where: { userId: user.id } });
+    expect(persisted).toBe(0);
+
+    // The token still authorises the draft-authoring endpoint (200, not 403).
+    const validate = await request(app)
+      .post("/api/admin/content/agent-authoring/validate")
+      .set({ authorization: `Bearer ${issued.body.token}` })
+      .send({ package: tokenPackage(`claim-${Date.now()}`) });
+    expect(validate.status).toBe(200);
+    expect(validate.body.valid).toBe(true);
+  });
+
   it("denies everything outside the draft-authoring allowlist", async () => {
     const { token, id } = await issueToken();
     const bearer = { authorization: `Bearer ${token}` };


### PR DESCRIPTION
Stage-test av agent-tokenet (manuelt testskript, punkt 2) ga `403 forbidden` («Requires one of roles: ADMINISTRATOR, SUBJECT_MATTER_OWNER») selv om tokenet ble utstedt av en admin/SMO.

## Rotårsak

I Entra-modus er de effektive rollene **DB-roller ∪ JWT-app-rollekrav** (authenticate.ts). JWT-kravrollene persisteres **ikke** som `RoleAssignment`. Token-auth-veien (#651) utledet rollene på nytt med `getActiveRoles(userId)` — som kun leser persisterte roller — så SMO/admin-rollen forsvant ved token-bruk → `requireAnyRole(admin_content)` ga 403. Lokale/seedede brukere har persisterte roller, derfor var alt grønt i CI og lokalt; feilen dukker kun opp i et ekte Entra-miljø.

## Fiks

Frys utstederens **effektive** roller på tokenet ved utstedelse og gjenbruk dem ved token-auth:
- Ny kolonne `AgentAuthoringToken.rolesJson` (migrasjon `20260707100000`, `DEFAULT '[]'`).
- `issueAgentAuthoringToken` lagrer `request.context.roles` (request-et passerte allerede `admin_content`-vakta, så rollene inkluderer ADMINISTRATOR/SMO uansett kilde).
- Token-auth bruker de frosne rollene; eldre tokens uten snapshot faller tilbake til `getActiveRoles`.

Deterministisk, uavhengig av rollekilde, og hindrer at et token eskalerer roller senere (rollene er frosset til utstedelsestidspunktet). Scope-vakta (`enforceAgentTokenScope`) og rute-herdingen er uendret.

## Test

- Ny regresjonstest i `agent-authoring-token.test.ts`: en bruker hvis SMO-rolle kun finnes i request-konteksten (mock `x-user-roles`-hint, 0 persisterte `RoleAssignment` — reproduserer JWT-claim-scenariet) utsteder token → `validate` gir **200, ikke 403**. Testen asserterer eksplisitt at brukeren har 0 persisterte roller.
- `npm run test:integration:native -- test/agent-authoring-token.test.ts` → 7/7 grønne.
- `npx tsc --noEmit` grønn.

Krever DB-migrasjon (kjøres automatisk i deploy). Etter merge + stage-deploy: lag et **nytt** token (eksisterende har tom snapshot) og kjør testskriptet på nytt fra punkt 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)