### PR TITLE
chore(observability): #497-incident — worker /healthz availability-test + alert + retro

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,26 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.37 - 2026-07-18
+
+chore(observability): #497-incident — ekstern availability-test + alert på worker-rollens /healthz
+
+Oppfølging etter worker-startup-hendelsen: worker var nede ~75 min uten at vi visste det, fordi den
+eneste eksterne tilgjengelighetstesten pinget kun web-appens `/healthz`. Worker-rollen eksponerer samme
+`/healthz`, men hadde ingen ekstern overvåking.
+
+- **`infra/azure/main.bicep`:** ny `workerHealthzAvailabilityTest` (webtest, EMEA ×2) + `workerHealthz
+  AvailabilityAlert` (metric-alert, failedLocationCount 2/2) som pinger worker-appens `/healthz` og
+  pager samme action group som web-testen. Speiler det eksisterende web-mønsteret (#405); additiv,
+  rører ingen identitet/KV/credential/parent-invariant.
+- **`doc/ops/WORKER_STARTUP_STORM_2026-07-18.md`:** incident-retro — tidslinje, rotårsak (oppstarts-
+  tilkoblingsstorm mot burstable DB), tiltak (herding 1.6.35 + denne overvåkingen), restlæring
+  (DB-kapasitet), og gjenopprettings-steg.
+
+**Utrulling:** infra-endring → **full deploy** (`deploy-azure.yml`) + prod what-if først. Additiv og
+lavrisiko (kun to nye Insights-ressurser, gated på `createObservabilityActionGroup`). Rollback:
+fjern de to ressursene. **Ingen app-atferdsendring.**
+
 ## 1.6.36 - 2026-07-18
 
 feat(participant): #767 — «Mine kurs»-område (Pågående/Fullførte) + kurs-fokusert UI på deltaker-sidene

--- a/doc/ops/WORKER_STARTUP_STORM_2026-07-18.md
+++ b/doc/ops/WORKER_STARTUP_STORM_2026-07-18.md
@@ -1,0 +1,53 @@
+# Incident: worker-rollen crashet ved oppstart (2026-07-18)
+
+## Sammendrag
+Etter prod-deploy av **1.6.33** (kurs-påminnelser, #497) klarte ikke **worker-rollen** å starte.
+Web-appen var upåvirket hele tiden (frisk `/healthz`, brukere merket ingenting). Worker var nede
+**~17:16–18:34 UTC (~75 min)** til den ble manuelt restartet — da kom den opp på nytt forsøk.
+
+## Tidslinje (UTC)
+- **17:14** — prod-deploy av 1.6.33 (code-only) trigget; worker-container starter på nytt.
+- **17:16–18:07** — warmup-probe pinger; containeren blir aldri klar.
+- **18:10** — `unhandled_rejection`: `AppealSlaMonitor.tick` → `prisma.appeal.findMany()` →
+  «Timed out fetching a new connection from the connection pool (limit 10, timeout 20s)».
+- **18:12** — `prisma.assessmentJob.findMany()` → «Can't reach database server …:5432».
+- **18:15** — `Bus error (core dumped)` → container exit **135** → `ContainerTimeout` (600s) → Azure
+  stopper worker-siten (auto-startet **ikke** på nytt).
+- **~18:20** — «runtime errors»-e-post mottatt; diagnose startet.
+- **18:31** — manuell `az webapp restart` av worker.
+- **18:34** — «Site startup probe succeeded» + «workers started [role=worker]» → stabil.
+
+## Rotårsak
+Ved oppstart fyrte alle seks bakgrunns-monitorene (assessment-worker, appeal-SLA, pseudonymisering,
+audit-retention, entra-synk, **+ ny kurs-påminnelses-monitor**) sin **første DB-spørring samtidig**.
+Mot en **burstable Postgres** med **Prisma-pool på 10** ga dette en tilkoblings-storm: spørringer fikk
+ikke tilkobling i tide, én propagerte som unhandled rejection, og under presset crashet Prisma-engine
+med `Bus error` (SIGBUS). 1.6.33 la til én monitor til, som tippet en allerede skjør oppstart over.
+
+Samme image startet fint ved restart → **ikke en deterministisk bug**, men en transient oppstartsstorm.
+
+## Overvåkings-gap (viktigste lærdom)
+Worker var nede i 75 min uten at vi visste det. Den eksterne tilgjengelighetstesten pinget kun
+**web-appens** `/healthz` — som var frisk. Worker-rollen hadde **ingen ekstern overvåking**, så et
+worker-havari var i praksis usynlig til noen tilfeldigvis fikk en e-post.
+
+## Tiltak
+1. **Herding (1.6.35, #769):**
+   - `src/index.ts` sprer nå monitor-oppstarten (`WORKER_STARTUP_STAGGER_MS`, default 3000 ms) så
+     første ticks ikke treffer DB samtidig.
+   - `AppealSlaMonitor`, `PseudonymizationMonitor`, `AuditRetentionMonitor` fikk `catch` i `tick()`
+     (en feilende tick logges nå i stedet for å bli en unhandled rejection).
+2. **Overvåking (denne PR):** ekstern availability-test + alert på **worker-rollens** `/healthz`
+   (`infra/azure/main.bicep`, speiler web-appens), så en worker-outage pager samme action group.
+
+## Restlæring / oppfølging
+- **DB-kapasitet:** burstable Postgres + Prisma-pool 10 er grunn-skjørheten. Herdingen fjerner
+  *triggeren*, men vurder å heve pool/DB-takhøyde eller overvåke connection-metning under last.
+- **SIGBUS:** exit 135 er en native Prisma-engine-crash under press; verdt å følge med på om det
+  gjentar seg selv med spredt oppstart.
+
+## Gjenoppretting hvis det skjer igjen
+1. Bekreft web vs. worker: `/healthz`-availability på web grønn, men worker-alerten fyrer.
+2. Verifiser DB er «Ready» (`az postgres flexible-server list`), så `az webapp restart` på worker.
+3. Verifiser oppstart i loggene: «workers started [role=worker]», ingen `Bus error`/exit 135.
+   (Prod-tenant: `az account set --subscription 5b3f760b-…` først.)

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -1738,6 +1738,77 @@ resource healthzAvailabilityAlert 'Microsoft.Insights/metricAlerts@2018-03-01' =
   }
 }
 
+// #497-incident (2026-07-18): the WORKER role crashed on startup and stayed down ~75 min, invisible to
+// us because the only external availability test pinged the WEB app's /healthz. The worker exposes the
+// same /healthz endpoint (siteConfig.healthCheckPath above), so give it its own external ping + alert —
+// a worker outage now pages the same action group instead of waiting for a chance email.
+resource workerHealthzAvailabilityTest 'Microsoft.Insights/webtests@2022-06-15' = if (createObservabilityActionGroup) {
+  name: toLower('${appNamePrefix}-${envCode}-worker-healthz-ping')
+  location: location
+  kind: 'standard'
+  tags: {
+    'hidden-link:${appInsights.id}': 'Resource'
+    environment: environmentName
+    costCenter: costCenter
+    owner: owner
+  }
+  properties: {
+    SyntheticMonitorId: toLower('${appNamePrefix}-${envCode}-worker-healthz-ping')
+    Name: '${appNamePrefix}-${envCode} worker /healthz availability'
+    Description: 'External ping of the WORKER role /healthz from EMEA — catches a worker-role outage that the web-app test cannot see (#497-incident).'
+    Enabled: true
+    Frequency: 300
+    Timeout: 30
+    Kind: 'standard'
+    RetryEnabled: true
+    Locations: [
+      { Id: 'emea-nl-ams-azr' }
+      { Id: 'emea-gb-db3-azr' }
+    ]
+    Request: {
+      RequestUrl: 'https://${workerApp.properties.defaultHostName}/healthz'
+      HttpVerb: 'GET'
+    }
+    ValidationRules: {
+      ExpectedHttpStatusCode: 200
+      SSLCheck: true
+      SSLCertRemainingLifetimeCheck: 7
+    }
+  }
+}
+
+resource workerHealthzAvailabilityAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = if (createObservabilityActionGroup) {
+  name: toLower('${appNamePrefix}-${envCode}-worker-healthz-availability')
+  location: 'global'
+  tags: {
+    environment: environmentName
+    costCenter: costCenter
+    owner: owner
+  }
+  properties: {
+    description: 'External worker-role /healthz availability test is failing — the worker (assessment/SLA/reminder jobs) is unreachable. See #497-incident.'
+    severity: 1
+    enabled: true
+    scopes: [
+      workerHealthzAvailabilityTest.id
+      appInsights.id
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT5M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria'
+      webTestId: workerHealthzAvailabilityTest.id
+      componentId: appInsights.id
+      failedLocationCount: 2
+    }
+    actions: [
+      {
+        actionGroupId: observabilityActionGroup.id
+      }
+    ]
+  }
+}
+
 // Production resource group CanNotDelete lock (#405). Blocks all DELETE operations on
 // resources in the prod RG. The May 2026 incident where a staging deactivate workflow
 // targeted production resources would have been blocked here with a 409 Conflict before

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.36",
+  "version": "1.6.37",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",


### PR DESCRIPTION
Oppfølging (#1+#3) etter worker-startup-hendelsen 2026-07-18.

## Bakgrunn
Worker-rollen var nede **~75 min** uten at vi visste det, fordi den eneste eksterne availability-testen pinget kun **web-appens** `/healthz` (som var frisk). Worker eksponerer samme `/healthz` (`siteConfig.healthCheckPath`), men hadde **ingen ekstern overvåking** — så et worker-havari var usynlig til noen tilfeldigvis fikk en e-post.

## Endringer
- **`infra/azure/main.bicep`:** `workerHealthzAvailabilityTest` (webtest, EMEA ×2) + `workerHealthzAvailabilityAlert` (metric-alert, `failedLocationCount` 2/2) som pinger **worker-appens** `/healthz` og pager samme action group som web-testen. Speiler det eksisterende web-mønsteret (#405). Gated på `createObservabilityActionGroup`. **Additiv** — rører ingen identitet/KV/credential/conditional-parent-invariant.
- **`doc/ops/WORKER_STARTUP_STORM_2026-07-18.md`:** incident-retro (tidslinje, rotårsak = oppstarts-tilkoblingsstorm mot burstable DB, tiltak = herding 1.6.35 + denne overvåkingen, restlæring = DB-kapasitet, gjenopprettings-steg).

## Verifisering
- `az bicep build` grønn (syntaks OK).
- Prod what-if kjøres før merge (`bicep-whatif-prod.yml`).

## Utrulling
Infra-endring → **full deploy** (`deploy-azure.yml`), **etter** at v1.6.36 er landet og worker verifisert. Lavrisiko (kun to nye Insights-ressurser). **Rollback:** fjern de to ressursene.

## Hard-invariant-sjekk
Ingen `enableRbacAuthorization`-kobling, ingen identitets-/KV-/credential-endring, ingen ny conditional resource med parent-avhengighet. Kun to nye `Microsoft.Insights`-ressurser (webtest + metricAlert) som refererer eksisterende `workerApp` + `appInsights` + `observabilityActionGroup`.

Relatert: #497-incident, #405 (web-availability-mønsteret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
