### PR TITLE
feat(course): #497 — automatiske kurs-frist-påminnelser (daglig bakgrunnsjobb)

### DIFF
--- a/doc/CONFIG_REFERENCE.md
+++ b/doc/CONFIG_REFERENCE.md
@@ -90,11 +90,13 @@ Core decision engine configuration. Controls pass/fail thresholds, manual review
 | `dueSoonDays` | `14` | Days before expiry when "due soon" state activates |
 | `reminderDaysBefore` | `[30, 7, 1]` | Days before expiry to send reminder notifications |
 
-**`courseReminders`** *(optional, has defaults)* - #497: schedule for course due-date reminders sent to
-enrolled participants (individual `CourseEnrollment.dueAt`). Driven by the daily `CourseReminderMonitor`
-(env `COURSE_REMINDER_INTERVAL_MS`, default 86_400_000 ms), which only runs in the worker role when
-`PARTICIPANT_NOTIFICATION_CHANNEL != disabled`. Emits audit actions `course_reminder_sent` /
-`course_reminder_failed`.
+**`courseReminders`** *(optional, has defaults)* - #497: schedule for course due-date reminders. Covers
+both individual `CourseEnrollment.dueAt` and class-assigned `CourseGroupAssignment.dueAt` (MANUAL classes
++ the "Alle deltakere" system class; ENTRA classes are skipped as their membership is not resolvable in a
+background job). Per (user, course) one effective due date is used — individual wins over class, earliest
+class wins among classes. Driven by the daily `CourseReminderMonitor` (env `COURSE_REMINDER_INTERVAL_MS`,
+default 86_400_000 ms), which only runs in the worker role when `PARTICIPANT_NOTIFICATION_CHANNEL !=
+disabled`. Emits audit actions `course_reminder_sent` / `course_reminder_failed`.
 
 | Field | Default | Description |
 |---|---|---|

--- a/doc/CONFIG_REFERENCE.md
+++ b/doc/CONFIG_REFERENCE.md
@@ -90,6 +90,16 @@ Core decision engine configuration. Controls pass/fail thresholds, manual review
 | `dueSoonDays` | `14` | Days before expiry when "due soon" state activates |
 | `reminderDaysBefore` | `[30, 7, 1]` | Days before expiry to send reminder notifications |
 
+**`courseReminders`** *(optional, has defaults)* - #497: schedule for course due-date reminders sent to
+enrolled participants (individual `CourseEnrollment.dueAt`). Driven by the daily `CourseReminderMonitor`
+(env `COURSE_REMINDER_INTERVAL_MS`, default 86_400_000 ms), which only runs in the worker role when
+`PARTICIPANT_NOTIFICATION_CHANNEL != disabled`. Emits audit actions `course_reminder_sent` /
+`course_reminder_failed`.
+
+| Field | Default | Description |
+|---|---|---|
+| `reminderDaysBefore` | `[7, 1]` | Days before `dueAt` to send "due soon" reminders (an "overdue" reminder is sent once after the due date passes) |
+
 ---
 
 ## benchmark-examples.json

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -47,6 +47,19 @@ kan testes ende-til-ende i UI. Individuell frist-tildeling har ennå ingen egen 
 datoen betød); (2) tildelte kurs-chips viser nå fristen («Frist: DD.MM.YYYY» / «Ingen frist») i stedet
 for bare tittelen. Formateres fra dato-delen (UTC) så vist dag aldri forskyves av tidssone. E2e utvidet.
 
+**Klasse-livssyklus konsistent med #705:** klasser hadde ingen vei tilbake fra arkivert (verken UI eller
+backend) og arkiverte klasser var usynlige. Nå:
+- Nytt backend-endepunkt `POST /api/admin/content/classes/:id/restore` (+ `classService.restoreClass` +
+  `classRepository.restoreClass` + audit-action `class_restored`). Systemklassen kan ikke gjenopprettes
+  (den arkiveres aldri).
+- `listClasses` returnerer nå både aktive og arkiverte klasser med `archivedAt` (+ `kind`), sortert
+  system → aktive → arkiverte.
+- Klasselista fikk **Aktive/Arkiverte/Alle-filter** (default Aktive), en **Type-kolonne**
+  (System/Manuell/Entra), en **«Arkivert»-status-badge**, og en symmetrisk **Gjenopprett**-handling —
+  samme mønster som kurs/seksjon/modul-listene.
+- Tester: integrasjon (archive→restore, liste eksponerer archivedAt/kind, system kan ikke gjenopprettes,
+  audit-spor) + e2e (filter, Type-kolonne, status-badge, Gjenopprett-handling).
+
 **Utenfor scope:** gjentatte overdue-purringer (v1 = én gang), opt-out (ingen modell finnes), ENTRA-
 klasse-medlemskap i bakgrunnsjobb, in-app/SMS-kanaler.
 

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,39 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.33 - 2026-07-18
+
+feat(course): #497 — automatiske kurs-frist-påminnelser (frist nærmer seg + forfalt) via daglig
+bakgrunnsjobb
+
+Siste «Done når»-pilar i Epic #478 (Tier 2 LMS): innhold ✓ + vurdering ✓ + progress ✓ + **varsling**.
+Deltakere med individuelle kurs-frister får nå automatiske e-post-påminnelser, uten at læreren følger
+opp manuelt. Kloner recert-påminnelses-mønsteret: audit-basert dedup gjør re-kjøring idempotent og
+restart-trygg.
+
+- **Ny orkestrator:** `runCourseReminderSchedule({ asOf, sendImpl? })` — henter individuelle
+  `CourseEnrollment.dueAt`-kandidater, hopper over fullførte (`deriveStatus === COMPLETED`), avmeldte,
+  deaktiverte/anonymiserte brukere og enrolments uten frist. **due-soon** fyrer på konfigurerbare
+  offsets (standard 7 og 1 dag før), **overdue** fyrer én gang etter passert frist.
+- **Ny monitor:** `CourseReminderMonitor` — env-gated `setInterval`-klasse (daglig,
+  `COURSE_REMINDER_INTERVAL_MS`), kjører kun i worker-rollen når `PARTICIPANT_NOTIFICATION_CHANNEL !=
+  disabled`; tick-feil logges og velter aldri workeren. Wiret i `src/index.ts`.
+- **Gjenbruk:** ACS-send via `sendViaAcs`, statusutledning via `deriveStatus`, audit via
+  `recordAuditEvent`. Nye audit-actions `course_reminder_sent` / `course_reminder_failed`.
+- **E-post:** `getCourseReminderNotificationMessage` (nb/nn/en-GB), ingen lenker (#688 — «Logg inn
+  på plattformen selv»).
+- **Config:** `courseReminders.reminderDaysBefore` (standard `[7, 1]`) i assessment-rules.
+- **Tester:** integrasjon (native pg) — due-soon/overdue-matching, ingen send for fullført/avmeldt/
+  inaktiv/uten-frist, idempotent re-kjøring; unit — monitor env-gate/feil-svelging, e-post-copy i alle
+  tre språk uten lenker. tsc grønn.
+
+**Scope v1 (bevisst avgrenset):** individuelle frister. Klasse-tildelte frister
+(`CourseGroupAssignment.dueAt` + «Alle deltakere»-ekspansjon), gjentatte overdue-purringer og opt-out
+er fase 2 innenfor #497.
+
+**Utrulling:** kun server-kode, ingen migrasjon. Monitoren er env-gated og trygg å merge før den slås
+på i prod. **Rollback:** ingen datamigrasjon — reverter koden.
+
 ## 1.6.32 - 2026-07-18
 
 fix(course): #502 — drop den deprecated CourseModule-join-tabellen (lukker #502)

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -39,9 +39,13 @@ Kloner recert-påminnelses-mønsteret: audit-basert dedup gjør re-kjøring idem
   ENTRA-skip; ingen send for fullført/avmeldt/inaktiv/uten-frist; idempotent re-kjøring. Unit — monitor
   env-gate/feil-svelging, e-post-copy i alle tre språk uten lenker. tsc grønn.
 
-**UI-testbar:** klasse-tildeling har allerede en frist-datovelger (Klasser → tildel kurs), så hele
-funksjonen kan testes ende-til-ende i UI. Individuell frist-tildeling har ennå ingen egen datovelger
-(kun API).
+**UI-testbar:** klasse-tildeling har en frist-datovelger (Klasser → tildel kurs), så hele funksjonen
+kan testes ende-til-ende i UI. Individuell frist-tildeling har ennå ingen egen datovelger (kun API).
+
+**Klasse-UI-forbedringer (samme arc):** (1) datofeltet ved kurs-tildeling har nå en synlig etikett
+«Frist (valgfri)» + hjelpetekst om at fristen driver påminnelser (var før kun en tooltip — uklart hva
+datoen betød); (2) tildelte kurs-chips viser nå fristen («Frist: DD.MM.YYYY» / «Ingen frist») i stedet
+for bare tittelen. Formateres fra dato-delen (UTC) så vist dag aldri forskyves av tidssone. E2e utvidet.
 
 **Utenfor scope:** gjentatte overdue-purringer (v1 = én gang), opt-out (ingen modell finnes), ENTRA-
 klasse-medlemskap i bakgrunnsjobb, in-app/SMS-kanaler.

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -5,32 +5,46 @@ This document tracks release versions and what each version includes.
 ## 1.6.33 - 2026-07-18
 
 feat(course): #497 — automatiske kurs-frist-påminnelser (frist nærmer seg + forfalt) via daglig
-bakgrunnsjobb
+bakgrunnsjobb, for både individuelle OG klasse-tildelte frister
 
 Siste «Done når»-pilar i Epic #478 (Tier 2 LMS): innhold ✓ + vurdering ✓ + progress ✓ + **varsling**.
-Deltakere med individuelle kurs-frister får nå automatiske e-post-påminnelser, uten at læreren følger
-opp manuelt. Kloner recert-påminnelses-mønsteret: audit-basert dedup gjør re-kjøring idempotent og
-restart-trygg.
+Deltakere med kurs-frister får nå automatiske e-post-påminnelser, uten at læreren følger opp manuelt.
+Kloner recert-påminnelses-mønsteret: audit-basert dedup gjør re-kjøring idempotent og restart-trygg.
 
