### PR TITLE
docs: #654 AA-6 lukk docs/test-sjekkliste for Agent Authoring (EPIC #647)

### DIFF
--- a/doc/AGENT_ACCESS_GUIDE.md
+++ b/doc/AGENT_ACCESS_GUIDE.md
@@ -37,5 +37,17 @@ begrenset til å lage utkast, og alt den lager må du selv gjennomgå og publise
 **Agenten sier 401/utløpt midt i jobben?** Lag et nytt token og lim det inn — agenten
 fortsetter der den slapp (det som allerede er opprettet, er trygt lagret som utkast).
 
+**Agenten sier at pakken har feil / ikke er gyldig?** Før noe opprettes, kjører agenten en
+validering. Er det feil, får den en liste med **hva** som er galt og **hvor** (f.eks. «en
+flervalgs-modul mangler spørsmål» eller «et kurs peker til en modul som ikke finnes»).
+Agenten skal rette dette selv og prøve igjen — du trenger ikke tolke feilmeldingene, men be
+den gjerne forklare hva den endret. Ingenting opprettes så lenge valideringen feiler.
+
+**Hva skjer hvis noe feiler etter at deler er opprettet (delvis suksess)?** Agenten stopper
+ved steget som feilet og forteller deg **hva som ble opprettet** (med lenker), **hva som
+feilet**, og **hva som gjenstår**. Den sletter aldri noe automatisk. De ferdige utkastene
+ligger trygt i biblioteket (usynlige for deltakere) — du kan beholde dem, be agenten fortsette,
+eller arkivere+slette dem i admin-UI.
+
 **Hvor blir det av utkastene hvis noe feiler underveis?** De ligger i biblioteket som
 vanlige utkast (usynlige for deltakere). Behold, fullfør eller arkiver+slett dem i admin-UI.

--- a/doc/FEATURE_SURFACE_MAP.md
+++ b/doc/FEATURE_SURFACE_MAP.md
@@ -239,3 +239,28 @@ pages — they are separate static JS/HTML files, so consistency is by conventio
 | Landing entry | capability `admin-content` path = `/admin-content/courses` (`src/config/capabilities.ts`) | «Innholdsforvaltning» opens on Kurs |
 
 **Guards:** `test/e2e/admin-content-classes.spec.ts` "admin buttons + top nav render in prod-shaped config" (asserts a REAL i18n key resolves, not raw); `test/e2e/admin-content-workspaces.spec.ts` course archive (filter pill), unpublish, sections lifecycle. When adding a column/filter to one list, mirror it where it applies and update this entry.
+
+## 15. Agent Authoring — draft-only invariant across 3 entities + token scope (EPIC #647)
+
+Agents create content through the **same** `admin_content` commands humans use, and the
+"agent-created content is never live" guarantee is enforced **per entity + per call**, not in
+one place. A change to any create/import path, or to the token scope, must keep all of these true.
+
+| Surface | Where | Draft-only rule |
+|---------|-------|-----------------|
+| Package contract (source of truth) | `src/modules/adminContent/agentAuthoringSchemas.ts` (`.strict()`, no publish/audit fields) | hallucinated publish fields → `unknown_field` |
+| Validation report + plan | `src/modules/adminContent/agentAuthoringValidationService.ts` | no DB writes; plan only when `errors == 0` |
+| Module create | `POST /modules/import` (`src/routes/adminContent.ts`) → `importModuleFromEnvelope` | agent tokens forced to `createNew` + `autoPublish:false`; empty `audit` ⇒ never auto-publishes |
+| Section create | `POST /sections` (`src/routes/adminSections.ts`) → `createSection({draft})` | agent tokens forced `draft:true` (else section auto-publishes on save) |
+| Course create | `POST /courses` (`src/routes/adminCourses.ts`) → `createCourse` | `publishedAt` stays null (no publish call) |
+| Course items | `PUT /courses/:id/items` | agent tokens: only on **unpublished** courses |
+| Token scope | `src/auth/agentTokenScope.ts` (`enforceAgentTokenScope`) | `aat_` tokens reach ONLY the 5 draft ops; no publish path, no token self-mint |
+| Token roles | `src/auth/agentAuthoringTokenService.ts` + `authenticate.ts` | issuer's effective roles frozen on the token (`rolesJson`) — not re-derived (#651 stage-403 fix) |
+| Audit trace | `source: agent_authoring` + `agentRunId` in every write's metadata (AA-5) | reconstruct a run from audit |
+| User surface | «Agent-tilgang» section on `/profile` (`public/profile.js`, role-gated via `/api/me` — see entry #12) | issue/copy-once/list/revoke |
+
+**Guards:** `test/agent-authoring-validate.test.ts` (validate + no-writes), `…-orchestration.test.ts`
+(drafts + links across all 3 modes, both roles), `…-audit.test.ts` (agentRunId + partial failure),
+`…-token.test.ts` (scope, expiry/revoke, role snapshot), `…-skill-import.test.ts` (fixture through
+the skill script), `test/unit/agent-authoring-validation.test.ts` (rules), `test/e2e/profile-agent-tokens.spec.ts`
+(token UI). User docs: `doc/AGENT_ACCESS_GUIDE.md`; API: `doc/API_REFERENCE.md`; design: `doc/design/AGENT_AUTHORING_647.md`.

--- a/doc/LOCAL_DEV_NO_DOCKER.md
+++ b/doc/LOCAL_DEV_NO_DOCKER.md
@@ -57,3 +57,23 @@ re-applies migrations + seeds), followed by `npm run dev:seed:consent`.
   locally. The two loops above cover local development.
 - Definition of done for user-facing changes (see CLAUDE.md): a Playwright e2e of the primary
   flow, written with the feature and run locally before deploy.
