### PR TITLE
docs(skills): forfatter-arbeidsflyt for a2-authoring-api — discover/design/preview/export

### DIFF
--- a/skills/a2-authoring-api/SKILL.md
+++ b/skills/a2-authoring-api/SKILL.md
@@ -25,41 +25,56 @@ point them to the admin UI links instead.
 
 ## Workflow
 
-1. **Collect requirements** from the user and the conversation/project context: number of
-   modules and sections, assessment mode(s) (`FREETEXT_PLUS_MCQ`, `MCQ_ONLY`,
-   `FREETEXT_ONLY`), primary language (`locale`), certification level, ordering, and the
-   actual subject matter the content should teach/assess.
-2. **Author the package**: an `a2-authoring-package/v1` JSON document. Full contract with
-   per-mode examples: [references/package-schema.md](references/package-schema.md). A
-   complete working example: [fixtures/example-package.json](fixtures/example-package.json).
-   Write real content — concrete task texts, rubric criteria tied to each module's topic,
-   plausible MCQ distractors — not lorem ipsum. Record the user's requirements verbatim in
-   `constraints` (audit trail).
-3. **Validate (dry-run)**: `POST /api/admin/content/agent-authoring/validate` with
-   `{ "package": <package> }` — or run
-   `node skills/a2-authoring-api/scripts/import-package.mjs --file pkg.json --base-url <url> --validate-only`.
-   The endpoint never writes; 200 with `valid: false` is a report, not an error.
-4. **Fix and re-validate**: `issues[].path` is a JSON path into your package and
-   `issues[].code` is stable — fix mechanically unambiguous errors (`required_for_mode`,
-   `unknown_client_ref`, `unknown_field`, …) and re-validate. If an issue requires a
-   judgment call (e.g. `possible_duplicate_title` — reuse the existing module instead?),
-   ask the user instead of guessing.
-5. **Confirm before writing** when the package is large (> ~5 objects), touches existing
-   content (`moduleId`/`sectionId` references), or the requirements were ambiguous. Show a
-   one-line-per-object summary of what will be created.
-6. **Execute the plan** returned by validate, in order. Call sequence, exact bodies, and
-   auth headers: [references/api-flow.md](references/api-flow.md). In a shell-capable
-   environment, prefer the reference script (it implements the whole flow):
+This skill is a **course-authoring conversation**, not just a JSON emitter. The craft —
+interviewing the user, designing a pedagogically sound course, and previewing it before
+building — is in **[references/authoring-playbook.md](references/authoring-playbook.md)**;
+read it. The four phases:
+
+### Phase 1 — Discover
+Interview the user for the few things that drive the design: goal, audience, **learning
+objectives** ("after this, a learner can ___"), source material to ground the content in,
+the assessment intent per objective, scope, language. When the user is vague, propose a
+concrete straw-man and let them correct it. (Playbook §1.)
+
+### Phase 2 — Design
+Turn objectives into structure: sections *teach*, modules *assess*. Choose the assessment
+mode per module deliberately — `MCQ_ONLY` for recall, `FREETEXT_ONLY` for applied
+judgment/reasoning, `FREETEXT_PLUS_MCQ` for both. Write **real** content grounded in the
+source material: concrete task texts, rubric criteria tied to each objective, MCQs with
+plausible distractors — never lorem ipsum. Order so teaching precedes assessment. (Playbook §2.)
+
+### Phase 3 — Preview & approve  (before building anything)
+**Render the whole course back to the user in the conversation and get explicit approval
+before you build the package, validate, or write anything.** Show the ordered outline plus,
+per item, the section content / task text / MCQs / rubric, then ask "ser dette riktig ut,
+vil du endre noe før jeg oppretter utkastene?" Iterate here — it is far cheaper than fixing
+created drafts. Use the preview template in the playbook (§3).
+
+### Phase 4 — Export
+Only after approval:
+1. **Build** the `a2-authoring-package/v1`. Contract + per-mode examples:
+   [references/package-schema.md](references/package-schema.md); working example:
+   [fixtures/example-package.json](fixtures/example-package.json). Record the user's stated
+   requirements verbatim in `constraints`.
+2. **Validate (dry-run)**: `POST /api/admin/content/agent-authoring/validate` with
+   `{ "package": <package> }`, or the script with `--validate-only`. Never writes; 200 with
+   `valid: false` is a report. Fix errors (`issues[].path`/`code` are stable); if a fix
+   changes what the learner sees, **re-preview** (Phase 3).
+3. **Create the drafts** in the plan's order. Call sequence, bodies, auth:
+   [references/api-flow.md](references/api-flow.md). In a shell environment prefer the script
+   (implements the whole flow):
    `node skills/a2-authoring-api/scripts/import-package.mjs --file pkg.json --base-url <url>`.