-- **Ny orkestrator:** `runCourseReminderSchedule({ asOf, sendImpl? })` — henter individuelle
-  `CourseEnrollment.dueAt`-kandidater, hopper over fullførte (`deriveStatus === COMPLETED`), avmeldte,
-  deaktiverte/anonymiserte brukere og enrolments uten frist. **due-soon** fyrer på konfigurerbare
-  offsets (standard 7 og 1 dag før), **overdue** fyrer én gang etter passert frist.
+- **Ny orkestrator:** `runCourseReminderSchedule({ asOf, sendImpl? })`. **due-soon** fyrer på
+  konfigurerbare offsets (standard 7 og 1 dag før), **overdue** fyrer én gang etter passert frist.
+  Hopper over fullførte (`deriveStatus === COMPLETED`), avmeldte, deaktiverte/anonymiserte brukere og
+  tildelinger uten frist.
+- **To frist-kilder:**
+  - **Individuelle** `CourseEnrollment.dueAt` (eksplisitt tildelte deltakere).
+  - **Klasse-tildelte** `CourseGroupAssignment.dueAt` — ekspandert til medlemmer: **MANUAL**-klasser
+    (`ClassMember`-rader) + system-klassen **«Alle deltakere»** (alle aktive deltakere). **ENTRA**-
+    klasser kan ikke oppløses i en bakgrunnsjobb (ingen token/lagrede medlemskanter) og hoppes over,
+    på samme måte som tildelings-e-posten.
+  - Per (bruker, kurs) beregnes **én effektiv frist**: individuell vinner over klasse; ved flere
+    klasse-frister vinner den tidligste. Dedup + presedens hindrer dobbel-varsling.
 - **Ny monitor:** `CourseReminderMonitor` — env-gated `setInterval`-klasse (daglig,
   `COURSE_REMINDER_INTERVAL_MS`), kjører kun i worker-rollen når `PARTICIPANT_NOTIFICATION_CHANNEL !=
-  disabled`; tick-feil logges og velter aldri workeren. Wiret i `src/index.ts`.
+  disabled`; tick-feil logges og velter aldri workeren. Wiret i `src/index.ts` (kjører også én gang
+  umiddelbart ved worker-oppstart).
 - **Gjenbruk:** ACS-send via `sendViaAcs`, statusutledning via `deriveStatus`, audit via
-  `recordAuditEvent`. Nye audit-actions `course_reminder_sent` / `course_reminder_failed`.
+  `recordAuditEvent`. Nye audit-actions `course_reminder_sent` / `course_reminder_failed`. Nye repo-
+  spørringer `findCourseGroupAssignmentsWithDueDate` (classRepository) + `findActiveParticipants`
+  (userRepository, for «Alle deltakere»).
 - **E-post:** `getCourseReminderNotificationMessage` (nb/nn/en-GB), ingen lenker (#688 — «Logg inn
   på plattformen selv»).
 - **Config:** `courseReminders.reminderDaysBefore` (standard `[7, 1]`) i assessment-rules.
-- **Tester:** integrasjon (native pg) — due-soon/overdue-matching, ingen send for fullført/avmeldt/
-  inaktiv/uten-frist, idempotent re-kjøring; unit — monitor env-gate/feil-svelging, e-post-copy i alle
-  tre språk uten lenker. tsc grønn.
+- **Tester:** integrasjon (native pg) — individuell due-soon/overdue-matching; klasse MANUAL-
+  ekspansjon; «Alle deltakere»-systemklasse; presedens (individuell > klasse, tidligste klasse vinner);
+  ENTRA-skip; ingen send for fullført/avmeldt/inaktiv/uten-frist; idempotent re-kjøring. Unit — monitor
+  env-gate/feil-svelging, e-post-copy i alle tre språk uten lenker. tsc grønn.
 
-**Scope v1 (bevisst avgrenset):** individuelle frister. Klasse-tildelte frister
-(`CourseGroupAssignment.dueAt` + «Alle deltakere»-ekspansjon), gjentatte overdue-purringer og opt-out
-er fase 2 innenfor #497.
+**UI-testbar:** klasse-tildeling har allerede en frist-datovelger (Klasser → tildel kurs), så hele
+funksjonen kan testes ende-til-ende i UI. Individuell frist-tildeling har ennå ingen egen datovelger
+(kun API).
+
+**Utenfor scope:** gjentatte overdue-purringer (v1 = én gang), opt-out (ingen modell finnes), ENTRA-
+klasse-medlemskap i bakgrunnsjobb, in-app/SMS-kanaler.
 
 **Utrulling:** kun server-kode, ingen migrasjon. Monitoren er env-gated og trygg å merge før den slås
 på i prod. **Rollback:** ingen datamigrasjon — reverter koden.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.32",
+  "version": "1.6.33",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-classes.js
+++ b/public/static/admin-content-classes.js
@@ -57,6 +57,15 @@ function courseTitle(raw) {
   }
 }
 
+// #497: a class-assigned due date (dueAt) is stored as UTC midnight of the picked date; format from the
+// date part so the displayed day never shifts by timezone. Returns "DD.MM.YYYY" or null.
+function formatDueDate(iso) {
+  if (!iso) return null;
+  const datePart = String(iso).slice(0, 10); // YYYY-MM-DD
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(datePart);
+  return m ? `${m[3]}.${m[2]}.${m[1]}` : null;
+}
+
 async function renderListView() {
   pageContent.innerHTML = `<div class="page-loading">Laster…</div>`;
   let classes = [];
@@ -188,7 +197,13 @@ async function openClass(id) {
     return;
   }
   const memberChips = members.map((m) => `<span class="chip">${escapeHtml(m.name)} <button data-remove-member="${escapeHtml(m.userId)}" aria-label="Fjern ${escapeHtml(m.name)}">×</button></span>`).join("");
-  const courseChips = courses.map((c) => `<span class="chip">${escapeHtml(courseTitle(c.title))} <button data-remove-course="${escapeHtml(c.courseId)}" aria-label="Fjern kurs">×</button></span>`).join("");
+  const courseChips = courses.map((c) => {
+    const due = formatDueDate(c.dueAt);
+    const dueLabel = due
+      ? `<span class="chip-due" style="color:var(--color-meta);font-size:12px;margin-left:4px">Frist: ${escapeHtml(due)}</span>`
+      : `<span class="chip-due" style="color:var(--color-meta);font-size:12px;margin-left:4px">Ingen frist</span>`;
+    return `<span class="chip">${escapeHtml(courseTitle(c.title))} ${dueLabel} <button data-remove-course="${escapeHtml(c.courseId)}" aria-label="Fjern kurs">×</button></span>`;
+  }).join("");
   const assignedIds = new Set(courses.map((c) => c.courseId));
   // #688: don't offer archived courses for assignment — they are retired and shouldn't be assigned.
   const courseOptions = allCourses.filter((c) => !assignedIds.has(c.id) && !c.archivedAt).map((c) => `<option value="${escapeHtml(c.id)}">${escapeHtml(courseTitle(c.title))}</option>`).join("");
@@ -208,9 +223,13 @@ async function openClass(id) {
       <div class="chip-row" id="courseChips">${courseChips || `<span style="color:var(--color-meta);font-size:13px">Ingen kurs tildelt ennå.</span>`}</div>
       <div class="inline-form">
         <select id="courseSelect"><option value="">Velg kurs…</option>${courseOptions}</select>
-        <input type="date" id="dueAtInput" title="Frist (valgfri)" />
+        <label for="dueAtInput" style="font-size:13px;color:var(--color-meta);display:inline-flex;align-items:center;gap:6px">
+          Frist (valgfri)
+          <input type="date" id="dueAtInput" title="Frist for å fullføre kurset (valgfri)" />
+        </label>
         <button id="assignCourseBtn" class="btn btn-secondary" style="width:auto">Tildel kurs</button>
       </div>
+      <p style="font-size:12px;color:var(--color-meta);margin:6px 0 0">Fristen brukes til automatiske påminnelser til deltakerne (frist nærmer seg / forfalt).</p>
     </div>`;
   document.getElementById("backToClasses").addEventListener("click", renderListView);
 

--- a/public/static/admin-content-classes.js
+++ b/public/static/admin-content-classes.js
@@ -66,45 +66,98 @@ function formatDueDate(iso) {
   return m ? `${m[3]}.${m[2]}.${m[1]}` : null;
 }
 
-async function renderListView() {
-  pageContent.innerHTML = `<div class="page-loading">Laster…</div>`;
-  let classes = [];
-  try {
-    classes = (await apiFetch("/api/admin/content/classes", getHeaders)).classes ?? [];
-  } catch (err) {
-    pageContent.innerHTML = `<p>Kunne ikke laste klasser: ${escapeHtml(err?.message ?? "")}</p>`;
-    return;
-  }
-  const rows = classes.map((c) => `
+// #705-family: classes now render Aktive/Arkiverte consistently with the other lifecycle lists.
+// Classes are 2-state (aktiv/arkivert) — no draft/publish — so the filter has Aktive/Arkiverte/Alle
+// (no "Publiserte"), and status is shown as an "Arkivert"-badge rather than the full 3-state badge.
+let classesFilter = "active";
+let classesCache = [];
+
+function classTypeLabel(c) {
+  if (c.isSystem) return "System";
+  if (c.kind === "ENTRA") return "Entra";
+  return "Manuell";
+}
+
+function filteredClasses() {
+  if (classesFilter === "archived") return classesCache.filter((c) => c.archivedAt);
+  if (classesFilter === "all") return classesCache;
+  return classesCache.filter((c) => !c.archivedAt);
+}
+
+function classFilterBar() {
+  const pills = [["active", "Aktive"], ["archived", "Arkiverte"], ["all", "Alle"]];
+  return `<div class="list-filters" role="group" aria-label="Filtrer klasser">${pills
+    .map(([key, label]) => `<button type="button" class="list-filter-btn${classesFilter === key ? " active" : ""}" data-filter="${key}">${escapeHtml(label)}</button>`)
+    .join("")}</div>`;
+}
+
+function renderClassesTable() {
+  const rows = filteredClasses().map((c) => {
+    const archived = !!c.archivedAt;
+    const systemBadge = c.isSystem ? `<span class="system-badge">System</span>` : "";
+    const statusBadge = archived ? ` <span class="status-badge status-badge--archived">Arkivert</span>` : "";
+    let action = "";
+    if (!c.isSystem) {
+      action = archived
+        ? `<button class="row-action-btn" data-action="restore" data-id="${escapeHtml(c.id)}" data-name="${escapeHtml(c.name)}">Gjenopprett</button>`
+        : `<button class="row-action-btn destructive" data-action="archive" data-id="${escapeHtml(c.id)}" data-name="${escapeHtml(c.name)}">Arkiver</button>`;
+    }
+    return `
     <tr>
-      <td>${escapeHtml(c.name)}${c.isSystem ? `<span class="system-badge">System</span>` : ""}</td>
+      <td>${escapeHtml(c.name)}${systemBadge}${statusBadge}</td>
+      <td>${escapeHtml(classTypeLabel(c))}</td>
       <td>${c._count?.members ?? 0}</td>
       <td>${c._count?.courseAssignments ?? 0}</td>
       <td class="col-actions">
         <div class="row-actions">
           <button class="row-action-btn" data-action="open" data-id="${escapeHtml(c.id)}">Administrer</button>
-          ${c.isSystem ? "" : `<button class="row-action-btn destructive" data-action="archive" data-id="${escapeHtml(c.id)}" data-name="${escapeHtml(c.name)}">Arkiver</button>`}
+          ${action}
         </div>
       </td>
-    </tr>`).join("");
+    </tr>`;
+  }).join("");
+  const body = document.getElementById("classesTableBody");
+  if (body) body.innerHTML = rows || `<tr><td colspan="5" style="color:var(--color-meta)">Ingen klasser i denne visningen.</td></tr>`;
+  document.querySelectorAll(".list-filter-btn").forEach((btn) => {
+    btn.classList.toggle("active", btn.dataset.filter === classesFilter);
+  });
+}
+
+async function renderListView() {
+  pageContent.innerHTML = `<div class="page-loading">Laster…</div>`;
+  try {
+    classesCache = (await apiFetch("/api/admin/content/classes", getHeaders)).classes ?? [];
+  } catch (err) {
+    pageContent.innerHTML = `<p>Kunne ikke laste klasser: ${escapeHtml(err?.message ?? "")}</p>`;
+    return;
+  }
   pageContent.innerHTML = `
     <div class="page-header"><h1>Klasser</h1><div style="display:flex;gap:8px">${isAdministrator ? `<button id="importUsersBtn" class="btn btn-secondary" style="width:auto" title="Importer brukere fra en JSON-fil eksportert fra Entra (delta-synk)">Importer brukere fra fil</button><input type="file" id="importUsersFile" accept="application/json,.json" style="display:none"><button id="syncEntraBtn" class="btn btn-secondary" style="width:auto" title="Importer brukere fra «Alle i A-2 Norge» i Entra (krever Graph-tilgang)">Synk brukere fra Entra</button>` : ""}<button id="newClassBtn" class="btn btn-primary" style="width:auto">+ Ny klasse</button></div></div>
     <p style="color:var(--color-meta);font-size:13px">En klasse er en gruppe deltakere du kan tildele kurs til samlet. «Alle deltakere» er en systemklasse (alle med deltakerrolle).</p>
+    ${classFilterBar()}
     <table class="classes-table">
-      <thead><tr><th>Navn</th><th>Medlemmer</th><th>Tildelte kurs</th><th></th></tr></thead>
-      <tbody id="classesTableBody">${rows || `<tr><td colspan="4" style="color:var(--color-meta)">Ingen klasser ennå.</td></tr>`}</tbody>
+      <thead><tr><th>Navn</th><th>Type</th><th>Medlemmer</th><th>Tildelte kurs</th><th></th></tr></thead>
+      <tbody id="classesTableBody"></tbody>
     </table>`;
+  renderClassesTable();
   document.getElementById("newClassBtn").addEventListener("click", createClassFlow);
   document.getElementById("syncEntraBtn")?.addEventListener("click", syncEntraUsers);
   const importBtn = document.getElementById("importUsersBtn");
   const importFile = document.getElementById("importUsersFile");
   importBtn?.addEventListener("click", () => importFile?.click());
   importFile?.addEventListener("change", () => importUsersFromFile(importFile));
+  pageContent.querySelector(".list-filters")?.addEventListener("click", (e) => {
+    const btn = e.target.closest("[data-filter]");
+    if (!btn) return;
+    classesFilter = btn.dataset.filter;
+    renderClassesTable();
+  });
   document.getElementById("classesTableBody").addEventListener("click", (e) => {
     const btn = e.target.closest("[data-action]");
     if (!btn) return;
     if (btn.dataset.action === "open") openClass(btn.dataset.id);
     if (btn.dataset.action === "archive") archiveClass(btn.dataset.id, btn.dataset.name);
+    if (btn.dataset.action === "restore") restoreClassInAdmin(btn.dataset.id, btn.dataset.name);
   });
 }
 
@@ -180,6 +233,18 @@ async function archiveClass(id, name) {
     await renderListView();
   } catch (err) {
     showToast(err?.message ?? "Kunne ikke arkivere.", "error");
+  }
+}
+
+// #705-family: reverse of archiveClass — restore an archived class so it is active again.
+async function restoreClassInAdmin(id, name) {
+  if (!window.confirm(`Gjenopprette klassen «${name}»?`)) return;
+  try {
+    await apiFetch(`/api/admin/content/classes/${encodeURIComponent(id)}/restore`, getHeaders, { method: "POST" });
+    showToast("Klasse gjenopprettet.", "success");
+    await renderListView();
+  } catch (err) {
+    showToast(err?.message ?? "Kunne ikke gjenopprette.", "error");
   }
 }
 

