### PR TITLE
feat(figures): #749 Lag B — skill-assistert figur-design + assets i agent-flyten (v1.6.23)

### DIFF
--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -199,7 +199,7 @@ ordinary create/import endpoints. Publishing is manual and is **not** part of th
 
 | Method | Path | Notes |
 |--------|------|-------|
-| `POST` | `/api/admin/content/agent-authoring/validate` | **AA-1 (#649).** Dry-run validation — **no DB writes**. Body `{ package: <a2-authoring-package/v1> }`. Returns `200 { valid, summary: { errors, warnings, objects }, issues: [{ severity: "error"\|"warning", path, code, message }], plan }` — 200 also for invalid packages (the report is the result). `plan` (topological execution order, ops `create_section`/`create_module`/`create_course`/`set_course_items`) is only populated when `errors == 0`. Covers all three `assessmentMode`s (`required_for_mode`/`forbidden_for_mode`), package rules (`duplicate_client_ref`, `unknown_client_ref`, `client_ref_type_mismatch`, `ref_or_id_required`, `ref_and_id_conflict`, `unknown_module_id`/`unknown_section_id`, `unknown_field` — publish/audit fields are rejected) and non-blocking warnings (`possible_duplicate_title`, `course_without_modules`). `400` only when the body isn't `{ package }` with the right `packageFormat`. |
+| `POST` | `/api/admin/content/agent-authoring/validate` | **AA-1 (#649).** Dry-run validation — **no DB writes**. Body `{ package: <a2-authoring-package/v1> }`. Returns `200 { valid, summary: { errors, warnings, objects }, issues: [{ severity: "error"\|"warning", path, code, message }], plan }` — 200 also for invalid packages (the report is the result). `plan` (topological execution order, ops `create_section`/`create_module`/`create_course`/`set_course_items`) is only populated when `errors == 0`. Covers all three `assessmentMode`s (`required_for_mode`/`forbidden_for_mode`), package rules (`duplicate_client_ref`, `unknown_client_ref`, `client_ref_type_mismatch`, `ref_or_id_required`, `ref_and_id_conflict`, `unknown_module_id`/`unknown_section_id`, `unknown_field` — publish/audit fields are rejected), section inline-figure rules (#763, Layer B: `missing_asset`, `duplicate_asset_source_id`, `unsupported_asset_mime`, `asset_too_large`, `asset_decode_failed`, `asset_svg_unsanitizable` errors; `unreferenced_asset` warning) and non-blocking warnings (`possible_duplicate_title`, `course_without_modules`). `400` only when the body isn't `{ package }` with the right `packageFormat`. |
 
 **Agent-friendly create/import responses (AA-2, #650):** the create/import calls the skill
 orchestrates accept an optional `clientRef` (pattern `[a-z0-9-]{1,64}`, echoed back in the
@@ -210,7 +210,15 @@ orchestrates accept an optional `clientRef` (pattern `[a-z0-9-]{1,64}`, echoed b
 - `POST /sections` → `links: { editor: "/admin-content/sections?id=:id" }`. Also accepts
   `draft: true` — the section is created in Utkast (`activeVersionId` stays `null`; content is
   preserved as version 1, published later via `POST /sections/:id/publish`). Default (omitted)
-  keeps auto-publish-on-save.
+  keeps auto-publish-on-save. **#763 (Layer B):** also accepts an OPTIONAL `assets[]` (inline
+  figures/images, same entry shape as the export/authoring asset — `{ sourceId, filename,
+  mimeType, sizeBytes, contentBase64, sourceLocale?, localizedVariants? }`, but `sourceId` is a
+  client-chosen ref token `[a-zA-Z0-9_-]{1,64}` the markdown references as `asset:<sourceId>`).
+  When present the server creates the section, imports the assets (mime allowlist + 5 MB
+  per-asset cap + SVG re-sanitisation, reusing the #749 importer), remaps every `asset:<sourceId>`
+  ref to the new `SectionAsset` id, and returns the `sourceId → assetId` map as `assetMap`. The
+  section create is auto-published only when `draft` is not `true` (agent-token requests still
+  require `draft: true`). This route accepts a larger 15 MB body to carry inlined assets.
 
 Agent imports must pass `autoPublish: false` (and the authoring contract has no `audit`, so
 source-publish auto-publication can never trigger). Retry-safe `Idempotency-Key` support is
@@ -299,7 +307,7 @@ Course export/import now transport a section's figures/images (`SectionAsset`), 
 
 | Method | Route | Description |
 |---|---|---|
-| `POST` | `/api/admin/content/sections` | Create a section (`title` + `bodyMarkdown`) → section + version 1 |
+| `POST` | `/api/admin/content/sections` | Create a section (`title` + `bodyMarkdown`) → section + version 1. Optional `draft`, `clientRef`, `agentRunId`, and (#763, Layer B) `assets[]` inline figures/images — imported + `asset:<sourceId>` refs remapped, `assetMap` (`sourceId→assetId`) echoed back. Larger 15 MB body for inlined assets |
 | `GET` | `/api/admin/content/sections` | List sections |
 | `GET` | `/api/admin/content/sections/:sectionId` | Section detail (active version's `bodyMarkdown`) |
 | `PATCH` | `/api/admin/content/sections/:sectionId/title` | Update title |

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,29 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.23 - 2026-07-11
+
+feat(figures): #749 Lag B — skill-assistert figur-design + assets i agent-flyten
+
+Bygger på Lag A (asset-transport, v1.6.22). To sider:
+
+- **Plattform:** `a2-authoring-package/v1` seksjons-payload får valgfri `assets[]` (`sourceId` =
+  klient-ref-token som markdown refererer via `asset:<sourceId>`); `POST /api/admin/content/sections`
+  tar imot `assets[]`, importerer dem (gjenbruker `importSectionAssets` — sanitér + mime/størrelse-
+  vakter), remapper `asset:<sourceId>`→ny id i markdown før lagring, og returnerer `sourceId→assetId`.
+  Egen større body-parser for /sections. Validate-endepunktet (AA-1) sjekker figur-konsistens per
+  seksjon: hver `asset:<ref>` ↔ en `assets[]`-post (`missing_asset`/`unreferenced_asset`), mime i
+  allowlist, dekodet størrelse ≤ `MAX_ASSET_BYTES`, SVG saniterer ikke til tomt, unik `sourceId`.
+- **Skill:** ny `references/figure-design.md` med kjerneprinsippet **«én figur, ett poeng»** og et
+  lite mal-sett (flyt, tre, bokser-og-piler, merket diagram — kun disse med mindre forfatter ber om
+  fri-form), SVG-only (agenten lager aldri raster), figurer grunnet i godkjent tekst/kilde,
+  oversettbar `<text>`. SKILL.md/playbook: figurer foreslås i Struktur-porten (én enkel figur per
+  visuelt poeng) og tegnes med teksten i Per-element-porten. Lokaliseringskontrollen dekker nå
+  figur-`<text>` (alle tre språk, etikett-antall bevart, token-bevaring, ingen blind-kopi); bevarings-
+  kontrollen behandler en godkjent figur som unikt innhold «fjern redundans» aldri kan droppe.
+- Tester: validate-asset-regler (unit), `/sections`+SVG-asset (integrasjon), localization/course-state
+  figur-utvidelser (unit). 762 unit + 3 integrasjon grønne. Skill ompakket til v1.6.23.
+
 ## 1.6.22 - 2026-07-11
 
 feat(content): #749 (Layer A) — carry section figures/images through export AND import

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.22",
+  "version": "1.6.23",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/skills/a2-authoring-api/SKILL.md
+++ b/skills/a2-authoring-api/SKILL.md
@@ -20,6 +20,7 @@ API/fallback mechanics: [references/api-flow.md](references/api-flow.md).
 Preserving approved content: **[references/content-preservation.md](references/content-preservation.md)**.
 Validating the fallback export: **[references/export-validation.md](references/export-validation.md)**.
 Translating to all three languages: **[references/localization.md](references/localization.md)**.
+Designing figures (SVG, "one figure, one point"): **[references/figure-design.md](references/figure-design.md)**.
 Deterministic checks live in `scripts/` (`course-state.mjs`, `export-validate.mjs`,
 `localization-check.mjs`) — run them; they are repo-unit-tested.
 
@@ -84,8 +85,21 @@ the three references above.
    **nb, nn and en-GB** of every student-facing field the schema localizes — not the primary text
    copied into every locale. Preserve meaning, difficulty, the correct answer, option count+order,
    and all formulas/identifiers/URLs; verify MCQ correct answers map to the same option in every
-   locale. Block production if a mandatory localized field is missing. (localization.md;
+   locale. **This extends to figure `<text>`:** each text-bearing SVG figure gets localizedVariants
+   for the other two locales (translate the labels, geometry unchanged). Block production if a
+   mandatory localized field — or a figure variant — is missing. (localization.md;
    `localization-check.mjs`.)
+
+9. **Design figures with the text (Layer B).** Where a section would otherwise be a wall of text,
+   propose **one simple figure per discrete visual point** and draw it as **SVG** integrated with
+   the element's text, so text + figure are approved as one whole. Principle: **one figure, one
+   point** — several simple figures beat one crowded diagram. SVG only (the agent never generates
+   raster; raster is author-supplied, never "translated"); a figure **diagrams approved
+   text/source and never invents data**; short labels in the one primary language as plain,
+   translatable `<text>` (#657). Draw only from the template set (flow / tree-decision /
+   boxes-and-arrows / labelled diagram) unless the author explicitly asks free-form. Figures are
+   proposed at the **Structure gate** and drafted at the **Per-element gate**; an approved figure
+   is **unique content** the preservation audit (#762) must never drop. (figure-design.md.)
 
 ## Two tracks (choose by the user's opening)
 

--- a/skills/a2-authoring-api/references/authoring-playbook.md
+++ b/skills/a2-authoring-api/references/authoring-playbook.md
@@ -73,6 +73,14 @@ Turn approved objectives into a concrete outline, and confirm it before writing 
 Present the outline as a table (sections + modules, order, mode, which objective each assesses)
 and iterate until the author confirms it. No element content is written yet.
 
+**Propose figure placements here (Layer B).** As you agree the structure, flag sections that would
+otherwise be dense prose and propose **where a figure earns its place — one simple figure per
+discrete visual point** (a process → a **flow**; a set of options/branches → a **tree/decision**; a
+few related entities → **boxes-and-arrows**; the parts of one thing → a **labelled diagram**).
+Several small figures beat one crowded one; a short definition stays prose. Propose *placements*
+only (which point, which template) — you draw the SVG at Gate 4 with the text. The author confirms
+which figures to design. See `figure-design.md`.
+
 ## Gate 4 — Each element (one at a time)
 
 Now write content, **one element per turn**, grounded in the source, and get each approved
@@ -92,8 +100,18 @@ Per module, write real, specific, sourced content:
 Per section: the teaching markdown, grounded in the source. Summarise long source rather than
 copying it verbatim, and keep claims to what the source supports.
 
-Anything the source doesn't cover → `[Avklaring: …]`, not invention. Approve each element, then
-move to the next.
+**Draw the figure in the same turn as the text (Layer B).** For each figure agreed at Gate 3,
+draft the **SVG in the same turn as the element's text** so they are reviewed as one integrated
+unit. The figure **diagrams what the text/source says — it never invents** data, numbers or
+relationships the source doesn't support. Use a template skeleton from `figure-design.md`, keep
+labels short and in the one primary language as plain `<text>` (never baked into paths), reference
+it from the markdown as `![alt](asset:<sourceId>)`. **Present the figure *with* the text in the
+preview** — show the SVG inline (rendered) AND describe it in words ("flyt: Motta sak → Vurder
+grunnlag → Fatt vedtak") so the author can approve the integrated whole: *"ser tekst + figur
+riktig ut sammen?"*. One figure, one point — if it's getting crowded, split it.
+
+Anything the source doesn't cover → `[Avklaring: …]`, not invention (figures included). Approve
+each element (text + figure together), then move to the next.
 
 ## Gate 5 — External QA (against the objectives)
 
@@ -110,6 +128,11 @@ rubber stamp.
 - **Check language consistency:** every title, task, rubric and MCQ must be in the one confirmed
   language. Flag any element that drifted (e.g. an English module title in a Norwegian course) —
   this is a real, easy-to-miss failure; fix it before producing.
+- **Check the figures (Layer B):** each figure makes **one point** and no more; it **matches the
+  approved text** (diagrams it, invents nothing beyond it); its labels are short and in the **one
+  primary language**; it is SVG with real `<text>` (not raster, not text-as-paths). Flag a figure
+  that is decorative, over-packed, contradicts the text, or has drifted language — fix before
+  producing.
 - Report findings to the author; fix gaps/overclaims before producing. Overclaims are resolved by
   softening to what the source supports or by `[Avklaring: …]`, never by inventing support.
 
@@ -118,11 +141,19 @@ rubber stamp.
 Only after QA passes and the author approves:
 
 1. Build the `a2-authoring-package/v1` (`package-schema.md`). Put the author's stated
-   requirements **and the confirmed sources** into `constraints` (audit trail).
+   requirements **and the confirmed sources** into `constraints` (audit trail). **Attach the
+   figures (Layer B):** for every section with an approved figure, add the SVG (and its localized
+   variants) to that section payload's `assets[]` — `{ sourceId, filename, mimeType:
+   "image/svg+xml", sizeBytes, contentBase64, sourceLocale, localizedVariants }` — and keep the
+   markdown ref as `asset:<sourceId>` (the server remaps it on create/import; never pre-remap).
+   Every `asset:<ref>` needs a matching entry and vice versa.
 2. Validate (dry-run) and fix errors; if a fix changes what the learner sees, re-confirm with the
-   author.
-3. Create the drafts in plan order (`api-flow.md`), report admin links + `agentRunId`, and remind
-   the author to review and publish manually.
+   author. Validate now also checks figures: `missing_asset` / `unreferenced_asset`, mime,
+   per-asset size, and that each SVG survives sanitisation.
+3. Create the drafts in plan order (`api-flow.md`). Section create carries `assets[]`; the response
+   returns an `assetMap` (`sourceId → assetId`) and the persisted markdown already points at the
+   new asset ids. Report admin links + `agentRunId`, and remind the author to review and publish
+   manually.
 
 ### Fallback when the agent can't reach the API
 
@@ -133,7 +164,9 @@ course import:
 1. Produce a self-contained course envelope (inline each module/section payload under
    `course.items[]` with `sortOrder`; `exportFormat`, `exportedAt`, `audit: {}`). Leaf payloads
    are identical to the authoring package — a mechanical re-wrap; see `package-schema.md`
-   §"Fallback format".
+   §"Fallback format". **Figures travel too:** each section's `assets[]` (SVG + localized
+   variants, base64) rides along in the envelope, and the `asset:<sourceId>` refs are remapped on
+   import (Layer A). Stay within the caps (5 MB/asset, 25 MB total decoded).
 2. Write it to `kurs-<navn>.json` and tell the author to import via **Innholdsforvaltning → Kurs →
    Importer kurs-pakke**. It creates the same drafts; nothing is published.
 3. **Validate before delivering.** Generate the file with `buildFallbackEnvelope`, then run the

--- a/skills/a2-authoring-api/references/figure-design.md
+++ b/skills/a2-authoring-api/references/figure-design.md
@@ -1,0 +1,141 @@
+# Figure design — "one figure, one point" (Layer B)
+
+How the skill proposes and draws figures inside the gated authoring dialogue. Companion to the
+design note `doc/design/COURSE_FIGURES_AND_ASSETS.md` (Layer B). Transport (how a figure travels
+through export/import and the authoring package) is Layer A — see `package-schema.md`
+§"Section figures/images". This file is about *designing* the figure, grounded in approved text.
+
+## The principle: one figure, one point
+
+**Each figure makes exactly one point.** A figure illustrates a single idea — one process, one
+comparison, one relationship — not a whole section compressed into a dense schematic. Prefer
+**several simple figures** over one crowded one. This is deliberate:
+
+- **Pedagogy:** one figure → one takeaway is easier to read and remember.
+- **Quality:** simple figures are what an LLM can author cleanly as SVG; complex ones drift into
+  messy, mislabelled output.
+- **Localization & maintenance:** few, short labels translate reliably and survive edits.
+
+A figure earns its place only where it genuinely aids understanding of a discrete visual point —
+never decoration, never a catch-all. A short definition is prose, not a diagram.
+
+## Hard rules
+
+1. **SVG only — the agent never generates raster.** SVG is text (the LLM can author it), its
+   `<text>` is translatable (#657), it is crisp at any size, and it is sanitisable. Raster
+   (PNG/JPEG/GIF/WebP) is **author-supplied only** — carried faithfully through transport, but
+   never generated and never "translated" by the agent (baked pixels can't be localized).
+2. **Diagram approved text/source — never invent.** A figure diagrams what the confirmed source
+   and the element's approved text already say. It introduces **no** data, numbers, steps, or
+   relationships the source doesn't support. The "never invent" principle (SKILL.md core rule 1)
+   extends to figures. At a genuine gap, leave it out or mark `[Avklaring: …]` — do not draw a
+   guess.
+3. **One primary language, short labels.** Figure `<text>` is written in the course's one
+   confirmed primary language (core rule 5), with short labels (a few words). Translation to the
+   other two locales happens after primary approval (see below and `localization.md`).
+4. **Plain, translatable `<text>` — never text baked into paths.** Every label is a real `<text>`
+   (optionally `<tspan>`) element so #657 SVG localization can extract and translate it. Text
+   converted to `<path>`/outlines, or rasterised, is untranslatable and forbidden.
+5. **Stay inside the template set.** Use only the four templates below, unless the author
+   **explicitly** asks for a free-form figure (an explicit exception, warned as lower-quality and
+   harder to localize). The templates keep figures simple by construction.
+6. **Sanitiser-safe.** The stored SVG passes A2's `sanitizeSvg` (scripts, `on*` handlers,
+   `<foreignObject>`, `<a>` are stripped). Author drawings with none of those — a figure that is
+   empty after sanitisation is rejected at validate/import time (`asset_svg_unsanitizable`).
+
+## The template set (the only shapes the skill draws)
+
+| Template | Use it for | One point it makes |
+|---|---|---|
+| **flow** | a process / sequence of steps | "these steps, in this order" |
+| **tree / decision** | branching choices, a hierarchy | "this choice leads here vs there" |
+| **boxes-and-arrows** | relationships between a few entities | "A relates to B relates to C" |
+| **labelled diagram** | parts of one thing | "this thing has these named parts" |
+
+If the point doesn't fit one of these, it is probably prose — or two simpler figures.
+
+## Ref + markdown
+
+A figure is referenced from the section `bodyMarkdown` as `![alt](asset:<sourceId>)`, where
+`<sourceId>` is a client-chosen token `[a-zA-Z0-9_-]{1,64}` that matches the figure's `assets[]`
+entry. On create/import A2 remaps `asset:<sourceId>` to the real `SectionAsset` id — leave the ref
+pointing at your `sourceId`; never pre-remap it. Every ref needs a matching asset and every asset
+should be referenced (validate reports `missing_asset` / `unreferenced_asset`).
+
+## Minimal sanitize-safe SVG skeletons
+
+Fill these in — keep the geometry, replace the `<text>` labels (short, primary language). Always
+include `xmlns` and a `viewBox`. No `<script>`, `on*`, `<foreignObject>`, `<a>`, no baked-in text.
+
+### flow
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 80" role="img">
+  <rect x="10" y="20" width="120" height="40" rx="6" fill="#eef" stroke="#333"/>
+  <text x="70" y="45" text-anchor="middle" font-size="14">Steg 1</text>
+  <line x1="130" y1="40" x2="180" y2="40" stroke="#333"/>
+  <rect x="180" y="20" width="120" height="40" rx="6" fill="#eef" stroke="#333"/>
+  <text x="240" y="45" text-anchor="middle" font-size="14">Steg 2</text>
+  <line x1="300" y1="40" x2="350" y2="40" stroke="#333"/>
+  <rect x="350" y="20" width="120" height="40" rx="6" fill="#eef" stroke="#333"/>
+  <text x="410" y="45" text-anchor="middle" font-size="14">Steg 3</text>
+</svg>
+```
+
+### tree / decision
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 200" role="img">
+  <rect x="150" y="10" width="100" height="40" rx="6" fill="#eef" stroke="#333"/>
+  <text x="200" y="35" text-anchor="middle" font-size="14">Spørsmål</text>
+  <line x1="180" y1="50" x2="90" y2="140" stroke="#333"/>
+  <line x1="220" y1="50" x2="310" y2="140" stroke="#333"/>
+  <rect x="30" y="140" width="120" height="40" rx="6" fill="#efe" stroke="#333"/>
+  <text x="90" y="165" text-anchor="middle" font-size="14">Ja → A</text>
+  <rect x="250" y="140" width="120" height="40" rx="6" fill="#fee" stroke="#333"/>
+  <text x="310" y="165" text-anchor="middle" font-size="14">Nei → B</text>
+</svg>
+```
+
+### boxes-and-arrows
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 120" role="img">
+  <rect x="10" y="40" width="110" height="40" rx="6" fill="#eef" stroke="#333"/>
+  <text x="65" y="65" text-anchor="middle" font-size="14">A</text>
+  <line x1="120" y1="60" x2="170" y2="60" stroke="#333" marker-end="url(#a)"/>
+  <rect x="170" y="40" width="110" height="40" rx="6" fill="#eef" stroke="#333"/>
+  <text x="225" y="65" text-anchor="middle" font-size="14">B</text>
+  <line x1="280" y1="60" x2="330" y2="60" stroke="#333" marker-end="url(#a)"/>
+  <rect x="330" y="40" width="80" height="40" rx="6" fill="#eef" stroke="#333"/>
+  <text x="370" y="65" text-anchor="middle" font-size="14">C</text>
+  <defs><marker id="a" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+    <path d="M0,0 L6,3 L0,6 Z" fill="#333"/></marker></defs>
+</svg>
+```
+
+### labelled diagram
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 200" role="img">
+  <circle cx="160" cy="100" r="70" fill="#eef" stroke="#333"/>
+  <line x1="160" y1="30" x2="160" y2="10" stroke="#333"/>
+  <text x="160" y="8" text-anchor="middle" font-size="13">Del 1</text>
+  <line x1="228" y1="118" x2="250" y2="128" stroke="#333"/>
+  <text x="252" y="132" font-size="13">Del 2</text>
+  <line x1="92" y1="118" x2="70" y2="128" stroke="#333"/>
+  <text x="10" y="132" font-size="13">Del 3</text>
+</svg>
+```
+
+## Localization of figures (after primary approval)
+
+Once the primary-language course is approved, each text-bearing SVG figure gets **localizedVariants**
+for the other two locales: translate the `<text>` runs, keep the geometry identical (same number of
+labels, same positions). The deterministic `checkLocalization` (`localization-check.mjs`,
+`checkFigureLocalization`) verifies every text-bearing SVG has a variant for each other locale, the
+variant's label count equals the original's, identifiers/formulas/URLs in labels are preserved, and
+the variant is not a blind copy of the original labels. See `localization.md`.
+
+## Preservation
+
+An approved figure is **unique content, not redundancy**. "Remove redundancy" may trim repeated
+prose but must never drop an approved figure or empty its labels. `course-state.mjs` treats a
+missing figure ref (`asset:<sourceId>`) or an emptied label as a blocking mandatory loss. See
+`content-preservation.md`.

--- a/skills/a2-authoring-api/references/localization.md
+++ b/skills/a2-authoring-api/references/localization.md
@@ -67,9 +67,33 @@ Block production if any mandatory localized field is missing. Equal structure ac
 checks — options are single localized objects shared across locales, so "one language lost an
 option" surfaces as that option missing a locale.
 
+## Figures are localized too (#763, Layer B)
+
+A figure whose labels are in one language breaks the multilingual promise exactly as untranslated
+prose does. After the primary is approved, **each text-bearing SVG figure gets `localizedVariants`
+for the other two locales**: translate the `<text>` runs, keep the geometry identical (same number
+of labels, same positions — geometry never changes, only the label strings). This reuses the #657
+SVG-localization mechanism (`sourceLocale` + per-locale variant blobs); it does not invent a new
+one. **Raster figures cannot be localized** (baked pixels) — if an author-supplied raster carries
+text, flag it as untranslatable and advise an SVG instead.
+
+`checkLocalization` (via `checkFigureLocalization`) extends the check to figures and **blocks** when:
+
+- **missingVariants** — a text-bearing SVG figure lacks a variant for one of the other two locales;
+- **textCountMismatches** — a variant's label count differs from the original's (a label was lost
+  or added — the geometry/structure drifted);
+- **tokenDrift** — a formula / URL / identifier / filename / article-reference present in an
+  original label is missing from a variant;
+- **blindCopies** — a variant's labels are identical to the original's translatable prose (the
+  figure was copied, not translated). Short single-word labels ("Start", "A", "72") that
+  legitimately stay identical are not flagged.
+
+The figure findings are returned under `result.figures` and folded into the top-level `blocks`.
+
 ## What is deterministic vs behavioral
 
 The check deterministically catches missing locales, answer-key drift, token loss and blind
-copies. It cannot judge **translation quality** (is the nynorsk natural? is the meaning faithful?)
-— that remains the skill's behavioral responsibility, ideally confirmed in the Gate 5 external QA
-pass with a reviewer who reads all three languages.
+copies — for prose fields **and** figure labels. It cannot judge **translation quality** (is the
+nynorsk natural? is the meaning faithful? do the translated labels still fit the drawing?) — that
+remains the skill's behavioral responsibility, ideally confirmed in the Gate 5 external QA pass
+with a reviewer who reads all three languages.

--- a/skills/a2-authoring-api/scripts/course-state.mjs
+++ b/skills/a2-authoring-api/scripts/course-state.mjs
@@ -25,6 +25,7 @@ export const MANDATORY_CATEGORIES = Object.freeze([
   "templates", // includes required attachments/templates
   "tasks",
   "assessmentCriteria",
+  "figures", // #763 (Layer B): an approved figure's ref + labels — a diagram is unique content, not redundancy
 ]);
 
 // Reductions larger than this fraction of the approved length require explicit approval
@@ -67,21 +68,44 @@ export function contains(haystack, needle) {
 //   unexpectedlyMissing  — absent and NOT approved for removal (this is the silent-drop bug)
 // Mandatory categories may only be preserved or moved: a deliberate OR unexpected loss of a
 // mandatory item is still a loss and blocks (see mandatoryLosses below).
-export function classifyItems({ mandatory = {}, deliberatelyRemoved = [] }, mainText, attachmentsText = "") {
+export function classifyItems({ mandatory = {}, deliberatelyRemoved = [], figures = [] }, mainText, attachmentsText = "") {
   const removedSet = new Set((deliberatelyRemoved ?? []).map(normalizeForSearch));
   const result = { preserved: [], moved: [], deliberatelyRemoved: [], unexpectedlyMissing: [] };
   const categories = new Set([...MANDATORY_CATEGORIES, ...Object.keys(mandatory ?? {})]);
 
+  const classify = (entry) => {
+    if (contains(mainText, entry.item)) result.preserved.push(entry);
+    else if (contains(attachmentsText, entry.item)) result.moved.push(entry);
+    else if (removedSet.has(normalizeForSearch(entry.item))) result.deliberatelyRemoved.push(entry);
+    else result.unexpectedlyMissing.push(entry);
+  };
+
   for (const category of categories) {
+    if (category === "figures") continue; // figures are objects, expanded below — not string items
     for (const item of mandatory?.[category] ?? []) {
-      const entry = { category, item, mandatory: MANDATORY_CATEGORIES.includes(category) };
-      if (contains(mainText, item)) result.preserved.push(entry);
-      else if (contains(attachmentsText, item)) result.moved.push(entry);
-      else if (removedSet.has(normalizeForSearch(item))) result.deliberatelyRemoved.push(entry);
-      else result.unexpectedlyMissing.push(entry);
+      classify({ category, item, mandatory: MANDATORY_CATEGORIES.includes(category) });
+    }
+  }
+
+  // #763 (Layer B): an approved figure is mandatory content. Each figure contributes its markdown
+  // REF (`asset:<sourceId>`) AND every label text as mandatory "figures" items — a dropped figure
+  // (ref gone) or an emptied/renamed label surfaces as an unexpectedly-missing mandatory loss.
+  for (const figure of figures ?? []) {
+    for (const item of figureItems(figure)) {
+      classify({ category: "figures", item, mandatory: true, sourceId: figure.sourceId });
     }
   }
   return result;
+}
+
+// The mandatory strings a single approved figure must keep: its markdown ref token and each label.
+function figureItems(figure) {
+  const items = [];
+  if (figure?.sourceId) items.push(`asset:${figure.sourceId}`);
+  for (const label of figure?.labels ?? []) {
+    if (typeof label === "string" && label.trim().length > 0) items.push(label);
+  }
+  return items;
 }
 
 // A mandatory item is "lost" if it is neither preserved nor moved (i.e. removed or missing).
@@ -223,24 +247,51 @@ function payloadText(payload) {
   return JSON.stringify(payload ?? {});
 }
 
+// #763 (Layer B): a figure's label text lives inside a base64-encoded SVG, so the JSON payload text
+// alone can't confirm a label survived. Decode each SVG asset (base + localized variants), strip
+// tags to expose the label text, and append it (plus the `asset:<sourceId>` ref) so the substring
+// classifier can verify approved figure refs + labels against the produced artifact.
+function figureSearchText(payloadWithAssets) {
+  const assets = payloadWithAssets?.assets ?? [];
+  const parts = [];
+  for (const asset of assets) {
+    if (!asset || typeof asset !== "object") continue;
+    if (asset.sourceId) parts.push(`asset:${asset.sourceId}`);
+    if (asset.mimeType !== "image/svg+xml") continue;
+    parts.push(decodeSvgText(asset.contentBase64));
+    for (const variant of asset.localizedVariants ?? []) parts.push(decodeSvgText(variant.contentBase64));
+  }
+  return parts.join(" ");
+}
+
+function decodeSvgText(contentBase64) {
+  try {
+    const svg = Buffer.from(String(contentBase64 ?? ""), "base64").toString("utf8");
+    return svg.replace(/<[^>]*>/g, " "); // strip tags, keep <text>/<tspan> label content
+  } catch {
+    return "";
+  }
+}
+
 // From an a2-authoring-package/v1 (objects[] carry clientRef) — the natural pre-export artifact.
+// Section objects may carry inline figures; their decoded label text + refs are folded into `text`.
 export function extractPackageElements(pkg) {
   return (pkg.objects ?? []).map((object) => ({
     ref: object.clientRef,
-    text: payloadText(object.payload),
+    text: `${payloadText(object.payload)} ${figureSearchText(object.payload)}`,
     attachmentsText: payloadText(object.payload?.attachments ?? object.payload?.activeVersion?.attachments),
   }));
 }
 
 // From a produced a2-content-export/v1 course envelope. The envelope is self-contained (no
 // clientRef), so items are zipped to `order` by position — the master's final order is the
-// contract that ties them together.
+// contract that ties them together. Section figures' decoded labels + refs are folded into `text`.
 export function extractEnvelopeElements(envelope, order) {
   const items = envelope?.course?.course?.items ?? [];
   const sorted = [...items].sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
   return sorted.map((item, index) => ({
     ref: order?.[index],
-    text: payloadText(item.module ?? item.section ?? item),
+    text: `${payloadText(item.module ?? item.section ?? item)} ${figureSearchText(item.section)}`,
     attachmentsText: payloadText((item.module ?? item.section)?.attachments),
   }));
 }

--- a/skills/a2-authoring-api/scripts/localization-check.mjs
+++ b/skills/a2-authoring-api/scripts/localization-check.mjs
@@ -135,9 +135,148 @@ function localeString(localized, lang) {
   return (localeValue(localized, lang) ?? "").trim();
 }
 
+// ---------------------------------------------------------------------------
+// Figure (SVG) localization (#763, Layer B)
+// ---------------------------------------------------------------------------
+// A text-bearing SVG figure must be translated the same way prose is: after the primary is
+// approved, each figure gets localizedVariants for the OTHER two locales (its `<text>` translated,
+// geometry unchanged). This mirrors the platform's #657 SVG-localization mechanism. We verify:
+// every text-bearing SVG has a variant for each other locale; the variant's label-count equals the
+// original's; identifiers/formulas/URLs in labels survive; and the variant is not a blind copy of
+// the original labels.
+
+// Minimal <text>/<tspan> extraction via regex, consistent with the platform's extractSvgTexts
+// (svgSanitizer.ts): leaf text runs in document order, trimmed, deduplicated. When a <text> holds
+// <tspan> children we take the tspans (not the concatenated parent) so a run is never counted twice.
+export function extractSvgTextRuns(svg) {
+  const source = String(svg ?? "");
+  const runs = [];
+  const seen = new Set();
+  const push = (raw) => {
+    const value = String(raw).replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
+    if (value.length > 0 && !seen.has(value)) {
+      seen.add(value);
+      runs.push(value);
+    }
+  };
+  for (const match of source.matchAll(/<text\b[^>]*>([\s\S]*?)<\/text>/gi)) {
+    const inner = match[1];
+    if (/<tspan\b/i.test(inner)) {
+      for (const tspan of inner.matchAll(/<tspan\b[^>]*>([\s\S]*?)<\/tspan>/gi)) push(tspan[1]);
+    } else {
+      push(inner);
+    }
+  }
+  return runs;
+}
+
+function decodeSvg(contentBase64) {
+  try {
+    return Buffer.from(String(contentBase64 ?? ""), "base64").toString("utf8");
+  } catch {
+    return "";
+  }
+}
+
+// Collect every SVG figure carried on a section object: { path, sourceId, sourceLocale, runs,
+// variants: [{ locale, runs }] }. Non-SVG (raster) assets are skipped — they cannot be translated
+// (baked pixels), which the localization check reports separately as untranslatable if they carry
+// author-declared text, but this deterministic check only covers SVG whose text it can read.
+export function collectFigures(pkg) {
+  const figures = [];
+  for (const object of pkg.objects ?? []) {
+    if (object.type !== "section") continue;
+    const ref = object.clientRef;
+    const assets = object.payload?.assets ?? [];
+    assets.forEach((asset, index) => {
+      if (asset?.mimeType !== "image/svg+xml") return;
+      figures.push({
+        path: `${ref}.assets[${index}]`,
+        sourceId: asset.sourceId,
+        sourceLocale: asset.sourceLocale ?? null,
+        runs: extractSvgTextRuns(decodeSvg(asset.contentBase64)),
+        variants: (asset.localizedVariants ?? []).map((variant) => ({
+          locale: variant.locale,
+          runs: extractSvgTextRuns(decodeSvg(variant.contentBase64)),
+        })),
+      });
+    });
+  }
+  return figures;
+}
+
+function preservedTokensOf(runs) {
+  const tokens = new Set();
+  for (const run of runs) for (const token of extractPreservedTokens(run)) tokens.add(token);
+  return tokens;
+}
+
+// A variant is a "blind copy" when its ordered label runs equal the original's AND the labels read
+// as translatable prose (>= 2 distinct alphabetic words of >= 4 chars). Short single-word labels
+// ("Start", "A", "72") that legitimately stay identical are NOT flagged.
+function figureRunsAreBlindCopy(originalRuns, variantRuns) {
+  if (originalRuns.length === 0 || originalRuns.length !== variantRuns.length) return false;
+  const identical = originalRuns.every(
+    (run, index) => run.toLowerCase() === (variantRuns[index] ?? "").toLowerCase(),
+  );
+  if (!identical) return false;
+  const words = (originalRuns.join(" ").match(/[\p{L}]{4,}/gu) ?? []).map((w) => w.toLowerCase());
+  return new Set(words).size >= 2;
+}
+
+// Deterministic figure-localization check. Blocks on a missing variant, a changed label count,
+// lost identifiers/formulas/URLs, or a blind copy of the original labels.
+export function checkFigureLocalization(pkg, { languages = LANGUAGES, primary = "nb" } = {}) {
+  const missingVariants = [];
+  const textCountMismatches = [];
+  const tokenDrift = [];
+  const blindCopies = [];
+
+  for (const figure of collectFigures(pkg)) {
+    if (figure.runs.length === 0) continue; // no translatable text → nothing to localize
+    const source = figure.sourceLocale ?? primary;
+    const targets = languages.filter((lang) => lang !== source);
+    const runsByLocale = new Map(figure.variants.map((v) => [v.locale, v.runs]));
+    const originalTokens = preservedTokensOf(figure.runs);
+
+    for (const locale of targets) {
+      if (!runsByLocale.has(locale)) {
+        missingVariants.push({ path: figure.path, sourceId: figure.sourceId, locale });
+        continue;
+      }
+      const variantRuns = runsByLocale.get(locale);
+      if (variantRuns.length !== figure.runs.length) {
+        textCountMismatches.push({
+          path: figure.path,
+          sourceId: figure.sourceId,
+          locale,
+          expected: figure.runs.length,
+          actual: variantRuns.length,
+        });
+      }
+      const variantTokens = preservedTokensOf(variantRuns);
+      for (const token of originalTokens) {
+        if (!variantTokens.has(token)) tokenDrift.push({ path: figure.path, sourceId: figure.sourceId, locale, token });
+      }
+      if (figureRunsAreBlindCopy(figure.runs, variantRuns)) {
+        blindCopies.push({ path: figure.path, sourceId: figure.sourceId, locale });
+      }
+    }
+  }
+
+  const reasons = [];
+  if (missingVariants.length > 0) reasons.push(`${missingVariants.length} SVG figure variant(s) missing a language`);
+  if (textCountMismatches.length > 0) reasons.push(`${textCountMismatches.length} SVG figure variant(s) with a changed label count`);
+  if (tokenDrift.length > 0) reasons.push(`${tokenDrift.length} identifier/formula/URL(s) lost in an SVG figure variant`);
+  if (blindCopies.length > 0) reasons.push(`${blindCopies.length} SVG figure variant(s) are a blind copy of the original labels`);
+
+  return { missingVariants, textCountMismatches, tokenDrift, blindCopies, blocks: reasons.length > 0, reasons };
+}
+
 // Full localization check over the package. Blocks on any missing locale, structural loss,
 // answer-key change, or preserved-token drift. Blind copies are reported and (by default) block,
 // because the requirement is REAL translations, not the primary copied into every locale.
+// #763 (Layer B): text-bearing SVG figures are localized too — folded into `figures` + `blocks`.
 export function checkLocalization(pkg, { languages = LANGUAGES, primary = "nb", blindCopyBlocks = true } = {}) {
   const { prose, mcqQuestions } = collectLocalizedFields(pkg);
   const missing = [];
@@ -183,12 +322,15 @@ export function checkLocalization(pkg, { languages = LANGUAGES, primary = "nb", 
     }
   }
 
+  const figures = checkFigureLocalization(pkg, { languages, primary });
+
   const reasons = [];
   if (missing.length > 0) reasons.push(`${missing.length} localized field(s) missing a language`);
   if (optionCountMismatches.length > 0) reasons.push(`${optionCountMismatches.length} option-count mismatch(es)`);
   if (answerKeyChanges.length > 0) reasons.push(`${answerKeyChanges.length} answer-key change(s) across languages`);
   if (tokenDrift.length > 0) reasons.push(`${tokenDrift.length} formula/URL/identifier(s) lost in a translation`);
   if (blindCopyBlocks && blindCopies.length > 0) reasons.push(`${blindCopies.length} field(s) are a blind copy of the primary language`);
+  reasons.push(...figures.reasons);
 
   return {
     primary,
@@ -198,6 +340,7 @@ export function checkLocalization(pkg, { languages = LANGUAGES, primary = "nb", 
     answerKeyChanges,
     optionCountMismatches,
     tokenDrift,
+    figures,
     blocks: reasons.length > 0,
     reasons,
   };

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import { appName, appVersion } from "./config/appMetadata.js";
 import { getParticipantConsoleRuntimeConfig } from "./config/participantConsole.js";
 import { SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES } from "./modules/adminContent/sourceMaterialExtractionService.js";
 import { COURSE_IMPORT_BODY_LIMIT_BYTES } from "./modules/adminContent/contentImportService.js";
+import { SECTION_CREATE_BODY_LIMIT_BYTES } from "./modules/course/sectionCommands.js";
 import { rolesFor } from "./config/capabilities.js";
 import { authenticate } from "./auth/authenticate.js";
 import { enforceAgentTokenScope } from "./auth/agentTokenScope.js";
@@ -53,6 +54,13 @@ app.use(
 app.use(
   "/api/admin/content/courses/import",
   express.json({ limit: COURSE_IMPORT_BODY_LIMIT_BYTES }),
+);
+// #763 (Layer B): section create (POST /sections) may inline figures/images (base64) → bodies
+// exceed 5 MB. Registered before the global parser so ONLY the /sections routes get the larger
+// limit; the express.json parser skips non-JSON (multipart asset uploads) and already-parsed bodies.
+app.use(
+  "/api/admin/content/sections",
+  express.json({ limit: SECTION_CREATE_BODY_LIMIT_BYTES }),
 );
 app.use(express.json({ limit: "5mb" }));
 app.use("/static", express.static(publicStaticPath));

--- a/src/modules/adminContent/agentAuthoringSchemas.ts
+++ b/src/modules/adminContent/agentAuthoringSchemas.ts
@@ -27,6 +27,39 @@ export const AUTHORING_PACKAGE_FORMAT = "a2-authoring-package/v1" as const;
 
 export { clientRefSchema };
 
+// #763 (Layer B): a client-chosen reference token an agent uses to tie a section's inline figure
+// to its markdown. UNLIKE the export `sourceId` (which is a source-environment DB id), an authoring
+// asset's `sourceId` is a free token the agent invents, referenced in `bodyMarkdown` as
+// `asset:<sourceId>`. Wider grammar than clientRef (allows `_` and upper-case) so it round-trips
+// through the export `sourceId` shape; still tight enough to stay a safe markdown ref.
+export const authoringAssetSourceIdSchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9_-]{1,64}$/, "asset sourceId must match [a-zA-Z0-9_-]{1,64}.");
+
+// #763 (Layer B): one inline section figure/image carried in an authoring package. Shape mirrors
+// the export `sectionAssetExportSchema` (base64 blob + optional #657 localized SVG variants), but
+// `sourceId` is a client-chosen ref token (see above). Strict so a hallucinated field fails loudly.
+export const authoringSectionAssetSchema = z
+  .object({
+    sourceId: authoringAssetSourceIdSchema,
+    filename: z.string().min(1),
+    mimeType: z.string().min(1),
+    sizeBytes: z.number().int().min(0),
+    contentBase64: z.string().min(1),
+    sourceLocale: z.string().min(1).nullable().optional(),
+    localizedVariants: z
+      .array(
+        z
+          .object({
+            locale: z.string().min(1),
+            contentBase64: z.string().min(1),
+          })
+          .strict(),
+      )
+      .optional(),
+  })
+  .strict();
+
 // Module payload = moduleExportPayloadSchema without `audit` (strict).
 export const authoringModulePayloadSchema = z
   .object({
@@ -55,10 +88,13 @@ export const authoringModulePayloadSchema = z
   .strict();
 
 // Section payload = sectionExportPayloadSchema without `audit` (strict).
+// #763 (Layer B): an OPTIONAL `assets[]` carries the section's inline figures/images; markdown
+// references each as `asset:<sourceId>`. Omit it entirely for a text-only section.
 export const authoringSectionPayloadSchema = z
   .object({
     title: localizedTextPatchSchema,
     bodyMarkdown: localizedTextPatchSchema,
+    assets: z.array(authoringSectionAssetSchema).optional(),
   })
   .strict();
 
@@ -120,4 +156,5 @@ export type AuthoringPackage = z.infer<typeof authoringPackageSchema>;
 export type AuthoringObject = z.infer<typeof authoringObjectSchema>;
 export type AuthoringModulePayload = z.infer<typeof authoringModulePayloadSchema>;
 export type AuthoringSectionPayload = z.infer<typeof authoringSectionPayloadSchema>;
+export type AuthoringSectionAsset = z.infer<typeof authoringSectionAssetSchema>;
 export type AuthoringCoursePayload = z.infer<typeof authoringCoursePayloadSchema>;

--- a/src/modules/adminContent/agentAuthoringValidationService.ts
+++ b/src/modules/adminContent/agentAuthoringValidationService.ts
@@ -10,11 +10,14 @@
 import { z } from "zod";
 import { prisma } from "../../db/prisma.js";
 import { localizedTextCodec, type LocalizedText } from "../../codecs/localizedTextCodec.js";
+import { sanitizeSvg } from "../course/svgSanitizer.js";
+import { ALLOWED_ASSET_MIME_TYPES, MAX_ASSET_BYTES, SVG_MIME_TYPE } from "../course/assetCommands.js";
 import {
   AUTHORING_PACKAGE_FORMAT,
   authoringPackageSchema,
   type AuthoringPackage,
   type AuthoringModulePayload,
+  type AuthoringSectionPayload,
 } from "./agentAuthoringSchemas.js";
 
 export type AuthoringIssueSeverity = "error" | "warning";
@@ -170,6 +173,120 @@ function checkAssessmentMode(payload: AuthoringModulePayload, basePath: string):
   return issues;
 }
 
+// #763 (Layer B): every `asset:<ref>` reference in a section's markdown (any locale value).
+// Matches the wider authoring sourceId grammar ([a-zA-Z0-9_-]), a superset of the runtime
+// `asset:<id>` grammar in sectionContent.ts.
+const ASSET_REF_RE = /asset:([a-zA-Z0-9_-]+)/g;
+
+function localizedStringValues(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (value !== null && typeof value === "object") {
+    return Object.values(value).filter((entry): entry is string => typeof entry === "string");
+  }
+  return [];
+}
+
+function assetRefsInMarkdown(bodyMarkdown: unknown): Set<string> {
+  const refs = new Set<string>();
+  for (const text of localizedStringValues(bodyMarkdown)) {
+    for (const match of text.matchAll(ASSET_REF_RE)) refs.add(match[1]);
+  }
+  return refs;
+}
+
+// #763 (Layer B) — pure section-asset rules. Every `asset:<ref>` in the markdown must have a
+// matching `assets[]` entry (missing_asset); every asset should be referenced
+// (unreferenced_asset — warning); mime must be allowed; the decoded blob must be within the
+// per-asset cap; SVG must survive sanitisation non-empty; a section may not reuse a `sourceId`.
+// No DB access — mirrors the import-time enforcement so the dry-run report matches what a later
+// `POST /sections` (or course import) would accept.
+function checkSectionAssets(payload: AuthoringSectionPayload, basePath: string): AuthoringIssue[] {
+  const issues: AuthoringIssue[] = [];
+  const assets = payload.assets ?? [];
+  if (assets.length === 0) return issues;
+
+  const refs = assetRefsInMarkdown(payload.bodyMarkdown);
+  const firstIndexBySourceId = new Map<string, number>();
+  const sourceIds = new Set<string>();
+
+  assets.forEach((asset, index) => {
+    const assetPath = `${basePath}.assets[${index}]`;
+
+    const firstIndex = firstIndexBySourceId.get(asset.sourceId);
+    if (firstIndex !== undefined) {
+      issues.push({
+        severity: "error",
+        path: `${assetPath}.sourceId`,
+        code: "duplicate_asset_source_id",
+        message: `sourceId '${asset.sourceId}' is already used by ${basePath}.assets[${firstIndex}].`,
+      });
+    } else {
+      firstIndexBySourceId.set(asset.sourceId, index);
+      sourceIds.add(asset.sourceId);
+    }
+
+    if (!ALLOWED_ASSET_MIME_TYPES.includes(asset.mimeType)) {
+      issues.push({
+        severity: "error",
+        path: `${assetPath}.mimeType`,
+        code: "unsupported_asset_mime",
+        message: `Unsupported mime '${asset.mimeType || "unknown"}'. Allowed: ${ALLOWED_ASSET_MIME_TYPES.join(", ")}.`,
+      });
+    }
+
+    const buffer = Buffer.from(asset.contentBase64, "base64");
+    if (buffer.byteLength === 0) {
+      issues.push({
+        severity: "error",
+        path: `${assetPath}.contentBase64`,
+        code: "asset_decode_failed",
+        message: `Asset '${asset.sourceId}' decodes to zero bytes (invalid base64?).`,
+      });
+    } else {
+      if (buffer.byteLength > MAX_ASSET_BYTES) {
+        issues.push({
+          severity: "error",
+          path: `${assetPath}.contentBase64`,
+          code: "asset_too_large",
+          message: `Asset '${asset.sourceId}' decodes to ${buffer.byteLength} bytes (max ${MAX_ASSET_BYTES}).`,
+        });
+      }
+      if (asset.mimeType === SVG_MIME_TYPE && sanitizeSvg(buffer.toString("utf8")) === "") {
+        issues.push({
+          severity: "error",
+          path: `${assetPath}.contentBase64`,
+          code: "asset_svg_unsanitizable",
+          message: `Asset '${asset.sourceId}' SVG is empty or invalid after sanitisation.`,
+        });
+      }
+    }
+  });
+
+  for (const ref of refs) {
+    if (!sourceIds.has(ref)) {
+      issues.push({
+        severity: "error",
+        path: `${basePath}.bodyMarkdown`,
+        code: "missing_asset",
+        message: `Markdown references asset:${ref} but no assets[] entry has sourceId '${ref}'.`,
+      });
+    }
+  }
+
+  for (const [sourceId, index] of firstIndexBySourceId) {
+    if (!refs.has(sourceId)) {
+      issues.push({
+        severity: "warning",
+        path: `${basePath}.assets[${index}]`,
+        code: "unreferenced_asset",
+        message: `Asset '${sourceId}' is never referenced by bodyMarkdown (expected asset:${sourceId}).`,
+      });
+    }
+  }
+
+  return issues;
+}
+
 function buildPlan(pkg: AuthoringPackage): AuthoringPlanStep[] {
   const plan: AuthoringPlanStep[] = [];
   for (const object of pkg.objects) {
@@ -236,6 +353,13 @@ export async function validateAuthoringPackage(
   pkg.objects.forEach((object, index) => {
     if (object.type === "module") {
       issues.push(...checkAssessmentMode(object.payload, `objects[${index}].payload`));
+    }
+  });
+
+  // #763 (Layer B): per-section inline-figure rules (ref/asset consistency, mime, size, SVG-safe).
+  pkg.objects.forEach((object, index) => {
+    if (object.type === "section") {
+      issues.push(...checkSectionAssets(object.payload, `objects[${index}].payload`));
     }
   });
 

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -17,6 +17,8 @@ export type {
 } from "./coursePublishService.js";
 export {
   createSection,
+  createSectionWithAssets,
+  remapAssetRefs,
   updateSectionTitle,
   updateSectionContent,
   getSection,
@@ -26,6 +28,8 @@ export {
   archiveSection,
   restoreSection,
   deleteSection,
+  SECTION_CREATE_BODY_LIMIT_BYTES,
+  type SectionAssetImportInput,
 } from "./sectionCommands.js";
 export {
   createSectionAsset,

--- a/src/modules/course/sectionCommands.ts
+++ b/src/modules/course/sectionCommands.ts
@@ -4,6 +4,36 @@ import { NotFoundError, ValidationError } from "../../errors/AppError.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes, agentAuthoringAuditMetadata, type AgentAuthoringContext } from "../../observability/auditEvents.js";
 import { assertSectionNotInAnyCourse } from "./contentLifecycle.js";
+import { importSectionAssets } from "./assetCommands.js";
+
+// #763 (Layer B): the agent section-create route inlines figures/images (base64), so the JSON body
+// can exceed the 5 MB global parser. Sized to cover a handful of SVG figures + localized variants
+// after base64 inflation. Applied to ONLY the /sections route prefix in app.ts (mirrors the
+// /courses/import pattern); every other endpoint stays at 5 MB.
+export const SECTION_CREATE_BODY_LIMIT_BYTES = 15 * 1024 * 1024; // 15 MB
+
+// One inline figure/image an agent supplies alongside a section (see authoringSectionAssetSchema).
+export interface SectionAssetImportInput {
+  sourceId: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  contentBase64: string;
+  sourceLocale?: string | null;
+  localizedVariants?: Array<{ locale: string; contentBase64: string }>;
+}
+
+// #763 (Layer B): rewrite every `asset:<sourceId>` markdown reference to the created SectionAsset
+// id, using the sourceId→newId map from importSectionAssets. Wider grammar ([a-zA-Z0-9_-]) than the
+// import path's remap because authoring sourceIds are client-chosen ref tokens (may carry `_`/`-`),
+// not DB cuids. Refs with no mapping are left untouched (a mistyped ref is not silently mangled).
+export function remapAssetRefs(serializedMarkdown: string, idMap: Map<string, string>): string {
+  if (idMap.size === 0) return serializedMarkdown;
+  return serializedMarkdown.replace(/asset:([a-zA-Z0-9_-]+)/g, (whole, sourceId: string) => {
+    const mapped = idMap.get(sourceId);
+    return mapped ? `asset:${mapped}` : whole;
+  });
+}
 
 // Section CRUD + versioning (#485/B1) for course learning sections (#476).
 // Mirrors Module/ModuleVersion: editing content publishes an immutable new
@@ -58,6 +88,53 @@ export async function createSection(input: {
     },
   });
   return created;
+}
+
+// #763 (Layer B): create a section AND its inline figures/images in one call. Ordering matches the
+// import path (importSectionPayload): create the section (version 1) with the SOURCE markdown →
+// import the assets to obtain their new ids → rewrite the version's `asset:<sourceId>` refs to the
+// new ids IN PLACE. The in-place update is deliberate: it never publishes a draft (activeVersionId
+// and publishedAt are untouched) and keeps a published section published without minting a new
+// version. Returns the (refreshed) section plus the sourceId→assetId map for the API response.
+// Any invalid asset throws (ValidationError) via importSectionAssets — no silent skip.
+export async function createSectionWithAssets(input: {
+  title: string;
+  bodyMarkdown: string;
+  actorId?: string;
+  draft?: boolean;
+  agent?: AgentAuthoringContext;
+  assets: ReadonlyArray<SectionAssetImportInput>;
+}) {
+  const section = await createSection({
+    title: input.title,
+    bodyMarkdown: input.bodyMarkdown,
+    actorId: input.actorId,
+    draft: input.draft,
+    agent: input.agent,
+  });
+
+  const idMap = await importSectionAssets(section.id, input.assets);
+
+  const remapped = remapAssetRefs(input.bodyMarkdown, idMap);
+  if (remapped !== input.bodyMarkdown) {
+    const latest = await prisma.courseSectionVersion.findFirst({
+      where: { sectionId: section.id },
+      orderBy: { versionNo: "desc" },
+      select: { id: true },
+    });
+    if (latest) {
+      await prisma.courseSectionVersion.update({
+        where: { id: latest.id },
+        data: { bodyMarkdown: remapped },
+      });
+    }
+  }
+
+  const refreshed = await prisma.courseSection.findUniqueOrThrow({
+    where: { id: section.id },
+    include: { activeVersion: true },
+  });
+  return { section: refreshed, assetMap: Object.fromEntries(idMap) };
 }
 
 export async function updateSectionTitle(sectionId: string, title: string) {

--- a/src/routes/adminSections.ts
+++ b/src/routes/adminSections.ts
@@ -3,6 +3,7 @@ import multer from "multer";
 import { z } from "zod";
 import {
   createSection,
+  createSectionWithAssets,
   updateSectionTitle,
   updateSectionContent,
   getSection,
@@ -19,6 +20,7 @@ import {
 } from "../modules/course/index.js";
 import { findCoursesForSections } from "../modules/course/contentLifecycle.js";
 import { localizedTextPatchSchema, generationLocaleSchema, clientRefSchema, agentRunIdSchema } from "../modules/adminContent/adminContentSchemas.js";
+import { authoringSectionAssetSchema } from "../modules/adminContent/agentAuthoringSchemas.js";
 import { sectionAdminLinks } from "../modules/adminContent/adminUiLinks.js";
 import { localizedTextCodec } from "../codecs/localizedTextCodec.js";
 import { NotFoundError } from "../errors/AppError.js";
@@ -52,6 +54,9 @@ const createSectionSchema = z.object({
   clientRef: clientRefSchema.optional(),
   // AA-5 (#653): stamped into the create's audit event (source: agent_authoring).
   agentRunId: agentRunIdSchema.optional(),
+  // #763 (Layer B): OPTIONAL inline figures/images. When present the section's assets are created
+  // and its `asset:<sourceId>` markdown refs are remapped to the new asset ids.
+  assets: z.array(authoringSectionAssetSchema).optional(),
 });
 const titleSchema = z.object({ title: localizedTextPatchSchema });
 const contentSchema = z.object({ bodyMarkdown: localizedTextPatchSchema });
@@ -100,12 +105,36 @@ adminSectionsRouter.post("/", async (request, response, next) => {
     return;
   }
   try {
+    const title = localizedTextCodec.serialize(parsed.data.title);
+    const bodyMarkdown = localizedTextCodec.serialize(parsed.data.bodyMarkdown);
+    const agent = { clientRef: parsed.data.clientRef, agentRunId: parsed.data.agentRunId };
+
+    // #763 (Layer B): with inline figures/images, create the section + its assets and remap the
+    // `asset:<sourceId>` refs; echo the sourceId→assetId map back so the skill can map its refs.
+    if (parsed.data.assets && parsed.data.assets.length > 0) {
+      const { section, assetMap } = await createSectionWithAssets({
+        title,
+        bodyMarkdown,
+        actorId: request.context?.userId,
+        draft: parsed.data.draft,
+        agent,
+        assets: parsed.data.assets,
+      });
+      response.status(201).json({
+        section: toDetail(section),
+        links: sectionAdminLinks(section.id),
+        assetMap,
+        ...(parsed.data.clientRef !== undefined ? { clientRef: parsed.data.clientRef } : {}),
+      });
+      return;
+    }
+
     const section = await createSection({
-      title: localizedTextCodec.serialize(parsed.data.title),
-      bodyMarkdown: localizedTextCodec.serialize(parsed.data.bodyMarkdown),
+      title,
+      bodyMarkdown,
       actorId: request.context?.userId,
       draft: parsed.data.draft,
-      agent: { clientRef: parsed.data.clientRef, agentRunId: parsed.data.agentRunId },
+      agent,
     });
     response.status(201).json({
       section: toDetail(section),

--- a/test/agent-authoring-section-assets.test.ts
+++ b/test/agent-authoring-section-assets.test.ts
@@ -1,0 +1,145 @@
+// #763 (Layer B) integration tests: POST /api/admin/content/sections accepts inline figures/images
+// (`assets[]`) alongside the section draft. Native Postgres profile; assets use the filesystem blob
+// fallback (no Azure). Modelled on m2-content-export-import-assets.test.ts + agent-authoring-token.
+//
+// Coverage:
+//   (a) draft:true + an SVG asset → section + SectionAsset row created, blob readable + sanitised,
+//       markdown `asset:<sourceId>` ref remapped to the new asset id, response carries the
+//       sourceId→assetId map; the section stays a draft (activeVersionId null).
+//   (b) the same via an agent token (draft-scoped) still works and is attributed to the issuer.
+//   (c) a section with an asset whose SVG cannot be sanitised is rejected (400).
+
+import request from "supertest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+import { getAsset } from "../src/modules/course/assetStorage.js";
+
+const adminHeaders = {
+  "x-user-id": "admin-1",
+  "x-user-email": "admin@company.com",
+  "x-user-name": "Platform Admin",
+};
+
+const SVG = '<svg xmlns="http://www.w3.org/2000/svg"><text>Steg 1</text></svg>';
+const SVG_EN = '<svg xmlns="http://www.w3.org/2000/svg"><text>Step 1</text></svg>';
+
+function svgAsset(sourceId: string, extra: Record<string, unknown> = {}) {
+  return {
+    sourceId,
+    filename: "flyt.svg",
+    mimeType: "image/svg+xml",
+    sizeBytes: SVG.length,
+    contentBase64: Buffer.from(SVG, "utf8").toString("base64"),
+    ...extra,
+  };
+}
+
+async function issueToken() {
+  const response = await request(app)
+    .post("/api/admin/content/agent-authoring/tokens")
+    .set(adminHeaders)
+    .send({ label: "figure-token" });
+  expect(response.status).toBe(201);
+  return response.body.token as string;
+}
+
+describe("#763 POST /sections with inline figures/images", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("(a) creates a draft section + SectionAsset, remaps the markdown ref, echoes sourceId→assetId", async () => {
+    const res = await request(app)
+      .post("/api/admin/content/sections")
+      .set(adminHeaders)
+      .send({
+        title: { nb: "Figur-seksjon" },
+        bodyMarkdown: { nb: "# Prosess\n\n![Flyt](asset:fig-flow)" },
+        draft: true,
+        clientRef: "sec-figur",
+        assets: [
+          svgAsset("fig-flow", {
+            sourceLocale: "nb",
+            localizedVariants: [{ locale: "en-GB", contentBase64: Buffer.from(SVG_EN, "utf8").toString("base64") }],
+          }),
+        ],
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const sectionId = res.body.section.id as string;
+    expect(res.body.clientRef).toBe("sec-figur");
+
+    // Response carries the sourceId → assetId map.
+    const assetMap = res.body.assetMap as Record<string, string>;
+    expect(Object.keys(assetMap)).toEqual(["fig-flow"]);
+    const newAssetId = assetMap["fig-flow"];
+    expect(newAssetId).toBeTruthy();
+    expect(newAssetId).not.toBe("fig-flow");
+
+    // Draft stayed a draft (never auto-published by the remap re-save).
+    const section = await prisma.courseSection.findUnique({
+      where: { id: sectionId },
+      select: { activeVersionId: true },
+    });
+    expect(section?.activeVersionId).toBeNull();
+
+    // A SectionAsset row exists; its SVG blob is stored + sanitised; the localized variant persisted.
+    const rows = await prisma.sectionAsset.findMany({ where: { sectionId } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(newAssetId);
+    const stored = (await getAsset(rows[0].blobPath)).toString("utf8");
+    expect(stored).toContain("<svg");
+    expect(stored).toContain("Steg 1");
+    const localized = rows[0].localizedBlobPaths as Record<string, string> | null;
+    expect(localized?.["en-GB"]).toBeTruthy();
+    expect((await getAsset(localized!["en-GB"])).toString("utf8")).toContain("Step 1");
+    expect(rows[0].sourceLocale).toBe("nb");
+
+    // The stored (draft) markdown ref was remapped from the source token to the new asset id.
+    const version = await prisma.courseSectionVersion.findFirst({
+      where: { sectionId },
+      orderBy: { versionNo: "desc" },
+    });
+    const body = version?.bodyMarkdown ?? "";
+    expect(body).toContain(`asset:${newAssetId}`);
+    expect(body).not.toContain("asset:fig-flow");
+  });
+
+  it("(b) works via an agent token (draft-scoped) and attributes to the issuer", async () => {
+    const token = await issueToken();
+    const res = await request(app)
+      .post("/api/admin/content/sections")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        title: { nb: "Token-figur" },
+        bodyMarkdown: { nb: "![f](asset:t1)" },
+        draft: true,
+        assets: [svgAsset("t1")],
+      });
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const newAssetId = (res.body.assetMap as Record<string, string>).t1;
+    expect(newAssetId).toBeTruthy();
+
+    const rows = await prisma.sectionAsset.findMany({ where: { sectionId: res.body.section.id } });
+    expect(rows).toHaveLength(1);
+    const version = await prisma.courseSectionVersion.findFirst({
+      where: { sectionId: res.body.section.id },
+      orderBy: { versionNo: "desc" },
+    });
+    expect(version?.bodyMarkdown ?? "").toContain(`asset:${newAssetId}`);
+  });
+
+  it("(c) rejects a section whose SVG cannot be sanitised (400)", async () => {
+    const notSvg = Buffer.from("<html><body>not an svg</body></html>", "utf8").toString("base64");
+    const res = await request(app)
+      .post("/api/admin/content/sections")
+      .set(adminHeaders)
+      .send({
+        title: { nb: "Ugyldig" },
+        bodyMarkdown: { nb: "![x](asset:bad)" },
+        draft: true,
+        assets: [svgAsset("bad", { contentBase64: notSvg })],
+      });
+    expect(res.status).toBe(400);
+  });
+});

--- a/test/unit/agent-authoring-course-state.test.ts
+++ b/test/unit/agent-authoring-course-state.test.ts
@@ -8,6 +8,7 @@ import {
   auditExport,
   checkGate6Readiness,
   reductionRatio,
+  extractPackageElements,
   // @ts-expect-error — .mjs skill script consumed as a library (see import-package.mjs pattern)
 } from "../../skills/a2-authoring-api/scripts/course-state.mjs";
 
@@ -182,6 +183,83 @@ describe("#762 gate-6 readiness", () => {
       ],
     };
     expect(checkGate6Readiness(master).ready).toBe(true);
+  });
+});
+
+describe("#763 (Layer B) approved figures are mandatory content", () => {
+  // An approved section that teaches with an SVG figure: the figure's ref + labels are mandatory.
+  const figureElement = {
+    clientRef: "sec-prosess",
+    type: "section",
+    status: "approved",
+    content: "# Saksgang\n\nFiguren viser stegene.\n\n![Saksgang](asset:fig-flow)",
+    figures: [{ sourceId: "fig-flow", labels: ["Motta sak", "Vurder grunnlag", "Fatt vedtak"] }],
+    mandatory: {},
+    deliberatelyRemoved: [],
+  };
+
+  it("reviewRevision blocks when an approved figure ref is dropped", () => {
+    // Revision keeps the labels but removes the ![](asset:fig-flow) reference.
+    const revised = "# Saksgang\n\nStegene er: Motta sak, Vurder grunnlag, Fatt vedtak.";
+    const result = reviewRevision(figureElement, revised, { reductionApproved: true });
+    expect(result.blocks).toBe(true);
+    expect(result.lostMandatory.some((e: { category: string; item: string }) => e.category === "figures" && e.item === "asset:fig-flow")).toBe(true);
+  });
+
+  it("reviewRevision blocks when a figure label is emptied/renamed", () => {
+    // Ref kept, but one label ("Fatt vedtak") is gone from the revision.
+    const revised = "# Saksgang\n\n![Saksgang](asset:fig-flow)\n\nSteg: Motta sak, Vurder grunnlag.";
+    const result = reviewRevision(figureElement, revised, { reductionApproved: true });
+    expect(result.blocks).toBe(true);
+    expect(result.lostMandatory.some((e: { item: string }) => e.item === "Fatt vedtak")).toBe(true);
+  });
+
+  it("reviewRevision passes when the figure ref + all labels survive", () => {
+    const revised = "# Saksgang\n\n![Saksgang](asset:fig-flow)\n\nSteg: Motta sak, Vurder grunnlag, Fatt vedtak.";
+    const result = reviewRevision(figureElement, revised, { reductionApproved: true });
+    expect(result.lostMandatory).toEqual([]);
+    expect(result.blocks).toBe(false);
+  });
+
+  it("auditExport reads figure labels out of the produced (base64) SVG and blocks on an emptied label", () => {
+    const svg = (labels: string[]) =>
+      `<svg xmlns="http://www.w3.org/2000/svg">${labels.map((l) => `<text>${l}</text>`).join("")}</svg>`;
+    const master = {
+      order: ["sec-prosess"],
+      elements: [figureElement],
+    };
+
+    // A package where the section carries the figure with ALL labels present in the SVG blob.
+    const goodPkg = {
+      objects: [
+        {
+          clientRef: "sec-prosess",
+          type: "section",
+          payload: {
+            title: "Saksgang",
+            bodyMarkdown: "![Saksgang](asset:fig-flow)",
+            assets: [
+              {
+                sourceId: "fig-flow",
+                filename: "flow.svg",
+                mimeType: "image/svg+xml",
+                sizeBytes: 1,
+                contentBase64: Buffer.from(svg(["Motta sak", "Vurder grunnlag", "Fatt vedtak"]), "utf8").toString("base64"),
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const goodAudit = auditExport(master, extractPackageElements(goodPkg));
+    expect(goodAudit.blocks).toBe(false);
+
+    // Same package, but the SVG lost the "Fatt vedtak" label → blocking mandatory loss.
+    const badPkg = structuredClone(goodPkg);
+    badPkg.objects[0].payload.assets[0].contentBase64 = Buffer.from(svg(["Motta sak", "Vurder grunnlag"]), "utf8").toString("base64");
+    const badAudit = auditExport(master, extractPackageElements(badPkg));
+    expect(badAudit.blocks).toBe(true);
+    expect(badAudit.lostMandatory.some((e: { item: string }) => e.item === "Fatt vedtak")).toBe(true);
   });
 });
 

--- a/test/unit/agent-authoring-localization.test.ts
+++ b/test/unit/agent-authoring-localization.test.ts
@@ -5,11 +5,51 @@
 import { describe, expect, it } from "vitest";
 import {
   checkLocalization,
+  checkFigureLocalization,
+  extractSvgTextRuns,
   extractPreservedTokens,
   isBlindCopy,
   presentLocales,
   // @ts-expect-error — .mjs skill script consumed as a library
 } from "../../skills/a2-authoring-api/scripts/localization-check.mjs";
+
+const b64 = (svg: string) => Buffer.from(svg, "utf8").toString("base64");
+
+// A section object carrying one SVG figure with the given base + per-locale variants.
+function figurePackage(
+  base: string,
+  variants: Array<{ locale: string; svg: string }>,
+  sourceLocale = "nb",
+): { packageFormat: string; objects: any[] } {
+  return {
+    packageFormat: "a2-authoring-package/v1",
+    objects: [
+      {
+        clientRef: "sec-figur",
+        type: "section",
+        payload: {
+          title: "Figur",
+          bodyMarkdown: "![f](asset:fig-1)",
+          assets: [
+            {
+              sourceId: "fig-1",
+              filename: "fig.svg",
+              mimeType: "image/svg+xml",
+              sizeBytes: base.length,
+              contentBase64: b64(base),
+              sourceLocale,
+              localizedVariants: variants.map((v) => ({ locale: v.locale, contentBase64: b64(v.svg) })),
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+const NB_FIG = '<svg xmlns="http://www.w3.org/2000/svg"><text>Behandlingsgrunnlag</text><text>Formål</text></svg>';
+const NN_FIG = '<svg xmlns="http://www.w3.org/2000/svg"><text>Handsamingsgrunnlag</text><text>Føremål</text></svg>';
+const EN_FIG = '<svg xmlns="http://www.w3.org/2000/svg"><text>Legal basis</text><text>Purpose</text></svg>';
 
 // A three-locale localized value.
 const L = (nb: string, nn: string, en: string) => ({ nb, nn, "en-GB": en });
@@ -147,5 +187,86 @@ describe("#762 checkLocalization", () => {
     const result = checkLocalization(pkg);
     expect(result.blocks).toBe(true);
     expect(result.blindCopies.length).toBeGreaterThan(0);
+  });
+});
+
+describe("#763 (Layer B) SVG figure localization", () => {
+  it("extractSvgTextRuns reads leaf <text>/<tspan> runs in order, deduplicated", () => {
+    expect(extractSvgTextRuns(NB_FIG)).toEqual(["Behandlingsgrunnlag", "Formål"]);
+    const tspans = '<svg><text><tspan>A</tspan><tspan>B</tspan></text><text>A</text></svg>';
+    expect(extractSvgTextRuns(tspans)).toEqual(["A", "B"]); // dedup, tspans preferred over parent
+    expect(extractSvgTextRuns('<svg><rect/></svg>')).toEqual([]);
+  });
+
+  it("a fully-translated text-bearing figure → PASSES", () => {
+    const result = checkFigureLocalization(
+      figurePackage(NB_FIG, [
+        { locale: "nn", svg: NN_FIG },
+        { locale: "en-GB", svg: EN_FIG },
+      ]),
+    );
+    expect(result.blocks).toBe(false);
+    expect(result.missingVariants).toEqual([]);
+    expect(result.textCountMismatches).toEqual([]);
+    expect(result.blindCopies).toEqual([]);
+    // And the full check folds it in without blocking (no other localized fields present).
+    expect(checkLocalization(figurePackage(NB_FIG, [
+      { locale: "nn", svg: NN_FIG },
+      { locale: "en-GB", svg: EN_FIG },
+    ])).figures.blocks).toBe(false);
+  });
+
+  it("a figure missing a locale variant → FAILS", () => {
+    const result = checkFigureLocalization(figurePackage(NB_FIG, [{ locale: "nn", svg: NN_FIG }]));
+    expect(result.blocks).toBe(true);
+    expect(result.missingVariants.some((m: { locale: string }) => m.locale === "en-GB")).toBe(true);
+    // Blocking bubbles up to the top-level check.
+    expect(checkLocalization(figurePackage(NB_FIG, [{ locale: "nn", svg: NN_FIG }])).blocks).toBe(true);
+  });
+
+  it("a variant with a different label count → FAILS", () => {
+    const EN_ONE = '<svg xmlns="http://www.w3.org/2000/svg"><text>Legal basis</text></svg>';
+    const result = checkFigureLocalization(
+      figurePackage(NB_FIG, [
+        { locale: "nn", svg: NN_FIG },
+        { locale: "en-GB", svg: EN_ONE },
+      ]),
+    );
+    expect(result.blocks).toBe(true);
+    expect(result.textCountMismatches.some((m: { locale: string; expected: number; actual: number }) =>
+      m.locale === "en-GB" && m.expected === 2 && m.actual === 1)).toBe(true);
+  });
+
+  it("a variant that blindly copies the original labels → FAILS", () => {
+    const result = checkFigureLocalization(
+      figurePackage(NB_FIG, [
+        { locale: "nn", svg: NN_FIG },
+        { locale: "en-GB", svg: NB_FIG }, // English variant left as the bokmål labels
+      ]),
+    );
+    expect(result.blocks).toBe(true);
+    expect(result.blindCopies.some((b: { locale: string }) => b.locale === "en-GB")).toBe(true);
+  });
+
+  it("an identifier/URL dropped from a variant label → FAILS (token drift)", () => {
+    const NB_URL = '<svg xmlns="http://www.w3.org/2000/svg"><text>Se https://gdpr.eu/art-5</text></svg>';
+    const NN_URL = '<svg xmlns="http://www.w3.org/2000/svg"><text>Sjå https://gdpr.eu/art-5</text></svg>';
+    const EN_NO_URL = '<svg xmlns="http://www.w3.org/2000/svg"><text>See the article</text></svg>';
+    const result = checkFigureLocalization(
+      figurePackage(NB_URL, [
+        { locale: "nn", svg: NN_URL },
+        { locale: "en-GB", svg: EN_NO_URL },
+      ]),
+    );
+    expect(result.blocks).toBe(true);
+    expect(result.tokenDrift.some((d: { locale: string; token: string }) => d.locale === "en-GB" && d.token.includes("gdpr.eu"))).toBe(true);
+  });
+
+  it("a raster (non-SVG) figure is not treated as a translatable figure", () => {
+    const pkg = figurePackage(NB_FIG, []);
+    pkg.objects[0].payload.assets[0].mimeType = "image/png";
+    const result = checkFigureLocalization(pkg);
+    expect(result.blocks).toBe(false);
+    expect(result.missingVariants).toEqual([]);
   });
 });

--- a/test/unit/agent-authoring-validation.test.ts
+++ b/test/unit/agent-authoring-validation.test.ts
@@ -245,6 +245,127 @@ describe("#649 agent authoring package validation", () => {
     expect(report.summary.warnings).toBe(2);
   });
 
+  describe("#763 (Layer B) section inline figures/images", () => {
+    const SVG = '<svg xmlns="http://www.w3.org/2000/svg"><text>Start</text></svg>';
+    const svgB64 = Buffer.from(SVG, "utf8").toString("base64");
+    const pngB64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64");
+
+    function sectionPackage(section: Record<string, unknown>) {
+      return {
+        packageFormat: "a2-authoring-package/v1",
+        objects: [{ clientRef: "sec", type: "section", payload: section }],
+      };
+    }
+
+    function svgAsset(overrides: Record<string, unknown> = {}) {
+      return {
+        sourceId: "fig-flow",
+        filename: "flow.svg",
+        mimeType: "image/svg+xml",
+        sizeBytes: SVG.length,
+        contentBase64: svgB64,
+        ...overrides,
+      };
+    }
+
+    it("accepts a section whose markdown ref matches an assets[] entry", async () => {
+      const report = await validateAuthoringPackage(
+        sectionPackage({ title: "S", bodyMarkdown: "![Flyt](asset:fig-flow)", assets: [svgAsset()] }),
+        emptyLookups(),
+      );
+      expect(report.valid).toBe(true);
+      expect(report.issues).toEqual([]);
+    });
+
+    it("flags a markdown ref with no matching asset (missing_asset)", async () => {
+      const report = await validateAuthoringPackage(
+        sectionPackage({ title: "S", bodyMarkdown: "![x](asset:ghost)", assets: [svgAsset()] }),
+        emptyLookups(),
+      );
+      expect(report.valid).toBe(false);
+      expect(report.issues).toContainEqual(
+        expect.objectContaining({ severity: "error", code: "missing_asset", path: "objects[0].payload.bodyMarkdown" }),
+      );
+      // The unused asset is also a (non-blocking) warning.
+      expect(report.issues).toContainEqual(expect.objectContaining({ severity: "warning", code: "unreferenced_asset" }));
+    });
+
+    it("warns (does not block) on an asset never referenced by markdown", async () => {
+      const report = await validateAuthoringPackage(
+        sectionPackage({ title: "S", bodyMarkdown: "Ingen figur her", assets: [svgAsset()] }),
+        emptyLookups(),
+      );
+      expect(report.valid).toBe(true);
+      expect(report.issues).toContainEqual(
+        expect.objectContaining({ severity: "warning", code: "unreferenced_asset", path: "objects[0].payload.assets[0]" }),
+      );
+    });
+
+    it("rejects a disallowed mime type (unsupported_asset_mime)", async () => {
+      const report = await validateAuthoringPackage(
+        sectionPackage({
+          title: "S",
+          bodyMarkdown: "![x](asset:fig-flow)",
+          assets: [svgAsset({ mimeType: "image/tiff", filename: "x.tiff", contentBase64: pngB64 })],
+        }),
+        emptyLookups(),
+      );
+      expect(report.valid).toBe(false);
+      expect(report.issues).toContainEqual(
+        expect.objectContaining({ code: "unsupported_asset_mime", path: "objects[0].payload.assets[0].mimeType" }),
+      );
+    });
+
+    it("rejects an oversized decoded asset (asset_too_large)", async () => {
+      // > 5 MB of decoded bytes; base64 of 6 MB of zero bytes.
+      const big = Buffer.alloc(6 * 1024 * 1024, 0).toString("base64");
+      const report = await validateAuthoringPackage(
+        sectionPackage({
+          title: "S",
+          bodyMarkdown: "![x](asset:fig-flow)",
+          assets: [svgAsset({ mimeType: "image/png", filename: "big.png", contentBase64: big })],
+        }),
+        emptyLookups(),
+      );
+      expect(report.valid).toBe(false);
+      expect(report.issues).toContainEqual(
+        expect.objectContaining({ code: "asset_too_large", path: "objects[0].payload.assets[0].contentBase64" }),
+      );
+    });
+
+    it("rejects a duplicate sourceId within a section (duplicate_asset_source_id)", async () => {
+      const report = await validateAuthoringPackage(
+        sectionPackage({
+          title: "S",
+          bodyMarkdown: "![x](asset:fig-flow)",
+          assets: [svgAsset(), svgAsset({ filename: "flow2.svg" })],
+        }),
+        emptyLookups(),
+      );
+      expect(report.valid).toBe(false);
+      expect(report.issues).toContainEqual(
+        expect.objectContaining({ code: "duplicate_asset_source_id", path: "objects[0].payload.assets[1].sourceId" }),
+      );
+    });
+
+    it("rejects an SVG that is empty after sanitisation (asset_svg_unsanitizable)", async () => {
+      // No <svg> root survives sanitisation → sanitizeSvg returns "".
+      const notSvg = Buffer.from("<html><body>not svg</body></html>", "utf8").toString("base64");
+      const report = await validateAuthoringPackage(
+        sectionPackage({
+          title: "S",
+          bodyMarkdown: "![x](asset:fig-flow)",
+          assets: [svgAsset({ contentBase64: notSvg })],
+        }),
+        emptyLookups(),
+      );
+      expect(report.valid).toBe(false);
+      expect(report.issues).toContainEqual(
+        expect.objectContaining({ code: "asset_svg_unsanitizable", path: "objects[0].payload.assets[0].contentBase64" }),
+      );
+    });
+  });
+
   it("returns structural schema errors with paths and no plan", async () => {
     const report = await validateAuthoringPackage(
       {


### PR DESCRIPTION
Fase 2 (Lag B) oppå asset-transporten fra #751 (v1.6.22). Ferdigstilt fra bakgrunnsagentens ucommittede arbeid etter en øktgrense (ikke et kodeproblem) — verifisert selv.

## Plattform
- **Authoring-pakke:** valgfri `assets[]` på seksjons-payload (`sourceId` = klient-ref-token, markdown refererer via `asset:<sourceId>`).
- **`POST /sections`:** tar imot `assets[]`, importerer (gjenbruker `importSectionAssets` → sanitér + mime/størrelse-vakter), remapper markdown-refene til nye id-er før lagring, returnerer `sourceId→assetId`. Egen større body-parser. Agent-token forblir draft-only.
- **Validate (AA-1):** per seksjon — hver `asset:<ref>` ↔ `assets[]`-post (`missing_asset`/`unreferenced_asset`), mime-allowlist, størrelse ≤ `MAX_ASSET_BYTES`, SVG saniterer ikke til tomt, unik `sourceId`.

## Skill
- Ny **`references/figure-design.md`**: **«én figur, ett poeng»**, mal-sett (flyt/tre/bokser-og-piler/merket diagram — kun disse med mindre forfatter ber om fri-form), **SVG-only** (agenten lager aldri raster; raster kun forfatter-levert, aldri «oversatt»), figurer grunnet i godkjent tekst/kilde (oppfinner ikke data), korte etiketter i ett primærspråk, oversettbar `<text>` (sanitér-sikre skjeletter).
- **SKILL.md/playbook:** figurer foreslås i Struktur-porten (én enkel figur per visuelt poeng), tegnes med teksten i Per-element-porten (godkjenn tekst+figur som ett hele), vist i preview.
- **Lokalisering (#762):** figur-`<text>` oversettes per språk; `checkLocalization` verifiserer alle tre språk, bevart etikett-antall, token-bevaring, ingen blind-kopi.
- **Bevaring (#762):** en godkjent figur er unikt innhold «fjern redundans» aldri kan droppe.

## Test (verifisert selv)
- `npx tsc --noEmit` ren; **762 unit** grønne (~18 nye: validate-asset-regler, localization/course-state figur-utvidelser); **3 integrasjon** grønne (`/sections`+SVG-asset: seksjon opprettet, `SectionAsset`-rad, ref remappet, `sourceId→assetId` returnert).
- Leste validate-sjekkene og section-create-flyten: saniterer før lagring, kaster på ugyldig (ingen stille skip).

Zip ompakket: `dist/skills/a2-authoring-api-v1.6.23.zip`. Refererer #749 + `doc/design/COURSE_FIGURES_AND_ASSETS.md`. Ikke merget/deployet.