-7. **Report the result**: one line per created object with its admin link
-   (`links.conversation`/`links.course`/`links.editor`), the run's `agentRunId` (audit
-   trace), plus an explicit closing note:
-   *"Alt er opprettet som utkast — gjennomgå og publiser manuelt i admin-UI."*
-8. **On partial failure**: stop at the failed step. Report per plan step what happened
-   (done / failed / skipped), what WAS created (IDs + links), the API error body, and the
-   `agentRunId` (every completed write is audit-logged with it, so the run is
-   reconstructable). Do NOT delete anything — drafts are harmless and may contain work
-   worth keeping; cleanup is the human's decision.
+4. **Report**: one line per created object with its admin link, plus the run's `agentRunId`,
+   and the closing note *"Alt er opprettet som utkast — gjennomgå og publiser manuelt i admin-UI."*
+
+**On partial failure:** stop at the failed step; report per step what happened
+(done/failed/skipped), what WAS created (IDs + links), the API error body, and the
+`agentRunId`. Never delete anything — cleanup is the human's decision.
+
+**If you can't reach the API at all** (sandboxed conversation with no outbound calls): don't
+lose the work — emit an `a2-content-export/v1` **course envelope** to a file and tell the
+user to import it via the admin-UI course import. This needs no token and no network from the
+agent. See the playbook (§4, Fallback).
 
 ## Security rules (hard)
 

