### PR TITLE
feat(assets): #758 — reklamer blob-lagring ved sletting av seksjon/kurs (v1.6.28)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,33 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.28 - 2026-07-14
+
+feat(assets): #758 — reklamer blob-lagring når seksjoner/kurs slettes
+
+Del av #478 (Tier 2 livssyklus). Til nå ble `SectionAsset`-rader cascade-slettet med seksjonen
+(`onDelete: Cascade`), men **selve blobene ble aldri slettet** — `assetStorage` hadde ingen slette-
+funksjon, og ingen kode slettet en blob. Foreldreløse figur-/bilde-blober hopet seg opp i Azure
+Blob Storage og ble betalt for i det uendelige. Prioritert nå fordi video / høyoppløselige bilder
+gjør hver lekket blob dyr — fokus på å sikre framtidige slettinger (ikke rydde eksisterende backlog).
+
+- **`assetStorage.deleteAsset(blobPath)`** — Azure `deleteIfExists` / fs `rm --force`. Idempotent
+  (manglende blob er ikke feil), så dobbel-slett/allerede-borte er trygt.
+- **`assetCommands.collectSectionAssetBlobPaths(sectionIds)`** — samler hver seksjons base-blob +
+  `localizedBlobPaths`-varianter, hentet **før** DB-slettingen (radene cascader bort). Dedup.
+- **`assetCommands.reclaimAssetBlobs(paths)`** — best-effort, kjøres **etter** commit (aldri før: en
+  rullet-tilbake transaksjon må ikke miste blober for en seksjon som fortsatt finnes). Feil logges,
+  velter aldri slettingen.
+- Koblet inn i begge choke points: `deleteSection` og `courseCascadeDeleteService` (#748-cascaden).
+  Størrelse-/type-agnostisk — virker likt for framtidig video/hi-res.
+- Tester: `deleteSection` fjerner base + varianter fysisk (verifisert via `getAsset` som kaster);
+  cascade-slett rydder eksklusive seksjoners blober. Bredere asset-suite grønn (ingen regresjon).
+
+Bevisst UTENFOR scope (lav prio, backlog lite nå): mark-and-sweep GC for eksisterende foreldreløse
+blober + andre kilder (import-feil, fjern-figur-uten-slett-seksjon, erstattede sertifikat-bilder).
+
+Server-kode. Ingen Prisma-migrasjon. Krever deploy for å tre i kraft.
+
 ## 1.6.27 - 2026-07-13
 
 docs(skill): #756 — håndhev komplett tre-språklig innhold (nb/nn/en-GB) ved produksjon

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.27",
+  "version": "1.6.28",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/course/assetCommands.ts
+++ b/src/modules/course/assetCommands.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { prisma } from "../../db/prisma.js";
 import { NotFoundError, ValidationError } from "../../errors/AppError.js";
-import { putAsset, getAsset } from "./assetStorage.js";
+import { putAsset, getAsset, deleteAsset } from "./assetStorage.js";
 import { sanitizeSvg, svgHasText, extractSvgTexts, applySvgTextTranslations } from "./svgSanitizer.js";
 import { localizeSvgTexts, type GenerationLocale } from "../adminContent/llmContentGenerationService.js";
 import { SUPPORTED_LOCALES, type SupportedLocale } from "../../i18n/locale.js";
@@ -81,6 +81,43 @@ function readLocalizedBlobPaths(value: unknown): Record<string, string> {
     return value as Record<string, string>;
   }
   return {};
+}
+
+// #758: every stored blob path the given sections' assets occupy — each asset's base blob plus every
+// localized SVG variant. Query this BEFORE the sections are deleted: `SectionAsset` cascades away
+// with the section (`onDelete: Cascade`), so afterwards there is nothing left to look the paths up
+// from. Returns a flat, de-duplicated list.
+export async function collectSectionAssetBlobPaths(sectionIds: string[]): Promise<string[]> {
+  if (sectionIds.length === 0) return [];
+  const assets = await prisma.sectionAsset.findMany({
+    where: { sectionId: { in: sectionIds } },
+    select: { blobPath: true, localizedBlobPaths: true },
+  });
+  const paths = new Set<string>();
+  for (const asset of assets) {
+    paths.add(asset.blobPath);
+    for (const variant of Object.values(readLocalizedBlobPaths(asset.localizedBlobPaths))) {
+      if (variant) paths.add(variant);
+    }
+  }
+  return [...paths];
+}
+
+// #758: best-effort blob reclamation. Call AFTER the DB delete has COMMITTED — never before, or a
+// rolled-back transaction would strand a live section whose blobs were already gone. A failed delete
+// is logged and skipped (the row is already deleted; a rare leftover blob is cheaper than a failed
+// user-facing delete), so this never throws.
+export async function reclaimAssetBlobs(blobPaths: string[]): Promise<void> {
+  for (const blobPath of blobPaths) {
+    try {
+      await deleteAsset(blobPath);
+    } catch (error) {
+      console.warn(
+        `[asset-reclaim] failed to delete blob "${blobPath}":`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
 }
 
 export async function getSectionAssetContent(

--- a/src/modules/course/assetStorage.ts
+++ b/src/modules/course/assetStorage.ts
@@ -40,3 +40,14 @@ export async function getAsset(blobPath: string): Promise<Buffer> {
   }
   return fs.readFile(path.join(localDir, blobPath));
 }
+
+// #758: reclaim a stored blob when its owning section/asset is deleted, so we stop paying for
+// orphaned figure/image storage. Idempotent — a missing blob is not an error (`deleteIfExists` /
+// `rm` with `force`), so double-deletes and already-gone paths are safe.
+export async function deleteAsset(blobPath: string): Promise<void> {
+  if (assetStorageMode === "blob") {
+    await getContainerClient().getBlockBlobClient(blobPath).deleteIfExists();
+    return;
+  }
+  await fs.rm(path.join(localDir, blobPath), { force: true });
+}

--- a/src/modules/course/courseCascadeDeleteService.ts
+++ b/src/modules/course/courseCascadeDeleteService.ts
@@ -7,6 +7,7 @@ import { localizeContentText } from "../../i18n/content.js";
 import { adminContentRepository } from "../adminContent/adminContentRepository.js";
 import { courseRepository } from "./courseRepository.js";
 import { findCoursesContainingModule, findCoursesContainingSection } from "./contentLifecycle.js";
+import { collectSectionAssetBlobPaths, reclaimAssetBlobs } from "./assetCommands.js";
 
 // #762 — ADMINISTRATOR-only destructive cleanup: delete a course together with the modules and
 // sections that ONLY that course owns, while never destroying real assessment/achievement records.
@@ -192,6 +193,10 @@ export async function cascadeDeleteCourse(
   const sparedModuleIds = analysis.sparedModules.map((m) => m.id);
   const sparedSectionIds = analysis.sparedSections.map((s) => s.id);
 
+  // #758: capture the exclusive sections' asset blob paths before the transaction deletes them —
+  // SectionAsset cascades away with each section, so this is the last chance to learn the paths.
+  const sectionBlobPaths = await collectSectionAssetBlobPaths(deletedSectionIds);
+
   await runInTransaction(async (tx) => {
     // 1. Unlink modules/sections from this course so the CourseItem Restrict FK no longer blocks
     //    deleting them. CourseModule is the deprecated join (kept during expand-contract) — remove
@@ -227,6 +232,10 @@ export async function cascadeDeleteCourse(
     //    guaranteed empty by the blocker check above.
     await tx.course.delete({ where: { id: courseId } });
   });
+
+  // #758: after commit, reclaim the deleted sections' asset blobs (best-effort — a failed blob
+  // delete never fails the cascade; the section rows are already gone).
+  await reclaimAssetBlobs(sectionBlobPaths);
 
   // Audit: one summary event for the course, plus a per-module deleted event (consistent with the
   // bulk purge). Audit rows have no FK to the deleted entities, so referencing removed ids is safe.

--- a/src/modules/course/sectionCommands.ts
+++ b/src/modules/course/sectionCommands.ts
@@ -4,7 +4,7 @@ import { NotFoundError, ValidationError } from "../../errors/AppError.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes, agentAuthoringAuditMetadata, type AgentAuthoringContext } from "../../observability/auditEvents.js";
 import { assertSectionNotInAnyCourse } from "./contentLifecycle.js";
-import { importSectionAssets } from "./assetCommands.js";
+import { importSectionAssets, collectSectionAssetBlobPaths, reclaimAssetBlobs } from "./assetCommands.js";
 
 // #763 (Layer B): the agent section-create route inlines figures/images (base64), so the JSON body
 // can exceed the 5 MB global parser. Sized to cover a handful of SVG figures + localized variants
@@ -301,12 +301,17 @@ export async function deleteSection(sectionId: string) {
   await assertSectionExists(sectionId);
   // G2: navngir kursene (konsistent med modul-sletting).
   await assertSectionNotInAnyCourse(sectionId, "slettes");
+  // #758: capture the section's asset blob paths before the delete — SectionAsset rows cascade away
+  // with the section, so afterwards there is nothing left to look them up from.
+  const blobPaths = await collectSectionAssetBlobPaths([sectionId]);
   await runInTransaction(async (tx) => {
     // Detach activeVersion FK before deleting versions to avoid the self-reference.
     await tx.courseSection.update({ where: { id: sectionId }, data: { activeVersionId: null } });
     await tx.courseSectionVersion.deleteMany({ where: { sectionId } });
     await tx.courseSection.delete({ where: { id: sectionId } });
   });
+  // After commit: reclaim the storage (best-effort — a failed blob delete never fails the delete).
+  await reclaimAssetBlobs(blobPaths);
 }
 
 async function assertSectionExists(sectionId: string) {

--- a/test/m2-course-cascade-delete.test.ts
+++ b/test/m2-course-cascade-delete.test.ts
@@ -3,6 +3,8 @@ import { afterAll, describe, expect, it } from "vitest";
 import { app } from "../src/app.js";
 import { prisma } from "../src/db/prisma.js";
 import { auditActions, auditEntityTypes } from "../src/observability/auditEvents.js";
+import { createSectionAsset } from "../src/modules/course/assetCommands.js";
+import { getAsset } from "../src/modules/course/assetStorage.js";
 
 // #762 — ADMINISTRATOR-only cascade delete of a course + the modules/sections it exclusively owns.
 // Verifies the safety model: exclusive deletable content is removed (incl. version rows), shared
@@ -174,6 +176,29 @@ describe("Course cascade delete (#762)", () => {
       where: { entityType: auditEntityTypes.course, entityId: courseId, action: auditActions.course.cascadeDeleted },
     });
     expect(audit).not.toBeNull();
+  });
+
+  // #758: cascade-deleting a course must reclaim the exclusive sections' asset blobs from storage,
+  // not just the DB rows — otherwise the images accumulate in storage forever.
+  it("reclaims the exclusive sections' asset blobs from storage on cascade delete", async () => {
+    const sectionId = await makeSection();
+    await createSectionAsset({
+      sectionId,
+      filename: "fig.svg",
+      mimeType: "image/svg+xml",
+      buffer: Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><text>Hei</text></svg>', "utf8"),
+    });
+    const before = await prisma.sectionAsset.findFirstOrThrow({ where: { sectionId }, select: { blobPath: true } });
+    await expect(getAsset(before.blobPath)).resolves.toBeInstanceOf(Buffer);
+
+    const courseId = await makeCourse([{ itemType: "SECTION", sectionId }]);
+    const res = await request(app).post(`/api/admin/content/courses/${courseId}/cascade-delete`).set(adminHeaders);
+    expect(res.status).toBe(200);
+    expect(res.body.deletedSectionIds).toContain(sectionId);
+
+    // Row cascaded AND the blob physically reclaimed.
+    expect(await prisma.sectionAsset.count({ where: { sectionId } })).toBe(0);
+    await expect(getAsset(before.blobPath)).rejects.toThrow();
   });
 
   // (b) A module used by ANOTHER course is spared — still exists, still in the other course, only

--- a/test/m2-section-assets.test.ts
+++ b/test/m2-section-assets.test.ts
@@ -2,6 +2,7 @@ import request from "supertest";
 import { afterAll, describe, expect, it } from "vitest";
 import { app } from "../src/app.js";
 import { prisma } from "../src/db/prisma.js";
+import { getAsset } from "../src/modules/course/assetStorage.js";
 
 const adminHeaders = {
   "x-user-id": "admin-1",
@@ -156,5 +157,45 @@ describe("Section asset upload + serve", () => {
   it("returns 404 for an unknown asset id", async () => {
     const res = await request(app).get("/api/content-assets/does-not-exist").set(participantHeaders);
     expect(res.status).toBe(404);
+  });
+
+  // #758: deleting a section must reclaim its stored blobs (base + localized variants), not just the
+  // DB rows — otherwise the images accumulate in storage forever.
+  it("reclaims asset blobs from storage when the section is deleted", async () => {
+    const sectionId = await createSection();
+    await request(app)
+      .post(`/api/admin/content/sections/${sectionId}/assets`)
+      .set(adminHeaders)
+      .attach("file", PNG_1PX, { filename: "pixel.png", contentType: "image/png" });
+    const svg = Buffer.from(
+      `<svg xmlns="http://www.w3.org/2000/svg" width="50" height="20"><text x="2" y="12">Start</text></svg>`,
+      "utf8",
+    );
+    await request(app)
+      .post(`/api/admin/content/sections/${sectionId}/assets`)
+      .set(adminHeaders)
+      .attach("file", svg, { filename: "d.svg", contentType: "image/svg+xml" });
+    // Localize the SVG so at least one variant blob also exists.
+    await request(app)
+      .post(`/api/admin/content/sections/${sectionId}/assets/localize`)
+      .set(adminHeaders)
+      .send({ sourceLocale: "nb" });
+
+    // Every stored blob path (base blobs + localized variants) — captured before deletion.
+    const rows = await prisma.sectionAsset.findMany({ where: { sectionId }, select: { blobPath: true, localizedBlobPaths: true } });
+    const blobPaths = rows.flatMap((r) => [
+      r.blobPath,
+      ...Object.values((r.localizedBlobPaths as Record<string, string> | null) ?? {}),
+    ]);
+    expect(blobPaths.length).toBeGreaterThanOrEqual(3); // png + svg base + ≥1 variant
+    for (const p of blobPaths) await expect(getAsset(p)).resolves.toBeInstanceOf(Buffer);
+
+    // Delete via the real route (deleteSection → reclaimAssetBlobs).
+    const del = await request(app).delete(`/api/admin/content/sections/${sectionId}`).set(adminHeaders);
+    expect(del.status).toBe(204);
+
+    // Rows cascaded AND blobs physically reclaimed.
+    expect(await prisma.sectionAsset.count({ where: { sectionId } })).toBe(0);
+    for (const p of blobPaths) await expect(getAsset(p)).rejects.toThrow();
   });
 });


### PR DESCRIPTION
Closes #758. Del av #478 (Tier 2 livssyklus).

## Problem
`SectionAsset`-rader cascade-slettes med seksjonen (`onDelete: Cascade`), men **blobene ble aldri slettet** — `assetStorage` hadde ingen slette-funksjon. Foreldreløse figur-/bilde-blober hoper seg opp i Azure Blob Storage og betales for i det uendelige. Prioritert nå fordi video / høyoppløselige bilder gjør hver lekket blob dyr.

## Løsning (go-forward)
- `assetStorage.deleteAsset(blobPath)` — Azure `deleteIfExists` / fs `rm --force`, idempotent.
- `collectSectionAssetBlobPaths(sectionIds)` — base + `localizedBlobPaths`-varianter, hentet **før** DB-slettingen (radene cascader bort).
- `reclaimAssetBlobs(paths)` — best-effort, **etter** commit (aldri før: rollback må ikke miste blober for en levende seksjon). Feil logges, velter ikke slettingen.
- Koblet inn i begge choke points: `deleteSection` + `courseCascadeDeleteService` (#748). Størrelse-/type-agnostisk (video/hi-res).

## Test
- `deleteSection` fjerner base + lokaliserte varianter **fysisk** (verifisert: `getAsset` kaster etterpå).
- Cascade-slett rydder eksklusive seksjoners blober.
- `tsc` grønn; bredere asset-suite grønn (ingen regresjon).

## Bevisst utenfor scope (lav prio)
Mark-and-sweep GC for **eksisterende** foreldreløse blober + andre kilder (import-feil, fjern-figur-uten-slett-seksjon, erstattede sertifikat-bilder). Egen sak ved behov.

## Utrulling
Server-kode → krever app-deploy for å tre i kraft. Ingen Prisma-migrasjon.

## Rollback
Ren revert; ingen data/infra/migrasjon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)