+
+### Agent Authoring smoke (EPIC #647)
+
+Drive the agent-authoring API against your local app without any agent or ChatGPT:
+
+```
+# App running via `npm run dev:local` (mock auth). In another shell:
+$env:A2_USER_ID   = 'content-owner-1'      # any id; role hint below grants access
+$env:A2_USER_ROLES = 'SUBJECT_MATTER_OWNER'
+$env:A2_BASE_URL  = 'http://127.0.0.1:3000'
+node skills/a2-authoring-api/scripts/import-package.mjs --file skills/a2-authoring-api/fixtures/example-package.json --validate-only
+node skills/a2-authoring-api/scripts/import-package.mjs --file skills/a2-authoring-api/fixtures/example-package.json
+```
+
+The fixture creates a course with 2 learning sections + one module of each assessment mode
+(FREETEXT_ONLY / MCQ_ONLY / FREETEXT_PLUS_MCQ) as **drafts**, and prints admin links + an
+`agentRunId`. Package the skill as a distributable zip with `npm run skill:package`.
+
+- Agent-authoring integration tests (native Postgres, no Docker):
+  `npm run test:integration:native -- test/agent-authoring-validate.test.ts test/agent-authoring-orchestration.test.ts test/agent-authoring-audit.test.ts test/agent-authoring-token.test.ts test/agent-authoring-skill-import.test.ts`

--- a/doc/route-map.md
+++ b/doc/route-map.md
@@ -57,3 +57,23 @@ The conversational and advanced editors are two modes of the same module workspa
 | `/api/admin/platform` | Admin | Platform administration |
 | `/participant/config` | Public (rate-limited) | Participant console bootstrap config |
 | `/healthz` | Public | Health check (no version info) |
