### PR TITLE
fix(skill): #749 (Layer B) — CLI-orkestratoren videresender seksjonsfigurer (v1.6.24)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -22,8 +22,13 @@ figurer gjennom — agent-flyten via referanse-CLI-en gjorde det ikke.
   kjører en figur-pakke gjennom `importPackage` og verifiserer at `SectionAsset`-raden opprettes,
   blobben er lesbar + sanitert, markdown-referansen remappes fra kilde-token til ny id, `assetMap`
   bobler opp, og seksjonen forblir utkast. Regresjonsvakt for nettopp dette hullet.
+- **Doc-gjeld i `package-schema.md` lukket samtidig:** seksjonseksempelet sa «markdown only, no
+  assets», og figur-transport-avsnittet påsto at skillen «does not yet design figures (Layer B, a
+  later phase)» — begge motsagt av kanonisk SKILL.md + figure-design.md (Layer B er levert).
+  Referansen dokumenterer nå authoring-pakkens valgfrie `assets[]` (klient-valgt `sourceId`,
+  ref/remap, `assetMap`-ekko, validate-kodene) og at figurer designes i strukturporten.
 - Ingen server-/schema-endring (endepunktet støttet allerede `assets[]`). Ingen Prisma-migrasjon.
-  Ingen deploy — skill-script + test. Skill ompakkes til v1.6.24.
+  Ingen deploy — skill-script + doc + test. Skill ompakkes til v1.6.24.
 
 ## 1.6.23 - 2026-07-11
 

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,29 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.24 - 2026-07-13
+
+fix(skill): #749 (Layer B) — CLI-orkestratoren videresender seksjonsfigurer
+
+Tetter et hull mellom endepunktet og referanse-orkestratoren funnet under test-forberedelse:
+`POST /api/admin/content/sections` tok imot `assets[]` (v1.6.23), men skill-skriptet
+`import-package.mjs` sitt `create_section`-steg sendte bare `title/bodyMarkdown/draft/clientRef/
+agentRunId` — **ikke** `assets`. En full CLI-import av en pakke med figurer validerte grønt og
+rapporterte «ok», men opprettet seksjonen **uten** figuren: markdownen beholdt en dinglende
+`asset:<sourceId>`-referanse uten blob. Bare selve endepunktet (og kurs-eksport/import, Lag A) bar
+figurer gjennom — agent-flyten via referanse-CLI-en gjorde det ikke.
+
+- **Fix:** `create_section` videresender nå `object.payload.assets` når den finnes (utelates for
+  ren-tekst-seksjoner), og eksponerer endepunktets `sourceId→assetId`-`assetMap` på den opprettede
+  seksjonen. Serveren gjør resten (opprett `SectionAsset`, saniter SVG, remap `asset:<sourceId>`→ny
+  id i lagret markdown). `import-package.d.mts` fikk `assetMap?` på `AuthoringCreatedObject`.
+- **Test (CLI-dekning):** ny ende-til-ende-case i `test/agent-authoring-skill-import.test.ts` som
+  kjører en figur-pakke gjennom `importPackage` og verifiserer at `SectionAsset`-raden opprettes,
+  blobben er lesbar + sanitert, markdown-referansen remappes fra kilde-token til ny id, `assetMap`
+  bobler opp, og seksjonen forblir utkast. Regresjonsvakt for nettopp dette hullet.
+- Ingen server-/schema-endring (endepunktet støttet allerede `assets[]`). Ingen Prisma-migrasjon.
+  Ingen deploy — skill-script + test. Skill ompakkes til v1.6.24.
+
 ## 1.6.23 - 2026-07-11
 
 feat(figures): #749 Lag B — skill-assistert figur-design + assets i agent-flyten

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.23",
+  "version": "1.6.24",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/skills/a2-authoring-api/references/package-schema.md
+++ b/skills/a2-authoring-api/references/package-schema.md
@@ -38,10 +38,55 @@ accept a partial object (e.g. only `nb`).
   "type": "section",
   "payload": {
     "title": "Introduksjon til GDPR",
-    "bodyMarkdown": "## Hva er GDPR\n…markdown only, no assets…"
+    "bodyMarkdown": "## Hva er GDPR\n\nGDPR regulerer …"
   }
 }
 ```
+
+A text-only section needs just `title` + `bodyMarkdown`. To include a figure, add an optional
+`assets[]` and reference each figure from the markdown as `![alt](asset:<sourceId>)` — see below.
+
+### Section figures — optional `assets[]` (#763, Layer B)
+
+The skill **designs** figures as part of authoring — propose one simple figure per visual point in
+the structure gate, draw it as SVG alongside the text (see [figure-design.md](figure-design.md)) —
+and carries them inline on the section payload:
+
+```json
+{
+  "clientRef": "prosess",
+  "type": "section",
+  "payload": {
+    "title": "Saksgangen",
+    "bodyMarkdown": "## Saksgang\n\n![Saksflyt](asset:fig-flow)",
+    "assets": [
+      {
+        "sourceId": "fig-flow",
+        "filename": "saksflyt.svg",
+        "mimeType": "image/svg+xml",
+        "sizeBytes": 1234,
+        "contentBase64": "PHN2Zy…",
+        "sourceLocale": "nb",
+        "localizedVariants": [ { "locale": "en-GB", "contentBase64": "PHN2Zy…" } ]
+      }
+    ]
+  }
+}
+```
+
+- **`sourceId` is a client-chosen token** (`[a-zA-Z0-9_-]{1,64}`) you invent — NOT a DB id. The
+  markdown references it as `asset:<sourceId>`; leave the ref pointing at your `sourceId`, never
+  pre-remap it.
+- On `create_section`, A2 imports each asset (re-sanitises SVG, mime/size guards), remaps every
+  `asset:<sourceId>` in the stored markdown to the new `SectionAsset` id, and **echoes the
+  `sourceId → assetId` map** back so you can track your refs. Same ref/remap + mime/limit contract as
+  the export `assets[]` (below): allowed mimes `image/svg+xml`, `image/png`, `image/jpeg`,
+  `image/gif`, `image/webp`; 5 MB per asset. Omit `assets` entirely for a text-only section.
+- The validate report checks figure consistency per section: `missing_asset`, `unreferenced_asset`
+  (warning), `unsupported_asset_mime`, `asset_too_large`, `asset_svg_unsanitizable`,
+  `duplicate_asset_source_id`.
+- **`localizedVariants`** carries the #657 translated-SVG variants (one base64 per locale), added
+  after the primary language is approved; omit for raster or untranslated figures.
 
 ## `type: "module"`
 
@@ -200,8 +245,11 @@ this, `asset:<id>` markdown refs would break on the destination). Each entry:
 - **`localizedVariants`** carries the #657 translated-SVG variants (one base64 per locale); omit
   for raster or untranslated figures. `assets` is fully optional — omit it entirely for a
   markdown-only section (old asset-less files import unchanged).
-- **Phase 1 (Layer A) is transport only.** The skill does not yet *design* figures (that is Layer B,
-  a later phase) — this documents how figures already present on a section travel through the file.
+- **Figures are designed by the skill (Layer B, shipped).** The skill proposes figures in the
+  structure gate and draws them as SVG alongside the text ([figure-design.md](figure-design.md)); an
+  authoring package carries them on the section payload (see "Section figures" above). This export
+  `assets[]` is the *transport* half — how figures on a section travel through the fallback file —
+  using the same ref/remap contract.
 - `exportFormat` / `exportedAt` / `scope: "course"` on the envelope. **`exportedAt` (and any
   `audit.publishedAt`) MUST be `Date.toISOString()` shape (`YYYY-MM-DDTHH:mm:ss.sssZ`)** — Zod
   `.datetime()` rejects timezone offsets and microseconds. Build this envelope with

--- a/skills/a2-authoring-api/scripts/import-package.d.mts
+++ b/skills/a2-authoring-api/scripts/import-package.d.mts
@@ -5,6 +5,9 @@ export interface AuthoringCreatedObject {
   type: "section" | "module" | "course";
   id: string;
   links: Record<string, string>;
+  // #763 (Layer B): present on sections created with inline figures/images — maps each
+  // authoring `sourceId` to the new SectionAsset id the endpoint minted.
+  assetMap?: Record<string, string>;
 }
 
 export interface AuthoringValidationReport {

--- a/skills/a2-authoring-api/scripts/import-package.mjs
+++ b/skills/a2-authoring-api/scripts/import-package.mjs
@@ -87,16 +87,27 @@ export async function importPackage({ baseUrl, headers, pkg, runId, fetchImpl = 
     let result;
 
     if (step.op === "create_section") {
+      // #763 (Layer B): forward the section's inline figures/images. The endpoint creates each
+      // SectionAsset, re-sanitises + remaps `asset:<sourceId>`→new asset id in the stored markdown,
+      // and echoes the sourceId→assetId map. Omit the field entirely for a text-only section.
+      const assets = object.payload.assets;
       result = await requestJson(fetchImpl, "POST", `${baseUrl}/api/admin/content/sections`, headers, {
         title: object.payload.title,
         bodyMarkdown: object.payload.bodyMarkdown,
         draft: true,
         clientRef: step.clientRef,
         agentRunId,
+        ...(assets && assets.length > 0 ? { assets } : {}),
       });
       if (result.ok) {
         idsByRef.set(step.clientRef, result.json.section.id);
-        created.push({ clientRef: step.clientRef, type: "section", id: result.json.section.id, links: result.json.links });
+        created.push({
+          clientRef: step.clientRef,
+          type: "section",
+          id: result.json.section.id,
+          links: result.json.links,
+          ...(result.json.assetMap ? { assetMap: result.json.assetMap } : {}),
+        });
       }
     } else if (step.op === "create_module") {
       result = await requestJson(fetchImpl, "POST", `${baseUrl}/api/admin/content/modules/import`, headers, {

--- a/test/agent-authoring-skill-import.test.ts
+++ b/test/agent-authoring-skill-import.test.ts
@@ -10,6 +10,7 @@ import type { AddressInfo } from "node:net";
 import { readFile } from "node:fs/promises";
 import { app } from "../src/app.js";
 import { prisma } from "../src/db/prisma.js";
+import { getAsset } from "../src/modules/course/assetStorage.js";
 import {
   importPackage,
   validatePackage,
@@ -115,6 +116,63 @@ describe("#652 a2-authoring-api skill happy path (fixture package → drafts via
       byRef.get("modul-avvik"),
       byRef.get("oppsummering"),
     ]);
+  });
+
+  it("#763 (Layer B): carries a section's inline figure through the CLI orchestrator", async () => {
+    // Regression guard: the reference orchestrator (import-package.mjs) must forward a section's
+    // `assets[]` on create_section. Before this, the endpoint accepted figures but the orchestrator
+    // dropped them — the section was created with a dangling `asset:<sourceId>` ref and no blob.
+    const suffix = `skill-figur-${Date.now()}`;
+    const pkg = await loadFixture(suffix);
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60" role="img"><text x="10" y="30" font-size="14">Motta</text></svg>';
+    const intro = pkg.objects.find((object: { clientRef: string }) => object.clientRef === "intro");
+    intro.payload.bodyMarkdown += "\n\n![Saksflyt](asset:fig-flow)";
+    intro.payload.assets = [
+      {
+        sourceId: "fig-flow",
+        filename: "saksflyt.svg",
+        mimeType: "image/svg+xml",
+        sizeBytes: svg.length,
+        contentBase64: Buffer.from(svg, "utf8").toString("base64"),
+        sourceLocale: "nb",
+      },
+    ];
+
+    const result = await importPackage({ baseUrl, headers, pkg });
+
+    expect(result.error).toBeNull();
+    expect(result.ok).toBe(true);
+
+    // The orchestrator surfaces the endpoint's sourceId→assetId map on the created section.
+    const introEntry = result.created.find((entry) => entry.clientRef === "intro");
+    expect(introEntry).toBeDefined();
+    const assetMap = introEntry!.assetMap;
+    expect(assetMap).toBeDefined();
+    const newAssetId = assetMap!["fig-flow"];
+    expect(newAssetId).toBeTruthy();
+    expect(newAssetId).not.toBe("fig-flow");
+
+    // A SectionAsset row exists and its sanitised SVG blob is readable.
+    const rows = await prisma.sectionAsset.findMany({ where: { sectionId: introEntry!.id } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(newAssetId);
+    expect((await getAsset(rows[0].blobPath)).toString("utf8")).toContain("Motta");
+
+    // The stored (draft) markdown ref was remapped from the source token to the new asset id.
+    const version = await prisma.courseSectionVersion.findFirst({
+      where: { sectionId: introEntry!.id },
+      orderBy: { versionNo: "desc" },
+      select: { bodyMarkdown: true },
+    });
+    expect(version?.bodyMarkdown ?? "").toContain(`asset:${newAssetId}`);
+    expect(version?.bodyMarkdown ?? "").not.toContain("asset:fig-flow");
+
+    // The section is still a draft (the remap re-save never auto-published it).
+    const section = await prisma.courseSection.findUniqueOrThrow({
+      where: { id: introEntry!.id },
+      select: { activeVersionId: true },
+    });
+    expect(section.activeVersionId).toBeNull();
   });
 
   it("stops before any write when the package is invalid", async () => {


### PR DESCRIPTION
## Hva

Tetter et hull mellom endepunktet og referanse-orkestratoren, funnet under test-forberedelse for v1.6.23-figurene.

`POST /api/admin/content/sections` tok imot `assets[]` (v1.6.23), men skill-skriptet `import-package.mjs` sitt `create_section`-steg sendte bare `title/bodyMarkdown/draft/clientRef/agentRunId` — **ikke** `assets`. En full CLI-import av en figur-pakke validerte grønt og rapporterte «ok», men opprettet seksjonen **uten** figuren: dinglende `asset:<sourceId>`-ref uten blob. Bare endepunktet selv + kurs-eksport/import (Lag A) bar figurer gjennom.

## Endring

- `create_section` videresender nå `object.payload.assets` (utelates for ren-tekst-seksjoner) og eksponerer endepunktets `sourceId→assetId`-`assetMap` på den opprettede seksjonen. Serveren gjør resten (opprett `SectionAsset`, saniter SVG, remap markdown).
- `import-package.d.mts`: `assetMap?` på `AuthoringCreatedObject`.
- **Test:** ny ende-til-ende-regresjonstest i `agent-authoring-skill-import.test.ts` — figur-pakke gjennom `importPackage` → `SectionAsset` opprettet, blob sanitert + lesbar, markdown-ref remappet, `assetMap` boblet opp, seksjon forblir utkast.

Ingen server-/schema-endring (endepunktet støttet allerede `assets[]`). Ingen Prisma-migrasjon. Skill repakket til v1.6.24.

## Test
- `tsc --noEmit` grønn.
- Ny + relaterte integrasjonstester (agent-authoring*, section-assets, export-import-assets) og figur-unit-tester grønne mot native test-Postgres.

## Rollback
Ren revert; ingen infra/data-effekt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)