### PR TITLE
fix: agent-produserte kurs-importer — figurer + tegnkoding + tre-språklighet [#754/#756, v1.6.25–27]

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,31 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.25 - 2026-07-13
+
+fix(content): #754 — figurer med bindestrek-/understrek-sourceId brytes ved kurs-import
+
+Bruker-rapportert: et ChatGPT-produsert kurs (skill v1.6.24) med to SVG-figurer importerte
+tilsynelatende OK, men figurene vistes ikke. Rotårsak er en **grammatikk-mismatch** på asset-ref:
+`sourceId`/ref-grammatikken er `[a-zA-Z0-9_-]{1,64}` (authoring-schema + `figure-design.md`), og
+agenter lager lovlige id-er med bindestrek (`fig-styringslogikker`). To flater brukte en for smal
+regex `[a-zA-Z0-9]+`:
+
+- `contentImportService.ts` (kurs-import-remap) matchet bare `asset:fig`, fant ingen mapping og lot
+  referansen peke på kilde-tokenet → dinglende ref.
+- `sectionContent.ts` (render-omskriving) samme; `asset:fig-…` ble ikke omskrevet til
+  `/api/content-assets/…`, og DOMPurify strippet den ukjente `asset:`-scheme → `<img>` uten `src`
+  (blank figur). De to andre flatene (validate `ASSET_REF_RE`, `/sections`-remap) var allerede brede
+  — derfor virket agent-`/sections`-stien, mens **fallback-fil-importen** feilet.
+
+- **Fix:** begge smale regexene utvidet til den kanoniske `[a-zA-Z0-9_-]+`.
+- **Tester:** integrasjon `(f)` i `m2-content-export-import-assets` — kurs-import med
+  bindestrek/understrek-`sourceId` verifiserer remap + at rendret HTML resolver hver figur (ingen
+  `asset:`-ref igjen); unit-case i `section-content-markdown` for id med `-`/`_`. Begge feilet før
+  fiksen, grønne etter.
+- **Merk:** allerede-importerte kurs må **re-importeres** etter deploy (lagret markdown ble ikke
+  remappet ved den opprinnelige importen). Ingen Prisma-migrasjon. Krever deploy (server-kode).
+
 ## 1.6.24 - 2026-07-13
 
 fix(skill): #749 (Layer B) — CLI-orkestratoren videresender seksjonsfigurer

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,30 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.26 - 2026-07-13
+
+fix(skill): #754 — ASCII-safe fallback-JSON + mojibake-guard i forfatter-flyten
+
+Andre halvdel av #754-verdikjeden. Ved feilsøking av det ChatGPT-produserte importkurset var de
+norske tegnene mojibake (`ø`→`Ã¸`, `æ`→`Ã¦`, `å`→`Ã¥`) — UTF-8-bytes tolket som Latin-1 et sted i
+generér→last ned→importér-kjeden. Plattformen kan ikke trygt reversere garble som først har «bakt
+seg inn» som ekte codepoints, så fiksen hører hjemme **ved kilden** (skillen), ikke ved import.
+
+- **`export-validate.mjs`:** ny `asciiSafeStringify` (escaper alt ikke-ASCII som `\uXXXX`) brukes nå
+  når fallback-fila skrives, så den leverte fila er **ren ASCII** og immun mot enhver
+  nedlasting/editor/transfer-omkoding. Ny `findMojibake` + navngitt round-trip-sjekk
+  `encoding-integrity` som **nekter å levere** en fil som allerede inneholder dobbelt-kodet tekst
+  (base64-blober hoppes over). `describeChecks` navngir sjekken.
+- **Instruksjoner (det som når ChatGPT):** SKILL.md (regel 7), `package-schema.md` (Fallback),
+  `authoring-playbook.md` (§Fallback) og `export-validation.md` krever nå ASCII-safe `\uXXXX`-JSON,
+  med begrunnelse. SVG-figurtekst er upåvirket (bruker XML-entiteter som `&#248;`).
+- **Tester:** unit-dekning for `asciiSafeStringify` (ren-ASCII output, round-trip), `findMojibake`
+  (fanger garble, ren tekst passerer, hopper over base64, riktig path), og round-trip (leverer ren
+  norsk tekst ASCII-safe / nekter mojibaket kilde). Real-schema round-trip fortsatt grønn (`\uXXXX`
+  dekoder korrekt).
+- Kun skill-script + skill-doc + test. **Ingen server-endring, ingen deploy.** Fiksen når ChatGPT
+  ved å laste den nye zip-en (`a2-authoring-api-v1.6.26.zip`) inn i GPT-en/prosjektet. Skill ompakket.
+
 ## 1.6.25 - 2026-07-13
 
 fix(content): #754 — figurer med bindestrek-/understrek-sourceId brytes ved kurs-import

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,32 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.27 - 2026-07-13
+
+docs(skill): #756 — håndhev komplett tre-språklig innhold (nb/nn/en-GB) ved produksjon
+
+Oppfølging fra samme import-test: et ChatGPT-produsert kurs fikk seksjons-`title`/`bodyMarkdown`
+kun på bokmål. Årsak: `section.title`/`bodyMarkdown` bruker `localizedTextPatchSchema` (delvis
+objekt tillatt), så en ren-bokmål seksjon avvises ikke ved import — i motsetning til kurs/modul-
+titler som krever alle tre. Manglende språk må da oversettes sentralt via plattformens on-demand
+LLM-lokalisering (token-kostnad); oversettes det én gang ved produksjon, unngås dette.
+
+`checkLocalization` (`localization-check.mjs`) fanger allerede manglende locale på seksjoner
+deterministisk — men den kan ikke kjøre i en ChatGPT-økt, så kravet må bæres av instruksjonene.
+Innstramming (skill-doc, ingen kodeendring):
+
+- **SKILL.md regel 8:** eksplisitt at levert fil MÅ være komplett i nb/nn/en-GB, **seksjoner
+  inkludert**; partial-skjemaet er ikke en snarvei (ren-bokmål seksjon = ufullstendig levering, ikke
+  gyldig kurs); token-begrunnelsen «oversett én gang her, unngå sentral kostnad».
+- **package-schema.md:** ny «⚠️ deliver all three»-note under «Localized text» med token-rasjonalet,
+  og seksjons- + figur-**eksemplene gjort tre-språklige** (de modellerte nb-only og var dermed feil
+  mal). Figur-eksempelet viser nå `localizedVariants` for både nn og en-GB.
+- **localization.md:** token-rasjonalet + skjema-asymmetrien (hvorfor ren-bokmål seksjon slipper
+  gjennom import) forklart eksplisitt.
+
+Kun skill-doc + versjon. Ingen kodeendring, ingen server-endring, ingen deploy — når ChatGPT via ny
+zip (`a2-authoring-api-v1.6.27.zip`). Skill ompakket.
+
 ## 1.6.26 - 2026-07-13
 
 fix(skill): #754 — ASCII-safe fallback-JSON + mojibake-guard i forfatter-flyten

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.24",
+  "version": "1.6.25",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.25",
+  "version": "1.6.26",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.26",
+  "version": "1.6.27",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/skills/a2-authoring-api/SKILL.md
+++ b/skills/a2-authoring-api/SKILL.md
@@ -85,15 +85,20 @@ the three references above.
    `roundTripFallbackExport` do this and fail delivery on any mojibake; if you hand-write the file,
    emit `\uXXXX` escapes yourself.
    (export-validation.md; `export-validate.mjs`.)
-8. **Localize to all three languages before production.** Fix one primary language for the
-   dialogue (principle 5), then after the primary is approved produce **real translations** for
-   **nb, nn and en-GB** of every student-facing field the schema localizes — not the primary text
-   copied into every locale. Preserve meaning, difficulty, the correct answer, option count+order,
-   and all formulas/identifiers/URLs; verify MCQ correct answers map to the same option in every
-   locale. **This extends to figure `<text>`:** each text-bearing SVG figure gets localizedVariants
-   for the other two locales (translate the labels, geometry unchanged). Block production if a
-   mandatory localized field — or a figure variant — is missing. (localization.md;
-   `localization-check.mjs`.)
+8. **Localize to all three languages before production — the delivered file must be complete.** Fix
+   one primary language for the dialogue (principle 5), then after the primary is approved produce
+   **real translations** for **nb, nn and en-GB** of every student-facing field the schema localizes
+   — not the primary text copied into every locale. **This includes sections:** `section.title` and
+   `bodyMarkdown` accept a *partial* object in the schema (for incremental UI edits), but that is
+   **not** a shortcut — a section shipped in only `nb` is an **incomplete delivery**, not a valid
+   course. Preserve meaning, difficulty, the correct answer, option count+order, and all
+   formulas/identifiers/URLs; verify MCQ correct answers map to the same option in every locale.
+   **This extends to figure `<text>`:** each text-bearing SVG figure gets localizedVariants for the
+   other two locales (translate the labels, geometry unchanged). Block production if a mandatory
+   localized field — or a figure variant — is missing. **Why it's mandatory:** any field left in one
+   language must be translated later by a human through the platform's on-demand LLM localizer —
+   **central token cost avoided entirely by translating once, here.** Translate at production; never
+   defer it to the platform. (localization.md; `localization-check.mjs`.)
 
 9. **Design figures with the text (Layer B).** Where a section would otherwise be a wall of text,
    propose **one simple figure per discrete visual point** and draw it as **SVG** integrated with

--- a/skills/a2-authoring-api/SKILL.md
+++ b/skills/a2-authoring-api/SKILL.md
@@ -78,7 +78,12 @@ the three references above.
    applies to every `audit.publishedAt`. The fallback file must be generated complete → written →
    read back → parsed → schema-validated → delivered only on pass; the validated file **is** the
    delivered file. Name the checks in the report (JSON parsing / export-schema / import-schema /
-   content-integrity / API dry-run / actual import) — **never say "validated" generically**.
+   content-integrity / encoding-integrity / API dry-run / actual import) — **never say "validated"
+   generically**. **Write the JSON ASCII-safe:** escape every non-ASCII character as `\uXXXX` so the
+   file is pure ASCII and `æ/ø/å` survive download/editor/transfer intact (raw UTF-8 re-encoded as
+   Latin-1 becomes `Ã¦/Ã¸/Ã¥` — unreadable in the course). `buildFallbackEnvelope` +
+   `roundTripFallbackExport` do this and fail delivery on any mojibake; if you hand-write the file,
+   emit `\uXXXX` escapes yourself.
    (export-validation.md; `export-validate.mjs`.)
 8. **Localize to all three languages before production.** Fix one primary language for the
    dialogue (principle 5), then after the primary is approved produce **real translations** for

