### PR TITLE
fix(ux): #736 profil blandet-locale + fjern statusprikk (v1.6.17)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,20 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.17 - 2026-07-07
+
+fix(ux): #736 profilsiden — blandet locale i fullførte-tabellene + fjernet statusprikk
+
+- **Blandet locale (Bestått/Vis bevis):** rotårsak var at språkbytte i nedtrekksmenyen kun
+  re-kjørte `applyTranslations()` på statiske `data-i18n`-etiketter, mens de dynamisk bygde
+  modul-/kurs-radene (rendret via `t()`) ikke ble re-rendret — så verdiene ble hengende på
+  forrige språk mens overskriftene byttet. Fiks: cache siste modul-/kursdata og re-render
+  `renderProfile`/`renderModules`/`renderCourses` ved språkbytte. E2e-guard som bytter locale
+  og asserterer at verdicellene følger med.
+- **Statusprikk «●»:** fjernet `::before`-dekoren på `.outcome--pass/--review/--fail` i
+  shared.css (typografisk et list-glyph; den fargede teksten formidler status alene). Treffer
+  alle tre flatene samtidig (profil, deltaker, fullførte moduler).
+
 ## 1.6.16 - 2026-07-07
 
 fix(i18n): manglende `nav.review`-nøkkel i profil-toppmenyen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.16",
+  "version": "1.6.17",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/profile.js
+++ b/public/profile.js
@@ -74,6 +74,11 @@ let participantRuntimeConfig = {
 let roleSwitchState = resolveRoleSwitchState(participantRuntimeConfig);
 let cachedMeData = null;
 let cachedDataExport = null;
+// #736: the completed-modules/courses tables are built dynamically via t(); a locale switch only
+// re-runs applyTranslations() on static [data-i18n] labels, so cache the last data and re-render
+// these on locale change — otherwise headers switch language while the values stay behind.
+let cachedModulesData = null;
+let cachedCoursesData = null;
 
 // ── Locale ────────────────────────────────────────────────────────────────────
 
@@ -620,17 +625,10 @@ async function loadProfileData() {
     apiFetch("/api/courses/completions", headers),
   ]);
 
-  if (modulesResult.status === "fulfilled") {
-    renderModules(modulesResult.value);
-  } else {
-    renderModules(null);
-  }
-
-  if (coursesResult.status === "fulfilled") {
-    renderCourses(coursesResult.value);
-  } else {
-    renderCourses(null);
-  }
+  cachedModulesData = modulesResult.status === "fulfilled" ? modulesResult.value : null;
+  cachedCoursesData = coursesResult.status === "fulfilled" ? coursesResult.value : null;
+  renderModules(cachedModulesData);
+  renderCourses(cachedCoursesData);
 
   // Agent access (AA-3, #731) — gated on the /api/me roles.
   await refreshAgentTokensSection(cachedMeData);
