### PR TITLE
feat(content): #749 (Layer A) carry section figures/images through export + import

### DIFF
--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -283,9 +283,17 @@ fields (`title`, `bodyMarkdown`) accept a string or a partial `{en-GB,nb,nn}` ob
 
 Classes (cohorts) assign a course to a group of participants dynamically: a participant is assigned a course if they belong to a class it is assigned to (evaluated at read time, never materialised). The built-in **"Alle deltakere"** system class covers all PARTICIPANT users. `GET /api/courses` and `GET /api/courses/enrollments` reflect class assignments (the latter with `source: "CLASS"`). Entra-linked classes (`kind=ENTRA`) are gated by the `classEntraLinkingEnabled` platform config (default off, CL-5).
 | `POST` | `/api/admin/content/courses/:courseId/localize-copy` | LLM-translate course title/description |
-| `GET` | `/api/admin/content/courses/:courseId/export-package` | Export envelope (inlines modules **and** sections in order, #512) |
-| `POST` | `/api/admin/content/courses/import` | Import a course envelope (recreates sections via `items`, falls back to modules-only v1) |
+| `GET` | `/api/admin/content/courses/:courseId/export-package` | Export envelope (inlines modules **and** sections in order, #512). Section figures/images travel inline as base64 (#749, see below) |
+| `POST` | `/api/admin/content/courses/import` | Import a course envelope (recreates sections via `items`, falls back to modules-only v1). Recreates section assets + remaps `asset:` refs (#749). Larger 35 MB body limit to carry inlined assets |
 | `DELETE` | `/api/admin/content/courses/:courseId` | Delete course |
+
+#### Section figures/images carried through export/import (#749, Layer A)
+
+Course export/import now transport a section's figures/images (`SectionAsset`), so figures survive a cross-environment round-trip and the authoring skill's fallback file — not just their markdown `asset:<id>` references. The transport is **additive** to `a2-content-export/v1` (no version-marker change); asset-less files exported before #749 import unchanged.
+
+- **Schema:** each section payload gains an OPTIONAL `assets[]`; each entry is `{ sourceId, filename, mimeType, sizeBytes, contentBase64, sourceLocale?, localizedVariants?: [{ locale, contentBase64 }] }`. `sourceId` is the source-environment `SectionAsset` id — used only to match `asset:<sourceId>` markdown refs, never persisted as an id.
+- **Export** inlines each `SectionAsset` blob (and every #657 localized SVG variant) as base64. Enforced caps: **5 MB per asset** and a **25 MB total-decoded-asset budget per envelope** — export fails `400 validation_error` if the total is exceeded (a figure is never silently dropped).
+- **Import** decodes each asset, enforces the **mime allowlist** (`image/svg+xml`, `image/png`, `image/jpeg`, `image/gif`, `image/webp`) and the 5 MB per-asset cap, **re-sanitises SVG** (base + variants; scripts/handlers/`foreignObject`/`<a>` stripped — defence in depth), stores it to a fresh blob under the new section, creates the `SectionAsset` row (preserving `sourceLocale`/localized variants), then **rewrites the section's active `bodyMarkdown`** so every `asset:<sourceId>` points at the new asset id. A failing asset surfaces a clear `400` naming the section/asset (no silent skip). Ordering is create-section → create-assets → re-save markdown with remapped refs, so the persisted active version never references source ids. See `doc/design/COURSE_FIGURES_AND_ASSETS.md` (Layer A). Skill figure *design* (Layer B) is a later phase.
 
 ### Learning sections (#476)
 

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,43 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.22 - 2026-07-11
+
+feat(content): #749 (Layer A) — carry section figures/images through export AND import
+
+Section figures/images (`SectionAsset`, blobs in storage referenced from markdown as
+`![alt](asset:<id>)`) now travel with a course through **export and import**, so figures survive a
+cross-environment round-trip and the `a2-authoring-api` skill's fallback file. Before this, export
+was markdown-only — the blobs were dropped and imported figures broke. This is the transport
+foundation (**Layer A**) for `doc/design/COURSE_FIGURES_AND_ASSETS.md`; the skill-assisted figure
+*design* (Layer B) is a later phase and is NOT included here.
+
+- **Schema (additive, no version-marker change):** `sectionExportPayloadSchema` gains an OPTIONAL
+  `assets[]` — `{ sourceId, filename, mimeType, sizeBytes, contentBase64, sourceLocale?,
+  localizedVariants?: [{ locale, contentBase64 }] }`. Old asset-less `a2-content-export/v1` files
+  import unchanged.
+- **Export** inlines each `SectionAsset` blob (+ #657 localized SVG variants) as base64. Caps:
+  5 MB per asset and a **25 MB total-decoded-asset budget per envelope** — export throws
+  `400 validation_error` if exceeded (never silently drops a figure).
+- **Import** decodes each asset, enforces the mime allowlist + per-asset cap, **re-sanitises SVG**
+  (base + variants, defence in depth), stores to a fresh blob under the new section, creates the
+  `SectionAsset` row (preserving `sourceLocale`/variants), then rewrites the section's active
+  `bodyMarkdown` so every `asset:<sourceId>` points at the new id (create-section → create-assets →
+  re-save remapped markdown; the persisted active version never references source ids). A failing
+  asset surfaces a clear error naming the section/asset — no silent skip.
+- **Body limit:** the course-import route gets a route-specific 35 MB `express.json` parser (covers
+  the 25 MB asset budget after base64 inflation); every other endpoint stays at 5 MB. Module import
+  is unchanged (modules carry no sections/assets).
+- **Skill (docs only this phase):** `skills/a2-authoring-api/references/package-schema.md` documents
+  the optional `assets[]` and the ref/remap contract; `scripts/export-validate.mjs`'s bundled
+  validator + the real-schema round-trip test now cover `assets[]`.
+- **Tests:** new integration file `test/m2-content-export-import-assets.test.ts` (round-trip raster +
+  SVG-with-localized-variant, import-side SVG sanitisation, disallowed-mime/oversized rejection,
+  over-25 MB export rejection, asset-less v1 unchanged); unit coverage that the schema accepts the
+  optional `assets[]`; the skill round-trip test now carries an asset.
+
+No Prisma migration (uses the existing `SectionAsset` model). No deploy.
+
 ## 1.6.21 - 2026-07-11
 
 chore(skill): a2-authoring-api #762 — preserve approved content, import-compatible fallback export, full three-language localization

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.21",
+  "version": "1.6.22",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/skills/a2-authoring-api/references/package-schema.md
+++ b/skills/a2-authoring-api/references/package-schema.md
@@ -164,6 +164,44 @@ Mapping from an `a2-authoring-package/v1`:
   no `clientRef`).
 - Add `audit: {}` to each module `activeVersion`, each section, and the course. Empty audit
   = no publish history ⇒ import never auto-publishes (drafts only).
+
+### Section figures/images — optional `assets[]` (#749, Layer A)
+
+A section payload MAY carry its figures/images inline so they survive export/import (without
+this, `asset:<id>` markdown refs would break on the destination). Each entry:
+
+```json
+{
+  "type": "SECTION", "sortOrder": 0,
+  "section": {
+    "title": "…", "bodyMarkdown": "![Diagram](asset:cmr8src…)", "audit": {},
+    "assets": [
+      {
+        "sourceId": "cmr8src…",
+        "filename": "diagram.svg",
+        "mimeType": "image/svg+xml",
+        "sizeBytes": 1234,
+        "contentBase64": "PHN2Zy…",
+        "sourceLocale": "nb",
+        "localizedVariants": [ { "locale": "en-GB", "contentBase64": "PHN2Zy…" } ]
+      }
+    ]
+  }
+}
+```
+
+- **Ref/remap contract:** `bodyMarkdown` references each figure as `![alt](asset:<sourceId>)`,
+  where `<sourceId>` equals the asset's `sourceId`. On import, A2 decodes each blob, **re-sanitises
+  SVG**, stores it to a fresh blob, creates a new `SectionAsset`, and rewrites every
+  `asset:<sourceId>` in the markdown to the new asset id — so `sourceId` is a *matching key only*,
+  never a destination id. Leave the markdown refs pointing at `sourceId`; do not pre-remap them.
+- **Allowed mime types:** `image/svg+xml`, `image/png`, `image/jpeg`, `image/gif`, `image/webp`.
+  Per-asset limit 5 MB; the whole export is capped at 25 MB of decoded asset bytes.
+- **`localizedVariants`** carries the #657 translated-SVG variants (one base64 per locale); omit
+  for raster or untranslated figures. `assets` is fully optional — omit it entirely for a
+  markdown-only section (old asset-less files import unchanged).
+- **Phase 1 (Layer A) is transport only.** The skill does not yet *design* figures (that is Layer B,
+  a later phase) — this documents how figures already present on a section travel through the file.
 - `exportFormat` / `exportedAt` / `scope: "course"` on the envelope. **`exportedAt` (and any
   `audit.publishedAt`) MUST be `Date.toISOString()` shape (`YYYY-MM-DDTHH:mm:ss.sssZ`)** — Zod
   `.datetime()` rejects timezone offsets and microseconds. Build this envelope with

--- a/skills/a2-authoring-api/scripts/export-validate.mjs
+++ b/skills/a2-authoring-api/scripts/export-validate.mjs
@@ -159,6 +159,32 @@ export function validateExportEnvelopeStructure(envelope) {
     if (!section || typeof section !== "object") return err(path, "section payload required");
     if (!isNonEmptyLocalized(section.title) && (section.title == null)) err(`${path}.title`, "required");
     validateAudit(section.audit, `${path}.audit`);
+    // #749 (Layer A): optional inlined figures/images. Mirrors sectionAssetExportSchema — each
+    // asset needs sourceId/filename/mimeType/contentBase64 (strings) + a non-negative sizeBytes;
+    // localizedVariants (if present) each need a locale + base64. Old asset-less files omit it.
+    if (section.assets !== undefined) {
+      if (!Array.isArray(section.assets)) {
+        err(`${path}.assets`, "must be an array");
+      } else {
+        section.assets.forEach((asset, ai) => {
+          const ap = `${path}.assets[${ai}]`;
+          if (!asset || typeof asset !== "object") return err(ap, "asset must be an object");
+          for (const field of ["sourceId", "filename", "mimeType", "contentBase64"]) {
+            if (typeof asset[field] !== "string" || asset[field].length === 0) err(`${ap}.${field}`, "required non-empty string");
+          }
+          if (!Number.isInteger(asset.sizeBytes) || asset.sizeBytes < 0) err(`${ap}.sizeBytes`, "must be a non-negative integer");
+          if (asset.localizedVariants !== undefined) {
+            if (!Array.isArray(asset.localizedVariants)) err(`${ap}.localizedVariants`, "must be an array");
+            else asset.localizedVariants.forEach((v, vi) => {
+              const vp = `${ap}.localizedVariants[${vi}]`;
+              if (!v || typeof v !== "object") return err(vp, "variant must be an object");
+              if (typeof v.locale !== "string" || v.locale.length === 0) err(`${vp}.locale`, "required non-empty string");
+              if (typeof v.contentBase64 !== "string" || v.contentBase64.length === 0) err(`${vp}.contentBase64`, "required non-empty string");
+            });
+          }
+        });
+      }
+    }
   };
 
   if (envelope.scope === "course" && envelope.course) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { appName, appVersion } from "./config/appMetadata.js";
 import { getParticipantConsoleRuntimeConfig } from "./config/participantConsole.js";
 import { SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES } from "./modules/adminContent/sourceMaterialExtractionService.js";
+import { COURSE_IMPORT_BODY_LIMIT_BYTES } from "./modules/adminContent/contentImportService.js";
 import { rolesFor } from "./config/capabilities.js";
 import { authenticate } from "./auth/authenticate.js";
 import { enforceAgentTokenScope } from "./auth/agentTokenScope.js";
@@ -45,6 +46,13 @@ app.use(securityHeadersMiddleware);
 app.use(
   "/api/admin/content/source-material/extract",
   express.json({ limit: SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES }),
+);
+// #749 (Layer A): course import inlines section figures/images (base64) → bodies exceed 5 MB.
+// Registered before the global parser (express.json skips once req._body is set) so ONLY this
+// route gets the larger limit; module import stays at 5 MB (modules carry no assets).
+app.use(
+  "/api/admin/content/courses/import",
+  express.json({ limit: COURSE_IMPORT_BODY_LIMIT_BYTES }),
 );
 app.use(express.json({ limit: "5mb" }));
 app.use("/static", express.static(publicStaticPath));

--- a/src/modules/adminContent/adminContentQueries.ts
+++ b/src/modules/adminContent/adminContentQueries.ts
@@ -2,6 +2,7 @@ import { adminContentRepository } from "./adminContentRepository.js";
 import type { SupportedLocale } from "../../i18n/locale.js";
 import { localizeContentText } from "../../i18n/content.js";
 import { decodeLocalizedText, safeParseJson, mapMcqSetVersion } from "./adminContentProjections.js";
+import { ValidationError } from "../../errors/AppError.js";
 
 // v1.2.20 (#460): "published_with_draft" skiller mellom (a) modul som aldri har vært
 // publisert (unpublished_draft) og (b) modul som er live med eldre publisert versjon
@@ -207,12 +208,16 @@ export async function buildCourseExportEnvelope(
     throw new Error("Course has no items to export.");
   }
 
+  // #749 (Layer A): running budget for inlined section-asset bytes across the whole envelope.
+  // Enforced inside buildSectionExportPayload; throws a ValidationError if the total exceeds the cap.
+  const assetBudget = { total: 0 };
+
   const itemPayloads = await Promise.all(
     [...courseItems]
       .sort((a, b) => a.sortOrder - b.sortOrder)
       .map(async (item) => {
         if (item.itemType === "SECTION" && item.section) {
-          const sectionVersion = await buildSectionExportPayload(item.section.id);
+          const sectionVersion = await buildSectionExportPayload(item.section.id, assetBudget);
           return { type: "SECTION" as const, sortOrder: item.sortOrder, section: sectionVersion };
         }
         const moduleId = item.moduleId ?? item.module?.id;
@@ -251,10 +256,30 @@ export async function buildCourseExportEnvelope(
 }
 
 // Inline a learning section's title + active-version markdown for export (#512).
-async function buildSectionExportPayload(sectionId: string): Promise<import("./adminContentSchemas.js").SectionExportPayload> {
+// #749 (Layer A): also inline the section's figures/images (SectionAsset) as base64 so imported
+// figures survive the round-trip. The markdown's `asset:<sourceId>` refs are left unchanged;
+// import remaps them to the newly created asset ids. `assetBudget` accumulates decoded asset bytes
+// across the whole envelope; the envelope-wide cap is enforced here so a figure is never dropped.
+async function buildSectionExportPayload(
+  sectionId: string,
+  assetBudget?: { total: number },
+): Promise<import("./adminContentSchemas.js").SectionExportPayload> {
   const { getSection } = await import("../course/sectionCommands.js");
+  const { loadSectionAssetsForExport, MAX_EXPORT_ASSET_TOTAL_BYTES } = await import("../course/assetCommands.js");
   const section = await getSection(sectionId);
   if (!section) throw new Error("Section not found for export.");
+
+  const { assets, totalBytes } = await loadSectionAssetsForExport(sectionId);
+  if (assetBudget) {
+    assetBudget.total += totalBytes;
+    if (assetBudget.total > MAX_EXPORT_ASSET_TOTAL_BYTES) {
+      throw new ValidationError(
+        `Course export exceeds the ${MAX_EXPORT_ASSET_TOTAL_BYTES}-byte total-asset cap ` +
+          `(figures sum to ${assetBudget.total} bytes). Reduce or split the course before exporting.`,
+      );
+    }
+  }
+
   return {
     title: (decodeLocalizedText(section.title) as never) ?? (section.title as never),
     bodyMarkdown: (section.activeVersion?.bodyMarkdown
@@ -266,6 +291,7 @@ async function buildSectionExportPayload(sectionId: string): Promise<import("./a
       publishedByEmail: null,
       sourceVersionNo: section.activeVersion?.versionNo ?? null,
     },
+    ...(assets.length > 0 ? { assets: assets as never } : {}),
   };
 }
 

--- a/src/modules/adminContent/adminContentSchemas.ts
+++ b/src/modules/adminContent/adminContentSchemas.ts
@@ -351,15 +351,40 @@ export const moduleExportPayloadSchema = z.object({
   }),
 });
 
+// One section figure/image inlined into the export (#749, Layer A). The blob binary
+// travels as base64 so the file is self-contained; on import it is decoded, SVG is
+// re-sanitised, stored to a fresh blob, and the section's `asset:<sourceId>` markdown
+// refs are remapped to the newly created SectionAsset id. `sourceId` is the SectionAsset
+// id in the SOURCE environment — used ONLY to match markdown refs, never persisted as an id.
+// `sourceLocale` + `localizedVariants` carry the #657 localized-SVG variants.
+export const sectionAssetExportSchema = z.object({
+  sourceId: z.string().min(1),
+  filename: z.string().min(1),
+  mimeType: z.string().min(1),
+  sizeBytes: z.number().int().min(0),
+  contentBase64: z.string().min(1),
+  sourceLocale: z.string().min(1).nullable().optional(),
+  localizedVariants: z
+    .array(
+      z.object({
+        locale: z.string().min(1),
+        contentBase64: z.string().min(1),
+      }),
+    )
+    .optional(),
+});
+
 // One learning section's payload — title + active-version markdown, both
-// localized. Assets (#483/F4) are not yet inlined; markdown-only for now (#512).
-// Sections legitimately have partial locales (an author may fill only nb), so
-// the export uses the patch schema (string OR partial object), not the strict
-// all-three-locale localizedTextSchema (#512 follow-up).
+// localized. #749 (Layer A) adds an OPTIONAL `assets[]` carrying the section's
+// figures/images inline (base64); old asset-less v1 files omit it and import
+// unchanged. Sections legitimately have partial locales (an author may fill only
+// nb), so the export uses the patch schema (string OR partial object), not the
+// strict all-three-locale localizedTextSchema (#512 follow-up).
 export const sectionExportPayloadSchema = z.object({
   title: localizedTextPatchSchema,
   bodyMarkdown: localizedTextPatchSchema,
   audit: exportAuditSchema.optional(),
+  assets: z.array(sectionAssetExportSchema).optional(),
 });
 
 // Course export inlines each module's full payload so the file is
@@ -405,6 +430,7 @@ export const exportEnvelopeSchema = z.object({
 export type ExportEnvelope = z.infer<typeof exportEnvelopeSchema>;
 export type ModuleExportPayload = z.infer<typeof moduleExportPayloadSchema>;
 export type SectionExportPayload = z.infer<typeof sectionExportPayloadSchema>;
+export type SectionAssetExport = z.infer<typeof sectionAssetExportSchema>;
 export type CourseExportPayload = z.infer<typeof courseExportPayloadSchema>;
 
 export const importBodySchema = z.object({

--- a/src/modules/adminContent/contentImportService.ts
+++ b/src/modules/adminContent/contentImportService.ts
@@ -24,7 +24,9 @@ import {
 import { adminContentRepository } from "./adminContentRepository.js";
 import { courseRepository } from "../course/courseRepository.js";
 import { createCourse, setCourseModules, setCourseItems, publishCourse, type CourseItemInput } from "../course/courseCommands.js";
-import { createSection } from "../course/sectionCommands.js";
+import { createSection, updateSectionContent } from "../course/sectionCommands.js";
+import { importSectionAssets } from "../course/assetCommands.js";
+import { ValidationError } from "../../errors/AppError.js";
 import { localizedTextCodec, type LocalizedText } from "../../codecs/localizedTextCodec.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import {
@@ -36,9 +38,65 @@ import {
 import type {
   ExportEnvelope,
   ModuleExportPayload,
+  SectionExportPayload,
 } from "./adminContentSchemas.js";
 
 export type ImportMode = "createNew" | "replaceExisting";
+
+// #749 (Layer A): the course-import route carries inlined section assets (base64), so the JSON body
+// can be far larger than the 5 MB global parser allows. Sized to cover the 25 MB total-asset cap
+// after base64 inflation (~1.33×) plus JSON/markdown headroom. Applied to ONLY the course-import
+// route in app.ts (module import cannot carry assets — modules have no sections). Keeping every
+// other endpoint at 5 MB limits the large-body surface.
+export const COURSE_IMPORT_BODY_LIMIT_BYTES = 35 * 1024 * 1024; // 35 MB
+
+// #749 (Layer A): rewrite every `asset:<sourceId>` reference in the serialised section markdown
+// to `asset:<newAssetId>` using the source→new id map produced when the section's assets are
+// re-created. Refs with no mapping are left untouched (defensive — an author-mistyped ref should
+// not be silently mangled). The markdown is the JSON-serialised localized string, so the replace
+// runs across every locale value at once. Mirrors the `asset:` ref grammar in sectionContent.ts.
+function remapAssetRefs(serializedMarkdown: string, idMap: Map<string, string>): string {
+  if (idMap.size === 0) return serializedMarkdown;
+  return serializedMarkdown.replace(/asset:([a-zA-Z0-9]+)/g, (whole, sourceId: string) => {
+    const mapped = idMap.get(sourceId);
+    return mapped ? `asset:${mapped}` : whole;
+  });
+}
+
+// #749: recreate one learning section (title + markdown) AND its inlined figures/images. Ordering
+// matters: the section (and version 1) is created first with the SOURCE markdown, then the assets
+// are re-created to obtain their new ids, then a NEW section version is saved whose markdown refs
+// point at the new asset ids — so the ACTIVE version never references source ids. Sections without
+// assets skip the second save (old asset-less v1 files behave exactly as before). A failure while
+// importing an asset throws with the section title for context; any blobs written before the
+// failure are orphaned (no row references them) — tolerable for v1, matching createSectionAsset.
+async function importSectionPayload(section: SectionExportPayload, actorId: string): Promise<string> {
+  const serializedMarkdown = serializeRequired(section.bodyMarkdown);
+  const created = await createSection({
+    title: serializeRequired(section.title),
+    bodyMarkdown: serializedMarkdown,
+    actorId,
+  });
+
+  const assets = section.assets ?? [];
+  if (assets.length === 0) return created.id;
+
+  let idMap: Map<string, string>;
+  try {
+    idMap = await importSectionAssets(created.id, assets);
+  } catch (error) {
+    const title = typeof section.title === "string" ? section.title : JSON.stringify(section.title);
+    const detail = error instanceof Error ? error.message : String(error);
+    // Keep the client-error status (asset validation failures are 400) while adding section context.
+    throw new ValidationError(`Failed to import assets for section "${title}": ${detail}`);
+  }
+
+  const remapped = remapAssetRefs(serializedMarkdown, idMap);
+  if (remapped !== serializedMarkdown) {
+    await updateSectionContent(created.id, remapped, actorId);
+  }
+  return created.id;
+}
 
 function serializeLocalized(value: LocalizedText | null | undefined): string | undefined {
   if (value === null || value === undefined) return undefined;
@@ -240,12 +298,8 @@ export async function importCourseFromEnvelope(
     const courseItemInputs: CourseItemInput[] = [];
     for (const entry of ordered) {
       if (entry.type === "SECTION") {
-        const section = await createSection({
-          title: serializeRequired(entry.section.title),
-          bodyMarkdown: serializeRequired(entry.section.bodyMarkdown),
-          actorId: options.actorId,
-        });
-        courseItemInputs.push({ type: "SECTION", sectionId: section.id });
+        const sectionId = await importSectionPayload(entry.section, options.actorId);
+        courseItemInputs.push({ type: "SECTION", sectionId });
         sectionCount += 1;
       } else {
         const imported = await importModulePayload(entry.module, { actorId: options.actorId, mode: "createNew" });

--- a/src/modules/course/assetCommands.ts
+++ b/src/modules/course/assetCommands.ts
@@ -12,6 +12,10 @@ export const SVG_MIME_TYPE = "image/svg+xml";
 // previously excluded outright (#483/F4) because raw SVG is an XSS vector.
 export const ALLOWED_ASSET_MIME_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp", SVG_MIME_TYPE];
 export const MAX_ASSET_BYTES = 5 * 1024 * 1024; // 5 MB
+// #749 (Layer A): total decoded-asset budget for one export envelope. Inlined blobs make the
+// file large; this caps the whole course export (sum of every section's base + localized-variant
+// bytes) so an export can never balloon unbounded. Export throws if exceeded — never silently drops.
+export const MAX_EXPORT_ASSET_TOTAL_BYTES = 25 * 1024 * 1024; // 25 MB
 
 export async function createSectionAsset(input: {
   sectionId: string;
@@ -175,4 +179,175 @@ export async function localizeSectionAssets(
   }
 
   return { localizedAssetCount, skippedAssetCount, targetLocales };
+}
+
+// =========================================================================
+// #749 (Layer A) — asset transport through export / import
+// =========================================================================
+
+// One inlined section asset ready to be serialised into an a2-content-export/v1 envelope.
+export interface ExportedSectionAsset {
+  sourceId: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  contentBase64: string;
+  sourceLocale?: string | null;
+  localizedVariants?: Array<{ locale: string; contentBase64: string }>;
+}
+
+/**
+ * #749: load every SectionAsset of a section with its blob binary (base64) plus each localized
+ * SVG variant (#657), ready to inline into an export envelope. Returns the assets and the total
+ * decoded byte count (base + variants) so the export builder can enforce the envelope-wide cap.
+ * The `sizeBytes` reported per asset is the ACTUAL base-blob byte length (not the stored metadata),
+ * so the importer can trust it.
+ */
+export async function loadSectionAssetsForExport(
+  sectionId: string,
+): Promise<{ assets: ExportedSectionAsset[]; totalBytes: number }> {
+  const rows = await prisma.sectionAsset.findMany({
+    where: { sectionId },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      filename: true,
+      mimeType: true,
+      blobPath: true,
+      sourceLocale: true,
+      localizedBlobPaths: true,
+    },
+  });
+
+  const assets: ExportedSectionAsset[] = [];
+  let totalBytes = 0;
+
+  for (const row of rows) {
+    const buffer = await getAsset(row.blobPath);
+    totalBytes += buffer.byteLength;
+
+    const localizedPaths = readLocalizedBlobPaths(row.localizedBlobPaths);
+    const localizedVariants: Array<{ locale: string; contentBase64: string }> = [];
+    for (const [locale, variantPath] of Object.entries(localizedPaths)) {
+      const variantBuffer = await getAsset(variantPath);
+      totalBytes += variantBuffer.byteLength;
+      localizedVariants.push({ locale, contentBase64: variantBuffer.toString("base64") });
+    }
+
+    assets.push({
+      sourceId: row.id,
+      filename: row.filename,
+      mimeType: row.mimeType,
+      sizeBytes: buffer.byteLength,
+      contentBase64: buffer.toString("base64"),
+      ...(row.sourceLocale ? { sourceLocale: row.sourceLocale } : {}),
+      ...(localizedVariants.length > 0 ? { localizedVariants } : {}),
+    });
+  }
+
+  return { assets, totalBytes };
+}
+
+// Decode + validate a single inlined blob: enforce the per-asset size cap and (for SVG) run the
+// sanitiser (defence in depth — the source may be a hand-crafted or tampered file). Returns the
+// bytes to store. Throws a clear ValidationError (naming the asset) on any failure.
+function decodeAndValidateAssetBytes(input: {
+  label: string;
+  mimeType: string;
+  contentBase64: string;
+}): Buffer {
+  let buffer: Buffer;
+  try {
+    buffer = Buffer.from(input.contentBase64, "base64");
+  } catch {
+    throw new ValidationError(`Asset "${input.label}" has invalid base64 content.`);
+  }
+  if (buffer.byteLength === 0) {
+    throw new ValidationError(`Asset "${input.label}" decoded to zero bytes.`);
+  }
+  if (buffer.byteLength > MAX_ASSET_BYTES) {
+    throw new ValidationError(
+      `Asset "${input.label}" too large (${buffer.byteLength} bytes, max ${MAX_ASSET_BYTES}).`,
+    );
+  }
+  if (input.mimeType === SVG_MIME_TYPE) {
+    const sanitized = sanitizeSvg(buffer.toString("utf8"));
+    if (!sanitized) {
+      throw new ValidationError(`Asset "${input.label}" SVG is empty or invalid after sanitisation.`);
+    }
+    return Buffer.from(sanitized, "utf8");
+  }
+  return buffer;
+}
+
+/**
+ * #749: recreate one section's exported assets in the destination. For each asset the blob is
+ * decoded, its mime is checked against the allowlist, the per-asset size cap is enforced, SVG is
+ * re-sanitised (base + every localized variant), the binary is written to a FRESH blob path under
+ * the new section, and a SectionAsset row is created (preserving sourceLocale + localizedBlobPaths
+ * when present). Returns a `sourceId -> newAssetId` map so the caller can remap the section's
+ * `asset:<sourceId>` markdown refs. Any invalid asset throws (no silent skip); the thrown error
+ * names the offending asset.
+ */
+export async function importSectionAssets(
+  sectionId: string,
+  assets: ReadonlyArray<{
+    sourceId: string;
+    filename: string;
+    mimeType: string;
+    sizeBytes: number;
+    contentBase64: string;
+    sourceLocale?: string | null;
+    localizedVariants?: Array<{ locale: string; contentBase64: string }>;
+  }>,
+): Promise<Map<string, string>> {
+  const idMap = new Map<string, string>();
+
+  for (const asset of assets) {
+    const label = asset.filename || asset.sourceId;
+    if (!ALLOWED_ASSET_MIME_TYPES.includes(asset.mimeType)) {
+      throw new ValidationError(
+        `Asset "${label}" has unsupported type (${asset.mimeType || "unknown"}). Allowed: PNG, JPEG, GIF, WebP, SVG.`,
+      );
+    }
+
+    const storedBuffer = decodeAndValidateAssetBytes({
+      label,
+      mimeType: asset.mimeType,
+      contentBase64: asset.contentBase64,
+    });
+
+    const safeName = (asset.filename || "file").replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 100) || "file";
+    const blobPath = `sections/${sectionId}/${randomUUID()}-${safeName}`;
+    await putAsset(blobPath, storedBuffer, asset.mimeType);
+
+    // Localized SVG variants (#657): each becomes a sibling blob, re-sanitised for defence in depth.
+    const localizedBlobPaths: Record<string, string> = {};
+    for (const variant of asset.localizedVariants ?? []) {
+      const variantBuffer = decodeAndValidateAssetBytes({
+        label: `${label} (${variant.locale})`,
+        mimeType: asset.mimeType,
+        contentBase64: variant.contentBase64,
+      });
+      const variantPath = `sections/${sectionId}/${randomUUID()}-${variant.locale}-${safeName}`;
+      await putAsset(variantPath, variantBuffer, asset.mimeType);
+      localizedBlobPaths[variant.locale] = variantPath;
+    }
+
+    const created = await prisma.sectionAsset.create({
+      data: {
+        sectionId,
+        filename: safeName,
+        mimeType: asset.mimeType,
+        blobPath,
+        sizeBytes: storedBuffer.byteLength,
+        sourceLocale: asset.sourceLocale ?? null,
+        localizedBlobPaths: Object.keys(localizedBlobPaths).length > 0 ? localizedBlobPaths : undefined,
+      },
+      select: { id: true },
+    });
+    idMap.set(asset.sourceId, created.id);
+  }
+
+  return idMap;
 }

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -32,8 +32,12 @@ export {
   listSectionAssets,
   getSectionAssetContent,
   localizeSectionAssets,
+  loadSectionAssetsForExport,
+  importSectionAssets,
   ALLOWED_ASSET_MIME_TYPES,
   MAX_ASSET_BYTES,
+  MAX_EXPORT_ASSET_TOTAL_BYTES,
+  type ExportedSectionAsset,
 } from "./assetCommands.js";
 export { courseRepository, createCourseRepository } from "./courseRepository.js";
 export { enrollmentRepository, createEnrollmentRepository } from "./enrollmentRepository.js";

--- a/test/m2-content-export-import-assets.test.ts
+++ b/test/m2-content-export-import-assets.test.ts
@@ -1,0 +1,306 @@
+// #749 (Layer A) integration tests: section figures/images (SectionAsset) carried through
+// export AND import, so figures survive a round-trip. Native Postgres profile; assets use the
+// filesystem blob fallback (no Azure). Modelled on m2-content-export-import.test.ts.
+//
+// Coverage:
+//   (a) round-trip a section with a raster asset AND an SVG asset with a localized variant →
+//       export → re-import → SectionAsset rows + blobs recreated, bodyMarkdown refs remapped to
+//       new ids, localized variant preserved.
+//   (b) an SVG with active content (script/onload) is sanitised on import.
+//   (c) a disallowed mime and an oversized asset are rejected on import.
+//   (d) a total envelope over 25 MB is rejected on export.
+//   (e) an old asset-less v1 file imports unchanged (no SectionAsset rows).
+
+import request from "supertest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+import { createSectionAsset, MAX_ASSET_BYTES } from "../src/modules/course/assetCommands.js";
+import { updateSectionContent } from "../src/modules/course/sectionCommands.js";
+import { putAsset, getAsset } from "../src/modules/course/assetStorage.js";
+
+const adminHeaders = {
+  "x-user-id": "admin-1",
+  "x-user-email": "admin@company.com",
+  "x-user-name": "Platform Admin",
+};
+
+const SVG_BASE = '<svg xmlns="http://www.w3.org/2000/svg"><text>Hei</text></svg>';
+const SVG_EN = '<svg xmlns="http://www.w3.org/2000/svg"><text>Hi</text></svg>';
+// Minimal 1x1 PNG (valid signature + IHDR-ish header; contents irrelevant for a raster blob).
+const PNG_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+async function createCourseWithSection(bodyMarkdownJson: string): Promise<{ courseId: string; sectionId: string }> {
+  const sectionRes = await request(app)
+    .post("/api/admin/content/sections")
+    .set(adminHeaders)
+    .send({ title: { nb: "Figur-seksjon" }, bodyMarkdown: { nb: "midlertidig" } });
+  expect(sectionRes.status).toBe(201);
+  const sectionId = sectionRes.body.section.id as string;
+  // Store the markdown (with asset refs) directly to control the exact serialized value.
+  await updateSectionContent(sectionId, bodyMarkdownJson, "admin-1");
+
+  const courseRes = await request(app)
+    .post("/api/admin/content/courses")
+    .set(adminHeaders)
+    .send({ title: { "en-GB": `Course ${Date.now()}`, nb: "Kurs", nn: "Kurs" } });
+  expect(courseRes.status).toBe(201);
+  const courseId = courseRes.body.course.id as string;
+
+  const itemsRes = await request(app)
+    .put(`/api/admin/content/courses/${courseId}/items`)
+    .set(adminHeaders)
+    .send({ items: [{ type: "SECTION", sectionId }] });
+  expect(itemsRes.status).toBe(204);
+  return { courseId, sectionId };
+}
+
+async function newSectionIdOf(courseId: string): Promise<string> {
+  const itemsRes = await request(app).get(`/api/admin/content/courses/${courseId}/items`).set(adminHeaders);
+  expect(itemsRes.status).toBe(200);
+  const section = (itemsRes.body.items as Array<{ type: string; sectionId?: string }>).find((i) => i.type === "SECTION");
+  expect(section?.sectionId).toBeTruthy();
+  return section!.sectionId as string;
+}
+
+describe("#749 section-asset export/import round-trip", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("(a) round-trips a raster + an SVG-with-localized-variant, recreating blobs and remapping refs", async () => {
+    // Section markdown references both assets by their source ids.
+    const { courseId, sectionId } = await createCourseWithSection(JSON.stringify({ nb: "placeholder" }));
+
+    const png = await createSectionAsset({ sectionId, filename: "diagram.png", mimeType: "image/png", buffer: PNG_BYTES });
+    const svg = await createSectionAsset({ sectionId, filename: "flyt.svg", mimeType: "image/svg+xml", buffer: Buffer.from(SVG_BASE, "utf8") });
+
+    // Attach a localized SVG variant (as #657 would) directly, so the round-trip carries it.
+    const variantPath = `sections/${sectionId}/variant-en-${svg.id}.svg`;
+    await putAsset(variantPath, Buffer.from(SVG_EN, "utf8"), "image/svg+xml");
+    await prisma.sectionAsset.update({
+      where: { id: svg.id },
+      data: { sourceLocale: "nb", localizedBlobPaths: { "en-GB": variantPath } },
+    });
+
+    const markdown = JSON.stringify({ nb: `# Figurer\n\n![Flyt](asset:${svg.id})\n\n![Diagram](asset:${png.id})` });
+    await updateSectionContent(sectionId, markdown, "admin-1");
+
+    // Export — the envelope must carry both assets inline.
+    const exportRes = await request(app).get(`/api/admin/content/courses/${courseId}/export-package`).set(adminHeaders);
+    expect(exportRes.status, JSON.stringify(exportRes.body)).toBe(200);
+    const items = exportRes.body.envelope.course.course.items as Array<{ type: string; section?: { assets?: unknown[] } }>;
+    const exportedAssets = (items.find((i) => i.type === "SECTION")?.section?.assets ?? []) as Array<{
+      sourceId: string;
+      mimeType: string;
+      contentBase64: string;
+      sourceLocale?: string | null;
+      localizedVariants?: Array<{ locale: string; contentBase64: string }>;
+    }>;
+    expect(exportedAssets).toHaveLength(2);
+    const exportedSvg = exportedAssets.find((a) => a.mimeType === "image/svg+xml")!;
+    expect(exportedSvg.sourceId).toBe(svg.id);
+    expect(exportedSvg.sourceLocale).toBe("nb");
+    expect(exportedSvg.localizedVariants).toHaveLength(1);
+    expect(exportedSvg.localizedVariants![0].locale).toBe("en-GB");
+    expect(Buffer.from(exportedSvg.localizedVariants![0].contentBase64, "base64").toString("utf8")).toContain("Hi");
+
+    // Import as a new course.
+    const importRes = await request(app)
+      .post("/api/admin/content/courses/import")
+      .set(adminHeaders)
+      .send({ payload: exportRes.body.envelope, mode: "createNew" });
+    expect(importRes.status, JSON.stringify(importRes.body)).toBe(201);
+    const newCourseId = importRes.body.courseId as string;
+    expect(newCourseId).not.toBe(courseId);
+
+    const newSectionId = await newSectionIdOf(newCourseId);
+    expect(newSectionId).not.toBe(sectionId);
+
+    const newAssets = await prisma.sectionAsset.findMany({ where: { sectionId: newSectionId }, orderBy: { createdAt: "asc" } });
+    expect(newAssets).toHaveLength(2);
+    const newPng = newAssets.find((a) => a.mimeType === "image/png")!;
+    const newSvg = newAssets.find((a) => a.mimeType === "image/svg+xml")!;
+    expect(newPng.id).not.toBe(png.id);
+    expect(newSvg.id).not.toBe(svg.id);
+
+    // Blobs recreated and readable.
+    const pngBlob = await getAsset(newPng.blobPath);
+    expect(pngBlob.byteLength).toBe(PNG_BYTES.byteLength);
+    const svgBlob = (await getAsset(newSvg.blobPath)).toString("utf8");
+    expect(svgBlob).toContain("Hei");
+
+    // Localized variant preserved under a fresh path.
+    const localized = newSvg.localizedBlobPaths as Record<string, string> | null;
+    expect(localized?.["en-GB"]).toBeTruthy();
+    expect(localized!["en-GB"]).not.toBe(variantPath);
+    expect((await getAsset(localized!["en-GB"])).toString("utf8")).toContain("Hi");
+    expect(newSvg.sourceLocale).toBe("nb");
+
+    // bodyMarkdown refs remapped to the NEW ids; source ids no longer present.
+    const newSection = await prisma.courseSection.findUnique({ where: { id: newSectionId }, include: { activeVersion: true } });
+    const newBody = newSection?.activeVersion?.bodyMarkdown ?? "";
+    expect(newBody).toContain(`asset:${newSvg.id}`);
+    expect(newBody).toContain(`asset:${newPng.id}`);
+    expect(newBody).not.toContain(`asset:${svg.id}`);
+    expect(newBody).not.toContain(`asset:${png.id}`);
+  });
+
+  it("(b) sanitises an SVG with active content (script/onload) on import", async () => {
+    const evilSvg =
+      '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script><text onload="alert(2)">Hei</text></svg>';
+    const envelope = {
+      exportFormat: "a2-content-export/v1",
+      exportedAt: new Date().toISOString(),
+      scope: "course",
+      course: {
+        course: {
+          title: { "en-GB": `Evil ${Date.now()}`, nb: "Ond", nn: "Ond" },
+          certificationLevel: null,
+          audit: {},
+          items: [
+            {
+              type: "SECTION",
+              sortOrder: 0,
+              section: {
+                title: { nb: "Ond seksjon" },
+                bodyMarkdown: { nb: "![x](asset:evil1)" },
+                audit: {},
+                assets: [
+                  {
+                    sourceId: "evil1",
+                    filename: "evil.svg",
+                    mimeType: "image/svg+xml",
+                    sizeBytes: evilSvg.length,
+                    contentBase64: Buffer.from(evilSvg, "utf8").toString("base64"),
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const importRes = await request(app)
+      .post("/api/admin/content/courses/import")
+      .set(adminHeaders)
+      .send({ payload: envelope, mode: "createNew" });
+    expect(importRes.status, JSON.stringify(importRes.body)).toBe(201);
+
+    const newSectionId = await newSectionIdOf(importRes.body.courseId);
+    const rows = await prisma.sectionAsset.findMany({ where: { sectionId: newSectionId } });
+    expect(rows).toHaveLength(1);
+    const stored = (await getAsset(rows[0].blobPath)).toString("utf8");
+    expect(stored).toContain("<svg");
+    expect(stored).toContain("Hei");
+    expect(stored.toLowerCase()).not.toContain("<script");
+    expect(stored.toLowerCase()).not.toContain("onload");
+  });
+
+  it("(c) rejects a disallowed mime and an oversized asset on import", async () => {
+    const baseEnvelope = (asset: Record<string, unknown>) => ({
+      exportFormat: "a2-content-export/v1",
+      exportedAt: new Date().toISOString(),
+      scope: "course",
+      course: {
+        course: {
+          title: { "en-GB": `Bad ${Date.now()}`, nb: "Feil", nn: "Feil" },
+          certificationLevel: null,
+          audit: {},
+          items: [
+            {
+              type: "SECTION",
+              sortOrder: 0,
+              section: { title: { nb: "S" }, bodyMarkdown: { nb: "![x](asset:a1)" }, audit: {}, assets: [asset] },
+            },
+          ],
+        },
+      },
+    });
+
+    const disallowed = await request(app)
+      .post("/api/admin/content/courses/import")
+      .set(adminHeaders)
+      .send({
+        payload: baseEnvelope({
+          sourceId: "a1",
+          filename: "doc.tiff",
+          mimeType: "image/tiff",
+          sizeBytes: 10,
+          contentBase64: Buffer.from("not-an-image", "utf8").toString("base64"),
+        }),
+        mode: "createNew",
+      });
+    expect(disallowed.status).toBe(400);
+    expect(disallowed.body.error).toBe("validation_error");
+
+    const oversizedBuffer = Buffer.alloc(MAX_ASSET_BYTES + 1, 0x41);
+    const oversized = await request(app)
+      .post("/api/admin/content/courses/import")
+      .set(adminHeaders)
+      .send({
+        payload: baseEnvelope({
+          sourceId: "a1",
+          filename: "huge.png",
+          mimeType: "image/png",
+          sizeBytes: oversizedBuffer.byteLength,
+          contentBase64: oversizedBuffer.toString("base64"),
+        }),
+        mode: "createNew",
+      });
+    expect(oversized.status).toBe(400);
+    expect(oversized.body.error).toBe("validation_error");
+  });
+
+  it("(d) rejects a total envelope over the 25 MB asset cap on export", async () => {
+    const { courseId, sectionId } = await createCourseWithSection(JSON.stringify({ nb: "over-cap" }));
+    // 6 x ~4.5 MB = ~27 MB > 25 MB total cap (each under the 5 MB per-asset limit).
+    const chunk = Buffer.alloc(Math.floor(4.5 * 1024 * 1024), 0x42);
+    for (let i = 0; i < 6; i += 1) {
+      await createSectionAsset({ sectionId, filename: `big-${i}.png`, mimeType: "image/png", buffer: chunk });
+    }
+
+    const exportRes = await request(app).get(`/api/admin/content/courses/${courseId}/export-package`).set(adminHeaders);
+    expect(exportRes.status).toBe(400);
+    expect(exportRes.body.error).toBe("validation_error");
+    expect(String(exportRes.body.message)).toMatch(/cap/i);
+  });
+
+  it("(e) imports an old asset-less v1 file unchanged (no SectionAsset rows)", async () => {
+    const envelope = {
+      exportFormat: "a2-content-export/v1",
+      exportedAt: new Date().toISOString(),
+      scope: "course",
+      course: {
+        course: {
+          title: { "en-GB": `Plain ${Date.now()}`, nb: "Enkel", nn: "Enkel" },
+          certificationLevel: null,
+          audit: {},
+          items: [
+            {
+              type: "SECTION",
+              sortOrder: 0,
+              // No `assets` key at all — the pre-#749 shape.
+              section: { title: { nb: "Ren tekst" }, bodyMarkdown: { nb: "# Bare tekst" }, audit: {} },
+            },
+          ],
+        },
+      },
+    };
+
+    const importRes = await request(app)
+      .post("/api/admin/content/courses/import")
+      .set(adminHeaders)
+      .send({ payload: envelope, mode: "createNew" });
+    expect(importRes.status, JSON.stringify(importRes.body)).toBe(201);
+
+    const newSectionId = await newSectionIdOf(importRes.body.courseId);
+    const rows = await prisma.sectionAsset.findMany({ where: { sectionId: newSectionId } });
+    expect(rows).toHaveLength(0);
+    const section = await prisma.courseSection.findUnique({ where: { id: newSectionId }, include: { activeVersion: true } });
+    expect(section?.activeVersion?.bodyMarkdown ?? "").toContain("Bare tekst");
+  });
+});

--- a/test/unit/agent-authoring-export-schema-roundtrip.test.ts
+++ b/test/unit/agent-authoring-export-schema-roundtrip.test.ts
@@ -22,7 +22,37 @@ const pkg = {
   packageFormat: "a2-authoring-package/v1",
   locale: "nb",
   objects: [
-    { clientRef: "intro", type: "section", payload: { title: "Introduksjon", bodyMarkdown: "## Intro\n\nPersonvern og GDPR." } },
+    {
+      clientRef: "intro",
+      type: "section",
+      // #749 (Layer A): the section carries an inline SVG figure referenced from the markdown.
+      payload: {
+        title: "Introduksjon",
+        bodyMarkdown: "## Intro\n\nPersonvern og GDPR.\n\n![Flyt](asset:cmr8source001)",
+        assets: [
+          {
+            sourceId: "cmr8source001",
+            filename: "flyt.svg",
+            mimeType: "image/svg+xml",
+            sizeBytes: 49,
+            contentBase64: Buffer.from(
+              '<svg xmlns="http://www.w3.org/2000/svg"><text>Hei</text></svg>',
+              "utf8",
+            ).toString("base64"),
+            sourceLocale: "nb",
+            localizedVariants: [
+              {
+                locale: "en-GB",
+                contentBase64: Buffer.from(
+                  '<svg xmlns="http://www.w3.org/2000/svg"><text>Hi</text></svg>',
+                  "utf8",
+                ).toString("base64"),
+              },
+            ],
+          },
+        ],
+      },
+    },
     {
       clientRef: "modul-fritekst",
       type: "module",
@@ -81,6 +111,20 @@ describe("#762 fallback export vs the REAL src schema", () => {
     expect(importResult.success).toBe(true);
 
     // The bundled validator agrees with the real schema on this good input.
+    expect(validateExportEnvelopeStructure(envelope).valid).toBe(true);
+  });
+
+  it("#749: the inline section asset survives the re-wrap and passes the real schema", () => {
+    const envelope = buildFallbackEnvelope(pkg, { exportedAt: "2026-07-10T21:05:15.364Z" });
+    const introItem = envelope.course.course.items.find((i: { type: string }) => i.type === "SECTION");
+    const asset = introItem.section.assets[0];
+    expect(asset.sourceId).toBe("cmr8source001");
+    expect(asset.mimeType).toBe("image/svg+xml");
+    expect(asset.localizedVariants).toHaveLength(1);
+    // The markdown still references the SOURCE id (import remaps it) — do NOT pre-remap.
+    expect(introItem.section.bodyMarkdown).toContain("asset:cmr8source001");
+    // Both the real schema and the bundled validator accept the assets[] array.
+    expect(exportEnvelopeSchema.safeParse(envelope).success).toBe(true);
     expect(validateExportEnvelopeStructure(envelope).valid).toBe(true);
   });
 

--- a/test/unit/section-asset-export-schema.test.ts
+++ b/test/unit/section-asset-export-schema.test.ts
@@ -1,0 +1,87 @@
+// #749 (Layer A): unit coverage that the export/import section schema accepts the new OPTIONAL
+// `assets[]` block and that old asset-less files still validate. No DB — pure schema checks.
+
+import { describe, expect, it } from "vitest";
+import {
+  sectionExportPayloadSchema,
+  exportEnvelopeSchema,
+} from "../../src/modules/adminContent/adminContentSchemas.js";
+
+const svgBase64 = Buffer.from(
+  '<svg xmlns="http://www.w3.org/2000/svg"><text>Hei</text></svg>',
+  "utf8",
+).toString("base64");
+
+describe("#749 sectionExportPayloadSchema assets[]", () => {
+  it("accepts a section WITHOUT assets (old v1 files import unchanged)", () => {
+    const result = sectionExportPayloadSchema.safeParse({
+      title: { nb: "Intro" },
+      bodyMarkdown: { nb: "# Hei" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a section WITH an asset carrying a localized variant", () => {
+    const result = sectionExportPayloadSchema.safeParse({
+      title: { nb: "Intro" },
+      bodyMarkdown: { nb: "# Hei\n\n![Flyt](asset:cmr8src001)" },
+      assets: [
+        {
+          sourceId: "cmr8src001",
+          filename: "flyt.svg",
+          mimeType: "image/svg+xml",
+          sizeBytes: 49,
+          contentBase64: svgBase64,
+          sourceLocale: "nb",
+          localizedVariants: [{ locale: "en-GB", contentBase64: svgBase64 }],
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an asset missing required fields (e.g. contentBase64)", () => {
+    const result = sectionExportPayloadSchema.safeParse({
+      title: { nb: "Intro" },
+      bodyMarkdown: { nb: "# Hei" },
+      assets: [{ sourceId: "x", filename: "f.png", mimeType: "image/png", sizeBytes: 1 }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a full course envelope whose section item carries assets", () => {
+    const envelope = {
+      exportFormat: "a2-content-export/v1",
+      exportedAt: "2026-07-11T00:00:00.000Z",
+      scope: "course",
+      course: {
+        course: {
+          title: { "en-GB": "C", nb: "K", nn: "K" },
+          certificationLevel: null,
+          audit: {},
+          items: [
+            {
+              type: "SECTION",
+              sortOrder: 0,
+              section: {
+                title: { nb: "Intro" },
+                bodyMarkdown: { nb: "![Flyt](asset:cmr8src001)" },
+                audit: {},
+                assets: [
+                  {
+                    sourceId: "cmr8src001",
+                    filename: "flyt.svg",
+                    mimeType: "image/svg+xml",
+                    sizeBytes: 49,
+                    contentBase64: svgBase64,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    };
+    expect(exportEnvelopeSchema.safeParse(envelope).success).toBe(true);
+  });
+});


### PR DESCRIPTION
Implements **Phase 1 (Layer A)** of `doc/design/COURSE_FIGURES_AND_ASSETS.md` — section figures/images (`SectionAsset`) now survive a course export → import round-trip and the `a2-authoring-api` skill's fallback file. Closes the gap where export was markdown-only, so imported figures broke. Fixes #749.

**Explicitly NOT in this PR:** Layer B (skill-assisted figure *design*) — that is a later phase. This PR is transport only, plus the schema + skill-doc extensions needed so assets can be represented.

## Schema addition (additive — keeps `a2-content-export/v1`, no version marker change)
`sectionExportPayloadSchema` gains an OPTIONAL `assets[]`; each entry:
`{ sourceId, filename, mimeType, sizeBytes, contentBase64, sourceLocale?, localizedVariants?: [{ locale, contentBase64 }] }`.
Old asset-less v1 files omit it and import unchanged (fully optional).

## Export flow (`buildCourseExportEnvelope` / section export)
- Loads each section's `SectionAsset` rows, reads the base blob + every #657 localized-variant blob via the blob layer, base64-encodes, populates `assets[]` (`sourceId` = source `SectionAsset` id). Markdown `asset:<sourceId>` refs left unchanged.
- Caps: **5 MB per asset** and a **25 MB total-decoded-asset budget per envelope** — throws `400 validation_error` if exceeded (never silently drops a figure).

## Import flow (`importCourseFromEnvelope`, SECTION branch)
1. base64-decode → enforce **mime allowlist** (`svg+xml`, `png`, `jpeg`, `gif`, `webp`) + per-asset `MAX_ASSET_BYTES`; **SVG re-sanitised** (`sanitizeSvg`) for base + every localized variant (defence in depth).
2. `putAsset` to a fresh `sections/<newSectionId>/<uuid>-<safeName>` path, siblings for variants; create the `SectionAsset` row (with `sourceLocale`/`localizedBlobPaths` when present).
3. Build a `sourceId → newAssetId` map.
4. **Rewrite the section's `bodyMarkdown`** so every `asset:<sourceId>` → `asset:<newAssetId>`, then save. **Ordering: create-section → create-assets → re-save remapped markdown**, so the persisted active version never references source ids (version 1 keeps source refs but is not active).

A failing asset surfaces a clear `400` naming the section/asset (no silent skip).

## Body limit
Course-import route (`POST /api/admin/content/courses/import`) gets a route-specific **35 MB** `express.json` parser (covers the 25 MB asset budget after base64 ~1.33× + headroom), mounted before the global 5 MB parser — every other endpoint stays at 5 MB. Module import is unchanged (modules carry no sections/assets — confirmed).

## Skill (docs only this phase)
- `references/package-schema.md` documents the optional `assets[]` + the ref/remap contract and that the fallback export may carry section assets.
- `scripts/export-validate.mjs` bundled validator now covers `assets[]`; the real-schema round-trip test (`test/unit/agent-authoring-export-schema-roundtrip.test.ts`) carries an inline asset.

## Tests (`npx tsc --noEmit` clean; unit 744 pass; new integration green)
- `test/m2-content-export-import-assets.test.ts` (native Postgres): (a) round-trip raster + SVG-with-localized-variant → blobs recreated, refs remapped, variant preserved; (b) SVG with script/onload sanitised on import; (c) disallowed-mime + oversized asset rejected; (d) >25 MB envelope rejected on export; (e) asset-less v1 imports unchanged.
- `test/unit/section-asset-export-schema.test.ts`: schema accepts optional `assets[]`, rejects malformed.

## Edge cases / notes
- **Create-section→assets→remap ordering:** import creates the section (v1, source refs) → creates assets → saves v2 with remapped refs; the ACTIVE version therefore never references source ids.
- **Blob orphan handling on partial failure:** an asset that fails mid-import can leave blobs written before the row is created (no row references them) — orphaned but harmless, matching existing `createSectionAsset` behaviour. Not wrapped in a transaction (blobs aren't transactional), consistent with the current import service.
- No Prisma migration (uses existing `SectionAsset`). Bumps `1.6.21 → 1.6.22` + `doc/VERSIONS.md`; `doc/API_REFERENCE.md` updated.

**Do NOT merge, do NOT deploy** per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
