### PR TITLE
fix(worker): herd oppstart mot connection-pool-storm som crashet prod-worker (#497-incident)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,31 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.35 - 2026-07-18
+
+fix(worker): herd oppstart mot connection-pool-storm som crashet prod-worker (#497-incident)
+
+**Hendelse (2026-07-18):** etter prod-deploy av 1.6.33 klarte ikke worker-rollen å starte. Ved oppstart
+fyrte alle seks bakgrunns-monitorene sin første DB-spørring samtidig → Prisma connection-pool (limit 10)
+gikk tom mot den burstable Postgres-en → `Bus error (core dumped)` / exit 135 → warmup-timeout → Azure
+stoppet worker-siten. Web-appen var upåvirket (frisk `/healthz`). Mitigert med worker-restart (kom opp
+på nytt forsøk — transient storm). Denne fiksen hindrer gjentakelse.
+
+- **Spredt oppstart:** `src/index.ts` starter nå de seks monitorene med en forsinkelse mellom hver
+  (`WORKER_STARTUP_STAGGER_MS`, default 3000 ms), så første tick ikke treffer DB samtidig. Assessment-
+  workeren starter først (ingen forsinkelse) så køprosessering begynner raskt. Spredningen hopper over
+  monitorer hvis prosessen allerede stenger ned.
+- **Feil-svelging:** `AppealSlaMonitor`, `PseudonymizationMonitor` og `AuditRetentionMonitor` manglet
+  `catch` i `tick()` — en feilende tick propagerte som en unhandled rejection. Alle tre logger nå og
+  fortsetter (samme mønster som de andre monitorene). Påminnelses-monitorens tick er allerede spredt
+  til sist av stagger-en, så den beholder sin oppstarts-kjøring uten å bidra til stormen.
+- **Config:** ny `WORKER_STARTUP_STAGGER_MS` i env (default 3000, 0 = ingen spredning).
+- **Tester:** unit — «tick-feil svelges + fortsetter å ticke» (AppealSla). tsc grønn.
+
+**Utrulling:** kun server-kode, ingen migrasjon. **Bør til prod før neste feature-deploy**, siden hver
+deploy restarter workeren og kan trigge stormen på nytt. **Rollback:** reverter koden (worker-restart
+er uansett en trygg gjenoppretting).
+
 ## 1.6.34 - 2026-07-18
 
 feat(nav): #765 — nytt «Deltakere»-toppmeny som samler Klasser + Manuell behandling + Resultater

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.34",
+  "version": "1.6.35",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -102,6 +102,10 @@ const envSchema = z.object({
   // #497: daglig bakgrunnsjobb for kurs-frist-påminnelser. Kjører kun i worker-rollen når
   // varselkanalen er aktiv (PARTICIPANT_NOTIFICATION_CHANNEL !== "disabled").
   COURSE_REMINDER_INTERVAL_MS: z.coerce.number().int().positive().default(86_400_000),
+  // #497-incident: ms mellom oppstart av hver bakgrunns-monitor i worker-rollen, slik at deres
+  // første DB-spørring ikke treffer samtidig (unngår connection-pool-storm ved oppstart). 0 = ingen
+  // spredning (start alle samtidig).
+  WORKER_STARTUP_STAGGER_MS: z.coerce.number().int().min(0).default(3000),
   AZURE_COMMUNICATION_SERVICES_CONNECTION_STRING: z.preprocess(
     (value) => (typeof value === "string" && value.trim().length === 0 ? undefined : value),
     z.string().optional(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,12 +87,25 @@ async function startServer() {
   }
 
   if (startWorkers) {
-    assessmentWorker!.start();
-    appealSlaMonitor!.start();
-    pseudonymizationMonitor!.start();
-    auditRetentionMonitor!.start();
-    entraUserSyncMonitor!.start();
-    courseReminderMonitor!.start();
+    // #497-incident (2026-07-18): starting all six background monitors at once made them fire their
+    // first DB query simultaneously. That startup connection storm exhausted the Prisma pool
+    // (limit 10) against the burstable Postgres and crashed the worker (SIGBUS / exit 135), failing
+    // container warm-up. Stagger the starts so first ticks are spread a few seconds apart, keeping
+    // peak connection demand well under the pool limit. The assessment worker starts first (no delay)
+    // so queue processing begins promptly.
+    const staggeredWorkers = [
+      assessmentWorker,
+      appealSlaMonitor,
+      pseudonymizationMonitor,
+      auditRetentionMonitor,
+      entraUserSyncMonitor,
+      courseReminderMonitor,
+    ];
+    staggeredWorkers.forEach((worker, index) => {
+      setTimeout(() => {
+        if (!shuttingDown) worker!.start();
+      }, index * env.WORKER_STARTUP_STAGGER_MS);
+    });
   }
 }
 

--- a/src/modules/appeal/AppealSlaMonitor.ts
+++ b/src/modules/appeal/AppealSlaMonitor.ts
@@ -54,6 +54,10 @@ export class AppealSlaMonitor {
     try {
       await this.runMonitor();
       this.lastCycleAt = new Date();
+    } catch (error) {
+      // #497-incident: a failing tick (e.g. a DB connection-pool timeout during the startup storm)
+      // must never escape as an unhandled rejection — log and let the monitor keep ticking.
+      console.warn(`[appeal-sla] monitor tick failed: ${error instanceof Error ? error.message : String(error)}`);
     } finally {
       this.running = false;
     }

--- a/src/modules/retention/AuditRetentionMonitor.ts
+++ b/src/modules/retention/AuditRetentionMonitor.ts
@@ -48,6 +48,9 @@ export class AuditRetentionMonitor {
     try {
       await this.runScan();
       this.lastCycleAt = new Date();
+    } catch (error) {
+      // #497-incident: never let a failing tick escape as an unhandled rejection — log and continue.
+      console.warn(`[audit-retention] monitor tick failed: ${error instanceof Error ? error.message : String(error)}`);
     } finally {
       this.running = false;
     }

--- a/src/modules/user/PseudonymizationMonitor.ts
+++ b/src/modules/user/PseudonymizationMonitor.ts
@@ -60,6 +60,9 @@ export class PseudonymizationMonitor {
     try {
       await this.runScan();
       this.lastCycleAt = new Date();
+    } catch (error) {
+      // #497-incident: never let a failing tick escape as an unhandled rejection — log and continue.
+      console.warn(`[pseudonymization] monitor tick failed: ${error instanceof Error ? error.message : String(error)}`);
     } finally {
       this.running = false;
     }

--- a/test/unit/appeal-sla-monitor.test.ts
+++ b/test/unit/appeal-sla-monitor.test.ts
@@ -73,6 +73,29 @@ describe("AppealSlaMonitor", () => {
     monitor.stop();
   });
 
+  // #497-incident: a tick whose DB query rejects (e.g. connection-pool timeout during the worker
+  // startup storm) must be swallowed — never an unhandled rejection — and the monitor must keep
+  // ticking. This is the fragility that crashed the prod worker on 2026-07-18.
+  it("swallows a failing tick and keeps ticking (#497-incident)", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const runMonitor = vi.fn().mockRejectedValue(new Error("Timed out fetching a new connection from the connection pool"));
+    const monitor = new AppealSlaMonitor(100, runMonitor);
+
+    monitor.start(); // immediate tick rejects internally
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runMonitor).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled(); // logged, not thrown
+    expect(monitor.getStatus().lastCycleAt).toBeNull(); // failed tick did not record a cycle
+
+    // running was reset in `finally`, so the next interval tick still fires after a failure.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(runMonitor).toHaveBeenCalledTimes(2);
+
+    monitor.stop();
+    warn.mockRestore();
+  });
+
   it("getStatus returns null lastCycleAt before first tick completes", () => {
     const monitor = new AppealSlaMonitor(1_000, vi.fn());
     expect(monitor.getStatus().lastCycleAt).toBeNull();


### PR DESCRIPTION
## Hendelse (2026-07-18)
Etter prod-deploy av **1.6.33** klarte ikke **worker-rollen** å starte. Ved oppstart fyrte alle seks bakgrunns-monitorene sin første DB-spørring samtidig → Prisma connection-pool (limit 10) gikk tom mot den burstable Postgres-en → `Bus error (core dumped)` / exit 135 → warmup-timeout → Azure stoppet worker-siten.

- **Web-appen var upåvirket** (frisk `/healthz`; tilgjengelighetstester 0 feil). Ingen datatap.
- **Mitigert** med worker-restart (kom opp på nytt forsøk 18:34 UTC — transient storm).
- Stacktrace: `AppealSlaMonitor.tick` → `prisma.appeal.findMany()` → «Timed out fetching a new connection from the connection pool», deretter «Can't reach database server» og `Bus error`.

Denne PR-en hindrer gjentakelse (hver deploy/recycle restarter workeren og kan trigge stormen igjen).

## Endringer
- **Spredt oppstart** (`src/index.ts`): de seks monitorene startes nå med en forsinkelse mellom hver (`WORKER_STARTUP_STAGGER_MS`, default 3000 ms), så første tick ikke treffer DB samtidig. Assessment-workeren starter først (ingen forsinkelse). Hopper over start hvis prosessen allerede stenger ned.
- **Feil-svelging**: `AppealSlaMonitor`, `PseudonymizationMonitor`, `AuditRetentionMonitor` manglet `catch` i `tick()` — en feilende tick propagerte som unhandled rejection. Alle tre logger nå og fortsetter (samme mønster som `EntraUserSyncMonitor`/`CourseReminderMonitor`).
- Påminnelses-monitorens tick beholdes (spredt til sist av stagger-en) — dropper den IKKE, siden det ville forsinket daglige påminnelser opptil 24t etter hver restart. Stagger-en fjerner den fra stormen uten den kostnaden.
- Ny env `WORKER_STARTUP_STAGGER_MS` (default 3000, 0 = av).

## Tester
- Unit: «tick-feil svelges + monitoren fortsetter å ticke» (AppealSla). `tsc --noEmit` grønn.
- Merk: stagger-en i `index.ts` er dekket av manuell/stage-verifisering (worker starter rent).

## Utrulling
Kun server-kode, **ingen migrasjon**. **Bør til prod før neste feature-deploy** (#765/#767). **Rollback:** reverter koden — worker-restart er uansett en trygg gjenoppretting.

Relatert: #497 (kurs-påminnelser, 1.6.33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
