### PR TITLE
test(course): #524 slice 3 — e2e add-section-from-library + «Oversett»/GUI-lås (lukker #524)

### DIFF
--- a/test/e2e/admin-content-course-sections.spec.ts
+++ b/test/e2e/admin-content-course-sections.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect, type Route } from "@playwright/test";
+import { mockCommonApis } from "./admin-content-helpers.js";
+
+// #524 (U3): the course builder can add a reusable learning section from the library. It must appear in
+// the mixed content list as a [SEKSJON] row — colour-coded / distinct from modules via data-item-type +
+// the type badge — with its title.
+test("course builder: add a section from the library renders it as a [SEKSJON] row", async ({ page }) => {
+  await mockCommonApis(page, {
+    courses: [
+      { id: "course-1", title: { nb: "Kurs" }, certificationLevel: "basic", moduleCount: 0, modules: [] },
+    ],
+    libraryModules: [],
+  });
+
+  // Library sections available to the picker (GET /api/admin/content/sections). Registered after
+  // mockCommonApis so this handler wins for the GET; other methods fall through.
+  await page.route("**/api/admin/content/sections", (route: Route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ sections: [{ id: "sec-1", title: { nb: "Innføring" } }] }),
+    });
+  });
+
+  await page.addInitScript(() => { try { localStorage.setItem("participant.locale", "nb"); } catch { /* ignore */ } });
+
+  await page.goto("/admin-content/courses/course-1");
+
+  // The picker is populated, and there is no section row yet.
+  await expect(page.locator("#sectionSelect option[value='sec-1']")).toHaveCount(1);
+  await expect(page.locator('#moduleList .module-list-item[data-item-type="SECTION"]')).toHaveCount(0);
+
+  // Add the section from the library.
+  await page.locator("#sectionSelect").selectOption("sec-1");
+  await page.locator("#addSectionBtn").click();
+
+  // It appears as a distinct [SEKSJON] row carrying the section title.
+  const sectionRow = page.locator('#moduleList .module-list-item[data-item-type="SECTION"]');
+  await expect(sectionRow).toHaveCount(1);
+  await expect(sectionRow.locator(".item-type-badge")).toHaveText("SEKSJON");
+  await expect(sectionRow).toContainText("Innføring");
+
+  // And it is no longer offered in the picker (can't add the same section twice).
+  await expect(page.locator("#sectionSelect option[value='sec-1']")).toHaveCount(0);
+});

--- a/test/e2e/section-editor.spec.ts
+++ b/test/e2e/section-editor.spec.ts
@@ -296,3 +296,59 @@ test("section editor: top workspace nav renders in prod-shaped config (roles fro
   await expect(page.locator('#workspaceNav a', { hasText: "Oversikt" })).toBeVisible();
   await expect(page.locator('#workspaceNav a', { hasText: "Vurdering" })).toBeVisible();
 });
+
+// #524 (U1): «Oversett» (#514) must LOCK the editor while the LLM translates the active language into
+// the others — the author must not edit/navigate mid-call — and then fill the other locales' fields.
+// Guards both the GUI-lock and the translated content landing in the right locale.
+test("section editor: «Oversett» locks the editor while translating, then fills the other locales", async ({ page }) => {
+  await mockBaseApis(page);
+  await page.route("**/api/admin/content/sections", (route: Route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ section: { id: "sec1", versionNo: 1 } }) });
+    }
+    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ sections: [] }) });
+  });
+  await page.route("**/api/admin/content/sections/preview", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ html: "<p>x</p>" }) }),
+  );
+
+  // Hold the localize response so the intermediate LOCKED state is observable.
+  let releaseLocalize: () => void = () => {};
+  const localizeHold = new Promise<void>((resolve) => { releaseLocalize = resolve; });
+  const requestedTargets: string[] = [];
+  await page.route("**/api/admin/content/sections/localize", async (route: Route) => {
+    const body = route.request().postDataJSON() as { targetLocale: string };
+    requestedTargets.push(body.targetLocale);
+    await localizeHold;
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ title: `T-${body.targetLocale}`, bodyMarkdown: `B-${body.targetLocale}` }),
+    });
+  });
+
+  await page.addInitScript(() => { try { localStorage.setItem("participant.locale", "nb"); } catch { /* ignore */ } });
+  await page.goto("/admin-content/sections");
+  await page.getByRole("button", { name: /Ny seksjon/ }).click();
+
+  // Fill the source (nb) language, then start translating.
+  await page.locator("#titleInput").fill("Tittel");
+  await page.locator("#markdownInput").fill("# Innhold");
+  await page.locator("#translateBtn").click();
+
+  // LOCKED: button shows the translating label and the edit controls are disabled.
+  await expect(page.locator("#translateBtn")).toHaveText(/Oversetter/);
+  await expect(page.locator("#saveBtn")).toBeDisabled();
+  await expect(page.locator("#titleInput")).toBeDisabled();
+  await expect(page.locator("#markdownInput")).toBeDisabled();
+
+  // Release the translation → unlocks and restores the button label.
+  releaseLocalize();
+  await expect(page.locator("#translateBtn")).toHaveText(/Oversett fra/);
+  await expect(page.locator("#saveBtn")).toBeEnabled();
+
+  // Both other locales were requested, and the nn tab now holds the translated title.
+  await expect.poll(() => [...requestedTargets].sort()).toEqual(["en-GB", "nn"]);
+  await page.locator('.lang-tab[data-locale="nn"]').click();
+  await expect(page.locator("#titleInput")).toHaveValue("T-nn");
+});


### PR DESCRIPTION
Siste slice av #524 — de to gjenstående ren-e2e-flatene. Lukker #524.

## Endringer
- **`admin-content-course-sections.spec.ts` (ny)** — U3: kursbygger «Legg til seksjon» fra bibliotek → seksjonen vises som en **[SEKSJON]-rad** (`data-item-type="SECTION"` + `.item-type-badge`=«SEKSJON») med tittel, og forsvinner fra plukkeren (ikke to ganger).
- **`section-editor.spec.ts`** — U1: «Oversett» (#514) **låser editoren** under LLM-kallet (`#translateBtn`/`#saveBtn`/`#titleInput`/`#markdownInput` disabled + label «Oversetter…»), fyller de andre locale-ene (verifisert via nn-fanen), og låser opp etterpå.

## #524-dekning nå komplett
| Flate | Dekning |
|---|---|
| U1 editor | locale-vakter (PR #771) + **«Oversett»/GUI-lås e2e** |
| U3 kursbygger | reorder/badge state (PR #771) + **add-section-from-library e2e** |
| P1/P2 deltaker-leser | `participant-section-reader.spec` (fra før) |

## Verifisering
Full e2e-suite **97 grønne** (inkl. de 2 nye). Test-only — ingen kildekode-endring, ingen versjonsbump.

Lukker #524. Del av #476 / #478.