+
+### Agent Authoring (EPIC #647) — under `/api/admin/content`
+
+Draft-only content authoring by AI agents. Full details: `doc/API_REFERENCE.md`,
+`doc/AGENT_ACCESS_GUIDE.md` (SMO/user flow), `doc/design/AGENT_AUTHORING_647.md`.
+
+| Route | Auth | Purpose |
+|---|---|---|
+| `POST /api/admin/content/agent-authoring/validate` | SMO / Admin (or agent token) | Dry-run an `a2-authoring-package/v1` — no DB writes; returns report + execution plan (AA-1) |
+| `POST /api/admin/content/agent-authoring/tokens` | SMO / Admin (user auth only) | Issue a short-lived `aat_` agent token; secret shown once (AA-3) |
+| `GET /api/admin/content/agent-authoring/tokens` | SMO / Admin | List own tokens (never the secret) |
+| `POST /api/admin/content/agent-authoring/tokens/:id/revoke` | SMO / Admin (owner or Admin) | Revoke a token immediately |
+
+Agent tokens (`Authorization: Bearer aat_…`) are scope-limited to the five draft-authoring
+operations (validate + `modules/import`, `sections`, `courses`, `courses/:id/items`) — every
+other route returns `403 agent_token_scope`.
+
+**User surface:** the **«Agent-tilgang»** section on `/profile` (issue/copy-once/list/revoke)
+is role-gated to SUBJECT_MATTER_OWNER / ADMINISTRATOR (#731). No new page/route — it is a
+section on the existing profile page.


### PR DESCRIPTION
Lukker #654 (AA-6) og dermed docs/test-sjekklisten for **EPIC #647**. Docs-only — ingen kodeendring, ingen versjonsbump.

## Docs (denne PR-en)

- **`doc/route-map.md`**: ny «Agent Authoring»-blokk under `/api/admin/content` (validate + token-endepunktene med auth), og notat om at «Agent-tilgang» er en rollegatet seksjon på eksisterende `/profile` (ikke ny rute).
- **`doc/FEATURE_SURFACE_MAP.md`**: ny entry **15** — draft-only-invarianten som distribuert flate (kontrakt → validate → modul/seksjon/kurs-create → items → token-scope → rolle-snapshot → audit → profil-UI), hver med kilde og guard-test. Fanger «riktig fiks, ufullstendig flate»-risikoen for hele sporet.
- **`doc/LOCAL_DEV_NO_DOCKER.md`**: Docker-fri skill-smoke (kjør `import-package.mjs` mot lokal app) + samlekommando for agent-authoring integrasjonstestene + `npm run skill:package`.
- **`doc/AGENT_ACCESS_GUIDE.md`**: to nye FAQ — hvordan valideringsfeil leses (i brukertermer) og hva som skjer ved delvis suksess.

## Testkravene i #654 — allerede oppfylt i tidligere skiver

| Krav | Dekket av |
|---|---|
| Unit/contract for package-schema + valideringsrapport | `test/unit/agent-authoring-validation.test.ts` (#649) |
| Integration: API happy path + valideringsfeil | `test/agent-authoring-validate.test.ts` (#649) |
| Browser/e2e for brukerreise (token-UI + returned links) | `test/e2e/profile-agent-tokens.spec.ts` (#731) |
| Skill smoke/fixture: seksjon + FREETEXT_ONLY + MCQ_ONLY + FREETEXT_PLUS_MCQ + item-rekkefølge | `test/agent-authoring-skill-import.test.ts` + `fixtures/example-package.json` (#652) |
| Draft-only, roller, returned URLs | `…-orchestration.test.ts` (#650), `…-token.test.ts` (#651), `…-audit.test.ts` (#653) |

## Akseptansekriterier (#654)

- [x] Dokumentasjon for teknisk API (`API_REFERENCE.md`) og bruker/SMO-flyt (`AGENT_ACCESS_GUIDE.md`)
- [x] Tester dekker package-validering, draft-only, roller og returned URLs (matrisen over)
- [x] `route-map.md` + `FEATURE_SURFACE_MAP.md` oppdatert
- [x] `LOCAL_DEV_NO_DOCKER.md` oppdatert med skill/API-smoke-kommandoer
- [x] PR-body peker til alle child-issues og lukker epicens docs/test-sjekkliste (under)

## EPIC #647 — sluttstatus

| Sak | Status |
|---|---|
| #648 AA-D1 design | ✅ #724 |
| #649 AA-1 validate | ✅ #725 (v1.6.10) |
| #650 AA-2 responser | ✅ #727 (v1.6.11) |
| #653 AA-5 audit/partial | ✅ #729 (v1.6.12) |
| #652 AA-4 skill | ✅ #728 |
| #651 AA-3 tokens | ✅ #732 (v1.6.13) + 403-fiks #737 (v1.6.15) |
| #731 token-UI | ✅ #735 (v1.6.14) |
| #654 AA-6 docs/test | ✅ denne PR |

Utenfor epicens kjerne (egne issues, ikke blokkere): #726 Idempotency-Key, #733 device-flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