--- a/skills/a2-authoring-api/references/authoring-playbook.md
+++ b/skills/a2-authoring-api/references/authoring-playbook.md
@@ -1,0 +1,135 @@
+# Authoring playbook — how to run a good course-authoring session
+
+This is the conversational craft of the skill: how to *interview* the user, *design* a
+pedagogically sound course, and *show it back* for approval before anything is created.
+The mechanics (package format, API calls) live in `package-schema.md` and `api-flow.md`;
+this file is about doing the authoring well.
+
+The platform's model, which shapes everything below:
+- **Learning sections teach** (markdown content, no assessment).
+- **Modules assess** — in one of three modes:
+  - `MCQ_ONLY` — multiple-choice only. For **recognition / factual recall** (definitions,
+    "which of these is correct", rules).
+  - `FREETEXT_ONLY` — a written answer graded by an LLM against a rubric. For **applied
+    judgment / reasoning / explanation** where *how* they argue matters.
+  - `FREETEXT_PLUS_MCQ` — both. For "check they know the facts **and** can apply them".
+- A **course** orders sections and modules into a learning path.
+- Everything you create is a **draft**; a human publishes later.
+
+---
+
+## Phase 1 — Discover (gather content & intent)
+
+Don't ask twenty questions. Get the few things that determine the design, and when the user
+is vague, **propose a concrete straw-man and let them correct it** — that is faster and gives
+them something to react to.
+
+Elicit (in roughly this order):
+
+1. **Goal & topic** — what should a learner get out of this? One or two sentences.
+2. **Audience** — who are they (role, seniority, prior knowledge)? This sets level, tone,
+   examples, and language.
+3. **Learning objectives** — the backbone. Phrase each as *"After this, a learner can ___"*
+   (identify…, apply…, decide…, explain…). Everything downstream derives from these. If the
+   user hasn't articulated them, propose 3–6 from the topic and confirm.
+4. **Source material** — do they have real content to ground this in (a policy, notes, a
+   document, a slide deck)? Ask them to paste/describe/upload it. **Ground the content in
+   their material; do not invent facts, figures, regulations, or quotes.** If there is no
+   source, say so plainly and keep claims general/uncontroversial.
+5. **Assessment intent, per objective** — for each objective, is it *recall* (→ lean
+   `MCQ_ONLY`), *applied judgment / written reasoning* (→ `FREETEXT_ONLY`), or *both*
+   (→ `FREETEXT_PLUS_MCQ`)? You choose the mode; confirm your reasoning with the user.
+6. **Scope** — how many modules and sections? If unspecified, propose a lean structure
+   (a few well-formed modules beat many thin ones). Map roughly one module per objective.
+7. **Language** (`locale`) and **certification level**.
+
+Record the user's stated requirements verbatim in the package's `constraints` (audit trail).
+
+## Phase 2 — Design (turn intent into a course)
+
+**Structure.** Each objective usually becomes: a *section* that teaches it (when the learner
+needs input) + a *module* that assesses it. Simple recall objectives may need only a module;
+context/background may need only a section. Order so that **teaching precedes assessment**,
+with an intro section first and (optionally) a summary section last.
+
+**Pick the mode per module deliberately** (this is the most common design mistake):
+- Recognition/recall, unambiguous right answer → `MCQ_ONLY`.
+- "Explain / analyse / decide and justify", where the reasoning is the point → `FREETEXT_ONLY`.
+- Knowledge that must then be applied → `FREETEXT_PLUS_MCQ`.
+
+**Write real, specific content:**
+- *Task text* (free-text modules): a concrete scenario or prompt, not "Discuss X". Give the
+  learner something to *do/decide*, ideally grounded in the source material.
+- *Rubric criteria*: each criterion tied to the objective, named, with a described scale
+  (e.g. `"identifisering": "0–4: identifiserer korrekt grunnlag og avgrenser mot alternativene"`).
+  Avoid a lone vague "quality" criterion — criteria must be observable.
+- *MCQ questions*: the stem tests **one** idea; 3–4 options; **distractors reflect real
+  misconceptions** (plausible, not obviously wrong); exactly one unambiguously correct
+  option; a short `rationale` explaining why. Never "all of the above".
+- *Assessor expected content* (free-text): what a strong answer contains — this guides the
+  LLM grader.
+
+**Scope discipline.** Prefer fewer, well-formed modules. A course that assesses six things
+shallowly is worse than one that assesses three things well.
+
+## Phase 3 — Preview & approve (show it BEFORE you build)
+
+**This is mandatory and happens before you build the package, validate, or write anything.**
+Render the whole course back to the user *in the conversation*, in readable form, and get
+explicit approval. Iterate on their feedback here — it is far cheaper than fixing created
+drafts.
+
+Use this shape:
+
+```
+## Forslag: <kurstittel>
+<én linje om kurset> · Målgruppe: <…> · Språk: <…> · Nivå: <…>
+
+Struktur (rekkefølge):
+1. 📄 Seksjon: <tittel>
+2. 📝 Modul: <tittel> — <mode> — vurderer: <objektiv>
+3. 📝 Modul: <tittel> — <mode> — vurderer: <objektiv>
+4. 📄 Seksjon: Oppsummering
+
+---
+### 1. Seksjon: <tittel>
+<selve innholdet, eller et sammendrag hvis langt>
+
+### 2. Modul: <tittel>  (FREETEXT_ONLY)
+**Oppgave:** <task text>
+**Vurderingskriterier:** <kriterium 1 (skala)>, <kriterium 2 (skala)>
+
+### 3. Modul: <tittel>  (MCQ_ONLY)
+**Spørsmål 1:** <stem>
+- a) <option>   b) <option>   c) <option ✓>   d) <option>
+  *Riktig: c — <rationale>*
+...
+```
+
+Then ask, explicitly: **"Ser dette riktig ut? Vil du endre rekkefølge, innhold, oppgaver
+eller vurderingsform før jeg oppretter utkastene?"** Only build the package after the user
+approves. Re-preview after any substantive change.
+
+## Phase 4 — Export
+
+Once approved, build the `a2-authoring-package/v1`, validate, and create the drafts
+(`api-flow.md`). If the validate report surfaces a content problem (e.g. an MCQ missing an
+answer), fix it and, if it changed what the learner sees, re-preview.
+
+### Fallback when the agent can't reach the API directly
+
+Some conversational environments can't make outbound calls to the installation. In that
+case **do not lose the work** — emit the course to disk in the platform's portable format
+and hand it to the user for manual import:
+
+1. Produce an **`a2-content-export/v1` course envelope** (self-contained: inlines each module
+   and section payload under `course.items[]` with `sortOrder`; `exportFormat`,
+   `exportedAt`, and `audit: {}` on each). The leaf payloads are the *same* shapes as the
+   authoring package, so this is a mechanical wrap. See `package-schema.md` for the mapping.
+2. Write it to a file, e.g. `kurs-<navn>.json`, and tell the user to import it via the
+   existing **admin-UI course import** (Innholdsforvaltning → importer). The import creates
+   the same drafts; nothing is published.
+
+This fallback needs no token and no network from the agent — only that the user can save a
+file and use the admin UI. Prefer the direct API when it's available (it returns deep links);
+use the file fallback when it isn't.