--- a/src/config/assessmentRules.ts
+++ b/src/config/assessmentRules.ts
@@ -125,6 +125,15 @@ export const rulesSchema = z.object({
       dueSoonDays: 14,
       reminderDaysBefore: [30, 7, 1],
     }),
+  // #497: kurs-frist-påminnelser. `reminderDaysBefore` = offsets (dager før dueAt) for
+  // "frist nærmer seg"-påminnelser; standard 7 og 1 dag før forfall.
+  courseReminders: z
+    .object({
+      reminderDaysBefore: z.array(z.number().int().min(0)).default([7, 1]),
+    })
+    .default({
+      reminderDaysBefore: [7, 1],
+    }),
 });
 
 export type AssessmentRules = z.infer<typeof rulesSchema>;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -99,6 +99,9 @@ const envSchema = z.object({
     z.string().url().optional(),
   ),
   PARTICIPANT_NOTIFICATION_WEBHOOK_TIMEOUT_MS: z.coerce.number().int().positive().default(5000),
+  // #497: daglig bakgrunnsjobb for kurs-frist-påminnelser. Kjører kun i worker-rollen når
+  // varselkanalen er aktiv (PARTICIPANT_NOTIFICATION_CHANNEL !== "disabled").
+  COURSE_REMINDER_INTERVAL_MS: z.coerce.number().int().positive().default(86_400_000),
   AZURE_COMMUNICATION_SERVICES_CONNECTION_STRING: z.preprocess(
     (value) => (typeof value === "string" && value.trim().length === 0 ? undefined : value),
     z.string().optional(),

--- a/src/i18n/notificationMessages.ts
+++ b/src/i18n/notificationMessages.ts
@@ -242,3 +242,80 @@ export function getDiscussionReplyNotificationMessage(
     nextStepGuidance: t.replyGuidance.replace("{title}", context.threadTitle),
   };
 }
+
+// #497: kurs-frist-påminnelser. To typer: due_soon (frist nærmer seg, N dager før) og overdue
+// (frist passert). Ingen lenker i e-post (#688) — mottakeren bes logge inn selv.
+export type CourseReminderKind = "due_soon" | "overdue";
+
+type CourseReminderLabels = {
+  dueSoonSubject: string; // {course}
+  dueSoonToday: string; // {course}
+  dueSoonInDays: string; // {course} {date} {days}
+  overdueSubject: string; // {course}
+  overdueGuidance: string; // {course} {date}
+};
+
+const courseReminderMessages: Record<SupportedLocale, CourseReminderLabels> = {
+  "en-GB": {
+    dueSoonSubject: "Reminder: «{course}» is due soon",
+    dueSoonToday: "The course «{course}» is due today ({date}).\n\nLog in to the platform to complete it.",
+    dueSoonInDays:
+      "The course «{course}» is due on {date} — {days} day(s) from now.\n\nLog in to the platform to complete it in time.",
+    overdueSubject: "Overdue: «{course}» has passed its due date",
+    overdueGuidance:
+      "The course «{course}» was due on {date} and is not yet completed.\n\nLog in to the platform to complete it as soon as possible.",
+  },
+  nb: {
+    dueSoonSubject: "Påminnelse: «{course}» har frist snart",
+    dueSoonToday: "Kurset «{course}» har frist i dag ({date}).\n\nLogg inn på plattformen for å fullføre det.",
+    dueSoonInDays:
+      "Kurset «{course}» har frist {date} — om {days} dag(er).\n\nLogg inn på plattformen for å fullføre det i tide.",
+    overdueSubject: "Forfalt: «{course}» har passert fristen",
+    overdueGuidance:
+      "Kurset «{course}» hadde frist {date} og er ennå ikke fullført.\n\nLogg inn på plattformen for å fullføre det så snart som mulig.",
+  },
+  nn: {
+    dueSoonSubject: "Påminning: «{course}» har frist snart",
+    dueSoonToday: "Kurset «{course}» har frist i dag ({date}).\n\nLogg inn på plattforma for å fullføre det.",
+    dueSoonInDays:
+      "Kurset «{course}» har frist {date} — om {days} dag(ar).\n\nLogg inn på plattforma for å fullføre det i tide.",
+    overdueSubject: "Forfalle: «{course}» har passert fristen",
+    overdueGuidance:
+      "Kurset «{course}» hadde frist {date} og er enno ikkje fullført.\n\nLogg inn på plattforma for å fullføre det så snart som mogleg.",
+  },
+};
+
+function formatDateOnly(date: Date, locale: SupportedLocale): string {
+  try {
+    return new Intl.DateTimeFormat(locale, { dateStyle: "long", timeZone: "UTC" }).format(date);
+  } catch {
+    return date.toISOString().slice(0, 10);
+  }
+}
+
+export function getCourseReminderNotificationMessage(
+  locale: SupportedLocale,
+  kind: CourseReminderKind,
+  context: { courseTitle: string; dueAt: Date; daysBefore?: number },
+): NotificationMessage {
+  const t = courseReminderMessages[locale];
+  const dateText = formatDateOnly(context.dueAt, locale);
+  if (kind === "overdue") {
+    return {
+      subject: t.overdueSubject.replace("{course}", context.courseTitle),
+      nextStepGuidance: t.overdueGuidance.replace("{course}", context.courseTitle).replace("{date}", dateText),
+    };
+  }
+  const days = context.daysBefore ?? 0;
+  const guidance =
+    days <= 0
+      ? t.dueSoonToday.replace("{course}", context.courseTitle).replace("{date}", dateText)
+      : t.dueSoonInDays
+          .replace("{course}", context.courseTitle)
+          .replace("{date}", dateText)
+          .replace("{days}", String(days));
+  return {
+    subject: t.dueSoonSubject.replace("{course}", context.courseTitle),
+    nextStepGuidance: guidance,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { AppealSlaMonitor } from "./modules/appeal/index.js";
 import { PseudonymizationMonitor } from "./modules/user/PseudonymizationMonitor.js";
 import { AuditRetentionMonitor } from "./modules/retention/AuditRetentionMonitor.js";
 import { EntraUserSyncMonitor } from "./modules/orgSync/EntraUserSyncMonitor.js";
+import { CourseReminderMonitor } from "./modules/course/CourseReminderMonitor.js";
 
 export function resolveProcessRoleFlags(role: string) {
   return {
@@ -25,6 +26,7 @@ const appealSlaMonitor = startWorkers ? new AppealSlaMonitor(env.APPEAL_SLA_MONI
 const pseudonymizationMonitor = startWorkers ? new PseudonymizationMonitor() : null;
 const auditRetentionMonitor = startWorkers ? new AuditRetentionMonitor() : null;
 const entraUserSyncMonitor = startWorkers ? new EntraUserSyncMonitor() : null;
+const courseReminderMonitor = startWorkers ? new CourseReminderMonitor() : null;
 
 const gracefulShutdown = (exitCode = 0) => {
   if (shuttingDown) {
@@ -37,6 +39,7 @@ const gracefulShutdown = (exitCode = 0) => {
   pseudonymizationMonitor?.stop();
   auditRetentionMonitor?.stop();
   entraUserSyncMonitor?.stop();
+  courseReminderMonitor?.stop();
 
   if (!server) {
     process.exit(exitCode);
@@ -74,6 +77,7 @@ async function startServer() {
           pseudonymizationMonitor: pseudonymizationMonitor?.getStatus() ?? null,
           auditRetentionMonitor: auditRetentionMonitor?.getStatus() ?? null,
           entraUserSyncMonitor: entraUserSyncMonitor?.getStatus() ?? null,
+          courseReminderMonitor: courseReminderMonitor?.getStatus() ?? null,
         },
       }));
     }).listen(env.PORT, () => {
@@ -88,6 +92,7 @@ async function startServer() {
     pseudonymizationMonitor!.start();
     auditRetentionMonitor!.start();
     entraUserSyncMonitor!.start();
+    courseReminderMonitor!.start();
   }
 }
 

--- a/src/modules/course/CourseReminderMonitor.ts
+++ b/src/modules/course/CourseReminderMonitor.ts
@@ -1,0 +1,71 @@
+import { env } from "../../config/env.js";
+import { runCourseReminderSchedule } from "./courseReminderService.js";
+
+// #497: scheduled background job that sends course due-date reminders (due-soon + overdue) to
+// enrolled participants. Only runs when a notification channel is active
+// (PARTICIPANT_NOTIFICATION_CHANNEL !== "disabled"); failures are logged and never crash the worker.
+// Env-gated setInterval class, same shape as EntraUserSyncMonitor.
+
+export type CourseReminderMonitorStatus = {
+  enabled: boolean;
+  lastCycleAt: string | null;
+  lastError: string | null;
+  lastSummary: unknown | null;
+};
+
+export class CourseReminderMonitor {
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private lastCycleAt: Date | null = null;
+  private lastError: string | null = null;
+  private lastSummary: unknown | null = null;
+
+  constructor(
+    private readonly pollIntervalMs = env.COURSE_REMINDER_INTERVAL_MS,
+    private readonly runSchedule: () => Promise<unknown> = () => runCourseReminderSchedule({ asOf: new Date() }),
+  ) {}
+
+  private get enabled(): boolean {
+    return env.PARTICIPANT_NOTIFICATION_CHANNEL !== "disabled";
+  }
+
+  start() {
+    if (this.timer || !this.enabled) {
+      return; // notification channel disabled → don't schedule
+    }
+    void this.tick();
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.pollIntervalMs);
+  }
+
+  stop() {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  getStatus(): CourseReminderMonitorStatus {
+    return {
+      enabled: this.enabled,
+      lastCycleAt: this.lastCycleAt?.toISOString() ?? null,
+      lastError: this.lastError,
+      lastSummary: this.lastSummary,
+    };
+  }
+
+  private async tick() {
+    if (this.running || !this.enabled) return;
+    this.running = true;
+    try {
+      this.lastSummary = await this.runSchedule();
+      this.lastCycleAt = new Date();
+      this.lastError = null;
+    } catch (error) {
+      this.lastError = error instanceof Error ? error.message : String(error);
+      console.warn(`[#497] Course reminder schedule failed: ${this.lastError}`);
+    } finally {
+      this.running = false;
+    }
+  }
+}

--- a/src/modules/course/classRepository.ts
+++ b/src/modules/course/classRepository.ts
@@ -41,15 +41,25 @@ export function createClassRepository(client: ClassRepositoryClient = prisma) {
       return client.class.update({ where: { id: classId }, data: { archivedAt: new Date() } });
     },
 
+    // #705-family: reverse of archiveClass — clear the soft-archive so the class is active again.
+    restoreClass(classId: string) {
+      return client.class.update({ where: { id: classId }, data: { archivedAt: null } });
+    },
+
     findClassById(classId: string) {
       return client.class.findUnique({ where: { id: classId } });
     },
 
-    // Non-archived classes, system classes first, then newest.
+    // All classes (active + archived) for the admin list — the frontend filters by Aktive/Arkiverte.
+    // System first, then active before archived, then newest. Includes archivedAt so the client can
+    // render status and offer archive/restore consistently with the other lifecycle lists (#705).
     listClasses() {
       return client.class.findMany({
-        where: { archivedAt: null },
-        orderBy: [{ isSystem: "desc" }, { createdAt: "desc" }],
+        orderBy: [
+          { isSystem: "desc" },
+          { archivedAt: { sort: "asc", nulls: "first" } },
+          { createdAt: "desc" },
+        ],
         select: {
           id: true,
           name: true,
@@ -57,6 +67,7 @@ export function createClassRepository(client: ClassRepositoryClient = prisma) {
           kind: true,
           entraGroupId: true,
           isSystem: true,
+          archivedAt: true,
           _count: { select: { members: true, courseAssignments: true } },
         },
       });

--- a/src/modules/course/classRepository.ts
+++ b/src/modules/course/classRepository.ts
@@ -114,6 +114,34 @@ export function createClassRepository(client: ClassRepositoryClient = prisma) {
         include: { course: { select: { id: true, title: true } } },
       });
     },
+
+    // #497 fase 2: class-assigned due dates for the reminder schedule. Only non-null dueAt on a
+    // non-archived class. Includes the course (id + localized title) and the class kind/isSystem so
+    // the service can expand membership (MANUAL rows are included; the system "Alle deltakere" class
+    // has no rows and is resolved separately; ENTRA classes are not resolvable in a background job
+    // and are skipped by the service).
+    findCourseGroupAssignmentsWithDueDate() {
+      return client.courseGroupAssignment.findMany({
+        where: { dueAt: { not: null }, class: { archivedAt: null } },
+        include: {
+          course: { select: { id: true, title: true } },
+          class: {
+            select: {
+              id: true,
+              kind: true,
+              isSystem: true,
+              members: {
+                select: {
+                  user: {
+                    select: { id: true, name: true, email: true, activeStatus: true, isAnonymized: true },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+    },
   };
 }
 

--- a/src/modules/course/classService.ts
+++ b/src/modules/course/classService.ts
@@ -44,6 +44,20 @@ export async function archiveClass(classId: string, actorId: string | null) {
   });
 }
 
+export async function restoreClass(classId: string, actorId: string | null) {
+  const klass = await requireClass(classId);
+  if (klass.isSystem) throw new ValidationError("System classes are never archived.");
+  if (!klass.archivedAt) return; // already active — idempotent no-op
+  await classRepository.restoreClass(classId);
+  await recordAuditEvent({
+    entityType: auditEntityTypes.class,
+    entityId: classId,
+    action: auditActions.class.restored,
+    actorId: actorId ?? undefined,
+    metadata: { classId },
+  });
+}
+
 export async function addMember(classId: string, userId: string, actorId: string | null) {
   const klass = await requireClass(classId);
   if (klass.isSystem || klass.kind !== "MANUAL") {

--- a/src/modules/course/courseReminderService.ts
+++ b/src/modules/course/courseReminderService.ts
@@ -13,12 +13,20 @@ import { recordAuditEvent } from "../../services/auditService.js";
 import { sendViaAcs } from "../certification/participantNotificationService.js";
 import { deriveStatus } from "./enrollmentService.js";
 import { enrollmentRepository } from "./enrollmentRepository.js";
+import { classRepository } from "./classRepository.js";
+import { findActiveParticipants } from "../../repositories/userRepository.js";
 
 // #497: automatiske kurs-frist-påminnelser (Epic #478, siste «Done når»-pilar). Klon av
 // recert-påminnelses-mønsteret (recertificationService.ts): audit-basert dedup gjør re-kjøring
-// idempotent og restart-trygg. v1 dekker INDIVIDUELLE (eksplisitt tildelte) CourseEnrollment.dueAt;
-// klasse-tildelte frister er fase 2. Ingen per-bruker locale finnes ennå → org-default (nb),
-// samme som diskusjonsvarsler.
+// idempotent og restart-trygg. Dekker to kilder til kurs-frister:
+//   1. INDIVIDUELLE (eksplisitt tildelte) CourseEnrollment.dueAt.
+//   2. KLASSE-tildelte CourseGroupAssignment.dueAt (fase 2), ekspandert til medlemmer — MANUAL-
+//      klasser (ClassMember-rader) + system-klassen «Alle deltakere» (alle aktive deltakere).
+//      ENTRA-klasser kan ikke oppløses i en bakgrunnsjobb (ingen token/lagrede medlemskanter) og
+//      hoppes over, på samme måte som tildelings-e-posten (classService).
+// Per (bruker, kurs) beregnes ÉN effektiv frist: individuell frist vinner over klasse; ved flere
+// klasse-frister vinner den tidligste. Slik unngås dobbel-varsling. Ingen per-bruker locale finnes
+// ennå → org-default (nb), samme som diskusjonsvarsler.
 
 const NOTIFY_LOCALE = "nb" as const;
 const NOTIFICATION_TYPE = "course_reminder";
@@ -53,6 +61,20 @@ export type CourseReminderScheduleSummary = {
   skippedNoTrigger: number;
   skippedCompleted: number;
   skippedInactive: number;
+  skippedEntraClass: number;
+};
+
+// En effektiv frist-kandidat per (bruker, kurs) etter sammenslåing av individuelle + klasse-kilder.
+type ReminderCandidate = {
+  userId: string;
+  courseId: string;
+  dueAt: Date;
+  recipientEmail: string;
+  recipientName: string | null;
+  courseTitle: string; // lokalisert
+  activeStatus: boolean;
+  isAnonymized: boolean;
+  source: "individual" | "class";
 };
 
 async function defaultSendCourseReminder(input: CourseReminderSendInput): Promise<CourseReminderSendResult> {
@@ -177,6 +199,87 @@ function dueDateIsBefore(dueAt: Date, asOf: Date): boolean {
   return due < now;
 }
 
+function localizeTitle(title: string): string {
+  return localizeContentText(NOTIFY_LOCALE, title) ?? title ?? "";
+}
+
+// Samler individuelle + klasse-tildelte frister til ÉN effektiv kandidat per (bruker, kurs).
+// Presedens: individuell frist vinner over klasse; ved flere klasse-frister vinner den tidligste.
+async function gatherCandidates(summary: CourseReminderScheduleSummary): Promise<ReminderCandidate[]> {
+  const map = new Map<string, ReminderCandidate>();
+  const keyOf = (userId: string, courseId: string) => `${userId}::${courseId}`;
+
+  // 1. Individuelle (eksplisitt tildelte) enrollments med frist.
+  const enrollments = await enrollmentRepository.findIndividualEnrollmentsWithDueDate();
+  for (const enrollment of enrollments) {
+    if (!enrollment.dueAt) continue;
+    map.set(keyOf(enrollment.userId, enrollment.courseId), {
+      userId: enrollment.userId,
+      courseId: enrollment.courseId,
+      dueAt: enrollment.dueAt,
+      recipientEmail: enrollment.user.email,
+      recipientName: enrollment.user.name,
+      courseTitle: localizeTitle(enrollment.course.title),
+      activeStatus: enrollment.user.activeStatus,
+      isAnonymized: enrollment.user.isAnonymized,
+      source: "individual",
+    });
+  }
+
+  // 2. Klasse-tildelte frister → ekspander til medlemmer. MANUAL = ClassMember-rader;
+  //    system-klassen «Alle deltakere» = alle aktive deltakere (ingen rader). ENTRA hoppes over.
+  const assignments = await classRepository.findCourseGroupAssignmentsWithDueDate();
+  let allParticipants: Array<{ id: string; name: string; email: string }> | null = null;
+
+  for (const assignment of assignments) {
+    if (!assignment.dueAt) continue;
+    if (assignment.class.kind === "ENTRA") {
+      summary.skippedEntraClass += 1;
+      continue;
+    }
+
+    const members: Array<{
+      id: string;
+      name: string;
+      email: string;
+      activeStatus: boolean;
+      isAnonymized: boolean;
+    }> = assignment.class.isSystem
+      ? (allParticipants ??= await findActiveParticipants()).map((u) => ({
+          ...u,
+          activeStatus: true,
+          isAnonymized: false,
+        }))
+      : assignment.class.members.map((m) => m.user);
+
+    const courseTitle = localizeTitle(assignment.course.title);
+    for (const user of members) {
+      const key = keyOf(user.id, assignment.courseId);
+      const existing = map.get(key);
+      if (existing) {
+        // Individuell frist vinner; ellers behold tidligste klasse-frist.
+        if (existing.source === "class" && assignment.dueAt < existing.dueAt) {
+          existing.dueAt = assignment.dueAt;
+        }
+        continue;
+      }
+      map.set(key, {
+        userId: user.id,
+        courseId: assignment.courseId,
+        dueAt: assignment.dueAt,
+        recipientEmail: user.email,
+        recipientName: user.name,
+        courseTitle,
+        activeStatus: user.activeStatus,
+        isAnonymized: user.isAnonymized,
+        source: "class",
+      });
+    }
+  }
+
+  return Array.from(map.values());
+}
+
 export async function runCourseReminderSchedule(input?: {
   asOf?: Date;
   sendImpl?: CourseReminderSendImpl;
@@ -198,22 +301,18 @@ export async function runCourseReminderSchedule(input?: {
     skippedNoTrigger: 0,
     skippedCompleted: 0,
     skippedInactive: 0,
+    skippedEntraClass: 0,
   };
 
-  const enrollments = await enrollmentRepository.findIndividualEnrollmentsWithDueDate();
+  const candidates = await gatherCandidates(summary);
 
-  for (const enrollment of enrollments) {
-    const dueAt = enrollment.dueAt;
-    if (!dueAt) {
-      summary.skippedNoTrigger += 1;
-      continue;
-    }
-    if (!enrollment.user.activeStatus || enrollment.user.isAnonymized) {
+  for (const candidate of candidates) {
+    if (!candidate.activeStatus || candidate.isAnonymized) {
       summary.skippedInactive += 1;
       continue;
     }
 
-    const status = await deriveStatus(enrollment.userId, enrollment.courseId, dueAt, asOf);
+    const status = await deriveStatus(candidate.userId, candidate.courseId, candidate.dueAt, asOf);
     if (status === "COMPLETED") {
       summary.skippedCompleted += 1;
       continue;
@@ -223,10 +322,10 @@ export async function runCourseReminderSchedule(input?: {
     let kind: CourseReminderKind | null = null;
     let daysBefore: number | undefined;
 
-    if (dueDateIsBefore(dueAt, asOf)) {
+    if (dueDateIsBefore(candidate.dueAt, asOf)) {
       kind = "overdue";
     } else {
-      const matched = reminderDaysBefore.find((d) => sameUtcDate(addDays(asOf, d), dueAt));
+      const matched = reminderDaysBefore.find((d) => sameUtcDate(addDays(asOf, d), candidate.dueAt));
       if (matched != null) {
         kind = "due_soon";
         daysBefore = matched;
@@ -238,8 +337,8 @@ export async function runCourseReminderSchedule(input?: {
       continue;
     }
 
-    const userId = enrollment.userId;
-    const alreadySent = await hasReminderBeenSent(enrollment.courseId, (metadataJson) => {
+    const userId = candidate.userId;
+    const alreadySent = await hasReminderBeenSent(candidate.courseId, (metadataJson) => {
       if (!metadataJson.includes(`"userId":"${userId}"`)) return false;
       if (kind === "overdue") {
         return metadataJson.includes('"kind":"overdue"');
@@ -257,32 +356,29 @@ export async function runCourseReminderSchedule(input?: {
 
     summary.processed += 1;
 
-    const courseTitle =
-      localizeContentText(NOTIFY_LOCALE, enrollment.course.title) ?? enrollment.course.title ?? "";
-
     const result = await send({
-      courseId: enrollment.courseId,
+      courseId: candidate.courseId,
       userId,
-      recipientEmail: enrollment.user.email,
-      recipientName: enrollment.user.name,
-      courseTitle,
+      recipientEmail: candidate.recipientEmail,
+      recipientName: candidate.recipientName,
+      courseTitle: candidate.courseTitle,
       kind,
-      dueAt,
+      dueAt: candidate.dueAt,
       daysBefore,
     });
 
     await recordAuditEvent({
       entityType: auditEntityTypes.course,
-      entityId: enrollment.courseId,
+      entityId: candidate.courseId,
       action: result.delivered ? auditActions.course.reminderSent : auditActions.course.reminderFailed,
       actorId: undefined,
       metadata: {
-        courseId: enrollment.courseId,
+        courseId: candidate.courseId,
         userId,
         kind,
         ...(daysBefore != null ? { daysBefore } : {}),
         asOfDate,
-        dueAt: dueAt.toISOString(),
+        dueAt: candidate.dueAt.toISOString(),
         channel: result.channel,
         delivered: result.delivered,
         failureReason: result.failureReason ?? null,

--- a/src/modules/course/courseReminderService.ts
+++ b/src/modules/course/courseReminderService.ts
@@ -1,0 +1,300 @@
+import { env } from "../../config/env.js";
+import { getAssessmentRules } from "../../config/assessmentRules.js";
+import { localizeContentText } from "../../i18n/content.js";
+import {
+  getCourseReminderNotificationMessage,
+  type CourseReminderKind,
+} from "../../i18n/notificationMessages.js";
+import { logOperationalEvent } from "../../observability/operationalLog.js";
+import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
+import { operationalEvents } from "../../observability/operationalEvents.js";
+import { auditRepository } from "../../repositories/auditRepository.js";
+import { recordAuditEvent } from "../../services/auditService.js";
+import { sendViaAcs } from "../certification/participantNotificationService.js";
+import { deriveStatus } from "./enrollmentService.js";
+import { enrollmentRepository } from "./enrollmentRepository.js";
+
+// #497: automatiske kurs-frist-påminnelser (Epic #478, siste «Done når»-pilar). Klon av
+// recert-påminnelses-mønsteret (recertificationService.ts): audit-basert dedup gjør re-kjøring
+// idempotent og restart-trygg. v1 dekker INDIVIDUELLE (eksplisitt tildelte) CourseEnrollment.dueAt;
+// klasse-tildelte frister er fase 2. Ingen per-bruker locale finnes ennå → org-default (nb),
+// samme som diskusjonsvarsler.
+
+const NOTIFY_LOCALE = "nb" as const;
+const NOTIFICATION_TYPE = "course_reminder";
+
+type ReminderChannel = "disabled" | "log" | "webhook" | "acs_email";
+
+export type CourseReminderSendInput = {
+  courseId: string;
+  userId: string;
+  recipientEmail: string;
+  recipientName: string | null;
+  courseTitle: string;
+  kind: CourseReminderKind;
+  dueAt: Date;
+  daysBefore?: number;
+};
+
+export type CourseReminderSendResult = {
+  delivered: boolean;
+  channel: ReminderChannel;
+  failureReason?: string;
+};
+
+export type CourseReminderSendImpl = (input: CourseReminderSendInput) => Promise<CourseReminderSendResult>;
+
+export type CourseReminderScheduleSummary = {
+  asOf: string;
+  processed: number;
+  sent: number;
+  failed: number;
+  skippedAlreadySent: number;
+  skippedNoTrigger: number;
+  skippedCompleted: number;
+  skippedInactive: number;
+};
+
+async function defaultSendCourseReminder(input: CourseReminderSendInput): Promise<CourseReminderSendResult> {
+  const channel = env.PARTICIPANT_NOTIFICATION_CHANNEL;
+  const message = getCourseReminderNotificationMessage(NOTIFY_LOCALE, input.kind, {
+    courseTitle: input.courseTitle,
+    dueAt: input.dueAt,
+    daysBefore: input.daysBefore,
+  });
+  const logPayload = {
+    notificationType: NOTIFICATION_TYPE,
+    courseId: input.courseId,
+    userId: input.userId,
+    recipientEmail: input.recipientEmail,
+    kind: input.kind,
+    dueAt: input.dueAt.toISOString(),
+    daysBefore: input.daysBefore ?? null,
+    emittedAt: new Date().toISOString(),
+  };
+
+  if (channel === "disabled") {
+    return { delivered: false, channel, failureReason: "channel_disabled" };
+  }
+
+  if (channel === "log") {
+    logOperationalEvent(operationalEvents.certification.participantNotificationSent, {
+      channel,
+      ...logPayload,
+    });
+    return { delivered: true, channel };
+  }
+
+  if (channel === "acs_email") {
+    const result = await sendViaAcs({
+      recipientEmail: input.recipientEmail,
+      recipientName: input.recipientName ?? undefined,
+      subject: message.subject,
+      body: message.nextStepGuidance,
+      logPayload: { channel, ...logPayload },
+    });
+    return { delivered: result.delivered, channel, failureReason: result.failureReason };
+  }
+
+  // webhook
+  const webhookUrl = env.PARTICIPANT_NOTIFICATION_WEBHOOK_URL;
+  if (!webhookUrl) {
+    logOperationalEvent(
+      operationalEvents.certification.participantNotificationFailed,
+      { channel, ...logPayload, failureReason: "missing_webhook_url" },
+      "error",
+    );
+    return { delivered: false, channel, failureReason: "missing_webhook_url" };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), env.PARTICIPANT_NOTIFICATION_WEBHOOK_TIMEOUT_MS);
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...logPayload, subject: message.subject, body: message.nextStepGuidance }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const failureReason = `webhook_non_2xx_${response.status}`;
+      logOperationalEvent(
+        operationalEvents.certification.participantNotificationFailed,
+        { channel, ...logPayload, failureReason },
+        "error",
+      );
+      return { delivered: false, channel, failureReason };
+    }
+    logOperationalEvent(operationalEvents.certification.participantNotificationSent, { channel, ...logPayload });
+    return { delivered: true, channel };
+  } catch (error) {
+    const failureReason = error instanceof Error ? error.message : "webhook_send_failed";
+    logOperationalEvent(
+      operationalEvents.certification.participantNotificationFailed,
+      { channel, ...logPayload, failureReason },
+      "error",
+    );
+    return { delivered: false, channel, failureReason };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// Audit-basert dedup: en påminnelse er allerede sendt hvis det finnes en `course_reminder_sent`-rad
+// på kurset som matcher denne mottakeren + typen. due_soon dedup-er per (userId, daysBefore, asOfDate);
+// overdue dedup-er per (userId) — v1 sender forfalt-purring kun én gang.
+async function hasReminderBeenSent(
+  courseId: string,
+  predicate: (metadataJson: string) => boolean,
+): Promise<boolean> {
+  const existing = await auditRepository.findAuditEventMetadataByEntityAndAction(
+    auditEntityTypes.course,
+    courseId,
+    auditActions.course.reminderSent,
+  );
+  return existing.some((event) => predicate(event.metadataJson));
+}
+
+function addDays(input: Date, days: number): Date {
+  const result = new Date(input);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+}
+
+function sameUtcDate(a: Date, b: Date): boolean {
+  return (
+    a.getUTCFullYear() === b.getUTCFullYear() &&
+    a.getUTCMonth() === b.getUTCMonth() &&
+    a.getUTCDate() === b.getUTCDate()
+  );
+}
+
+// Er dueAt-datoen (UTC) strengt før asOf-datoen (UTC)? Brukes for overdue-deteksjon uavhengig av
+// klokkeslett — en frist «i går» er forfalt selv om asOf er tidlig på dagen.
+function dueDateIsBefore(dueAt: Date, asOf: Date): boolean {
+  const due = Date.UTC(dueAt.getUTCFullYear(), dueAt.getUTCMonth(), dueAt.getUTCDate());
+  const now = Date.UTC(asOf.getUTCFullYear(), asOf.getUTCMonth(), asOf.getUTCDate());
+  return due < now;
+}
+
+export async function runCourseReminderSchedule(input?: {
+  asOf?: Date;
+  sendImpl?: CourseReminderSendImpl;
+}): Promise<CourseReminderScheduleSummary> {
+  const asOf = input?.asOf ?? new Date();
+  const send = input?.sendImpl ?? defaultSendCourseReminder;
+  const asOfDate = asOf.toISOString().slice(0, 10);
+
+  const reminderDaysBefore = Array.from(new Set(getAssessmentRules().courseReminders.reminderDaysBefore))
+    .filter((value) => value >= 0)
+    .sort((a, b) => b - a);
+
+  const summary: CourseReminderScheduleSummary = {
+    asOf: asOf.toISOString(),
+    processed: 0,
+    sent: 0,
+    failed: 0,
+    skippedAlreadySent: 0,
+    skippedNoTrigger: 0,
+    skippedCompleted: 0,
+    skippedInactive: 0,
+  };
+
+  const enrollments = await enrollmentRepository.findIndividualEnrollmentsWithDueDate();
+
+  for (const enrollment of enrollments) {
+    const dueAt = enrollment.dueAt;
+    if (!dueAt) {
+      summary.skippedNoTrigger += 1;
+      continue;
+    }
+    if (!enrollment.user.activeStatus || enrollment.user.isAnonymized) {
+      summary.skippedInactive += 1;
+      continue;
+    }
+
+    const status = await deriveStatus(enrollment.userId, enrollment.courseId, dueAt, asOf);
+    if (status === "COMPLETED") {
+      summary.skippedCompleted += 1;
+      continue;
+    }
+
+    // Bestem type: forfalt (dueAt < i dag) → overdue, ellers sjekk due_soon-offsets.
+    let kind: CourseReminderKind | null = null;
+    let daysBefore: number | undefined;
+
+    if (dueDateIsBefore(dueAt, asOf)) {
+      kind = "overdue";
+    } else {
+      const matched = reminderDaysBefore.find((d) => sameUtcDate(addDays(asOf, d), dueAt));
+      if (matched != null) {
+        kind = "due_soon";
+        daysBefore = matched;
+      }
+    }
+
+    if (kind == null) {
+      summary.skippedNoTrigger += 1;
+      continue;
+    }
+
+    const userId = enrollment.userId;
+    const alreadySent = await hasReminderBeenSent(enrollment.courseId, (metadataJson) => {
+      if (!metadataJson.includes(`"userId":"${userId}"`)) return false;
+      if (kind === "overdue") {
+        return metadataJson.includes('"kind":"overdue"');
+      }
+      return (
+        metadataJson.includes('"kind":"due_soon"') &&
+        metadataJson.includes(`"daysBefore":${daysBefore}`) &&
+        metadataJson.includes(`"asOfDate":"${asOfDate}"`)
+      );
+    });
+    if (alreadySent) {
+      summary.skippedAlreadySent += 1;
+      continue;
+    }
+
+    summary.processed += 1;
+
+    const courseTitle =
+      localizeContentText(NOTIFY_LOCALE, enrollment.course.title) ?? enrollment.course.title ?? "";
+
+    const result = await send({
+      courseId: enrollment.courseId,
+      userId,
+      recipientEmail: enrollment.user.email,
+      recipientName: enrollment.user.name,
+      courseTitle,
+      kind,
+      dueAt,
+      daysBefore,
+    });
+
+    await recordAuditEvent({
+      entityType: auditEntityTypes.course,
+      entityId: enrollment.courseId,
+      action: result.delivered ? auditActions.course.reminderSent : auditActions.course.reminderFailed,
+      actorId: undefined,
+      metadata: {
+        courseId: enrollment.courseId,
+        userId,
+        kind,
+        ...(daysBefore != null ? { daysBefore } : {}),
+        asOfDate,
+        dueAt: dueAt.toISOString(),
+        channel: result.channel,
+        delivered: result.delivered,
+        failureReason: result.failureReason ?? null,
+      },
+    });
+
+    if (result.delivered) {
+      summary.sent += 1;
+    } else {
+      summary.failed += 1;
+    }
+  }
+
+  return summary;
+}

--- a/src/modules/course/enrollmentRepository.ts
+++ b/src/modules/course/enrollmentRepository.ts
@@ -63,6 +63,20 @@ export function createEnrollmentRepository(client: EnrollmentRepositoryClient = 
         include: { user: { select: { id: true, name: true, email: true, department: true } } },
       });
     },
+
+    // #497: individual (explicitly assigned) enrollments that carry a due date, for the reminder
+    // schedule. Skips revoked enrollments and enrollments without a dueAt at the query level; the
+    // service layer further filters completed courses and inactive/anonymized users. Includes the
+    // participant + the (localized) course title so no extra per-row lookups are needed.
+    findIndividualEnrollmentsWithDueDate() {
+      return client.courseEnrollment.findMany({
+        where: { revokedAt: null, dueAt: { not: null } },
+        include: {
+          user: { select: { id: true, name: true, email: true, activeStatus: true, isAnonymized: true } },
+          course: { select: { id: true, title: true } },
+        },
+      });
+    },
   };
 }
 

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -50,6 +50,7 @@ export { isClassEntraLinkingEnabled, CLASS_ENTRA_LINKING_KEY } from "./classConf
 export {
   createClass,
   archiveClass,
+  restoreClass,
   addMember,
   removeMember,
   listClasses,

--- a/src/observability/auditEvents.ts
+++ b/src/observability/auditEvents.ts
@@ -86,6 +86,9 @@ export const auditActions = {
     // #762: destruktiv opprydding — slett kurs + dets eksklusivt-eide moduler/seksjoner.
     cascadeDeleted: "course_cascade_deleted",
     completionIssued: "course_completion_issued",
+    // #497: automatiske frist-påminnelser (frist nærmer seg / forfalt) fra bakgrunnsjobben.
+    reminderSent: "course_reminder_sent",
+    reminderFailed: "course_reminder_failed",
   },
   section: {
     created: "section_created",
@@ -321,6 +324,29 @@ export type AuditMetadataByAction = {
     userId: string;
     courseId: string;
     certificateId: string;
+  }>;
+  // #497: frist-påminnelse sendt/feilet. `daysBefore` er kun satt for kind="due_soon".
+  [auditActions.course.reminderSent]: EventMetadata<{
+    courseId: string;
+    userId: string;
+    kind: "due_soon" | "overdue";
+    daysBefore?: number;
+    asOfDate: string;
+    dueAt: string;
+    channel: string;
+    delivered: boolean;
+    failureReason?: string | null;
+  }>;
+  [auditActions.course.reminderFailed]: EventMetadata<{
+    courseId: string;
+    userId: string;
+    kind: "due_soon" | "overdue";
+    daysBefore?: number;
+    asOfDate: string;
+    dueAt: string;
+    channel: string;
+    delivered: boolean;
+    failureReason?: string | null;
   }>;
   [auditActions.enrollment.assigned]: EventMetadata<{
     userId: string;

--- a/src/observability/auditEvents.ts
+++ b/src/observability/auditEvents.ts
@@ -105,6 +105,7 @@ export const auditActions = {
   class: {
     created: "class_created",
     archived: "class_archived",
+    restored: "class_restored",
     memberAdded: "class_member_added",
     memberRemoved: "class_member_removed",
     courseAssigned: "class_course_assigned",
@@ -357,6 +358,7 @@ export type AuditMetadataByAction = {
   [auditActions.enrollment.selfEnrolled]: EventMetadata<{ userId: string; courseId: string }>;
   [auditActions.class.created]: EventMetadata<{ classId: string; name: string }>;
   [auditActions.class.archived]: EventMetadata<{ classId: string }>;
+  [auditActions.class.restored]: EventMetadata<{ classId: string }>;
   [auditActions.class.memberAdded]: EventMetadata<{ classId: string; userId: string }>;
   [auditActions.class.memberRemoved]: EventMetadata<{ classId: string; userId: string }>;
   [auditActions.class.courseAssigned]: EventMetadata<{ classId: string; courseId: string }>;

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -1,4 +1,5 @@
 import type { AppRole as AppRoleType } from "@prisma/client";
+import { AppRole } from "../db/prismaRuntime.js";
 import type { AuthPrincipal } from "../auth/principal.js";
 import { parseEntraGroupRoleMapJson } from "../auth/entraRoleMap.js";
 import { prisma } from "../db/prisma.js";
@@ -126,6 +127,26 @@ export async function upsertUserFromPrincipal(principal: AuthPrincipal) {
       },
     });
   }
+}
+
+// #497 fase 2: resolves the dynamic membership of the built-in "Alle deltakere" system class — all
+// active, non-anonymized users holding an active PARTICIPANT role. Mirrors the role-active predicate
+// used elsewhere (validFrom <= now, validTo null-or-future).
+export async function findActiveParticipants(at = new Date()) {
+  return prisma.user.findMany({
+    where: {
+      activeStatus: true,
+      isAnonymized: false,
+      roleAssignments: {
+        some: {
+          appRole: AppRole.PARTICIPANT,
+          validFrom: { lte: at },
+          OR: [{ validTo: null }, { validTo: { gte: at } }],
+        },
+      },
+    },
+    select: { id: true, name: true, email: true },
+  });
 }
 
 export async function getActiveRoles(userId: string, at = new Date()): Promise<AppRoleType[]> {

--- a/src/routes/adminClasses.ts
+++ b/src/routes/adminClasses.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   createClass,
   archiveClass,
+  restoreClass,
   addMember,
   removeMember,
   listClasses,
@@ -49,6 +50,15 @@ adminClassesRouter.delete("/:classId", async (request: Request<{ classId: string
   try {
     await archiveClass(request.params.classId, request.context?.userId ?? null);
     response.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+adminClassesRouter.post("/:classId/restore", async (request: Request<{ classId: string }>, response, next) => {
+  try {
+    await restoreClass(request.params.classId, request.context?.userId ?? null);
+    response.json({ ok: true });
   } catch (error) {
     next(error);
   }

--- a/test/e2e/admin-content-classes.spec.ts
+++ b/test/e2e/admin-content-classes.spec.ts
@@ -125,6 +125,55 @@ test("classes admin: list, create, add a student via search, and assign a course
   await expect(page.locator("#courseChips")).toContainText("Frist: 17.07.2026");
 });
 
+// #705-family: classes render consistently with the other lifecycle lists — Aktive/Arkiverte filter,
+// a Type column (System/Manuell/Entra), an "Arkivert" status badge, and a symmetric Gjenopprett action.
+test("classes admin: Aktive/Arkiverte filter, Type column, and restore action", async ({ page }) => {
+  await mockBaseApis(page);
+  const classes = [
+    { id: "cls_all_participants", name: "Alle deltakere", isSystem: true, kind: "MANUAL", archivedAt: null, _count: { members: 3, courseAssignments: 1 } },
+    { id: "cls-active", name: "Kull Aktiv", isSystem: false, kind: "MANUAL", archivedAt: null, _count: { members: 2, courseAssignments: 0 } },
+    { id: "cls-entra", name: "Entra-gruppe", isSystem: false, kind: "ENTRA", archivedAt: null, _count: { members: 0, courseAssignments: 0 } },
+    { id: "cls-arch", name: "Kull Arkivert", isSystem: false, kind: "MANUAL", archivedAt: "2026-01-01T00:00:00.000Z", _count: { members: 1, courseAssignments: 0 } },
+  ];
+  await page.route("**/api/admin/content/classes", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ classes }) }),
+  );
+  let restoreUrl: string | null = null;
+  await page.route("**/api/admin/content/classes/*/restore", (route: Route) => {
+    restoreUrl = route.request().url();
+    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true }) });
+  });
+
+  await page.goto("/admin-content/classes");
+  await expect(page.locator("h1")).toContainText("Klasser");
+  const body = page.locator("#classesTableBody");
+
+  // Default "Aktive": active classes shown, archived hidden.
+  await expect(body).toContainText("Kull Aktiv");
+  await expect(body).toContainText("Alle deltakere");
+  await expect(body).not.toContainText("Kull Arkivert");
+
+  // Type column labels are present.
+  await expect(body).toContainText("System");
+  await expect(body).toContainText("Entra");
+  await expect(body).toContainText("Manuell");
+
+  // The system class has no archive/restore action.
+  await expect(body.locator('[data-action="archive"][data-id="cls_all_participants"]')).toHaveCount(0);
+
+  // Switch to "Arkiverte": only the archived class, with an "Arkivert" badge + a Gjenopprett action.
+  await page.locator('.list-filter-btn[data-filter="archived"]').click();
+  await expect(body).toContainText("Kull Arkivert");
+  await expect(body).not.toContainText("Kull Aktiv");
+  await expect(body).toContainText("Arkivert");
+  await expect(body.locator('[data-action="restore"][data-id="cls-arch"]')).toBeVisible();
+
+  // Restore → confirm dialog → POST /:classId/restore.
+  page.once("dialog", (dialog) => dialog.accept());
+  await body.locator('[data-action="restore"][data-id="cls-arch"]').click();
+  await expect.poll(() => restoreUrl).toContain("/classes/cls-arch/restore");
+});
+
 // #690: the "Synk brukere fra Entra" button is ADMINISTRATOR-only and triggers the Entra user sync.
 test("classes admin: Entra user-sync button is admin-only and posts to the sync endpoint", async ({ page }) => {
   // SUBJECT_MATTER_OWNER must NOT see the button.

--- a/test/e2e/admin-content-classes.spec.ts
+++ b/test/e2e/admin-content-classes.spec.ts
@@ -59,6 +59,10 @@ test("classes admin: list, create, add a student via search, and assign a course
   await page.route("**/api/admin/content/classes/*/courses", (route: Route) => {
     if (route.request().method() === "POST") {
       coursePosted = true;
+      // #497: mirror the server — persist the assigned course WITH its due date so the re-rendered
+      // chip can display the frist.
+      const body = route.request().postDataJSON() as { courseId: string; dueAt?: string };
+      state.assignedCourses.push({ courseId: body.courseId, title: JSON.stringify({ nb: "Arbeidsmiljø" }), dueAt: body.dueAt ?? null });
       return route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ ok: true }) });
     }
     return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ courses: state.assignedCourses }) });
@@ -107,10 +111,18 @@ test("classes admin: list, create, add a student via search, and assign a course
   await expect(page.locator('#courseSelect option[value="course-arch"]')).toHaveCount(0);
   await expect(page.locator('#courseSelect option[value="course-1"]')).toHaveCount(1);
 
-  // Assign a course.
+  // #497: the due-date input carries a visible label so it is clear what the date means.
+  await expect(page.locator('label[for="dueAtInput"]')).toContainText("Frist");
+
+  // Assign a course WITH a due date.
   await page.locator("#courseSelect").selectOption("course-1");
+  await page.locator("#dueAtInput").fill("2026-07-17");
   await page.locator("#assignCourseBtn").click();
   await expect.poll(() => coursePosted).toBe(true);
+
+  // #497: the assigned-course chip shows the frist (formatted DD.MM.YYYY, no timezone shift).
+  await expect(page.locator("#courseChips")).toContainText("Arbeidsmiljø");
+  await expect(page.locator("#courseChips")).toContainText("Frist: 17.07.2026");
 });
 
 // #690: the "Synk brukere fra Entra" button is ADMINISTRATOR-only and triggers the Entra user sync.

--- a/test/m2-classes.test.ts
+++ b/test/m2-classes.test.ts
@@ -107,6 +107,49 @@ describe("Class (cohort) management + dynamic assignment (#645/CL-2)", () => {
     expect((await request(app).post("/api/admin/content/classes").set(participantHeaders(`cls-forbid-${Date.now()}`)).send({ name: "Nope" })).status).toBe(403);
   });
 
+  // #705-family: a class can be archived AND restored (symmetric lifecycle), the list returns both
+  // active and archived classes with archivedAt + kind so the admin UI can filter/badge them, and the
+  // system class can never be restored (it is never archived).
+  it("archives then restores a class; the list exposes archivedAt + kind; system class cannot be restored", async () => {
+    const created = await request(app).post("/api/admin/content/classes").set(adminHeaders).send({ name: "Kull lifecycle" });
+    const classId = created.body.class.id as string;
+
+    type ClassRow = { id: string; kind: string; isSystem: boolean; archivedAt: string | null };
+    const findRow = async (): Promise<ClassRow | undefined> => {
+      const list = await request(app).get("/api/admin/content/classes").set(adminHeaders);
+      return (list.body.classes as ClassRow[]).find((c) => c.id === classId);
+    };
+
+    // Freshly created → active, MANUAL, and present in the list with archivedAt null + kind exposed.
+    let row = await findRow();
+    expect(row).toBeTruthy();
+    expect(row?.archivedAt).toBeNull();
+    expect(row?.kind).toBe("MANUAL");
+
+    // Archive → still in the list (so the UI can show it under "Arkiverte"), now with archivedAt set.
+    expect((await request(app).delete(`/api/admin/content/classes/${classId}`).set(adminHeaders)).status).toBe(204);
+    row = await findRow();
+    expect(row?.archivedAt).not.toBeNull();
+
+    // Restore → active again.
+    expect((await request(app).post(`/api/admin/content/classes/${classId}/restore`).set(adminHeaders)).status).toBe(200);
+    row = await findRow();
+    expect(row?.archivedAt).toBeNull();
+
+    // An audit trail records both transitions.
+    const auditActionsForClass = (
+      await prisma.auditEvent.findMany({ where: { entityType: "class", entityId: classId }, select: { action: true } })
+    ).map((e) => e.action);
+    expect(auditActionsForClass).toContain("class_archived");
+    expect(auditActionsForClass).toContain("class_restored");
+
+    // The system class is never archived → restoring it is rejected.
+    expect((await request(app).post(`/api/admin/content/classes/${SYSTEM_ALL_PARTICIPANTS_CLASS_ID}/restore`).set(adminHeaders)).status).toBe(400);
+
+    await prisma.auditEvent.deleteMany({ where: { entityType: "class", entityId: classId } });
+    await prisma.class.delete({ where: { id: classId } });
+  });
+
   // #688: archived courses must not be assignable to a class.
   it("refuses to assign an archived course to a class", async () => {
     const courseId = await createRestrictedCourse();

--- a/test/m2-course-reminders.test.ts
+++ b/test/m2-course-reminders.test.ts
@@ -1,16 +1,18 @@
-import { afterAll, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { prisma } from "../src/db/prisma.js";
 import {
   runCourseReminderSchedule,
   type CourseReminderSendInput,
   type CourseReminderSendResult,
 } from "../src/modules/course/courseReminderService.js";
+import { SYSTEM_ALL_PARTICIPANTS_CLASS_ID } from "../src/modules/course/classRepository.js";
 import { auditActions, auditEntityTypes } from "../src/observability/auditEvents.js";
 
-// #497 — course due-date reminders. Exercises the orchestrator against native Postgres with an
-// injected capturing sendImpl (no real email regardless of channel). Verifies: due-soon fires on
-// offset match, overdue fires once, no send for completed / revoked / inactive / no-dueAt, and that
-// a same-asOf re-run is idempotent (audit-based dedup).
+// #497 — course due-date reminders. Runs the orchestrator against native Postgres with an injected
+// capturing sendImpl (no real email). Covers both sources: individual CourseEnrollment.dueAt (v1) and
+// class-assigned CourseGroupAssignment.dueAt (fase 2 — MANUAL + system "Alle deltakere"; ENTRA skipped).
+// Assertions are filtered to each test's own user IDs so they are robust against unrelated rows in the
+// shared test DB; each test cleans up in afterEach.
 
 const T = new Date("2026-03-01T12:00:00.000Z"); // fixed "asOf"
 
@@ -29,47 +31,20 @@ function makeCapture() {
   return { sent, sendImpl };
 }
 
+// Only the sends addressed to user IDs this test created — ignores unrelated shared-DB rows.
+function ownedSends(sent: CourseReminderSendInput[], ownedUserIds: string[]) {
+  const owned = new Set(ownedUserIds);
+  return new Map(sent.filter((s) => owned.has(s.userId)).map((s) => [s.userId, s]));
+}
+
 describe("Course due-date reminders (#497)", () => {
   const stamp = `${Date.now()}-${Math.round(performance.now())}`;
-  const createdUserIds: string[] = [];
-  let courseId = "";
+  let seq = 0;
+  const courseIds: string[] = [];
+  const userIds: string[] = [];
+  const classIds: string[] = [];
 
-  async function makeUser(tag: string, opts: { activeStatus?: boolean } = {}): Promise<string> {
-    const user = await prisma.user.create({
-      data: {
-        externalId: `cr-${tag}-${stamp}`,
-        name: `CR ${tag}`,
-        email: `cr-${tag}-${stamp}@x.test`,
-        activeStatus: opts.activeStatus ?? true,
-      },
-      select: { id: true },
-    });
-    createdUserIds.push(user.id);
-    return user.id;
-  }
-
-  async function enrol(userId: string, dueAt: Date | null, opts: { revoked?: boolean } = {}) {
-    await prisma.courseEnrollment.create({
-      data: {
-        userId,
-        courseId,
-        source: "INDIVIDUAL",
-        dueAt,
-        revokedAt: opts.revoked ? new Date() : null,
-      },
-    });
-  }
-
-  afterAll(async () => {
-    await prisma.auditEvent.deleteMany({ where: { entityType: auditEntityTypes.course, entityId: courseId } });
-    await prisma.courseCompletion.deleteMany({ where: { courseId } });
-    await prisma.courseEnrollment.deleteMany({ where: { courseId } });
-    if (courseId) await prisma.course.delete({ where: { id: courseId } });
-    if (createdUserIds.length) await prisma.user.deleteMany({ where: { id: { in: createdUserIds } } });
-    await prisma.$disconnect();
-  });
-
-  it("sends due-soon + overdue to the right participants and is idempotent", async () => {
+  async function makeCourse(): Promise<string> {
     const course = await prisma.course.create({
       data: {
         title: JSON.stringify({ "en-GB": "Reminder course", nb: "Påminnelseskurs", nn: "Påminningskurs" }),
@@ -77,8 +52,74 @@ describe("Course due-date reminders (#497)", () => {
       },
       select: { id: true },
     });
-    courseId = course.id;
+    courseIds.push(course.id);
+    return course.id;
+  }
 
+  async function makeUser(tag: string, opts: { activeStatus?: boolean; participant?: boolean } = {}): Promise<string> {
+    seq += 1;
+    const user = await prisma.user.create({
+      data: {
+        externalId: `cr-${tag}-${stamp}-${seq}`,
+        name: `CR ${tag}`,
+        email: `cr-${tag}-${stamp}-${seq}@x.test`,
+        activeStatus: opts.activeStatus ?? true,
+        ...(opts.participant
+          ? { roleAssignments: { create: { appRole: "PARTICIPANT", validFrom: new Date("2020-01-01T00:00:00.000Z") } } }
+          : {}),
+      },
+      select: { id: true },
+    });
+    userIds.push(user.id);
+    return user.id;
+  }
+
+  async function enrol(userId: string, courseId: string, dueAt: Date | null, opts: { revoked?: boolean } = {}) {
+    await prisma.courseEnrollment.create({
+      data: { userId, courseId, source: "INDIVIDUAL", dueAt, revokedAt: opts.revoked ? new Date() : null },
+    });
+  }
+
+  async function makeClass(kind: "MANUAL" | "ENTRA", memberUserIds: string[]): Promise<string> {
+    seq += 1;
+    const cls = await prisma.class.create({
+      data: {
+        name: `CR class ${stamp}-${seq}`,
+        kind,
+        ...(kind === "ENTRA" ? { entraGroupId: `grp-${stamp}-${seq}` } : {}),
+        members: { create: memberUserIds.map((userId) => ({ userId })) },
+      },
+      select: { id: true },
+    });
+    classIds.push(cls.id);
+    return cls.id;
+  }
+
+  async function assignClass(courseId: string, classId: string, dueAt: Date | null) {
+    await prisma.courseGroupAssignment.create({ data: { courseId, classId, dueAt } });
+  }
+
+  afterEach(async () => {
+    await prisma.auditEvent.deleteMany({
+      where: { entityType: auditEntityTypes.course, entityId: { in: courseIds } },
+    });
+    await prisma.courseCompletion.deleteMany({ where: { courseId: { in: courseIds } } });
+    await prisma.courseEnrollment.deleteMany({ where: { courseId: { in: courseIds } } });
+    await prisma.courseGroupAssignment.deleteMany({
+      where: { OR: [{ courseId: { in: courseIds } }, { classId: { in: classIds } }] },
+    });
+    await prisma.classMember.deleteMany({ where: { classId: { in: classIds } } });
+    await prisma.roleAssignment.deleteMany({ where: { userId: { in: userIds } } });
+    if (classIds.length) await prisma.class.deleteMany({ where: { id: { in: classIds } } });
+    if (courseIds.length) await prisma.course.deleteMany({ where: { id: { in: courseIds } } });
+    if (userIds.length) await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+    courseIds.length = 0;
+    userIds.length = 0;
+    classIds.length = 0;
+  });
+
+  it("individual: sends due-soon + overdue to the right participants and is idempotent", async () => {
+    const courseId = await makeCourse();
     const dueSoon7 = await makeUser("due7");
     const dueSoon1 = await makeUser("due1");
     const overdue = await makeUser("overdue");
@@ -88,56 +129,86 @@ describe("Course due-date reminders (#497)", () => {
     const revoked = await makeUser("revoked");
     const noDue = await makeUser("nodue");
 
-    await enrol(dueSoon7, daysFromT(7));
-    await enrol(dueSoon1, daysFromT(1));
-    await enrol(overdue, daysFromT(-3));
-    await enrol(notYet, daysFromT(3)); // no offset match, not overdue
-    await enrol(completed, daysFromT(7));
-    await enrol(inactive, daysFromT(-3));
-    await enrol(revoked, daysFromT(7), { revoked: true });
-    await enrol(noDue, null);
+    await enrol(dueSoon7, courseId, daysFromT(7));
+    await enrol(dueSoon1, courseId, daysFromT(1));
+    await enrol(overdue, courseId, daysFromT(-3));
+    await enrol(notYet, courseId, daysFromT(3)); // no offset match, not overdue
+    await enrol(completed, courseId, daysFromT(7));
+    await enrol(inactive, courseId, daysFromT(-3));
+    await enrol(revoked, courseId, daysFromT(7), { revoked: true });
+    await enrol(noDue, courseId, null);
+    await prisma.courseCompletion.create({ data: { userId: completed, courseId, moduleSnapshotJson: "[]" } });
 
-    // completed user has a CourseCompletion → deriveStatus === COMPLETED → skipped.
-    await prisma.courseCompletion.create({
-      data: { userId: completed, courseId, moduleSnapshotJson: "[]" },
-    });
-
+    const owned = [dueSoon7, dueSoon1, overdue, notYet, completed, inactive, revoked, noDue];
     const first = makeCapture();
-    const summary = await runCourseReminderSchedule({ asOf: T, sendImpl: first.sendImpl });
+    await runCourseReminderSchedule({ asOf: T, sendImpl: first.sendImpl });
+    const sentTo = ownedSends(first.sent, owned);
 
-    const sentTo = new Map(first.sent.map((s) => [s.userId, s]));
     expect(new Set(sentTo.keys())).toEqual(new Set([dueSoon7, dueSoon1, overdue]));
-
     expect(sentTo.get(dueSoon7)?.kind).toBe("due_soon");
     expect(sentTo.get(dueSoon7)?.daysBefore).toBe(7);
-    expect(sentTo.get(dueSoon1)?.kind).toBe("due_soon");
+    expect(sentTo.get(dueSoon7)?.courseTitle).toBe("Påminnelseskurs"); // localized (nb)
     expect(sentTo.get(dueSoon1)?.daysBefore).toBe(1);
     expect(sentTo.get(overdue)?.kind).toBe("overdue");
     expect(sentTo.get(overdue)?.daysBefore).toBeUndefined();
 
-    // Localized course title resolved (org-default nb).
-    expect(sentTo.get(dueSoon7)?.courseTitle).toBe("Påminnelseskurs");
+    // Idempotent: same-asOf re-run sends nothing new for our users (audit dedup).
+    const second = makeCapture();
+    await runCourseReminderSchedule({ asOf: T, sendImpl: second.sendImpl });
+    expect(ownedSends(second.sent, owned).size).toBe(0);
 
-    expect(summary.sent).toBe(3);
-    expect(summary.failed).toBe(0);
-    expect(summary.skippedCompleted).toBe(1); // completed
-    expect(summary.skippedInactive).toBe(1); // inactive
-
-    // Audit rows persisted with correct metadata.
     const auditRows = await prisma.auditEvent.findMany({
-      where: {
-        entityType: auditEntityTypes.course,
-        entityId: courseId,
-        action: auditActions.course.reminderSent,
-      },
+      where: { entityType: auditEntityTypes.course, entityId: courseId, action: auditActions.course.reminderSent },
     });
     expect(auditRows).toHaveLength(3);
+  });
 
-    // Idempotent: a same-asOf re-run sends nothing new (audit-based dedup).
-    const second = makeCapture();
-    const summary2 = await runCourseReminderSchedule({ asOf: T, sendImpl: second.sendImpl });
-    expect(second.sent).toHaveLength(0);
-    expect(summary2.sent).toBe(0);
-    expect(summary2.skippedAlreadySent).toBe(3);
+  it("class: expands MANUAL membership, applies precedence (individual > class, earliest class wins), skips ENTRA", async () => {
+    const courseId = await makeCourse();
+
+    const onlyClass = await makeUser("onlyclass"); // member of a class due in 7 days
+    const bothIndOverdue = await makeUser("both"); // individual overdue + class due-soon → individual wins
+    const twoClasses = await makeUser("twoclass"); // in two classes (due 7 and due 1) → earliest (1) wins
+    const entraOnly = await makeUser("entra"); // only in an ENTRA class → skipped
+
+    const m1 = await makeClass("MANUAL", [onlyClass, bothIndOverdue, twoClasses]);
+    const m2 = await makeClass("MANUAL", [twoClasses]);
+    const entra = await makeClass("ENTRA", [entraOnly]);
+
+    await assignClass(courseId, m1, daysFromT(7));
+    await assignClass(courseId, m2, daysFromT(1));
+    await assignClass(courseId, entra, daysFromT(7));
+    await enrol(bothIndOverdue, courseId, daysFromT(-3)); // individual overdue
+
+    const owned = [onlyClass, bothIndOverdue, twoClasses, entraOnly];
+    const cap = makeCapture();
+    const summary = await runCourseReminderSchedule({ asOf: T, sendImpl: cap.sendImpl });
+    const sentTo = ownedSends(cap.sent, owned);
+
+    expect(new Set(sentTo.keys())).toEqual(new Set([onlyClass, bothIndOverdue, twoClasses]));
+    expect(sentTo.get(onlyClass)?.kind).toBe("due_soon");
+    expect(sentTo.get(onlyClass)?.daysBefore).toBe(7);
+    // individual due date (overdue) wins over the class due-soon:
+    expect(sentTo.get(bothIndOverdue)?.kind).toBe("overdue");
+    // earliest of the two class due dates (1 day) wins → single reminder:
+    expect(sentTo.get(twoClasses)?.kind).toBe("due_soon");
+    expect(sentTo.get(twoClasses)?.daysBefore).toBe(1);
+    // ENTRA class is not resolvable in a background job → skipped, no send:
+    expect(sentTo.has(entraOnly)).toBe(false);
+    expect(summary.skippedEntraClass).toBeGreaterThanOrEqual(1);
+  });
+
+  it("class: the system 'Alle deltakere' class reaches active participants", async () => {
+    const courseId = await makeCourse();
+    const participant = await makeUser("sysparticipant", { participant: true });
+
+    await assignClass(courseId, SYSTEM_ALL_PARTICIPANTS_CLASS_ID, daysFromT(1));
+
+    const cap = makeCapture();
+    await runCourseReminderSchedule({ asOf: T, sendImpl: cap.sendImpl });
+    const sentTo = ownedSends(cap.sent, [participant]);
+
+    expect(sentTo.get(participant)?.kind).toBe("due_soon");
+    expect(sentTo.get(participant)?.daysBefore).toBe(1);
   });
 });

--- a/test/m2-course-reminders.test.ts
+++ b/test/m2-course-reminders.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { prisma } from "../src/db/prisma.js";
+import {
+  runCourseReminderSchedule,
+  type CourseReminderSendInput,
+  type CourseReminderSendResult,
+} from "../src/modules/course/courseReminderService.js";
+import { auditActions, auditEntityTypes } from "../src/observability/auditEvents.js";
+
+// #497 — course due-date reminders. Exercises the orchestrator against native Postgres with an
+// injected capturing sendImpl (no real email regardless of channel). Verifies: due-soon fires on
+// offset match, overdue fires once, no send for completed / revoked / inactive / no-dueAt, and that
+// a same-asOf re-run is idempotent (audit-based dedup).
+
+const T = new Date("2026-03-01T12:00:00.000Z"); // fixed "asOf"
+
+function daysFromT(days: number): Date {
+  const d = new Date(T);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d;
+}
+
+function makeCapture() {
+  const sent: CourseReminderSendInput[] = [];
+  const sendImpl = async (input: CourseReminderSendInput): Promise<CourseReminderSendResult> => {
+    sent.push(input);
+    return { delivered: true, channel: "log" };
+  };
+  return { sent, sendImpl };
+}
+
+describe("Course due-date reminders (#497)", () => {
+  const stamp = `${Date.now()}-${Math.round(performance.now())}`;
+  const createdUserIds: string[] = [];
+  let courseId = "";
+
+  async function makeUser(tag: string, opts: { activeStatus?: boolean } = {}): Promise<string> {
+    const user = await prisma.user.create({
+      data: {
+        externalId: `cr-${tag}-${stamp}`,
+        name: `CR ${tag}`,
+        email: `cr-${tag}-${stamp}@x.test`,
+        activeStatus: opts.activeStatus ?? true,
+      },
+      select: { id: true },
+    });
+    createdUserIds.push(user.id);
+    return user.id;
+  }
+
+  async function enrol(userId: string, dueAt: Date | null, opts: { revoked?: boolean } = {}) {
+    await prisma.courseEnrollment.create({
+      data: {
+        userId,
+        courseId,
+        source: "INDIVIDUAL",
+        dueAt,
+        revokedAt: opts.revoked ? new Date() : null,
+      },
+    });
+  }
+
+  afterAll(async () => {
+    await prisma.auditEvent.deleteMany({ where: { entityType: auditEntityTypes.course, entityId: courseId } });
+    await prisma.courseCompletion.deleteMany({ where: { courseId } });
+    await prisma.courseEnrollment.deleteMany({ where: { courseId } });
+    if (courseId) await prisma.course.delete({ where: { id: courseId } });
+    if (createdUserIds.length) await prisma.user.deleteMany({ where: { id: { in: createdUserIds } } });
+    await prisma.$disconnect();
+  });
+
+  it("sends due-soon + overdue to the right participants and is idempotent", async () => {
+    const course = await prisma.course.create({
+      data: {
+        title: JSON.stringify({ "en-GB": "Reminder course", nb: "Påminnelseskurs", nn: "Påminningskurs" }),
+        publishedAt: new Date(),
+      },
+      select: { id: true },
+    });
+    courseId = course.id;
+
+    const dueSoon7 = await makeUser("due7");
+    const dueSoon1 = await makeUser("due1");
+    const overdue = await makeUser("overdue");
+    const notYet = await makeUser("notyet");
+    const completed = await makeUser("completed");
+    const inactive = await makeUser("inactive", { activeStatus: false });
+    const revoked = await makeUser("revoked");
+    const noDue = await makeUser("nodue");
+
+    await enrol(dueSoon7, daysFromT(7));
+    await enrol(dueSoon1, daysFromT(1));
+    await enrol(overdue, daysFromT(-3));
+    await enrol(notYet, daysFromT(3)); // no offset match, not overdue
+    await enrol(completed, daysFromT(7));
+    await enrol(inactive, daysFromT(-3));
+    await enrol(revoked, daysFromT(7), { revoked: true });
+    await enrol(noDue, null);
+
+    // completed user has a CourseCompletion → deriveStatus === COMPLETED → skipped.
+    await prisma.courseCompletion.create({
+      data: { userId: completed, courseId, moduleSnapshotJson: "[]" },
+    });
+
+    const first = makeCapture();
+    const summary = await runCourseReminderSchedule({ asOf: T, sendImpl: first.sendImpl });
+
+    const sentTo = new Map(first.sent.map((s) => [s.userId, s]));
+    expect(new Set(sentTo.keys())).toEqual(new Set([dueSoon7, dueSoon1, overdue]));
+
+    expect(sentTo.get(dueSoon7)?.kind).toBe("due_soon");
+    expect(sentTo.get(dueSoon7)?.daysBefore).toBe(7);
+    expect(sentTo.get(dueSoon1)?.kind).toBe("due_soon");
+    expect(sentTo.get(dueSoon1)?.daysBefore).toBe(1);
+    expect(sentTo.get(overdue)?.kind).toBe("overdue");
+    expect(sentTo.get(overdue)?.daysBefore).toBeUndefined();
+
+    // Localized course title resolved (org-default nb).
+    expect(sentTo.get(dueSoon7)?.courseTitle).toBe("Påminnelseskurs");
+
+    expect(summary.sent).toBe(3);
+    expect(summary.failed).toBe(0);
+    expect(summary.skippedCompleted).toBe(1); // completed
+    expect(summary.skippedInactive).toBe(1); // inactive
+
+    // Audit rows persisted with correct metadata.
+    const auditRows = await prisma.auditEvent.findMany({
+      where: {
+        entityType: auditEntityTypes.course,
+        entityId: courseId,
+        action: auditActions.course.reminderSent,
+      },
+    });
+    expect(auditRows).toHaveLength(3);
+
+    // Idempotent: a same-asOf re-run sends nothing new (audit-based dedup).
+    const second = makeCapture();
+    const summary2 = await runCourseReminderSchedule({ asOf: T, sendImpl: second.sendImpl });
+    expect(second.sent).toHaveLength(0);
+    expect(summary2.sent).toBe(0);
+    expect(summary2.skippedAlreadySent).toBe(3);
+  });
+});

--- a/test/unit/course-reminder-message.test.ts
+++ b/test/unit/course-reminder-message.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { getCourseReminderNotificationMessage } from "../../src/i18n/notificationMessages.js";
+import type { SupportedLocale } from "../../src/i18n/locale.js";
+
+// #497 — course reminder email copy. Must render in nb/nn/en-GB and, per #688, contain NO links
+// (participants are asked to log in themselves).
+
+const LOCALES: SupportedLocale[] = ["nb", "nn", "en-GB"];
+const dueAt = new Date("2026-03-08T00:00:00.000Z");
+
+function assertNoLinks(text: string) {
+  expect(text).not.toMatch(/https?:\/\//i);
+  expect(text).not.toMatch(/www\./i);
+}
+
+describe("getCourseReminderNotificationMessage (#497)", () => {
+  it.each(LOCALES)("renders a due-soon message with the course + day count in %s", (locale) => {
+    const message = getCourseReminderNotificationMessage(locale, "due_soon", {
+      courseTitle: "HMS Grunnkurs",
+      dueAt,
+      daysBefore: 7,
+    });
+    expect(message.subject).toContain("HMS Grunnkurs");
+    expect(message.nextStepGuidance).toContain("HMS Grunnkurs");
+    expect(message.nextStepGuidance).toContain("7");
+    assertNoLinks(message.subject);
+    assertNoLinks(message.nextStepGuidance);
+  });
+
+  it.each(LOCALES)("renders a due-today message when daysBefore is 0 in %s", (locale) => {
+    const message = getCourseReminderNotificationMessage(locale, "due_soon", {
+      courseTitle: "HMS Grunnkurs",
+      dueAt,
+      daysBefore: 0,
+    });
+    expect(message.nextStepGuidance).toContain("HMS Grunnkurs");
+    assertNoLinks(message.nextStepGuidance);
+  });
+
+  it.each(LOCALES)("renders an overdue message in %s", (locale) => {
+    const message = getCourseReminderNotificationMessage(locale, "overdue", {
+      courseTitle: "HMS Grunnkurs",
+      dueAt,
+    });
+    expect(message.subject).toContain("HMS Grunnkurs");
+    expect(message.nextStepGuidance).toContain("HMS Grunnkurs");
+    assertNoLinks(message.subject);
+    assertNoLinks(message.nextStepGuidance);
+  });
+});

--- a/test/unit/course-reminder-monitor.test.ts
+++ b/test/unit/course-reminder-monitor.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// #497 — CourseReminderMonitor is env-gated on PARTICIPANT_NOTIFICATION_CHANNEL and must never crash
+// the worker when a schedule run throws. We toggle the channel via a mutable mock env object.
+
+const mockEnv = {
+  PARTICIPANT_NOTIFICATION_CHANNEL: "log" as string,
+  COURSE_REMINDER_INTERVAL_MS: 86_400_000,
+};
+
+vi.mock("../../src/config/env.js", () => ({ env: mockEnv }));
+vi.mock("../../src/modules/course/courseReminderService.js", () => ({
+  runCourseReminderSchedule: vi.fn().mockResolvedValue({ sent: 0 }),
+}));
+
+const { CourseReminderMonitor } = await import("../../src/modules/course/CourseReminderMonitor.js");
+
+afterEach(() => {
+  mockEnv.PARTICIPANT_NOTIFICATION_CHANNEL = "log";
+  vi.clearAllMocks();
+});
+
+describe("CourseReminderMonitor (#497)", () => {
+  it("does not schedule when the notification channel is disabled", () => {
+    mockEnv.PARTICIPANT_NOTIFICATION_CHANNEL = "disabled";
+    const run = vi.fn().mockResolvedValue({});
+    const monitor = new CourseReminderMonitor(1000, run);
+    monitor.start();
+    expect(monitor.getStatus().enabled).toBe(false);
+    expect(run).not.toHaveBeenCalled();
+    monitor.stop();
+  });
+
+  it("runs an immediate tick on start when enabled", async () => {
+    const run = vi.fn().mockResolvedValue({ sent: 2 });
+    const monitor = new CourseReminderMonitor(1_000_000, run);
+    monitor.start();
+    await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(1));
+    const status = monitor.getStatus();
+    expect(status.enabled).toBe(true);
+    expect(status.lastError).toBeNull();
+    expect(status.lastSummary).toEqual({ sent: 2 });
+    monitor.stop();
+  });
+
+  it("swallows a schedule error without crashing and records lastError", async () => {
+    const run = vi.fn().mockRejectedValue(new Error("boom"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const monitor = new CourseReminderMonitor(1_000_000, run);
+    monitor.start();
+    await vi.waitFor(() => expect(monitor.getStatus().lastError).toBe("boom"));
+    monitor.stop();
+    warn.mockRestore();
+  });
+
+  it("stop() is safe when never started", () => {
+    const monitor = new CourseReminderMonitor(1000, vi.fn());
+    expect(() => monitor.stop()).not.toThrow();
+  });
+});


### PR DESCRIPTION
Lukker den siste «Done når»-pilaren i **Epic #478** (Tier 2 LMS): innhold ✓ + vurdering ✓ + progress ✓ + **varsling**. Dekker **både individuelle og klasse-tildelte** kurs-frister, så hele funksjonen er UI-testbar.

## Hva
Deltakere med kurs-frister får automatiske e-post-påminnelser fra en daglig bakgrunnsjobb:
- **frist nærmer seg** (due_soon) — konfigurerbare offsets, standard **7 og 1 dag** før frist
- **forfalt** (overdue) — sendes **én gang** etter passert frist

Audit-basert dedup gjør re-kjøring idempotent og restart-trygg (klonet fra recert-påminnelsene).

## To frist-kilder → én effektiv frist per (bruker, kurs)
- **Individuelle** `CourseEnrollment.dueAt` (eksplisitt tildelte deltakere).
- **Klasse-tildelte** `CourseGroupAssignment.dueAt` — ekspandert til medlemmer:
  - **MANUAL**-klasser → `ClassMember`-rader
  - system-klassen **«Alle deltakere»** → alle aktive deltakere (`findActiveParticipants`)
  - **ENTRA**-klasser → **hoppes over** (medlemskap er ikke oppløsbart i en bakgrunnsjobb uten token/lagrede kanter), speiler `classService`s tildelings-e-post
- **Presedens:** individuell frist vinner over klasse; ved flere klasse-frister vinner den tidligste. Dedup + presedens hindrer dobbel-varsling.

## Endringer
- **Ny** `courseReminderService.ts` — `runCourseReminderSchedule({ asOf, sendImpl? })`. Hopper over fullførte (`deriveStatus === COMPLETED`), avmeldte, deaktiverte/anonymiserte brukere og tildelinger uten frist.
- **Ny** `CourseReminderMonitor.ts` — env-gated `setInterval` (daglig, `COURSE_REMINDER_INTERVAL_MS`), kjører kun i worker-rollen når `PARTICIPANT_NOTIFICATION_CHANNEL != disabled`; kjører også én gang ved worker-oppstart; tick-feil velter aldri workeren. Wiret i `src/index.ts`.
- Nye audit-actions `course_reminder_sent` / `course_reminder_failed` + metadata-schema.
- Nye repo-spørringer `classRepository.findCourseGroupAssignmentsWithDueDate` + `userRepository.findActiveParticipants`.
- `getCourseReminderNotificationMessage` (nb/nn/en-GB), **ingen lenker** (#688).
- `courseReminders.reminderDaysBefore` (standard `[7,1]`) i assessment-rules; dokumentert i `CONFIG_REFERENCE.md`.

## Tester
- **Integrasjon** (native pg): individuell due-soon/overdue-matching; klasse MANUAL-ekspansjon; «Alle deltakere»-systemklasse; presedens (individuell > klasse, tidligste klasse vinner); ENTRA-skip; **ingen** send for fullført/avmeldt/inaktiv/uten-frist; **idempotent** re-kjøring.
- **Unit**: monitor env-gate/feil-svelging/start-stop; e-post-copy i alle tre språk uten lenker.
- `tsc --noEmit` grønn; berørte enrollment/completion-suiter grønne.

## UI-testbarhet
Klasse-tildeling har allerede en frist-datovelger (**Klasser → tildel kurs**), så funksjonen kan testes ende-til-ende i UI. Individuell frist-tildeling har ennå ingen egen datovelger (kun API).

## Utenfor scope
Gjentatte overdue-purringer (én gang nå), opt-out (ingen modell), ENTRA-klasse-medlemskap i bakgrunnsjobb, in-app/SMS.

## Utrulling
Kun server-kode, **ingen migrasjon**. Monitoren er env-gated og trygg å merge før den slås på i prod. **Rollback:** reverter koden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