--- a/skills/a2-authoring-api/references/authoring-playbook.md
+++ b/skills/a2-authoring-api/references/authoring-playbook.md
@@ -174,5 +174,9 @@ course import:
    the file is not "validated" until this passes, and the validated file is the delivered file.
    Report the named checks (never a generic "validated"). See
    [export-validation.md](export-validation.md).
+4. **Write it ASCII-safe (#754).** The round-trip emits the JSON with every non-ASCII char escaped as
+   `\uXXXX` and fails delivery on any mojibake, so `æ/ø/å` survive download/import intact. If you
+   hand-write the file (no script), escape non-ASCII yourself — a raw UTF-8 file re-encoded as
+   Latin-1 turns Norwegian text into `Ã¦/Ã¸/Ã¥` in the imported course.
 
 No token or network needed — only that the author can save a file and use the admin UI.

--- a/skills/a2-authoring-api/references/export-validation.md
+++ b/skills/a2-authoring-api/references/export-validation.md
@@ -45,8 +45,11 @@ object and then hand over a differently-written one.
 
 `roundTripFallbackExport(envelope, { filePath, contentIntegrity? })` performs exactly this
 (dates normalised before the write) and returns `{ delivered, file, checks, envelope }`.
-`delivered` is `true` only when JSON parsing, export-schema validation and import-schema
-validation all pass and content-integrity did not fail.
+`delivered` is `true` only when JSON parsing, export-schema validation, import-schema validation
+and encoding-integrity all pass and content-integrity did not fail. The write is **ASCII-safe**
+(#754): every non-ASCII char is emitted as a `\uXXXX` escape so `æ/ø/å` survive any
+download/editor/transfer re-encoding, and `encoding-integrity` refuses to deliver a file that
+already contains double-encoded (`Ã¦/Ã¸/Ã¥`) text.
 
 ## The bundled validator, and why the repo test matters
 
@@ -72,6 +75,7 @@ The production report must distinguish these by name; `describeChecks(report)` p
 | **export-schema validation** | structure matches `a2-content-export/v1` |
 | **import-schema validation** | passes the same acceptance A2's import applies (incl. strict datetimes) |
 | **content-integrity** | loss audit vs the master (see content-preservation.md) |
+| **encoding-integrity** | the read-back file has no double-encoded (`Ã¦/Ã¸/Ã¥`) text; the delivered file is ASCII-safe (`\uXXXX`) (#754) |
 | **API dry-run** | **unavailable** — A2 has no import dry-run endpoint (course import writes) |
 | **actual import** | done by a human in the admin UI; the skill never imports |
 

--- a/skills/a2-authoring-api/references/localization.md
+++ b/skills/a2-authoring-api/references/localization.md
@@ -6,6 +6,14 @@ language for the whole dialogue (core principle 5 — never mix languages while 
 once the primary version is approved, produce **real translations** for all three before
 production — never the same bokmål text copied into every locale field.
 
+**The delivered course must be complete in all three languages — including sections.** The platform
+*can* translate a missing locale on demand, but it does so with a central LLM call that costs tokens
+every time. Translating once, here at production, avoids that recurring central cost entirely — so
+completeness is **mandatory, not "nice to have."** Note the schema asymmetry that makes this easy to
+get wrong: `section.title`/`bodyMarkdown` accept a *partial* object (only `nb` validates at import),
+so a single-language section will **not** be rejected by the platform — the skill must self-enforce
+completeness via `checkLocalization` before delivering.
+
 Deterministic helper: [scripts/localization-check.mjs](../scripts/localization-check.mjs)
 (`checkLocalization`). Unit-tested in `test/unit/agent-authoring-localization.test.ts`.
 

--- a/skills/a2-authoring-api/references/package-schema.md
+++ b/skills/a2-authoring-api/references/package-schema.md
@@ -25,10 +25,20 @@ Design rationale: `doc/design/AGENT_AUTHORING_647.md` §2.
 
 ## Localized text
 
-Every `title`/text field accepts either a **plain string** (recommended — applies to all
-locales) or a locale object. Module/course titles use the strict object form
-(`{"en-GB": "…", "nb": "…", "nn": "…"}` — all three required); section `title`/`bodyMarkdown`
-accept a partial object (e.g. only `nb`).
+Every `title`/text field accepts either a **plain string** or a locale object. Module/course titles
+use the strict object form (`{"en-GB": "…", "nb": "…", "nn": "…"}` — all three required); section
+`title`/`bodyMarkdown` accept a *partial* object (e.g. only `nb`).
+
+> **⚠️ Deliver ALL THREE languages (`nb`, `nn`, `en-GB`) for every localized field — sections
+> included.** The partial-object allowance on `section.title`/`bodyMarkdown` exists for incremental
+> edits in the admin UI; it is **NOT** a licence for an agent to ship a single-language course. A
+> course produced by this skill must be complete in nb, nn **and** en-GB at generation time, with
+> **real translations** — never the primary text copied into every locale, and never one locale left
+> out. **Why it is mandatory, not "ideal":** anything left in one language must be translated later
+> by a human via the platform's on-demand LLM localizer — **central token cost we avoid entirely by
+> translating once, here, at production.** `checkLocalization` blocks a missing locale and flags a
+> blind-copy (see [localization.md](localization.md)). Use a plain string ONLY for a genuinely
+> locale-independent value (a proper noun, a number) — never as a shortcut past translating prose.
 
 ## `type: "section"`
 
@@ -37,14 +47,20 @@ accept a partial object (e.g. only `nb`).
   "clientRef": "intro",
   "type": "section",
   "payload": {
-    "title": "Introduksjon til GDPR",
-    "bodyMarkdown": "## Hva er GDPR\n\nGDPR regulerer …"
+    "title": { "nb": "Introduksjon til GDPR", "nn": "Introduksjon til GDPR", "en-GB": "Introduction to GDPR" },
+    "bodyMarkdown": {
+      "nb": "## Hva er GDPR\n\nGDPR regulerer behandling av personopplysninger …",
+      "nn": "## Kva er GDPR\n\nGDPR regulerer behandling av personopplysningar …",
+      "en-GB": "## What is the GDPR\n\nThe GDPR governs the processing of personal data …"
+    }
   }
 }
 ```
 
-A text-only section needs just `title` + `bodyMarkdown`. To include a figure, add an optional
-`assets[]` and reference each figure from the markdown as `![alt](asset:<sourceId>)` — see below.
+A section needs `title` + `bodyMarkdown`, **each carrying all three locales** (`nb`, `nn`, `en-GB`)
+with real translations — see the mandatory-completeness note above. To include a figure, add an
+optional `assets[]` and reference each figure from the markdown as `![alt](asset:<sourceId>)` —
+below.
 
 ### Section figures — optional `assets[]` (#763, Layer B)
 
@@ -57,8 +73,12 @@ and carries them inline on the section payload:
   "clientRef": "prosess",
   "type": "section",
   "payload": {
-    "title": "Saksgangen",
-    "bodyMarkdown": "## Saksgang\n\n![Saksflyt](asset:fig-flow)",
+    "title": { "nb": "Saksgangen", "nn": "Sakshandsaminga", "en-GB": "The case workflow" },
+    "bodyMarkdown": {
+      "nb": "## Saksgang\n\n![Saksflyt](asset:fig-flow)",
+      "nn": "## Sakshandsaming\n\n![Saksflyt](asset:fig-flow)",
+      "en-GB": "## Case workflow\n\n![Case flow](asset:fig-flow)"
+    },
     "assets": [
       {
         "sourceId": "fig-flow",
@@ -67,7 +87,10 @@ and carries them inline on the section payload:
         "sizeBytes": 1234,
         "contentBase64": "PHN2Zy…",
         "sourceLocale": "nb",
-        "localizedVariants": [ { "locale": "en-GB", "contentBase64": "PHN2Zy…" } ]
+        "localizedVariants": [
+          { "locale": "nn", "contentBase64": "PHN2Zy…" },
+          { "locale": "en-GB", "contentBase64": "PHN2Zy…" }
+        ]
       }
     ]
   }

--- a/skills/a2-authoring-api/references/package-schema.md
+++ b/skills/a2-authoring-api/references/package-schema.md
@@ -256,6 +256,14 @@ this, `asset:<id>` markdown refs would break on the destination). Each entry:
   `buildFallbackEnvelope` and validate it with the round-trip in
   [export-validation.md](export-validation.md) (`scripts/export-validate.mjs`); do not hand-roll
   the date or call the file "validated" without the read-back check.
+- **Encoding — write ASCII-safe JSON (#754).** Escape every non-ASCII character as a `\uXXXX` JSON
+  escape so the delivered file is pure ASCII. A `\uXXXX` escape decodes to the correct codepoint in
+  any JSON parser regardless of the file's byte encoding, so Norwegian `æ/ø/å` cannot be corrupted by
+  a download/editor/transfer that re-encodes UTF-8 as Latin-1 (which turns them into `Ã¦/Ã¸/Ã¥`).
+  `buildFallbackEnvelope` + `roundTripFallbackExport` emit ASCII-safe output and **refuse to deliver**
+  a file that already contains such mojibake (the `encoding-integrity` check); if you hand-write the
+  file instead, emit the `\uXXXX` escapes yourself. (SVG figure text is unaffected — it uses XML
+  numeric entities like `&#248;`.)
 
 Only whole courses use this fallback path; a lone module can use the module-scoped envelope
 (`scope: "module"`) the same way.

--- a/skills/a2-authoring-api/scripts/export-validate.mjs
+++ b/skills/a2-authoring-api/scripts/export-validate.mjs
@@ -41,6 +41,50 @@ export function isStrictDatetime(value) {
   return typeof value === "string" && STRICT_DATETIME_RE.test(value);
 }
 
+// #754: emit ASCII-safe JSON — every non-ASCII char as a `\uXXXX` escape — so the DELIVERED file is
+// pure ASCII and survives any download/editor/transfer that would otherwise re-encode UTF-8. That
+// re-encoding is what turns æ/ø/å into Ã¦/Ã¸/Ã¥ (UTF-8 bytes read as Latin-1). A `\uXXXX` escape is
+// decoded to the correct codepoint by every JSON parser regardless of the file's byte encoding, so
+// the class of bug cannot occur. (SVG asset text already uses XML numeric entities; this covers the
+// title/markdown/description prose.)
+export function asciiSafeStringify(value, space = 2) {
+  return JSON.stringify(value, null, space).replace(
+    /[-￿]/g,
+    (ch) => `\\u${ch.charCodeAt(0).toString(16).padStart(4, "0")}`,
+  );
+}
+
+// #754: the UTF-8-decoded-as-Latin-1 double-encoding signature — a leading byte Ã (U+00C3) or
+// Â (U+00C2) followed by a continuation byte (U+0080–U+00BF). Norwegian/European prose virtually
+// never contains this legitimately, so it is a high-precision "this text is already mis-encoded"
+// signal. Detection only — a mojibaked source cannot be safely reversed, so the fix is to reject it
+// (and to write ASCII-safe going forward), never to guess the original bytes.
+const MOJIBAKE_RE = /[ÂÃ][-¿]/;
+
+// Walk every string value in an envelope; return [{ path, sample }] for values that look
+// double-encoded. `contentBase64` blobs are skipped — they are not human text.
+export function findMojibake(value, path = "") {
+  const offenders = [];
+  const walk = (v, p) => {
+    if (typeof v === "string") {
+      if (MOJIBAKE_RE.test(v)) offenders.push({ path: p, sample: v.slice(0, 40) });
+      return;
+    }
+    if (Array.isArray(v)) {
+      v.forEach((item, i) => walk(item, `${p}[${i}]`));
+      return;
+    }
+    if (v && typeof v === "object") {
+      for (const [k, child] of Object.entries(v)) {
+        if (k === "contentBase64") continue;
+        walk(child, p ? `${p}.${k}` : k);
+      }
+    }
+  };
+  walk(value, path);
+  return offenders;
+}
+
 // Every datetime field at risk in an export envelope: the top-level exportedAt, and every
 // audit.publishedAt (course audit + each item's module/section audit). Returns [{ path, value }].
 export function collectDatetimeFields(envelope) {
@@ -290,6 +334,7 @@ export async function roundTripFallbackExport(
     exportSchemaValidation: { status: "not-run" },
     importSchemaValidation: { status: "not-run" },
     contentIntegrity: { status: "not-run" },
+    encodingIntegrity: { status: "not-run" },
     apiDryRun: { status: "unavailable", detail: "A2 has no import dry-run endpoint (course import writes)" },
     actualImport: { status: "skipped", detail: "human imports the delivered file via the admin UI; the skill never imports" },
   };
@@ -297,8 +342,9 @@ export async function roundTripFallbackExport(
   // Step 1: normalise dates on the complete, generated envelope before writing.
   const normalized = normalize ? normalizeEnvelopeDates(envelope) : envelope;
 
-  // Step 2: write.
-  await writeFileImpl(filePath, `${JSON.stringify(normalized, null, 2)}\n`, "utf8");
+  // Step 2: write ASCII-safe (#754) — every non-ASCII char as `\uXXXX` so the delivered file is pure
+  // ASCII and immune to the UTF-8→Latin-1 re-encoding that produces æ/ø/å → Ã¦/Ã¸/Ã¥ mojibake.
+  await writeFileImpl(filePath, `${asciiSafeStringify(normalized, 2)}\n`, "utf8");
 
   // Step 3-4: read back and parse the FINISHED file (never the in-memory object).
   let parsed;
@@ -328,10 +374,17 @@ export async function roundTripFallbackExport(
       : { status: "pass" };
   }
 
+  // Step 5d: encoding integrity (#754) — the read-back file must carry no double-encoded (mojibake)
+  // text. A garbled source cannot be safely reversed, so it is NOT deliverable: the author must fix
+  // the source encoding (or regenerate) rather than ship unreadable Norwegian into the course.
+  const mojibake = findMojibake(parsed);
+  checks.encodingIntegrity = mojibake.length === 0 ? { status: "pass" } : { status: "fail", offenders: mojibake };
+
   const passed =
     checks.jsonParsing.status === "pass" &&
     checks.exportSchemaValidation.status === "pass" &&
     checks.importSchemaValidation.status === "pass" &&
+    checks.encodingIntegrity.status === "pass" &&
     checks.contentIntegrity.status !== "fail";
 
   return { delivered: passed, file: filePath, checks, envelope: parsed };
@@ -350,6 +403,7 @@ export function describeChecks(report) {
     exportSchemaValidation: "export-schema validation",
     importSchemaValidation: "import-schema validation",
     contentIntegrity: "content-integrity",
+    encodingIntegrity: "encoding-integrity",
     apiDryRun: "API dry-run",
     actualImport: "actual import",
   };

--- a/src/modules/adminContent/contentImportService.ts
+++ b/src/modules/adminContent/contentImportService.ts
@@ -54,10 +54,12 @@ export const COURSE_IMPORT_BODY_LIMIT_BYTES = 35 * 1024 * 1024; // 35 MB
 // to `asset:<newAssetId>` using the source→new id map produced when the section's assets are
 // re-created. Refs with no mapping are left untouched (defensive — an author-mistyped ref should
 // not be silently mangled). The markdown is the JSON-serialised localized string, so the replace
-// runs across every locale value at once. Mirrors the `asset:` ref grammar in sectionContent.ts.
+// runs across every locale value at once. Grammar is the canonical `[a-zA-Z0-9_-]` asset-ref set
+// (#754): agent fallback files carry invented sourceIds like `fig-styringslogikker` — a narrower
+// class would match only up to the first hyphen and leave the ref dangling.
 function remapAssetRefs(serializedMarkdown: string, idMap: Map<string, string>): string {
   if (idMap.size === 0) return serializedMarkdown;
-  return serializedMarkdown.replace(/asset:([a-zA-Z0-9]+)/g, (whole, sourceId: string) => {
+  return serializedMarkdown.replace(/asset:([a-zA-Z0-9_-]+)/g, (whole, sourceId: string) => {
     const mapped = idMap.get(sourceId);
     return mapped ? `asset:${mapped}` : whole;
   });

--- a/src/modules/course/sectionContent.ts
+++ b/src/modules/course/sectionContent.ts
@@ -81,7 +81,11 @@ export function sanitizeSectionHtml(html: string): string {
 // the translated SVG variant for that language pane (raster/untranslated assets ignore it).
 function resolveAssetUrls(html: string, locale?: string): string {
   const suffix = locale ? `?locale=${encodeURIComponent(locale)}` : "";
-  return html.replace(/(<img\b[^>]*\bsrc=")asset:([a-zA-Z0-9]+)(")/gi, `$1/api/content-assets/$2${suffix}$3`);
+  // Canonical asset-ref grammar `[a-zA-Z0-9_-]` (#754). A narrower class stops at the first hyphen,
+  // leaving `asset:fig-x` unresolved — DOMPurify then strips the unknown `asset:` scheme and the
+  // <img> loses its src entirely (a blank figure). Real ids are cuids, but refs may carry an
+  // agent-invented sourceId if an upstream remap missed it, so match the full documented grammar.
+  return html.replace(/(<img\b[^>]*\bsrc=")asset:([a-zA-Z0-9_-]+)(")/gi, `$1/api/content-assets/$2${suffix}$3`);
 }
 
 /**

--- a/test/m2-content-export-import-assets.test.ts
+++ b/test/m2-content-export-import-assets.test.ts
@@ -17,6 +17,7 @@ import { prisma } from "../src/db/prisma.js";
 import { createSectionAsset, MAX_ASSET_BYTES } from "../src/modules/course/assetCommands.js";
 import { updateSectionContent } from "../src/modules/course/sectionCommands.js";
 import { putAsset, getAsset } from "../src/modules/course/assetStorage.js";
+import { renderSectionMarkdown } from "../src/modules/course/sectionContent.js";
 
 const adminHeaders = {
   "x-user-id": "admin-1",
@@ -267,6 +268,61 @@ describe("#749 section-asset export/import round-trip", () => {
     expect(exportRes.status).toBe(400);
     expect(exportRes.body.error).toBe("validation_error");
     expect(String(exportRes.body.message)).toMatch(/cap/i);
+  });
+
+  it("(f) #754 remaps refs whose sourceId contains hyphens/underscores (agent fallback files)", async () => {
+    // An agent (e.g. ChatGPT via the skill) invents sourceIds like `fig-styringslogikker`
+    // ([a-zA-Z0-9_-]{1,64}). The import-time remap must rewrite the WHOLE ref, not stop at the
+    // first hyphen — otherwise the ref keeps pointing at the source token and the figure breaks.
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><text>Styringslogikker</text></svg>';
+    const envelope = {
+      exportFormat: "a2-content-export/v1",
+      exportedAt: new Date().toISOString(),
+      scope: "course",
+      course: {
+        course: {
+          title: { "en-GB": `Hyphen ${Date.now()}`, nb: "Bindestrek", nn: "Bindestrek" },
+          certificationLevel: null,
+          audit: {},
+          items: [
+            {
+              type: "SECTION",
+              sortOrder: 0,
+              section: {
+                title: { nb: "Figur-seksjon" },
+                bodyMarkdown: { nb: "# Styring\n\n![Tre logikker](asset:fig-styringslogikker)\n\n![Flyt](asset:fig_nytte-2)" },
+                audit: {},
+                assets: [
+                  { sourceId: "fig-styringslogikker", filename: "a.svg", mimeType: "image/svg+xml", sizeBytes: svg.length, contentBase64: Buffer.from(svg, "utf8").toString("base64") },
+                  { sourceId: "fig_nytte-2", filename: "b.svg", mimeType: "image/svg+xml", sizeBytes: svg.length, contentBase64: Buffer.from(svg, "utf8").toString("base64") },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const importRes = await request(app)
+      .post("/api/admin/content/courses/import")
+      .set(adminHeaders)
+      .send({ payload: envelope, mode: "createNew" });
+    expect(importRes.status, JSON.stringify(importRes.body)).toBe(201);
+
+    const newSectionId = await newSectionIdOf(importRes.body.courseId);
+    const rows = await prisma.sectionAsset.findMany({ where: { sectionId: newSectionId }, orderBy: { createdAt: "asc" } });
+    expect(rows).toHaveLength(2);
+
+    const section = await prisma.courseSection.findUnique({ where: { id: newSectionId }, include: { activeVersion: true } });
+    const body = section?.activeVersion?.bodyMarkdown ?? "";
+    // Every ref remapped to a real new asset id; no source token survives.
+    for (const row of rows) expect(body).toContain(`asset:${row.id}`);
+    expect(body).not.toContain("asset:fig-styringslogikker");
+    expect(body).not.toContain("asset:fig_nytte-2");
+    // The rendered HTML resolves each figure to the serve endpoint (no dangling asset: ref).
+    const html = renderSectionMarkdown(JSON.parse(body).nb);
+    expect(html).not.toContain('src="asset:');
+    for (const row of rows) expect(html).toContain(`/api/content-assets/${row.id}`);
   });
 
   it("(e) imports an old asset-less v1 file unchanged (no SectionAsset rows)", async () => {

--- a/test/unit/agent-authoring-export-validate.test.ts
+++ b/test/unit/agent-authoring-export-validate.test.ts
@@ -12,6 +12,8 @@ import {
   roundTripFallbackExport,
   claimsImportValidated,
   describeChecks,
+  asciiSafeStringify,
+  findMojibake,
   // @ts-expect-error — .mjs skill script consumed as a library
 } from "../../skills/a2-authoring-api/scripts/export-validate.mjs";
 
@@ -165,6 +167,54 @@ describe("#762 round-trip fallback export", () => {
     });
     expect(report.delivered).toBe(false);
     expect(report.checks.contentIntegrity.status).toBe("fail");
+  });
+});
+
+describe("#754 encoding integrity (mojibake guard)", () => {
+  // Build non-ASCII from char codes so THIS test file stays ASCII and its own bytes can't drift.
+  const oe = String.fromCharCode(0xf8); // ø
+  const ae = String.fromCharCode(0xe6); // æ
+  const aa = String.fromCharCode(0xe5); // å
+  const garbledOe = String.fromCharCode(0xc3, 0xb8); // ø as UTF-8 bytes read as Latin-1: Ã¸
+
+  it("asciiSafeStringify escapes every non-ASCII char (delivered file is pure ASCII)", () => {
+    const out = asciiSafeStringify({ t: `Forel${oe}pig l${ae}ringsm${aa}l` });
+    expect(out).toContain("\\u00f8");
+    expect(out).toContain("\\u00e6");
+    expect(out).toContain("\\u00e5");
+    // No raw byte above 0x7f survives.
+    expect([...out].every((c) => c.charCodeAt(0) < 128)).toBe(true);
+    // Round-trips back to the original text.
+    expect(JSON.parse(out).t).toBe(`Forel${oe}pig l${ae}ringsm${aa}l`);
+  });
+
+  it("findMojibake flags double-encoded text, passes clean text, skips base64 blobs", () => {
+    expect(findMojibake({ t: `Forel${garbledOe}pig` })).toHaveLength(1);
+    expect(findMojibake({ t: `Forel${oe}pig` })).toHaveLength(0);
+    expect(findMojibake({ contentBase64: `AAAA${garbledOe}` })).toHaveLength(0);
+    expect(findMojibake({ s: { deep: [`ok`, `bad${garbledOe}`] } })[0].path).toBe("s.deep[1]");
+  });
+
+  it("round-trip delivers clean Norwegian text as ASCII-safe and passes encoding-integrity", async () => {
+    const fs = memoryFs();
+    const envelope = buildFallbackEnvelope(pkg, { exportedAt: "2026-07-10T21:05:15.364Z" });
+    envelope.course.course.description = { nb: `Forel${oe}pig importtest med l${ae}ringsseksjon` };
+    const report = await roundTripFallbackExport(envelope, { filePath: "kurs.json", ...fs });
+    expect(report.delivered).toBe(true);
+    expect(report.checks.encodingIntegrity.status).toBe("pass");
+    // The written file carries no raw non-ASCII bytes — encoding-proof by construction.
+    expect([...(fs.files.get("kurs.json") ?? "")].every((c) => c.charCodeAt(0) < 128)).toBe(true);
+    expect(fs.files.get("kurs.json")).toContain("\\u00f8");
+  });
+
+  it("round-trip does NOT deliver when the source text is already mojibaked", async () => {
+    const fs = memoryFs();
+    const envelope = buildFallbackEnvelope(pkg, { exportedAt: "2026-07-10T21:05:15.364Z" });
+    envelope.course.course.description = { nb: `Forel${garbledOe}pig` };
+    const report = await roundTripFallbackExport(envelope, { filePath: "kurs.json", ...fs });
+    expect(report.delivered).toBe(false);
+    expect(report.checks.encodingIntegrity.status).toBe("fail");
+    expect(report.checks.encodingIntegrity.offenders[0].path).toContain("description");
   });
 });
 

--- a/test/unit/section-content-markdown.test.ts
+++ b/test/unit/section-content-markdown.test.ts
@@ -105,4 +105,12 @@ describe("asset URL resolution (#483/F4)", () => {
     const html = renderSectionMarkdown("![x](https://a-2.no/f.png)");
     expect(html).toContain('src="https://a-2.no/f.png"');
   });
+
+  // #754: the asset-ref grammar allows `-` and `_` (authoring sourceId is [a-zA-Z0-9_-]{1,64}).
+  // The render rewrite must match the whole ref, not stop at the first hyphen.
+  it("rewrites asset ids containing hyphens and underscores", () => {
+    const html = renderSectionMarkdown("![Figur](asset:fig-styringslogikker_2)");
+    expect(html).toContain('src="/api/content-assets/fig-styringslogikker_2"');
+    expect(html).not.toContain("asset:fig-styringslogikker_2");
+  });
 });


### PR DESCRIPTION
Tre funn fra samme import-test-økt av et ChatGPT-produsert kurs. Fixes #754, #756.

## 1.6.25 — figur-refs med bindestrek (server-kode, krever deploy) — #754
Kurs-import-remap + render brukte for smal `[a-zA-Z0-9]+`; `asset:fig-…` ble ikke omskrevet → figur uten `src`. Utvidet til `[a-zA-Z0-9_-]+`. **Deployet til stage, verifisert av bruker (figurer renders).** Integrasjon `(f)` + render-unit.

## 1.6.26 — ASCII-safe fallback-JSON + mojibake-guard (skill, ingen deploy) — #754
`asciiSafeStringify` (`\uXXXX`) + `findMojibake` + `encoding-integrity`-sjekk i round-trip, så levert fil er encoding-immun og en garblet fil ikke leveres. Instruksjoner oppdatert. (Merk: brukerens fil viste seg ren UTF-8 — mojibaken var en innlimings-artefakt; dette er forsikring.)

## 1.6.27 — tre-språklighet håndhevet ved produksjon (skill, ingen deploy) — #756
Seksjons-`title`/`bodyMarkdown` bruker patch-skjema (partial), så ren-bokmål seksjon avvises ikke ved import → manglende språk oversettes sentralt (token-kostnad). SKILL.md regel 8 + `package-schema.md` (note + tre-språklige eksempler) + `localization.md` strammet inn med token-rasjonalet. `checkLocalization` dekker allerede seksjoner deterministisk.

## Test
`tsc` grønn. Asset-, export-validate/round-trip/section- og localization-suiter grønne mot native Postgres.

## Utrulling
- 1.6.25: app-deploy (gjort på stage); allerede-importerte kurs re-importeres.
- 1.6.26 + 1.6.27: last ny skill-zip `a2-authoring-api-v1.6.27.zip` inn i ChatGPT-GPT-en/prosjektet. Ingen deploy.

## Rollback
Ren revert; ingen data/infra/migrasjon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)