--- a/skills/a2-authoring-api/references/package-schema.md
+++ b/skills/a2-authoring-api/references/package-schema.md
@@ -130,3 +130,41 @@ FREETEXT_PLUS_MCQ: include both the free-text triple and `mcqSet`.
 
 `plan` (only when `errors == 0`) is the execution order:
 `create_section`* → `create_module`* → `create_course` → `set_course_items`.
+
+## Fallback format: `a2-content-export/v1` course envelope (for manual import)
+
+When the agent can't call the API (see playbook §4), emit the course as a **self-contained
+`a2-content-export/v1` course envelope** written to disk; the user imports it via the
+existing admin-UI course import. The **leaf payloads are identical** to the authoring
+package (same `module`/`activeVersion`/`section` shapes) — the conversion is a mechanical
+re-wrap:
+
+```json
+{
+  "exportFormat": "a2-content-export/v1",
+  "exportedAt": "<now ISO>",
+  "scope": "course",
+  "course": {
+    "course": {
+      "title": "…", "description": "…", "certificationLevel": "…",
+      "audit": {},
+      "items": [
+        { "type": "SECTION", "sortOrder": 0, "section": { …section payload…, "audit": {} } },
+        { "type": "MODULE",  "sortOrder": 1, "module":  { …module payload…  } }
+      ]
+    }
+  }
+}
+```
+
+Mapping from an `a2-authoring-package/v1`:
+- Each package `course.items[]` entry → a `course.items[]` entry here, in array order, with
+  `sortOrder` = index; resolve `ref` → the referenced object's inlined payload.
+- Inline each referenced module/section payload directly (this format is self-contained —
+  no `clientRef`).
+- Add `audit: {}` to each module `activeVersion`, each section, and the course. Empty audit
+  = no publish history ⇒ import never auto-publishes (drafts only).
+- `exportFormat` / `exportedAt` / `scope: "course"` on the envelope.
+
+Only whole courses use this fallback path; a lone module can use the module-scoped envelope
+(`scope: "module"`) the same way.


### PR DESCRIPTION
Første versjon av skillens samtale-UX — flytter tyngdepunktet fra «emit JSON» til å faktisk *guide* en fagansvarlig gjennom å lage et godt kurs. Ren skill-docs, ingen kode, ingen versjonsbump. **Ment som utgangspunkt for finjustering**, ikke fasit.

## Hva

- **Ny `references/authoring-playbook.md`** — selve håndverket:
  - **Discover:** intervjuguide (mål, målgruppe, **læringsmål** som «etter dette kan en lærende ___», kildemateriale å forankre innholdet i, vurderingsintensjon per mål, omfang, språk). Regel: når brukeren er vag, foreslå en konkret straw-man og la dem korrigere.
  - **Design:** seksjoner *underviser* / moduler *vurderer*; bevisst modusvalg (`MCQ_ONLY` for gjenkjenning, `FREETEXT_ONLY` for anvendt vurdering, `FREETEXT_PLUS_MCQ` for begge); rubrikk-/MCQ-kvalitet (kriterier knyttet til mål, plausible distraktorer); rekkefølge (undervis før vurdering); omfangsdisiplin.
  - **Preview & approve:** en konkret mal for å vise HELE kurset i samtalen — struktur + per element oppgave/MCQ/rubrikk — og eksplisitt godkjenning **før** pakken bygges/valideres/opprettes.
- **SKILL.md** restrukturert til de fire fasene (Discover → Design → Preview → Export), peker på playbooken.
- **Fallback dokumentert** (som avtalt): kan agenten ikke nå API-et, emit en `a2-content-export/v1` **kursenvelope** til disk → importer via admin-UI. `package-schema.md` har den mekaniske mappingen fra authoring-pakken (delte leaf-payloads, `audit: {}` ⇒ ingen auto-publisering).

## Bevisst utenfor denne PR-en (neste steg)

- Skript-flagg `--emit-course-envelope` så fallback blir én kommando (i dag: dokumentert mapping).
- Lengre token-TTL (din tilbakemelding) og OpenAPI/Action-spec for ChatGPT — egne endringer.

Husk `npm run skill:package` + redeploy av zip ved neste distribusjon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)