### PR TITLE
feat(admin-content): #744 course-builder «Åpne» links + #745 library course filter

### DIFF
--- a/doc/FEATURE_SURFACE_MAP.md
+++ b/doc/FEATURE_SURFACE_MAP.md
@@ -241,6 +241,7 @@ pages — they are separate static JS/HTML files, so consistency is by conventio
 | Shared element | Where | Notes |
 |----------------|-------|-------|
 | Filter pills | `.list-filters`/`.list-filter-btn` in `shared.css`; built per page (`courseFilterBar`/`sectionFilterBar`; modules uses its own `.library-filter-btn`) | Alle/Aktive/Publiserte/Arkiverte |
+| Course filter dropdown (#745) | modules: `#libraryCourseFilter` (`.library-course-select`) built by `rebuildCourseFilterOptions`; sections: `#sectionCourseFilter` (`.list-course-select`) built by `sectionCourseFilterBar` | «Alle kurs» / per-course / «Ikke i noe kurs»; client-side, dedupes each item's `courses[]`, composes with status filter + search. NOT on the Kurs list itself. |
 | Status badge | `.status-badge--{draft,published,archived}` in `shared.css` (entry #13) | Utkast/Publisert/Arkivert |
 | Action row | `.row-actions` in `shared.css` | wraps `.row-action-btn` group |
 | "Used in courses" popover | `.course-count-btn`/`.courses-popover` in `shared.css`; `showCoursesPopover` (library), `showSectionCoursesPopover` (sections) | count + click popover |
@@ -248,7 +249,9 @@ pages — they are separate static JS/HTML files, so consistency is by conventio
 | Kalibrering tab + reveal | `#navKalibrering` in each `.html` + `renderContentAreaNav()` role-gate in each page JS | role-gated visibility |
 | Landing entry | capability `admin-content` path = `/admin-content/courses` (`src/config/capabilities.ts`) | «Innholdsforvaltning» opens on Kurs |
 
-**Guards:** `test/e2e/admin-content-classes.spec.ts` "admin buttons + top nav render in prod-shaped config" (asserts a REAL i18n key resolves, not raw); `test/e2e/admin-content-workspaces.spec.ts` course archive (filter pill), unpublish, sections lifecycle. When adding a column/filter to one list, mirror it where it applies and update this entry.
+**Guards:** `test/e2e/admin-content-classes.spec.ts` "admin buttons + top nav render in prod-shaped config" (asserts a REAL i18n key resolves, not raw); `test/e2e/admin-content-workspaces.spec.ts` course archive (filter pill), unpublish, sections lifecycle; `test/e2e/admin-content-course-links-library-filter.spec.ts` course filter (modules + sections). When adding a column/filter to one list, mirror it where it applies and update this entry.
+
+Related (course builder, not a list page): the course builder item list (`renderModuleList` in `admin-content-courses.js`) gives each row an **«Åpne»** link (`target="_blank"`) to that item's editor — module → `/admin-content/module/<id>/conversation`, section → `/admin-content/sections?id=<id>` (#744, same guard spec).
 
 ## 15. Agent Authoring — draft-only invariant across 3 entities + token scope (EPIC #647)
 

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,33 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.19 - 2026-07-10
+
+feat(admin-content): #744 «Åpne»-lenker i kursbyggeren + #745 kurs-filter i modul-/seksjonsbibliotekene
+
+**#744 — åpne et element fra kursbyggeren.** Innholdslista i kursbyggeren
+(`admin-content-courses.js`, `/admin-content/courses/:courseId`, seksjonen «Innhold i kurset
+(moduler og seksjoner)») hadde ingen vei inn til det enkelte elementets editor. Hver rad får nå en
+**«Åpne»**-lenke ved siden av «Fjern» som åpner editoren i **ny fane** (`target="_blank"
+rel="noopener"`), så kursbyggeren ikke går tapt: modul → `/admin-content/module/<id>/conversation`,
+seksjon → `/admin-content/sections?id=<id>`. Hardkodet norsk «Åpne» for å matche naboene
+(«Fjern»/«Diskusjon»), gjenbruker eksisterende rad-/knapp-CSS.
+
+**#745 — filtrer bibliotekene på kurs.** Modul-biblioteket (`admin-content-library.js`) og
+seksjons-biblioteket (`admin-content-sections.js`) er flate lister som blir lange under
+agent-masseproduksjon. Begge får nå en **kurs-nedtrekksmeny** («Kurs:») ved siden av filter-linja:
+**«Alle kurs»** (default, ingen filtrering) + ett valg per distinkt kurs (dedupe på `course.id` på
+tvers av elementenes `courses`-arrayer, sortert på tittel) + **«Ikke i noe kurs»** (elementer uten
+kurs). Filteret er rent klientside — gjenbruker `courses`-dataene som «Brukt i kurs»-popoveren
+allerede har, ingen backend-endring. Det komponerer med status-filter + søk + sortering (ekstra
+predikat), og dropdownen bygges på nytt hver gang dataene lastes. In-memory-valg (ingen persistering
+på tvers av reload), som øvrige filtre. Hardkodet norske etiketter.
+
+Tester: `test/e2e/admin-content-course-links-library-filter.spec.ts` (e2e) — #744 modul-/seksjonsrad-
+lenker (href + `target=_blank`); #745 kurs-filter i modul- og seksjonsbiblioteket
+(«Kurs A» viser X/skjuler Y, «Ikke i noe kurs» viser Y/skjuler X, «Alle kurs» viser begge) + at
+filteret komponerer med søk. Ingen skjemaendring, ingen rute-endring.
+
 ## 1.6.18 - 2026-07-07
 
 feat(courses): #734 kaskade-publisering — publiser aldri et kurs med upublisert innhold

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.18",
+  "version": "1.6.19",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-library.html
+++ b/public/admin-content-library.html
@@ -61,6 +61,23 @@
       .library-search:focus { outline: 2px solid var(--color-blue); outline-offset: 1px; border-color: transparent; }
 
       .library-filters { display: flex; flex-wrap: wrap; gap: 6px; }
+
+      /* #745: kurs-filter (dropdown) ved siden av filter-pillene. */
+      .library-course-filter { display: flex; align-items: center; gap: 8px; }
+      .library-course-filter label { font-size: 13px; font-weight: 600; color: var(--color-meta); }
+      .library-course-select {
+        width: auto;
+        min-height: 0;
+        padding: 5px 10px;
+        font-size: 13px;
+        font-family: inherit;
+        border: 1px solid var(--color-border-soft);
+        border-radius: var(--radius-card);
+        background: var(--color-surface);
+        color: var(--color-text);
+        max-width: 260px;
+      }
+      .library-course-select:focus { outline: 2px solid var(--color-blue); outline-offset: 1px; border-color: transparent; }
       .library-filter-btn {
         /* width:auto + min-height:0 overstyrer global button{width:100%} så filtrene blir kompakte piller på rad. */
         width: auto;
@@ -283,6 +300,13 @@
           <button class="library-filter-btn" data-filter="unpublished_draft">Har upublisert utkast</button>
           <button class="library-filter-btn" data-filter="published">Publiserte</button>
           <button class="library-filter-btn" data-filter="archived">Arkiverte</button>
+        </div>
+        <!-- #745: klientside-filter på kurs. Options bygges i JS fra modulenes `courses`. -->
+        <div class="library-course-filter">
+          <label for="libraryCourseFilter">Kurs:</label>
+          <select id="libraryCourseFilter" class="library-course-select">
+            <option value="__all__">Alle kurs</option>
+          </select>
         </div>
       </div>
 

--- a/public/admin-content-sections.html
+++ b/public/admin-content-sections.html
@@ -8,6 +8,25 @@
     <link rel="stylesheet" href="/static/loading.css" />
     <link rel="stylesheet" href="/static/toast.css" />
     <style>
+      /* #745: rad som holder status-filter-pillene og kurs-dropdownen på samme linje. */
+      .list-filters-row { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); margin-bottom: var(--space-2); }
+      .list-filters-row .list-filters { margin-bottom: 0; }
+      .list-course-filter { display: flex; align-items: center; gap: 8px; }
+      .list-course-filter label { font-size: 13px; font-weight: 600; color: var(--color-meta); }
+      .list-course-select {
+        width: auto;
+        min-height: 0;
+        padding: 5px 10px;
+        font-size: 13px;
+        font-family: inherit;
+        border: 1px solid var(--color-border-soft);
+        border-radius: var(--radius-card);
+        background: var(--color-surface);
+        color: var(--color-text);
+        max-width: 260px;
+      }
+      .list-course-select:focus { outline: 2px solid var(--color-blue); outline-offset: 1px; border-color: transparent; }
+
       .content-area-nav {
         display: flex;
         gap: 0;

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -1401,7 +1401,13 @@ function renderModuleList() {
   }
 
   container.innerHTML = `<div class="module-list" id="moduleList">
-    ${courseModules.map((m, i) => `
+    ${courseModules.map((m, i) => {
+      // #744: åpne elementets editor i ny fane så kursbyggeren ikke går tapt.
+      // Modul → samtale-editoren; seksjon → seksjons-editoren.
+      const openHref = m.type === "SECTION"
+        ? `/admin-content/sections?id=${encodeURIComponent(m.refId)}`
+        : `/admin-content/module/${encodeURIComponent(m.refId)}/conversation`;
+      return `
       <div class="module-list-item" data-item-type="${m.type}" data-ref-id="${escapeHtml(m.refId)}">
         <span class="module-list-item-order">${i + 1}.</span>
         <span class="item-type-badge">${m.type === "SECTION" ? "SEKSJON" : "MODUL"}</span>
@@ -1412,9 +1418,11 @@ function renderModuleList() {
           </label>
           <button class="module-move-btn" data-move="up" data-index="${i}" ${i === 0 ? "disabled" : ""} aria-label="Flytt opp">↑</button>
           <button class="module-move-btn" data-move="down" data-index="${i}" ${i === courseModules.length - 1 ? "disabled" : ""} aria-label="Flytt ned">↓</button>
+          <a href="${openHref}" class="module-move-btn" style="text-decoration:none;display:inline-flex;align-items:center" target="_blank" rel="noopener">Åpne</a>
           <button class="module-remove-btn" data-remove="${i}" aria-label="Fjern modul">Fjern</button>
         </div>
-      </div>`).join("")}
+      </div>`;
+    }).join("")}
   </div>`;
 
   document.getElementById("moduleList")?.addEventListener("click", handleModuleListClick);

--- a/public/static/admin-content-library.js
+++ b/public/static/admin-content-library.js
@@ -70,6 +70,8 @@ const appVersionLabel = document.getElementById("appVersion");
 const localeSelect = document.getElementById("localeSelect");
 const libraryContent = document.getElementById("libraryContent");
 const librarySearch = document.getElementById("librarySearch");
+// #745: klientside-filter på kurs. Bygges fra modulenes egne `courses`-arrayer.
+const libraryCourseFilter = document.getElementById("libraryCourseFilter");
 const createModuleBtn = document.getElementById("createModuleBtn");
 const createModuleDialog = document.getElementById("createModuleDialog");
 const createModuleForm = document.getElementById("createModuleForm");
@@ -105,6 +107,9 @@ let allModules = [];
 // Default filter is "active" so authors land on a curated list of currently relevant
 // modules. Arkiverte/older versions er fortsatt tilgjengelig via filter-knappene.
 let activeFilter = "active";
+// #745: valgt kurs i kurs-filteret. "__all__" = ingen filtrering (default),
+// "__none__" = moduler som ikke er i noe kurs, ellers en course-id.
+let courseFilter = "__all__";
 let searchQuery = "";
 let sortColumn = "title"; // "title" | "updatedAt"
 let sortDirection = "asc"; // "asc" | "desc"
@@ -192,6 +197,35 @@ function resolveActiveWorkspaceRoles() {
 // Filter logic
 // ---------------------------------------------------------------------------
 
+// #745: bygg listen med distinkte kurs fra alle modulers `courses`-array (dedupe på id),
+// sortert på tittel. Brukes til å fylle kurs-filter-dropdownen.
+function collectCourseFilterOptions(modules) {
+  const byId = new Map();
+  for (const m of modules) {
+    for (const c of (m.courses ?? [])) {
+      if (c && c.id && !byId.has(c.id)) byId.set(c.id, String(c.title ?? c.id));
+    }
+  }
+  return [...byId.entries()]
+    .map(([id, title]) => ({ id, title }))
+    .sort((a, b) => a.title.localeCompare(b.title, currentLocale));
+}
+
+// #745: fyll kurs-dropdownen på nytt hver gang dataene lastes. Bevarer valgt kurs hvis det
+// fortsatt finnes; ellers faller vi tilbake til "Alle kurs".
+function rebuildCourseFilterOptions() {
+  if (!libraryCourseFilter) return;
+  const options = collectCourseFilterOptions(allModules);
+  const valid = new Set(["__all__", "__none__", ...options.map(o => o.id)]);
+  if (!valid.has(courseFilter)) courseFilter = "__all__";
+  libraryCourseFilter.innerHTML = [
+    `<option value="__all__">Alle kurs</option>`,
+    ...options.map(o => `<option value="${escapeHtml(o.id)}">${escapeHtml(o.title)}</option>`),
+    `<option value="__none__">Ikke i noe kurs</option>`,
+  ].join("");
+  libraryCourseFilter.value = courseFilter;
+}
+
 function applyFilter(modules) {
   let result = modules;
   const q = searchQuery.trim().toLowerCase();
@@ -200,6 +234,12 @@ function applyFilter(modules) {
       (m.title ?? "").toLowerCase().includes(q) ||
       m.id.toLowerCase().includes(q)
     );
+  }
+  // #745: kurs-filter komponerer med status-filter + søk + sortering (ekstra predikat).
+  if (courseFilter === "__none__") {
+    result = result.filter(m => (m.courses ?? []).length === 0);
+  } else if (courseFilter !== "__all__") {
+    result = result.filter(m => (m.courses ?? []).some(c => c && c.id === courseFilter));
   }
   if (activeFilter === "active") result = result.filter(m => m.status !== "archived");
   else if (activeFilter === "archived") result = result.filter(m => m.status === "archived");
@@ -639,6 +679,8 @@ async function loadModules() {
   try {
     const data = await apiFetch(`/api/admin/content/modules/library?locale=${encodeURIComponent(currentLocale)}`, getHeaders);
     allModules = data.modules ?? [];
+    // #745: gjenoppbygg kurs-dropdownen når dataene lastes (nye/fjernede kurs-koblinger).
+    rebuildCourseFilterOptions();
     renderLibrary();
   } catch (err) {
     libraryContent.innerHTML = `<div class="library-empty"><p class="library-empty-title">Kunne ikke laste moduler.</p><p class="library-empty-text">${escapeHtml(err?.message ?? "")}</p></div>`;
@@ -739,6 +781,12 @@ async function init() {
   // Search
   librarySearch?.addEventListener("input", () => {
     searchQuery = librarySearch.value;
+    renderLibrary();
+  });
+
+  // #745: kurs-filter (in-memory, ingen persistering på tvers av reload — som øvrige filtre).
+  libraryCourseFilter?.addEventListener("change", () => {
+    courseFilter = libraryCourseFilter.value;
     renderLibrary();
   });
 

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -177,6 +177,10 @@ function statusBadge(status) {
 
 // #705-UX(A): filter-piller (Alle/Aktive/Publiserte/Arkiverte) likt modul-biblioteket.
 let sectionsFilter = "active";
+// #745: valgt kurs i kurs-filteret. "__all__" = ingen filtrering (default),
+// "__none__" = seksjoner som ikke er i noe kurs, ellers en course-id. In-memory
+// (ingen persistering på tvers av reload), som øvrige filtre på siden.
+let sectionCourseFilter = "__all__";
 let allSections = []; // siste hentede liste — slås opp av «Brukt i kurs»-popoveren.
 
 // #705-UX(G): popover som viser hvilke kurs en seksjon brukes i (likt modul-biblioteket).
@@ -211,6 +215,40 @@ function filterSections(sections) {
   return sections.filter((s) => !s.archivedAt); // active
 }
 
+// #745: kurs-filter komponerer med status-filteret (ekstra predikat). "__none__" beholder
+// seksjoner uten kurs; en course-id beholder seksjoner som er i det kurset.
+function applySectionCourseFilter(sections) {
+  if (sectionCourseFilter === "__none__") return sections.filter((s) => (s.courses ?? []).length === 0);
+  if (sectionCourseFilter !== "__all__") return sections.filter((s) => (s.courses ?? []).some((c) => c && c.id === sectionCourseFilter));
+  return sections;
+}
+
+// #745: distinkte kurs på tvers av alle seksjoners `courses`-array (dedupe på id), sortert på tittel.
+function collectSectionCourseFilterOptions(sections) {
+  const byId = new Map();
+  for (const s of sections) {
+    for (const c of (s.courses ?? [])) {
+      if (c && c.id && !byId.has(c.id)) byId.set(c.id, String(c.title ?? c.id));
+    }
+  }
+  return [...byId.entries()]
+    .map(([id, title]) => ({ id, title }))
+    .sort((a, b) => a.title.localeCompare(b.title, currentLocale));
+}
+
+// #745: kurs-dropdown, bygget per render fra dataene. Bevarer valgt kurs hvis det fortsatt finnes.
+function sectionCourseFilterBar(sections) {
+  const options = collectSectionCourseFilterOptions(sections);
+  const valid = new Set(["__all__", "__none__", ...options.map((o) => o.id)]);
+  if (!valid.has(sectionCourseFilter)) sectionCourseFilter = "__all__";
+  const opts = [
+    `<option value="__all__"${sectionCourseFilter === "__all__" ? " selected" : ""}>Alle kurs</option>`,
+    ...options.map((o) => `<option value="${escapeHtml(o.id)}"${o.id === sectionCourseFilter ? " selected" : ""}>${escapeHtml(o.title)}</option>`),
+    `<option value="__none__"${sectionCourseFilter === "__none__" ? " selected" : ""}>Ikke i noe kurs</option>`,
+  ].join("");
+  return `<div class="list-course-filter"><label for="sectionCourseFilter">Kurs:</label><select id="sectionCourseFilter" class="list-course-select">${opts}</select></div>`;
+}
+
 function sectionFilterBar() {
   const pills = [
     ["all", L("filterAll")],
@@ -234,7 +272,8 @@ async function renderListView() {
     return;
   }
 
-  const visible = filterSections(sections);
+  // #745: status-filter (piller) + kurs-filter (dropdown) komponeres.
+  const visible = applySectionCourseFilter(filterSections(sections));
 
   // #705: samme handlings-rekkefølge og status-vokabular som modul/kurs.
   const rows = visible.map((s) => {
@@ -273,7 +312,7 @@ async function renderListView() {
       <h1>${escapeHtml(L("heading"))}</h1>
       <button type="button" id="newSectionBtn" class="btn btn-primary" style="width:auto">${escapeHtml(L("newSection"))}</button>
     </div>
-    ${sectionFilterBar()}
+    <div class="list-filters-row">${sectionFilterBar()}${sectionCourseFilterBar(sections)}</div>
     ${visible.length === 0
       ? `<div class="empty-state"><p class="empty-state-text">${escapeHtml(L("empty"))}</p></div>`
       : `<div class="sections-table-wrap"><table class="sections-table">
@@ -285,6 +324,11 @@ async function renderListView() {
     const btn = event.target.closest("[data-filter]");
     if (!btn) return;
     sectionsFilter = btn.dataset.filter;
+    renderListView();
+  });
+  // #745: kurs-filter — re-render lista med det valgte kurset.
+  document.getElementById("sectionCourseFilter")?.addEventListener("change", (event) => {
+    sectionCourseFilter = event.target.value;
     renderListView();
   });
   document.getElementById("sectionsTableBody")?.addEventListener("click", (event) => {

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -25,6 +25,7 @@ const LABELS = {
     showArchived: "Show archived", hideArchived: "Hide archived",
     filterAll: "All", filterActive: "Active", filterPublished: "Published", filterArchived: "Archived",
     colCourses: "Used in courses", coursesPopoverTitle: "Used in courses", noCourses: "Not used in any course.",
+    courseFilterLabel: "Course:", courseFilterAll: "All courses", courseFilterNone: "Not in any course",
     published: "Section published.", unpublished: "Section unpublished.",
     archived: "Section archived.", restored: "Section restored.", confirmArchive: "Archive this section?",
     colUpdated: "Last changed", edit: "Edit", del: "Delete", empty: "No sections yet.",
@@ -43,6 +44,7 @@ const LABELS = {
     showArchived: "Vis arkiverte", hideArchived: "Skjul arkiverte",
     filterAll: "Alle", filterActive: "Aktive", filterPublished: "Publiserte", filterArchived: "Arkiverte",
     colCourses: "Brukt i kurs", coursesPopoverTitle: "Brukt i kurs", noCourses: "Ikke brukt i noe kurs.",
+    courseFilterLabel: "Kurs:", courseFilterAll: "Alle kurs", courseFilterNone: "Ikke i noe kurs",
     published: "Seksjon publisert.", unpublished: "Seksjon avpublisert.",
     archived: "Seksjon arkivert.", restored: "Seksjon gjenopprettet.", confirmArchive: "Arkivere denne seksjonen?",
     colUpdated: "Sist endret", edit: "Rediger", del: "Slett", empty: "Ingen seksjoner ennå.",
@@ -61,6 +63,7 @@ const LABELS = {
     showArchived: "Vis arkiverte", hideArchived: "Skjul arkiverte",
     filterAll: "Alle", filterActive: "Aktive", filterPublished: "Publiserte", filterArchived: "Arkiverte",
     colCourses: "Brukt i kurs", coursesPopoverTitle: "Brukt i kurs", noCourses: "Ikke brukt i noe kurs.",
+    courseFilterLabel: "Kurs:", courseFilterAll: "Alle kurs", courseFilterNone: "Ikkje i noko kurs",
     published: "Seksjon publisert.", unpublished: "Seksjon avpublisert.",
     archived: "Seksjon arkivert.", restored: "Seksjon gjenoppretta.", confirmArchive: "Arkivere denne seksjonen?",
     colUpdated: "Sist endra", edit: "Rediger", del: "Slett", empty: "Ingen seksjonar enno.",
@@ -242,11 +245,11 @@ function sectionCourseFilterBar(sections) {
   const valid = new Set(["__all__", "__none__", ...options.map((o) => o.id)]);
   if (!valid.has(sectionCourseFilter)) sectionCourseFilter = "__all__";
   const opts = [
-    `<option value="__all__"${sectionCourseFilter === "__all__" ? " selected" : ""}>Alle kurs</option>`,
+    `<option value="__all__"${sectionCourseFilter === "__all__" ? " selected" : ""}>${escapeHtml(L("courseFilterAll"))}</option>`,
     ...options.map((o) => `<option value="${escapeHtml(o.id)}"${o.id === sectionCourseFilter ? " selected" : ""}>${escapeHtml(o.title)}</option>`),
-    `<option value="__none__"${sectionCourseFilter === "__none__" ? " selected" : ""}>Ikke i noe kurs</option>`,
+    `<option value="__none__"${sectionCourseFilter === "__none__" ? " selected" : ""}>${escapeHtml(L("courseFilterNone"))}</option>`,
   ].join("");
-  return `<div class="list-course-filter"><label for="sectionCourseFilter">Kurs:</label><select id="sectionCourseFilter" class="list-course-select">${opts}</select></div>`;
+  return `<div class="list-course-filter"><label for="sectionCourseFilter">${escapeHtml(L("courseFilterLabel"))}</label><select id="sectionCourseFilter" class="list-course-select">${opts}</select></div>`;
 }
 
 function sectionFilterBar() {

--- a/test/e2e/admin-content-course-links-library-filter.spec.ts
+++ b/test/e2e/admin-content-course-links-library-filter.spec.ts
@@ -166,7 +166,9 @@ test.describe("#745 section library — filter by course", () => {
 
     const courseSelect = page.locator("#sectionCourseFilter");
     await expect(courseSelect).toBeVisible();
-    await expect(courseSelect.locator("option")).toContainText(["Alle kurs", "Kurs A", "Ikke i noe kurs"]);
+    // The sections library is localized (L()); in the default en-GB e2e locale the fixed options
+    // render in English — this guards against hardcoded Norwegian creeping back onto this page.
+    await expect(courseSelect.locator("option")).toContainText(["All courses", "Kurs A", "Not in any course"]);
 
     await courseSelect.selectOption("course-a");
     await expect(page.locator(".sections-table")).toContainText("Section X");

--- a/test/e2e/admin-content-course-links-library-filter.spec.ts
+++ b/test/e2e/admin-content-course-links-library-filter.spec.ts
@@ -1,0 +1,183 @@
+import { expect, test } from "@playwright/test";
+import type { Route } from "@playwright/test";
+
+import { mockCommonApis } from "./admin-content-helpers.js";
+
+// e2e for #744 (course-builder "Åpne" links) + #745 (library course filter).
+//
+// Reuses the shared admin-content mock harness. The library HTML is reached via its static
+// file path (the e2e static server maps `/admin-content` to the conversational shell — see
+// admin-content-module-library.spec.ts). The course builder + sections list are reached via
+// their canonical routes, which the static server serves (as in admin-content-workspaces.spec.ts).
+const LIBRARY_PATH = "/admin-content-library.html";
+
+test.describe("#744 course builder — per-item 'Åpne' editor links (new tab)", () => {
+  test("module row links to its conversation editor and section row to the section editor, both target=_blank", async ({ page }) => {
+    await mockCommonApis(page, {
+      courses: [
+        {
+          id: "course-1",
+          title: "Labour rights",
+          description: null,
+          certificationLevel: "basic",
+          moduleCount: 1,
+          updatedAt: "2026-04-18T12:00:00.000Z",
+          publishedAt: null,
+          archivedAt: null,
+          modules: [],
+        },
+      ],
+      libraryModules: [{ id: "module-1", title: "Trade unions", status: "published" }],
+    });
+
+    // The course builder loads its interleaved item list from `/courses/:id/items` — not covered
+    // by the shared harness glob (two path segments). Provide one MODULE + one SECTION item.
+    await page.route("**/api/admin/content/courses/*/items", async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [
+            { type: "MODULE", moduleId: "module-1", title: "Trade unions", sortOrder: 0, discussionsEnabled: true },
+            { type: "SECTION", sectionId: "section-1", title: "Intro reading", sortOrder: 1, discussionsEnabled: true },
+          ],
+        }),
+      });
+    });
+    // Section picker load in the builder — return an empty library (not under test here).
+    await page.route("**/api/admin/content/sections", async (route: Route) => {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ sections: [] }) });
+    });
+
+    await page.goto("/admin-content/courses/course-1");
+
+    const moduleRow = page.locator('.module-list-item[data-item-type="MODULE"]');
+    const sectionRow = page.locator('.module-list-item[data-item-type="SECTION"]');
+    await expect(moduleRow).toBeVisible();
+    await expect(sectionRow).toBeVisible();
+
+    // Module item → conversation editor, new tab.
+    const moduleOpen = moduleRow.getByRole("link", { name: "Åpne" });
+    await expect(moduleOpen).toHaveAttribute("href", "/admin-content/module/module-1/conversation");
+    await expect(moduleOpen).toHaveAttribute("target", "_blank");
+    await expect(moduleOpen).toHaveAttribute("rel", /noopener/);
+
+    // Section item → section editor, new tab.
+    const sectionOpen = sectionRow.getByRole("link", { name: "Åpne" });
+    await expect(sectionOpen).toHaveAttribute("href", "/admin-content/sections?id=section-1");
+    await expect(sectionOpen).toHaveAttribute("target", "_blank");
+
+    // The "Åpne" link sits next to "Fjern" in the row's action area.
+    await expect(moduleRow.locator(".module-list-item-actions")).toContainText("Åpne");
+    await expect(moduleRow.locator(".module-list-item-actions")).toContainText("Fjern");
+  });
+});
+
+test.describe("#745 module library — filter by course", () => {
+  test("selecting a course keeps only its modules; 'Ikke i noe kurs' keeps course-less modules; 'Alle kurs' shows all", async ({ page }) => {
+    await mockCommonApis(page, {
+      libraryModules: [
+        { id: "module-x", title: "Module X", status: "published", courseCount: 1, courses: [{ id: "course-a", title: "Kurs A" }] },
+        { id: "module-y", title: "Module Y", status: "published", courseCount: 0, courses: [] },
+      ],
+    });
+
+    await page.goto(LIBRARY_PATH);
+
+    const table = page.locator(".library-table");
+    await expect(table).toContainText("Module X");
+    await expect(table).toContainText("Module Y");
+
+    const courseSelect = page.locator("#libraryCourseFilter");
+    // The dropdown was rebuilt from the data: it offers "Kurs A" plus the two fixed groups.
+    await expect(courseSelect.locator("option")).toContainText(["Alle kurs", "Kurs A", "Ikke i noe kurs"]);
+
+    // Select "Kurs A" → only X survives.
+    await courseSelect.selectOption("course-a");
+    await expect(table).toContainText("Module X");
+    await expect(table).not.toContainText("Module Y");
+
+    // Select "Ikke i noe kurs" → only Y survives.
+    await courseSelect.selectOption("__none__");
+    await expect(table).toContainText("Module Y");
+    await expect(table).not.toContainText("Module X");
+
+    // Back to "Alle kurs" → both visible.
+    await courseSelect.selectOption("__all__");
+    await expect(table).toContainText("Module X");
+    await expect(table).toContainText("Module Y");
+  });
+
+  test("course filter composes with the search box", async ({ page }) => {
+    await mockCommonApis(page, {
+      libraryModules: [
+        { id: "module-x", title: "Trade unions", status: "published", courseCount: 1, courses: [{ id: "course-a", title: "Kurs A" }] },
+        { id: "module-z", title: "Bargaining basics", status: "published", courseCount: 1, courses: [{ id: "course-a", title: "Kurs A" }] },
+      ],
+    });
+
+    await page.goto(LIBRARY_PATH);
+    await page.locator("#libraryCourseFilter").selectOption("course-a");
+    await expect(page.locator(".library-table")).toContainText("Trade unions");
+    await expect(page.locator(".library-table")).toContainText("Bargaining basics");
+
+    // Search narrows within the course-filtered set.
+    await page.locator("#librarySearch").fill("bargaining");
+    await expect(page.locator(".library-table")).toContainText("Bargaining basics");
+    await expect(page.locator(".library-table")).not.toContainText("Trade unions");
+  });
+});
+
+test.describe("#745 section library — filter by course", () => {
+  test("selecting a course keeps only its sections; 'Ikke i noe kurs' keeps course-less sections; 'Alle kurs' shows all", async ({ page }) => {
+    await mockCommonApis(page);
+
+    const sections = [
+      {
+        id: "section-x",
+        title: "Section X",
+        versionNo: 1,
+        activeVersionId: "v1",
+        archivedAt: null,
+        updatedAt: "2026-04-18T12:00:00.000Z",
+        courseCount: 1,
+        courses: [{ id: "course-a", title: "Kurs A" }],
+      },
+      {
+        id: "section-y",
+        title: "Section Y",
+        versionNo: 1,
+        activeVersionId: "v1",
+        archivedAt: null,
+        updatedAt: "2026-04-18T12:00:00.000Z",
+        courseCount: 0,
+        courses: [],
+      },
+    ];
+    await page.route("**/api/admin/content/sections", async (route: Route) => {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ sections }) });
+    });
+
+    await page.goto("/admin-content/sections");
+
+    const table = page.locator(".sections-table");
+    await expect(table).toContainText("Section X");
+    await expect(table).toContainText("Section Y");
+
+    const courseSelect = page.locator("#sectionCourseFilter");
+    await expect(courseSelect).toBeVisible();
+    await expect(courseSelect.locator("option")).toContainText(["Alle kurs", "Kurs A", "Ikke i noe kurs"]);
+
+    await courseSelect.selectOption("course-a");
+    await expect(page.locator(".sections-table")).toContainText("Section X");
+    await expect(page.locator(".sections-table")).not.toContainText("Section Y");
+
+    await page.locator("#sectionCourseFilter").selectOption("__none__");
+    await expect(page.locator(".sections-table")).toContainText("Section Y");
+    await expect(page.locator(".sections-table")).not.toContainText("Section X");
+
+    await page.locator("#sectionCourseFilter").selectOption("__all__");
+    await expect(page.locator(".sections-table")).toContainText("Section X");
+    await expect(page.locator(".sections-table")).toContainText("Section Y");
+  });
+});

--- a/test/e2e/admin-content-helpers.ts
+++ b/test/e2e/admin-content-helpers.ts
@@ -16,6 +16,9 @@ type MockLibraryModule = {
   title?: string;
   status?: string;
   courseCount?: number;
+  // #745: modules carry the courses they belong to (used by the "Brukt i kurs" popover
+  // and the course filter). Kept optional so existing fixtures are unaffected.
+  courses?: Array<{ id: string; title: string }>;
 };
 
 type MockCourse = {


### PR DESCRIPTION
Closes #744, closes #745.

Two admin-content **frontend-only** features (static JS in `public/static/`). No backend, no schema, no route changes.

## #744 — «Åpne» links in the course builder
The course builder's «Innhold i kurset (moduler og seksjoner)» item list (`public/static/admin-content-courses.js`, `/admin-content/courses/:courseId`) had no way to open an item's editor. Each row now gets an **«Åpne»** link next to «Fjern» that opens the item's editor in a **new tab** (`target="_blank" rel="noopener"`) so the builder isn't lost:
- module item → `/admin-content/module/<id>/conversation`
- section item → `/admin-content/sections?id=<id>`

Design decisions: new-tab editor links; hardcoded Norwegian «Åpne» to match its neighbours («Fjern»/«Diskusjon»), no new i18n key; reuses the row's existing button CSS.

## #745 — filter libraries by course
The module library (`admin-content-library.js`) and section library (`admin-content-sections.js`) are flat lists that get long under agent mass-production. Both get a **client-side course dropdown** («Kurs:») next to the filter bar:
- **«Alle kurs»** (default, no filtering) + one option per distinct course (deduped by `course.id` across every item's `courses[]`, sorted by title) + **«Ikke i noe kurs»** (items with no courses).
- Reuses the `courses` data already carried for the «Brukt i kurs» popover — **no backend change**. Composes with the existing status filter + text search + sort (additional predicate). The dropdown rebuilds whenever the data reloads. In-memory selection (no persistence across reload), matching the other filters. Hardcoded Norwegian labels.

## Tests
`test/e2e/admin-content-course-links-library-filter.spec.ts` (mocks the admin APIs via the shared harness):
- #744: module row link → `…/module/<id>/conversation` + `target=_blank`; section row link → `/admin-content/sections?id=<id>`.
- #745: for both the module and section library — selecting «Kurs A» shows the item in that course and hides the course-less one; «Ikke i noe kurs» inverts it; «Alle kurs» shows both. Plus a compose-with-search case. Mock payloads include `courses: [{id,title}]` + `courseCount`.

`npx tsc --noEmit` clean; `npm run test:e2e:admin-content` green (88 + 4 new = 92 passing, existing specs unchanged). Verified visually with headless Playwright (link renders as a button next to «Fjern»; dropdown sits under the filter pills).

## Docs
- `package.json` 1.6.18 → **1.6.19**, `doc/VERSIONS.md` entry.
- `doc/FEATURE_SURFACE_MAP.md` #14: added the shared course-filter row (both selectors) + a note on the builder «Åpne» links.
- No `doc/route-map.md` change (routes unchanged).

**Do not merge / do not deploy** — left open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
