### PR TITLE
test(e2e): #613 — test-server speiler produksjon for /admin-content

### DIFF
--- a/scripts/test/admin-content-static-server.mjs
+++ b/scripts/test/admin-content-static-server.mjs
@@ -26,8 +26,11 @@ function send(response, statusCode, body, headers = {}) {
 }
 
 function resolvePublicFile(requestPath) {
+  // #613: mirror production — `/admin-content` serves the module library (route-map.md canonical),
+  // NOT the conversation shell. The shell (admin-content.html) has no bare production route (it lives
+  // at `/admin-content/module/:id/conversation`), so shell e2e loads it via its file path directly.
   if (requestPath === "/" || requestPath === "/admin-content") {
-    return path.join(publicRoot, "admin-content.html");
+    return path.join(publicRoot, "admin-content-library.html");
   }
   if (requestPath === "/admin-content/advanced") {
     return path.join(publicRoot, "admin-content-advanced.html");

--- a/test/e2e/admin-content-module-library.spec.ts
+++ b/test/e2e/admin-content-module-library.spec.ts
@@ -10,13 +10,11 @@ import { clickEnabledButton, mockCommonApis } from "./admin-content-helpers.js";
 // harness + mock API used by `admin-content-workspaces.spec.ts` (shared via
 // `admin-content-helpers.ts`).
 //
-// Routing note: the canonical production route for the library is `/admin-content`
-// (see doc/route-map.md), but the e2e static server (`admin-content-static-server.mjs`)
-// still maps `/admin-content` to the conversational shell (tracked in #613). The library
-// HTML is reached here via its static file path `/admin-content-library.html`, which the
-// static server serves through its public-file fallback. The library page's behaviour is
-// identical regardless of the URL that served the HTML.
-const LIBRARY_PATH = "/admin-content-library.html";
+// #613: the e2e static server now mirrors production — `/admin-content` serves the module library
+// (`admin-content-library.html`), matching doc/route-map.md + src/app.ts. Navigate via the canonical
+// route. (The conversational shell, which has no bare production route, is loaded by the workspaces
+// spec via its `/admin-content.html` file path instead.)
+const LIBRARY_PATH = "/admin-content";
 
 test.describe("admin content module library", () => {
   test("lists library modules in a table with per-row open actions", async ({ page }) => {

--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -13,6 +13,11 @@ import {
   buildMockModuleExport,
 } from "./admin-content-helpers.js";
 
+// #613: the conversational shell (`admin-content.html`) has no bare production route — it lives at
+// `/admin-content/module/:id/conversation`, while `/admin-content` serves the module library. The
+// shell tests below exercise its in-page flows (idle "create new module", source step), so they load
+// the shell HTML directly via its `/admin-content.html` file path (the static server's public-file
+// fallback), independent of the library route.
 test.describe("admin content browser coverage", () => {
   test("advanced editor can save, publish, and unpublish a module version", async ({ page }) => {
     await mockCommonApis(page, {
@@ -238,7 +243,7 @@ test.describe("admin content browser coverage", () => {
   test("shell can create a new module, generate content, and save without losing the module ID", async ({ page }) => {
     await mockCommonApis(page);
 
-    await page.goto("/admin-content");
+    await page.goto("/admin-content.html");
 
     await clickEnabledButton(page, "Create new module");
     await submitActiveChatInput(page, "Trade unions");
@@ -293,7 +298,7 @@ test.describe("admin content browser coverage", () => {
       await route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ mcqSetVersion: { id: "mcq-1" } }) });
     });
 
-    await page.goto("/admin-content");
+    await page.goto("/admin-content.html");
     await clickEnabledButton(page, "Create new module");
     await submitActiveChatInput(page, "Essay module");
     await submitActiveChatInput(page, "Source notes for a free-text-only essay module.");
@@ -342,7 +347,7 @@ test.describe("admin content browser coverage", () => {
       });
     });
 
-    await page.goto("/admin-content");
+    await page.goto("/admin-content.html");
     await clickEnabledButton(page, "Create new module");
     await submitActiveChatInput(page, "Crawl module");
 
@@ -362,7 +367,7 @@ test.describe("admin content browser coverage", () => {
   test("shell source step accepts a file between 2 and 10 MB", async ({ page }) => {
     await mockCommonApis(page);
 
-    await page.goto("/admin-content");
+    await page.goto("/admin-content.html");
     await clickEnabledButton(page, "Create new module");
     await submitActiveChatInput(page, "Big file module");
 
@@ -400,7 +405,7 @@ test.describe("admin content browser coverage", () => {
       });
     });
 
-    await page.goto("/admin-content");
+    await page.goto("/admin-content.html");
     await clickEnabledButton(page, "Create new module");
     await submitActiveChatInput(page, "Image-heavy module");
 
@@ -437,7 +442,7 @@ test.describe("admin content browser coverage", () => {
       });
     });
 
-    await page.goto("/admin-content");
+    await page.goto("/admin-content.html");
     await clickEnabledButton(page, "Create new module");
     await submitActiveChatInput(page, "URL module");
 
@@ -465,7 +470,7 @@ test.describe("admin content browser coverage", () => {
       });
     });
 
-    await page.goto("/admin-content");
+    await page.goto("/admin-content.html");
 
     await clickEnabledButton(page, "Create new module");
     await submitActiveChatInput(page, "Quiz module");
@@ -877,7 +882,7 @@ test.describe("admin content browser coverage", () => {
   test("shell source-material upload keeps extracted content out of the input and sends it to generation", async ({ page }) => {
     const state = await mockCommonApis(page);
 
-    await page.goto("/admin-content");
+    await page.goto("/admin-content.html");
 
     await clickEnabledButton(page, "Create new module");
     await submitActiveChatInput(page, "Upload module");
@@ -1093,7 +1098,7 @@ test.describe("admin content browser coverage", () => {
       ],
     });
 
-    await page.goto("/admin-content");
+    await page.goto("/admin-content.html");
 
     await expect(page.locator("#moduleWorkspaceTitle")).toBeVisible();
     await expect(page.getByText("What would you like to do?")).toBeVisible();
@@ -1385,7 +1390,7 @@ test.describe("admin content browser coverage", () => {
       courses: [],
     });
 
-    await page.goto("/admin-content");
+    await page.goto("/admin-content.html");
     const shellResults = await new AxeBuilder({ page })
       .disableRules(["color-contrast"])
       .analyze();


### PR DESCRIPTION
Closes #613.

Test-serveren (`admin-content-static-server.mjs`) mappet `/admin-content` til samtale-shellen, men produksjon (route-map.md + app.ts) serverer **biblioteket** der. Fikset mappingen.

**Nøkkel:** shellen (`admin-content.html`) har **ingen bar produksjonsrute** — den ligger på `/admin-content/module/:id/conversation`. Så de 10 shell-testene i `admin-content-workspaces.spec.ts` laster shellen via fil-stien `/admin-content.html` (test-serverens public-file-fallback), mens bibliotek-spec-en nå bruker den kanoniske `/admin-content`.

Dette var forsøket som ble trukket ut av #760 fordi det brøt shell-testene (de navigerte til `/admin-content` og forventet shellen). Nå med shell-test-navigasjonen oppdatert.

## Test
Full admin-content-e2e: **92/92 grønne** lokalt. Test-only, ingen versjonsbump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)