@@ -644,6 +642,11 @@ loadMeButton.addEventListener("click", async () => {
 
 localeSelect.addEventListener("change", () => {
   setLocale(localeSelect.value);
+  // #736: re-render the dynamically built content so table values follow the new locale, not just
+  // the static [data-i18n] labels that applyTranslations() handles.
+  if (cachedMeData) renderProfile(cachedMeData);
+  renderModules(cachedModulesData);
+  renderCourses(cachedCoursesData);
 });
 
 rolesInput.addEventListener("input", () => {

--- a/public/static/shared.css
+++ b/public/static/shared.css
@@ -643,25 +643,17 @@ body.auth-resolving .mock-identity-card {
   margin-top: calc(var(--space-1) * 0.5);
 }
 
+/* #736: status is conveyed by the coloured text alone. The leading "●" dot (a list-glyph
+   typographically) was removed — the coloured label carries pass/review/fail on all three
+   surfaces (profile, participant, participant-completed). */
 .outcome--pass,
 .outcome--review,
 .outcome--fail {
   font-weight: 600;
 }
-.outcome--pass::before,
-.outcome--review::before,
-.outcome--fail::before {
-  content: "● ";
-  font-size: 0.65em;
-  vertical-align: middle;
-  margin-right: 1px;
-}
 .outcome--pass { color: var(--color-success); }
-.outcome--pass::before { color: var(--color-success); }
 .outcome--review { color: var(--color-warning); }
-.outcome--review::before { color: var(--color-warning); }
 .outcome--fail { color: var(--color-error); }
-.outcome--fail::before { color: var(--color-error); }
 
 .history-list {
   display: grid;

--- a/test/e2e/profile-locale-switch.spec.ts
+++ b/test/e2e/profile-locale-switch.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+// #736: switching the locale on the profile page must re-render the dynamically built
+// completed-modules/courses tables too — not just the static [data-i18n] labels. Previously a
+// switch left the value cells (pass/fail, "view certificate") in the old language while headers
+// changed, producing a mixed-locale page.
+
+async function mockProfile(page: Page) {
+  await page.route("**/participant/config", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        authMode: "mock",
+        navigation: { items: [], workspaceItems: [] },
+        identityDefaults: {
+          participant: { userId: "p-1", email: "p@x.no", name: "P", department: "X", roles: ["PARTICIPANT"] },
+        },
+        calibrationWorkspace: { accessRoles: [] },
+        flow: {},
+        output: {},
+      }),
+    }),
+  );
+  await page.route("**/version", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "test" }) }),
+  );
+  await page.route("**/api/me", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      // No user.locale → the page keeps the localStorage locale (en-GB) so the manual switch is what's tested.
+      body: JSON.stringify({
+        user: { id: "p-1", name: "P", email: "p@x.no", roles: ["PARTICIPANT"] },
+        consent: { accepted: true, currentVersion: "1.0" },
+      }),
+    }),
+  );
+  await page.route("**/api/queue-counts", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ counts: {} }) }),
+  );
+  await page.route("**/api/modules/completed**", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        modules: [
+          {
+            moduleTitle: "Module A",
+            latestCompletedAt: "2026-06-20T10:00:00.000Z",
+            latestDecision: { totalScore: 100, passFailTotal: true },
+          },
+        ],
+      }),
+    }),
+  );
+  await page.route("**/api/courses/completions", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        completions: [
+          { courseId: "c1", certificateId: "cert-1", completedAt: "2026-06-20T10:00:00.000Z", courseTitle: "Course A", certificationLevel: "basic" },
+        ],
+      }),
+    }),
+  );
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem("participant.locale", "en-GB");
+    } catch {
+      /* ignore */
+    }
+  });
+}
+
+test("profile: switching locale re-renders the completed tables, not just the headers", async ({ page }) => {
+  await mockProfile(page);
+  await page.goto("/profile");
+
+  // Loaded in English: pass value + certificate link are the en-GB strings.
+  await expect(page.locator("#modulesBody")).toContainText("Pass");
+  await expect(page.locator("#coursesBody")).toContainText("View certificate");
+
+  // Switch to Norwegian bokmål.
+  await page.selectOption("#localeSelect", "nb");
+
+  // The dynamically built value cells must follow the new locale (no mixed-locale leftovers).
+  await expect(page.locator("#modulesBody")).toContainText("Bestått");
+  await expect(page.locator("#coursesBody")).toContainText("Vis bevis");
+  await expect(page.locator("#modulesBody")).not.toContainText("Pass");
+  await expect(page.locator("#coursesBody")).not.toContainText("View certificate");
+});


### PR DESCRIPTION
Lukker #736 — de to kosmetiske funnene fra profil-testingen.

## 1. Blandet locale i fullførte moduler/kurs
Rotårsak (korrigert fra opprinnelig hypotese): språkbytte i nedtrekksmenyen kjørte kun `applyTranslations()` på statiske `data-i18n`-etiketter. De **dynamisk bygde** modul-/kurstabellene (rendret via `t()` i `renderModules`/`renderCourses`) ble ikke re-rendret, så verdiene («Bestått», «Vis bevis») ble hengende på forrige språk mens overskriftene byttet → engelske overskrifter + norske verdier.

**Fiks:** cache siste modul-/kursdata (`cachedModulesData`/`cachedCoursesData`) og re-render `renderProfile`/`renderModules`/`renderCourses` i `localeSelect`-change-handleren. E2e-guard (`profile-locale-switch.spec.ts`): last i en-GB, bytt til nb, assert at verdicellene blir «Bestått»/«Vis bevis» og at de gamle en-GB-verdiene ikke henger igjen.

## 2. Statusprikk «●»
Fjernet `::before`-dekoren på `.outcome--pass/--review/--fail` i `shared.css` (besluttet i #736 — typografisk et list-glyph; den fargede teksten formidler status alene). Siden alle tre flatene (profil, deltaker-visning, fullførte moduler) deler CSS-klassen, retter én endring alle samtidig.

## Test
`npx tsc --noEmit` grønn; profil-e2e-ene (locale-switch + certificate-link + agent-tokens) 4/4 grønne. Ingen backend-endring.

Merges og deployes til stage sammen med denne runden.