### PR TITLE
feat(dashboard): #498 — lærer/SMO kohort-status-dashboard (2.0.0: Tier 2 komplett)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,40 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.0 - 2026-07-19
+
+**Milepæl — Tier 2 LMS komplett (#478): fra assessment-motor til kursforløp.** Med kohort-status-
+dashboardet (#498) er alle «Done når»-pilarene i Epic #478 levert (innhold ✓ vurdering ✓ progresjon ✓
+varsling ✓ dashboard ✓). Major-bump markerer at plattformen har utviklet seg fra en ren
+vurderings-motor til en kurs-basert LMS.
+
+feat(dashboard): #498 — lærer/SMO kohort-status-dashboard (siste Tier 2-pilar, lukker #478)
+
+Ny «Status»-fane under «Deltakere»-området (`/deltakere/status`): velg et kurs → se deltakernes
+enrollment-status (**Tildelt / Påbegynt / Forfalt / Fullført**) aggregert over kursets **effektive
+audience** (individuelle CourseEnrollment + klasse-tildelte medlemmer), med per-klasse-breakdown.
+Siste «Done når»-pilar i Epic #478 (Tier 2 LMS).
+
+- **Backend:** `cohortStatusService.ts` — `resolveCourseAudience(courseId)` (kurs-scoped, individuell +
+  klasse-ekspandert audience, presedens individuell>klasse/tidligste klasse-frist, MANUAL + «Alle
+  deltakere», hopper over ENTRA) + `getCohortStatus` (status-count-aggregat + per-klasse via
+  `deriveStatus`). Ny `classRepository.findCourseGroupAssignmentsForCourse` (kurs-scoped, uten
+  dueAt-filter). Read-time-analog av påminnelses-jobbens audience-ekspansjon.
+- **API:** ny capability `cohort_dashboard` (`/api/cohort-status`, roller SMO/ADMIN/REPORT_READER) +
+  `cohortStatus.ts`-router: `GET /courses` (publiserte kurs-picker) + `GET /course/:id` (aggregat).
+- **UI:** `cohort-status.html` + `cohort-status.js` + `cohort-status-translations.js` (nb/nn/en).
+  Ny «Status»-fane i `deltakere-subnav.js` (rollegated) + i de andre Deltakere-sidenes bar.
+- **Tester:** integrasjon (aggregat med individuell+klasse-ekspansjon, per-klasse, /courses-picker,
+  403 for PARTICIPANT) + e2e (picker→last→status-kort+per-klasse, aktiv fane, rollegating). tsc grønn.
+- **Design-writeup:** `doc/design/COHORT_STATUS_DASHBOARD_498.md` (beslutninger + trade-offs + neste
+  steg) for review.
+
+**Kjent MVP-avgrensning:** `deriveStatus` kjører 1–2 spørringer per deltaker (N+1); greit for typiske
+kohorter, batch ved store. Individuelle enrollments filtreres ikke på aktiv/anonymisert (klasse-medlemmer
+gjør det). Detaljer i writeup-en.
+
+**Utrulling:** kun server+klient-kode, ingen migrasjon. **Går kun til stage foreløpig** (ikke prod).
+
 ## 1.6.37 - 2026-07-18
 
 chore(observability): #497-incident — ekstern availability-test + alert på worker-rollens /healthz

--- a/doc/design/COHORT_STATUS_DASHBOARD_498.md
+++ b/doc/design/COHORT_STATUS_DASHBOARD_498.md
@@ -1,0 +1,55 @@
+# #498 — Teacher/SMO cohort-status dashboard (design writeup)
+
+Status: bygget, stage-deployet (ikke prod). For review. Siste «Done når»-pilar i Epic #478 (Tier 2 LMS).
+
+## Mål
+Gi en lærer/SMO ett blikk på **hvor kohorten står** på et kurs: hvor mange deltakere er **Tildelt /
+Påbegynt / Forfalt / Fullført**, totalt og per klasse.
+
+## Beslutninger
+
+1. **Egen side under «Deltakere», ikke utvidelse av `/results`.**
+   - `/results` bruker en *submission/modul-basert* status (NOT_STARTED/IN_PROGRESS/COMPLETED) og en
+     submission-avledet «enrolled»-populasjon. #498 trenger **enrollment-status-modellen**
+     (ASSIGNED/IN_PROGRESS/OVERDUE/COMPLETED fra `deriveEnrollmentStatus`) over den **effektive
+     audience** (CourseEnrollment + klasse-ekspandert). Å blande to semantisk ulike status-akser i samme
+     tabell ville forvirret.
+   - Målgruppe: **SMO** (+ ADMIN + REPORT_READER). `/api/reports` er kun ADMIN+REPORT_READER; «Deltakere»-
+     sub-navet er allerede rollegated for nettopp SMO/ADMIN/REPORT_READER — så en ny «Status»-fane der
+     passer IA + rollegating uten å utvide `reports`-rollene.
+
+2. **Effektiv audience = individuell + klasse-ekspandert, én rad per (bruker, kurs).**
+   - Individuell: `CourseEnrollment` (aktive, ikke-revokerte).
+   - Klasse: `CourseGroupAssignment` → MANUAL-klassers `ClassMember` + system-klassen «Alle deltakere»
+     (alle aktive deltakere). ENTRA-klasser hoppes over (medlemskap ikke oppløsbart read-time — speiler
+     påminnelses-jobben).
+   - **Presedens:** individuell vinner over klasse; blant klasser vinner tidligste frist. Dette er read-
+     time-analogen av påminnelses-jobbens `gatherCandidates` — men kurs-scoped og **uten dueAt-filter**
+     (dashboardet viser alle, med eller uten frist). Bevisst *ikke* delt kode med reminderen ennå: de er
+     ulikt scoped (global/dueAt vs. kurs/alle); en felles `resolveCourseAudience` kan ekstraheres senere
+     hvis en tredje forbruker dukker opp.
+
+3. **Status utledes med eksisterende `deriveStatus`** (COMPLETED→OVERDUE→IN_PROGRESS→ASSIGNED).
+
+## Kjente MVP-avgrensninger (bevisste)
+- **N+1:** `deriveStatus` kjører 1–2 spørringer per deltaker (completion-oppslag + started-probe). Greit
+  for typiske kohorter; batch completion/started-oppslagene hvis kohorter blir store.
+- **Individuelle enrollments filtreres ikke på aktiv/anonymisert** (klasse-medlemmer gjør det, via
+  member-select). Symmetri kan legges til hvis inaktive individuelt-tildelte skal utelates.
+- **Per-klasse-breakdown teller kun deltakere hvis *effektive* kilde er klassen** (en bruker som er
+  både individuelt tildelt og klasse-medlem vinner individuell → ikke i klasse-bøtta). Bevisst: bøtta =
+  «deltakere som er her *via* denne klassen».
+- **Ingen drill-down til deltaker-liste** i v1 (kun aggregat + per-klasse). Naturlig neste steg.
+
+## Overflate
+- Backend: `src/modules/course/cohortStatusService.ts` (`resolveCourseAudience`, `getCohortStatus`),
+  `classRepository.findCourseGroupAssignmentsForCourse`, `src/routes/cohortStatus.ts`, capability
+  `cohort_dashboard` i `capabilities.ts`, mount i `app.ts`.
+- Frontend: `public/cohort-status.html` + `cohort-status.js` + `i18n/cohort-status-translations.js`,
+  «Status»-fane i `deltakere-subnav.js` (+ baren på de andre Deltakere-sidene), rute `/deltakere/status`.
+- Tester: `test/m2-cohort-status.test.ts` (integrasjon) + `test/e2e/cohort-status.spec.ts`.
+
+## Neste steg (etter review)
+- Drill-down: klikk en status/klasse → deltaker-liste (gjenbruk `listCourseEnrollments`-mønsteret).
+- Batch `deriveStatus` hvis kohorter vokser.
+- Vurder felles `resolveCourseAudience` delt med reminder-jobben.

--- a/doc/route-map.md
+++ b/doc/route-map.md
@@ -32,9 +32,9 @@ The conversational and advanced editors are two modes of the same module workspa
 ## Participant, «Deltakere» and review workspaces
 
 The **«Deltakere»** top-nav area (#765) groups the participant-/outcome-oriented surfaces —
-`/deltakere/klasser`, `/review`, `/results` — behind one menu item, with a shared, role-gated
-sub-navigation bar (`public/static/deltakere-subnav.js`). `/review` and `/results` keep their URLs;
-only Klasser moved (from `/admin-content/classes`).
+`/deltakere/klasser`, `/deltakere/status`, `/review`, `/results` — behind one menu item, with a shared,
+role-gated sub-navigation bar (`public/static/deltakere-subnav.js`). `/review` and `/results` keep their
+URLs; only Klasser moved (from `/admin-content/classes`).
 
 | Route | Workspace |
 |---|---|
@@ -42,6 +42,7 @@ only Klasser moved (from `/admin-content/classes`).
 | `/participant/completed` | «Mine kurs» → **Fullførte**-fane: kursbevis + fullførte moduler (#767) |
 | `/certificate?id=<certificateId>` | Printable course certificate view (#550) |
 | `/deltakere/klasser` | Classes (cohorts) admin — list, create, members, course assignment (#645/CL-3; moved here in #765) |
+| `/deltakere/status` | Teacher/SMO cohort-status dashboard — enrollment status counts per course (#498) |
 | `/review` | Manual review queue and workspace (a «Deltakere» sub-tab) |
 | `/calibration` | Calibration reviewer workspace |
 | `/results` | Results / history view (a «Deltakere» sub-tab) |
@@ -58,6 +59,7 @@ only Klasser moved (from `/admin-content/classes`).
 | `/api/courses` | Participant | Browse courses; read learning sections + mark read (#476); discussion/Q&A threads + replies (#495) |
 | `/api/me` | All | Current user identity and roles |
 | `/api/reviews` | Reviewer / Admin | Manual review queue and override |
+| `/api/cohort-status` | SMO / Admin / Report reader | Cohort enrollment-status aggregate per course (#498) |
 | `/api/appeals` | Appeal Handler / Admin | Appeal queue and resolution |
 | `/api/admin/content` | SMO / Admin | Module, course, and learning-section content management |
 | `/api/admin/platform` | Admin | Platform administration |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.37",
+  "version": "2.0.0",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-classes.html
+++ b/public/admin-content-classes.html
@@ -49,6 +49,7 @@
            deltakere-subnav.js). Aktiv fane settes ut fra URL av samme script. -->
       <nav id="deltakereSubnav" class="content-area-nav" aria-label="Deltakere">
         <a href="/deltakere/klasser" class="content-area-nav-link" id="subnavKlasser">Klasser</a>
+        <a href="/deltakere/status" class="content-area-nav-link" id="subnavStatus">Status</a>
         <a href="/review" class="content-area-nav-link" id="subnavReview">Manuell behandling</a>
         <a href="/results" class="content-area-nav-link" id="subnavResults">Resultater</a>
       </nav>

--- a/public/cohort-status.html
+++ b/public/cohort-status.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en-GB">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A2 Cohort status</title>
+    <link rel="stylesheet" href="/static/shared.css" />
+    <style>
+      .status-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: var(--space-1); margin-top: var(--space-1); }
+      .status-card { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-2); background: var(--color-surface, #fff); }
+      .status-card .status-value { font-size: 32px; font-weight: 800; line-height: 1; }
+      .status-card .status-label { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-meta); margin-top: 6px; }
+      .status-card--assigned .status-value { color: #42526b; }
+      .status-card--in_progress .status-value { color: #0d3f9e; }
+      .status-card--overdue .status-value { color: var(--color-error, #b3261e); }
+      .status-card--completed .status-value { color: #1f7a4d; }
+      .status-card--total { background: var(--color-blue-light); }
+      .table-wrap { overflow-x: auto; border: 1px solid var(--color-table-wrap-border); border-radius: var(--space-1); margin-top: var(--space-1); }
+      table { width: 100%; border-collapse: collapse; min-width: 520px; }
+      th, td { border-bottom: 1px solid var(--color-table-border); padding: var(--space-1); font-size: 13px; text-align: left; }
+      th { font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-meta); }
+    </style>
+  </head>
+  <body>
+    <a href="#main-content" class="skip-nav" data-i18n="nav.skipToContent">Skip to main content</a>
+    <main id="main-content" class="layout-container">
+      <div class="page-top-bar">
+        <nav id="workspaceNav" class="workspace-nav"></nav>
+        <div class="locale-picker">
+          <span id="appVersion" class="version-badge">…</span>
+          <label for="localeSelect" class="sr-only" data-i18n="locale.label">Language</label>
+          <select id="localeSelect" class="locale-select-compact"></select>
+        </div>
+      </div>
+      <!-- #498: «Deltakere»-området, med Status-fanen (rollegates av deltakere-subnav.js). -->
+      <nav id="deltakereSubnav" class="content-area-nav" aria-label="Deltakere">
+        <a href="/deltakere/klasser" class="content-area-nav-link" id="subnavKlasser">Klasser</a>
+        <a href="/deltakere/status" class="content-area-nav-link" id="subnavStatus">Status</a>
+        <a href="/review" class="content-area-nav-link" id="subnavReview">Manuell behandling</a>
+        <a href="/results" class="content-area-nav-link" id="subnavResults">Resultater</a>
+      </nav>
+      <h1 data-i18n="cohortPage.title">Cohort status</h1>
+      <p class="small" data-i18n="cohortPage.subtitle">Participant status per course.</p>
+
+      <section class="card mock-identity-card">
+        <details class="mock-identity-panel">
+          <summary><span data-i18n="identity.title">Test User</span><span class="mock-identity-dev-badge" data-i18n="identity.devOnlyBadge">Dev only</span></summary>
+          <div class="mock-identity-panel-body">
+            <div class="row">
+              <div><label for="userId" data-i18n="identity.userId">User Id</label><input id="userId" value="content-owner-1" autocomplete="off" /></div>
+              <div><label for="email" data-i18n="identity.email">Email</label><input id="email" value="smo@company.com" autocomplete="email" /></div>
+            </div>
+            <div class="row">
+              <div><label for="name" data-i18n="identity.name">Name</label><input id="name" value="Platform Subject Matter Owner" autocomplete="name" /></div>
+              <div><label for="department" data-i18n="identity.department">Department</label><input id="department" value="Learning" autocomplete="organization" /></div>
+            </div>
+            <div>
+              <label for="roles" data-i18n="identity.roles">Roles (comma-separated)</label>
+              <input id="roles" value="SUBJECT_MATTER_OWNER" autocomplete="off" />
+            </div>
+            <div id="mockRolePresetContainer">
+              <label for="mockRolePreset" data-i18n="identity.rolePreset">Role preset</label>
+              <select id="mockRolePreset"></select>
+              <div class="small" id="mockRolePresetHint"></div>
+            </div>
+            <button id="loadMe" class="btn-secondary" data-i18n="identity.loadMe">Show my user details</button>
+          </div>
+        </details>
+      </section>
+
+      <section class="card">
+        <div class="row">
+          <div style="flex:1;min-width:240px">
+            <label for="courseSelect" data-i18n="cohort.picker.label">Course</label>
+            <select id="courseSelect"></select>
+          </div>
+        </div>
+        <div class="small" id="cohortMeta" aria-live="polite"></div>
+      </section>
+
+      <section class="card">
+        <div id="cohortEmpty" class="small" data-i18n="cohort.empty">Select a course to see its cohort status.</div>
+        <div id="statusCards" class="status-grid" aria-live="polite" hidden></div>
+
+        <div id="byClassSection" hidden>
+          <h2 data-i18n="cohort.byClass.title" style="font-size:16px;margin-top:var(--space-2)">By class</h2>
+          <div id="byClassEmpty" class="small" data-i18n="cohort.byClass.empty" hidden>No class assignments for this course.</div>
+          <div class="table-wrap" tabindex="0" role="region" aria-label="Cohort status by class">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col" data-i18n="cohort.byClass.class">Class</th>
+                  <th scope="col" data-i18n="cohort.status.ASSIGNED">Assigned</th>
+                  <th scope="col" data-i18n="cohort.status.IN_PROGRESS">In progress</th>
+                  <th scope="col" data-i18n="cohort.status.OVERDUE">Overdue</th>
+                  <th scope="col" data-i18n="cohort.status.COMPLETED">Completed</th>
+                  <th scope="col" data-i18n="cohort.byClass.total">Participants</th>
+                </tr>
+              </thead>
+              <tbody id="byClassBody"></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <div class="small" id="outputStatus" aria-live="polite" aria-atomic="true" style="margin: var(--space-1) 0;"></div>
+      <section id="debugOutputSection" class="card" hidden>
+        <h2 data-i18n="output.title">System response</h2>
+        <pre id="output" class="pre-content"></pre>
+      </section>
+    </main>
+    <script src="/static/i18n/cohort-status-translations.js" type="module"></script>
+    <script src="/static/cohort-status.js" type="module"></script>
+    <script src="/static/deltakere-subnav.js" type="module"></script>
+    <script src="/static/workspace-help.js" type="module"></script>
+  </body>
+</html>

--- a/public/cohort-status.js
+++ b/public/cohort-status.js
@@ -1,0 +1,274 @@
+import { renderWorkspaceNavigationWithProfile } from "/static/workspace-nav.js";
+import { resolveInitialLocale } from "/static/i18n-locale.js";
+import { escapeHtml } from "/static/html-escape.js";
+import { localeLabels, supportedLocales, translations } from "/static/i18n/cohort-status-translations.js";
+import { apiFetch, buildConsoleHeaders, getConsoleConfig } from "/static/api-client.js";
+import { initConsentGuard } from "/static/consent-guard.js";
+import {
+  findMatchingPreset,
+  resolveRoleSwitchState,
+  resolveWorkspaceNavigationItems,
+} from "/static/participant-console-state.js";
+
+// #498: teacher/SMO cohort-status dashboard. Pick a course → see enrollment-status counts (assigned /
+// in progress / overdue / completed) over its effective audience (individual + class-assigned), with a
+// per-class breakdown. Backed by GET /api/cohort-status/*.
+
+const appVersionLabel = document.getElementById("appVersion");
+const localeSelect = document.getElementById("localeSelect");
+const rolesInput = document.getElementById("roles");
+const workspaceNav = document.getElementById("workspaceNav");
+const mockRolePresetContainer = document.getElementById("mockRolePresetContainer");
+const mockRolePresetSelect = document.getElementById("mockRolePreset");
+const mockRolePresetHint = document.getElementById("mockRolePresetHint");
+const loadMeButton = document.getElementById("loadMe");
+const output = document.getElementById("output");
+const outputStatus = document.getElementById("outputStatus");
+const debugOutputSection = document.getElementById("debugOutputSection");
+const courseSelect = document.getElementById("courseSelect");
+const cohortMeta = document.getElementById("cohortMeta");
+const cohortEmpty = document.getElementById("cohortEmpty");
+const statusCards = document.getElementById("statusCards");
+const byClassSection = document.getElementById("byClassSection");
+const byClassEmpty = document.getElementById("byClassEmpty");
+const byClassBody = document.getElementById("byClassBody");
+
+let currentLocale = resolveInitialLocale(supportedLocales);
+let participantRuntimeConfig = { authMode: "mock", navigation: { items: [] }, identityDefaults: {} };
+let roleSwitchState = resolveRoleSwitchState(participantRuntimeConfig);
+
+function t(key) {
+  return translations[currentLocale]?.[key] ?? translations["en-GB"]?.[key] ?? key;
+}
+
+function headers() {
+  return buildConsoleHeaders({
+    userId: document.getElementById("userId")?.value,
+    email: document.getElementById("email")?.value,
+    name: document.getElementById("name")?.value,
+    department: document.getElementById("department")?.value,
+    roles: rolesInput?.value,
+    locale: currentLocale,
+  });
+}
+
+function log(data) {
+  if (!output) return;
+  output.textContent = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+}
+
+function setMessage(text, type = "info") {
+  if (!outputStatus) return;
+  outputStatus.textContent = text;
+  outputStatus.className = `small field-${type}`;
+}
+
+function applyTranslations() {
+  for (const el of document.querySelectorAll("[data-i18n]")) {
+    const key = el.getAttribute("data-i18n");
+    if (key) el.textContent = t(key);
+  }
+  renderWorkspaceNavigation();
+}
+
+function populateLocaleSelect() {
+  if (!localeSelect) return;
+  localeSelect.innerHTML = "";
+  for (const locale of supportedLocales) {
+    const option = document.createElement("option");
+    option.value = locale;
+    option.textContent = localeLabels[locale] ?? locale;
+    if (locale === currentLocale) option.selected = true;
+    localeSelect.appendChild(option);
+  }
+}
+
+function renderRolePresetControl() {
+  if (!mockRolePresetContainer) return;
+  if (!roleSwitchState.enabled) {
+    mockRolePresetContainer.hidden = true;
+    return;
+  }
+  mockRolePresetContainer.hidden = false;
+  mockRolePresetSelect.innerHTML = "";
+  const manual = document.createElement("option");
+  manual.value = "";
+  manual.textContent = t("identity.rolePresetManual");
+  mockRolePresetSelect.appendChild(manual);
+  for (const preset of roleSwitchState.presets) {
+    const option = document.createElement("option");
+    option.value = preset;
+    option.textContent = preset;
+    mockRolePresetSelect.appendChild(option);
+  }
+  mockRolePresetSelect.value = findMatchingPreset(rolesInput.value, roleSwitchState.presets);
+  mockRolePresetHint.textContent = t("identity.rolePresetHint");
+}
+
+function renderWorkspaceNavigation() {
+  if (!workspaceNav) return;
+  const items = resolveWorkspaceNavigationItems(
+    participantRuntimeConfig?.navigation?.items,
+    rolesInput?.value ?? "",
+    window.location.pathname,
+  );
+  renderWorkspaceNavigationWithProfile({
+    workspaceNav,
+    localePicker: document.querySelector(".locale-picker"),
+    items,
+    buildLabel: (item) => t(item.labelKey),
+  });
+}
+
+function applyIdentityDefaults() {
+  const defaults =
+    participantRuntimeConfig?.identityDefaults?.contentAdmin ??
+    participantRuntimeConfig?.identityDefaults?.reportReader ??
+    participantRuntimeConfig?.identityDefaults ??
+    null;
+  if (!defaults || typeof defaults !== "object" || !defaults.userId) return;
+  const set = (id, value) => { const el = document.getElementById(id); if (el && value != null) el.value = value; };
+  set("userId", defaults.userId);
+  set("email", defaults.email);
+  set("name", defaults.name);
+  set("department", defaults.department);
+  if (rolesInput && Array.isArray(defaults.roles)) rolesInput.value = defaults.roles.join(",");
+}
+
+function setLocale(locale) {
+  currentLocale = supportedLocales.includes(locale) ? locale : "en-GB";
+  try { localStorage.setItem("participant.locale", currentLocale); } catch { /* ignore */ }
+  document.documentElement.lang = currentLocale;
+  applyTranslations();
+}
+
+// --- Cohort dashboard logic -------------------------------------------------
+
+function statusCard(cls, value, label) {
+  return `<div class="status-card status-card--${cls}"><div class="status-value">${value}</div><div class="status-label">${escapeHtml(label)}</div></div>`;
+}
+
+function renderCohort(summary) {
+  if (cohortEmpty) cohortEmpty.hidden = true;
+  if (statusCards) {
+    statusCards.hidden = false;
+    const c = summary.counts ?? {};
+    statusCards.innerHTML = [
+      statusCard("total", summary.total ?? 0, t("cohort.total")),
+      statusCard("assigned", c.ASSIGNED ?? 0, t("cohort.status.ASSIGNED")),
+      statusCard("in_progress", c.IN_PROGRESS ?? 0, t("cohort.status.IN_PROGRESS")),
+      statusCard("overdue", c.OVERDUE ?? 0, t("cohort.status.OVERDUE")),
+      statusCard("completed", c.COMPLETED ?? 0, t("cohort.status.COMPLETED")),
+    ].join("");
+  }
+  if (byClassSection) {
+    byClassSection.hidden = false;
+    const rows = summary.byClass ?? [];
+    if (byClassEmpty) byClassEmpty.hidden = rows.length > 0;
+    if (byClassBody) {
+      byClassBody.innerHTML = rows
+        .map((b) => {
+          const bc = b.counts ?? {};
+          return `<tr><td>${escapeHtml(b.className ?? b.classId)}</td><td>${bc.ASSIGNED ?? 0}</td><td>${bc.IN_PROGRESS ?? 0}</td><td>${bc.OVERDUE ?? 0}</td><td>${bc.COMPLETED ?? 0}</td><td>${b.total ?? 0}</td></tr>`;
+        })
+        .join("");
+    }
+  }
+  if (cohortMeta) {
+    const when = summary.generatedAt ? new Date(summary.generatedAt).toLocaleString(currentLocale) : "";
+    cohortMeta.textContent = `${t("cohort.generatedAt")}: ${when}`;
+  }
+}
+
+function showCohortEmpty() {
+  if (cohortEmpty) cohortEmpty.hidden = false;
+  if (statusCards) statusCards.hidden = true;
+  if (byClassSection) byClassSection.hidden = true;
+  if (cohortMeta) cohortMeta.textContent = "";
+}
+
+async function loadCourses() {
+  try {
+    const data = await apiFetch("/api/cohort-status/courses", headers);
+    const courses = data.courses ?? [];
+    if (courses.length === 0) {
+      courseSelect.innerHTML = `<option value="">${escapeHtml(t("cohort.picker.empty"))}</option>`;
+      courseSelect.disabled = true;
+      return;
+    }
+    courseSelect.disabled = false;
+    courseSelect.innerHTML =
+      `<option value="">${escapeHtml(t("cohort.picker.placeholder"))}</option>` +
+      courses.map((c) => `<option value="${escapeHtml(c.id)}">${escapeHtml(c.title)}</option>`).join("");
+  } catch (error) {
+    setMessage(error?.message ?? t("cohort.error"), "error");
+  }
+}
+
+async function loadCohort(courseId) {
+  if (!courseId) {
+    showCohortEmpty();
+    return;
+  }
+  try {
+    const summary = await apiFetch(`/api/cohort-status/course/${encodeURIComponent(courseId)}`, headers);
+    renderCohort(summary);
+    log(summary);
+    setMessage("", "info");
+  } catch (error) {
+    setMessage(error?.message ?? t("cohort.error"), "error");
+    showCohortEmpty();
+  }
+}
+
+// --- Bootstrap --------------------------------------------------------------
+
+async function init() {
+  try {
+    participantRuntimeConfig = await getConsoleConfig();
+    roleSwitchState = resolveRoleSwitchState(participantRuntimeConfig);
+  } catch {
+    participantRuntimeConfig = { authMode: "mock", navigation: { items: [] }, identityDefaults: {} };
+  }
+  document.body.classList.toggle("auth-entra", roleSwitchState.authMode === "entra");
+  populateLocaleSelect();
+  applyIdentityDefaults();
+  renderRolePresetControl();
+
+  if (roleSwitchState.authMode === "entra") {
+    try {
+      const me = await apiFetch("/api/me", headers);
+      if (Array.isArray(me?.user?.roles) && me.user.roles.length > 0) rolesInput.value = me.user.roles.join(",");
+    } catch { /* nav renders with identity defaults */ }
+  }
+
+  applyTranslations();
+  await initConsentGuard(headers, currentLocale);
+
+  try {
+    const body = await apiFetch("/version", { headers: {} });
+    if (appVersionLabel) appVersionLabel.textContent = `v${body.version ?? "unknown"}`;
+  } catch {
+    if (appVersionLabel) appVersionLabel.textContent = "unknown";
+  }
+
+  await loadCourses();
+}
+
+localeSelect?.addEventListener("change", () => setLocale(localeSelect.value));
+mockRolePresetSelect?.addEventListener("change", () => {
+  if (!mockRolePresetSelect.value || !roleSwitchState.enabled) return;
+  rolesInput.value = mockRolePresetSelect.value;
+  renderWorkspaceNavigation();
+});
+rolesInput?.addEventListener("input", () => {
+  mockRolePresetSelect.value = findMatchingPreset(rolesInput.value, roleSwitchState.presets) ?? "";
+  renderWorkspaceNavigation();
+});
+courseSelect?.addEventListener("change", () => loadCohort(courseSelect.value));
+loadMeButton?.addEventListener("click", async () => {
+  try { log(await apiFetch("/api/me", headers)); } catch (error) { log(error?.message ?? "Error"); }
+});
+if (debugOutputSection) debugOutputSection.hidden = new URLSearchParams(window.location.search).get("debug") !== "1";
+
+void init();

--- a/public/i18n/cohort-status-translations.js
+++ b/public/i18n/cohort-status-translations.js
@@ -1,0 +1,80 @@
+import {
+  localeLabels as baseLocaleLabels,
+  supportedLocales as baseSupportedLocales,
+  translations as participantTranslations,
+} from "./participant-translations.js";
+
+export const supportedLocales = baseSupportedLocales;
+export const localeLabels = baseLocaleLabels;
+
+// #498: cohort-status dashboard copy. Inherits nav/identity keys from the participant base; adds the
+// dashboard-specific keys here (nb/nn/en-GB).
+const extra = {
+  "en-GB": {
+    "nav.profile": "Profile",
+    "cohortPage.title": "Cohort status",
+    "cohortPage.subtitle": "Participant status per course — assigned, in progress, overdue, completed.",
+    "cohort.picker.label": "Course",
+    "cohort.picker.placeholder": "Select a course…",
+    "cohort.picker.empty": "No published courses.",
+    "cohort.empty": "Select a course to see its cohort status.",
+    "cohort.total": "Participants",
+    "cohort.generatedAt": "Updated",
+    "cohort.status.ASSIGNED": "Assigned",
+    "cohort.status.IN_PROGRESS": "In progress",
+    "cohort.status.OVERDUE": "Overdue",
+    "cohort.status.COMPLETED": "Completed",
+    "cohort.byClass.title": "By class",
+    "cohort.byClass.class": "Class",
+    "cohort.byClass.total": "Participants",
+    "cohort.byClass.empty": "No class assignments for this course.",
+    "cohort.error": "Could not load cohort status.",
+  },
+  nb: {
+    "nav.profile": "Profil",
+    "cohortPage.title": "Kohort-status",
+    "cohortPage.subtitle": "Deltakernes status per kurs — tildelt, påbegynt, forfalt, fullført.",
+    "cohort.picker.label": "Kurs",
+    "cohort.picker.placeholder": "Velg et kurs…",
+    "cohort.picker.empty": "Ingen publiserte kurs.",
+    "cohort.empty": "Velg et kurs for å se kohort-status.",
+    "cohort.total": "Deltakere",
+    "cohort.generatedAt": "Oppdatert",
+    "cohort.status.ASSIGNED": "Tildelt",
+    "cohort.status.IN_PROGRESS": "Påbegynt",
+    "cohort.status.OVERDUE": "Forfalt",
+    "cohort.status.COMPLETED": "Fullført",
+    "cohort.byClass.title": "Per klasse",
+    "cohort.byClass.class": "Klasse",
+    "cohort.byClass.total": "Deltakere",
+    "cohort.byClass.empty": "Ingen klasse-tildelinger for dette kurset.",
+    "cohort.error": "Kunne ikke laste kohort-status.",
+  },
+  nn: {
+    "nav.profile": "Profil",
+    "cohortPage.title": "Kohort-status",
+    "cohortPage.subtitle": "Deltakarane sin status per kurs — tildelt, påbyrja, forfalle, fullført.",
+    "cohort.picker.label": "Kurs",
+    "cohort.picker.placeholder": "Vel eit kurs…",
+    "cohort.picker.empty": "Ingen publiserte kurs.",
+    "cohort.empty": "Vel eit kurs for å sjå kohort-status.",
+    "cohort.total": "Deltakarar",
+    "cohort.generatedAt": "Oppdatert",
+    "cohort.status.ASSIGNED": "Tildelt",
+    "cohort.status.IN_PROGRESS": "Påbyrja",
+    "cohort.status.OVERDUE": "Forfalle",
+    "cohort.status.COMPLETED": "Fullført",
+    "cohort.byClass.title": "Per klasse",
+    "cohort.byClass.class": "Klasse",
+    "cohort.byClass.total": "Deltakarar",
+    "cohort.byClass.empty": "Ingen klasse-tildelingar for dette kurset.",
+    "cohort.error": "Kunne ikkje laste kohort-status.",
+  },
+};
+
+export const translations = Object.fromEntries(
+  supportedLocales.map((locale) => [
+    locale,
+    { ...(participantTranslations[locale] ?? {}), ...(extra[locale] ?? {}) },
+  ]),
+);

--- a/public/results.html
+++ b/public/results.html
@@ -40,6 +40,7 @@
       <!-- #765: «Deltakere»-området deler denne undernavigasjonen (rollegates av deltakere-subnav.js). -->
       <nav id="deltakereSubnav" class="content-area-nav" aria-label="Deltakere">
         <a href="/deltakere/klasser" class="content-area-nav-link" id="subnavKlasser">Klasser</a>
+        <a href="/deltakere/status" class="content-area-nav-link" id="subnavStatus">Status</a>
         <a href="/review" class="content-area-nav-link" id="subnavReview">Manuell behandling</a>
         <a href="/results" class="content-area-nav-link" id="subnavResults">Resultater</a>
       </nav>

--- a/public/review.html
+++ b/public/review.html
@@ -62,6 +62,7 @@
       <!-- #765: «Deltakere»-området deler denne undernavigasjonen (rollegates av deltakere-subnav.js). -->
       <nav id="deltakereSubnav" class="content-area-nav" aria-label="Deltakere">
         <a href="/deltakere/klasser" class="content-area-nav-link" id="subnavKlasser">Klasser</a>
+        <a href="/deltakere/status" class="content-area-nav-link" id="subnavStatus">Status</a>
         <a href="/review" class="content-area-nav-link" id="subnavReview">Manuell behandling</a>
         <a href="/results" class="content-area-nav-link" id="subnavResults">Resultater</a>
       </nav>

--- a/public/static/deltakere-subnav.js
+++ b/public/static/deltakere-subnav.js
@@ -9,12 +9,15 @@ import { getConsoleConfig, buildConsoleHeaders, apiFetch } from "/static/api-cli
 
 const LINK_ROLES = {
   subnavKlasser: ["SUBJECT_MATTER_OWNER", "ADMINISTRATOR"],
+  // #498: cohort-status dashboard — same audience as Resultater.
+  subnavStatus: ["SUBJECT_MATTER_OWNER", "ADMINISTRATOR", "REPORT_READER"],
   subnavReview: ["REVIEWER", "APPEAL_HANDLER", "ADMINISTRATOR"],
   subnavResults: ["SUBJECT_MATTER_OWNER", "ADMINISTRATOR", "REPORT_READER"],
 };
 
 const ACTIVE_BY_PREFIX = [
   ["/deltakere/klasser", "subnavKlasser"],
+  ["/deltakere/status", "subnavStatus"],
   ["/review", "subnavReview"],
   ["/results", "subnavResults"],
 ];

--- a/scripts/test/admin-content-static-server.mjs
+++ b/scripts/test/admin-content-static-server.mjs
@@ -45,6 +45,10 @@ function resolvePublicFile(requestPath) {
   if (requestPath === "/deltakere/klasser") {
     return path.join(publicRoot, "admin-content-classes.html");
   }
+  // #498: cohort-status dashboard, a «Deltakere» sub-tab.
+  if (requestPath === "/deltakere/status") {
+    return path.join(publicRoot, "cohort-status.html");
+  }
   if (requestPath === "/review") {
     return path.join(publicRoot, "review.html");
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,7 @@ import { auditRouter } from "./routes/audit.js";
 import { reviewsRouter } from "./routes/reviews.js";
 import { appealsRouter } from "./routes/appeals.js";
 import { reportsRouter } from "./routes/reports.js";
+import { cohortStatusRouter } from "./routes/cohortStatus.js";
 import { adminContentRouter } from "./routes/adminContent.js";
 import { adminModulesRouter } from "./routes/adminModules.js";
 import { adminPlatformRouter } from "./routes/adminPlatform.js";
@@ -188,6 +189,11 @@ app.get("/results", (_request, response) => {
   response.sendFile(path.resolve(process.cwd(), "public", "results.html"));
 });
 
+// #498: teacher/SMO cohort-status dashboard — a «Deltakere»-area sub-tab.
+app.get("/deltakere/status", (_request, response) => {
+  response.sendFile(path.resolve(process.cwd(), "public", "cohort-status.html"));
+});
+
 app.get("/participant/config", generalApiLimiter, (_request, response) => {
   response.json(participantConsoleRuntimeConfig);
 });
@@ -215,6 +221,7 @@ app.use("/api/reviews", requireAnyRole(rolesFor("reviews")), reviewsRouter);
 app.use("/api/appeals", requireAnyRole(rolesFor("appeals")), appealsRouter);
 app.use("/api/queue-counts", requireAnyRole(rolesFor("queue_counts")), queueCountsRouter);
 app.use("/api/reports", requireAnyRole(rolesFor("reports")), reportsRouter);
+app.use("/api/cohort-status", requireAnyRole(rolesFor("cohort_dashboard")), cohortStatusRouter);
 // Calibration access is a runtime-configurable override — see CALIBRATION_ACCESS_OVERRIDE note in capabilities.ts.
 // Roles come from calibrationWorkspace.accessRoles in participant-console.json, not from API_ROUTE_CAPABILITIES.
 app.use(

--- a/src/config/capabilities.ts
+++ b/src/config/capabilities.ts
@@ -97,6 +97,13 @@ export const API_ROUTE_CAPABILITIES = [
     roles: [AppRole.ADMINISTRATOR, AppRole.REPORT_READER],
   },
   {
+    // #498: teacher/SMO cohort-status dashboard. Same audience as the «Deltakere → Resultater» sub-tab
+    // (SMO + ADMINISTRATOR + REPORT_READER) — SMO is intentionally included here (unlike /api/reports).
+    id: "cohort_dashboard",
+    prefix: "/api/cohort-status",
+    roles: [AppRole.SUBJECT_MATTER_OWNER, AppRole.ADMINISTRATOR, AppRole.REPORT_READER],
+  },
+  {
     id: "admin_content",
     prefix: "/api/admin/content",
     roles: [AppRole.ADMINISTRATOR, AppRole.SUBJECT_MATTER_OWNER],

--- a/src/modules/course/classRepository.ts
+++ b/src/modules/course/classRepository.ts
@@ -126,6 +126,34 @@ export function createClassRepository(client: ClassRepositoryClient = prisma) {
       });
     },
 
+    // #498: all class assignments for ONE course (on non-archived classes), with the class kind/isSystem
+    // + member users, so the cohort-status dashboard can expand the effective audience. Unlike the
+    // reminder reader below, this is course-scoped and NOT filtered on dueAt (the dashboard shows every
+    // participant, due or not). ENTRA classes are included but the service skips their (unresolvable)
+    // membership; the system "Alle deltakere" class has no rows and is resolved separately.
+    findCourseGroupAssignmentsForCourse(courseId: string) {
+      return client.courseGroupAssignment.findMany({
+        where: { courseId, class: { archivedAt: null } },
+        include: {
+          class: {
+            select: {
+              id: true,
+              name: true,
+              kind: true,
+              isSystem: true,
+              members: {
+                select: {
+                  user: {
+                    select: { id: true, name: true, email: true, activeStatus: true, isAnonymized: true },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+    },
+
     // #497 fase 2: class-assigned due dates for the reminder schedule. Only non-null dueAt on a
     // non-archived class. Includes the course (id + localized title) and the class kind/isSystem so
     // the service can expand membership (MANUAL rows are included; the system "Alle deltakere" class

--- a/src/modules/course/cohortStatusService.ts
+++ b/src/modules/course/cohortStatusService.ts
@@ -1,0 +1,128 @@
+import { prisma } from "../../db/prisma.js";
+import { NotFoundError } from "../../errors/AppError.js";
+import { deriveStatus } from "./enrollmentService.js";
+import type { EnrollmentStatus } from "./enrollmentStatus.js";
+import { enrollmentRepository } from "./enrollmentRepository.js";
+import { classRepository } from "./classRepository.js";
+import { findActiveParticipants } from "../../repositories/userRepository.js";
+
+// #498: teacher/SMO cohort-status dashboard. Aggregates the EnrollmentStatus (ASSIGNED / IN_PROGRESS /
+// OVERDUE / COMPLETED) over a course's EFFECTIVE audience — individual CourseEnrollment rows plus
+// class-assigned members (MANUAL classes + the "Alle deltakere" system class; ENTRA classes are not
+// resolvable, mirroring the reminder job). One effective row per (user, course): an individual
+// enrollment wins over a class assignment; among classes the earliest due date wins. This is the
+// read-time analogue of the reminder job's audience expansion (courseReminderService.gatherCandidates),
+// but course-scoped and NOT filtered on dueAt (the dashboard shows every participant, due or not).
+
+const STATUSES: EnrollmentStatus[] = ["ASSIGNED", "IN_PROGRESS", "OVERDUE", "COMPLETED"];
+
+type AudienceMember = {
+  userId: string;
+  dueAt: Date | null;
+  source: "individual" | "class";
+  classId: string | null;
+  className: string | null;
+};
+
+export async function resolveCourseAudience(courseId: string): Promise<AudienceMember[]> {
+  const map = new Map<string, AudienceMember>();
+
+  // 1. Individual (explicitly assigned) enrolments — active (non-revoked) rows.
+  const enrollments = await enrollmentRepository.findActiveEnrollmentsForCourse(courseId);
+  for (const enrollment of enrollments) {
+    map.set(enrollment.userId, {
+      userId: enrollment.userId,
+      dueAt: enrollment.dueAt,
+      source: "individual",
+      classId: null,
+      className: null,
+    });
+  }
+
+  // 2. Class-assigned members. MANUAL = ClassMember rows; system "Alle deltakere" = all active
+  //    participants; ENTRA = skipped (membership not resolvable at read time).
+  const assignments = await classRepository.findCourseGroupAssignmentsForCourse(courseId);
+  let allParticipants: Array<{ id: string; name: string; email: string }> | null = null;
+  for (const assignment of assignments) {
+    if (assignment.class.kind === "ENTRA") continue;
+    const members: Array<{ id: string; activeStatus: boolean; isAnonymized: boolean }> = assignment.class.isSystem
+      ? (allParticipants ??= await findActiveParticipants()).map((u) => ({ ...u, activeStatus: true, isAnonymized: false }))
+      : assignment.class.members.map((m) => m.user);
+
+    for (const user of members) {
+      if (!user.activeStatus || user.isAnonymized) continue;
+      const existing = map.get(user.id);
+      if (existing) {
+        // Individual wins; among class assignments keep the earliest due date.
+        if (existing.source === "class" && assignment.dueAt && (!existing.dueAt || assignment.dueAt < existing.dueAt)) {
+          existing.dueAt = assignment.dueAt;
+        }
+        continue;
+      }
+      map.set(user.id, {
+        userId: user.id,
+        dueAt: assignment.dueAt,
+        source: "class",
+        classId: assignment.class.id,
+        className: assignment.class.name,
+      });
+    }
+  }
+
+  return Array.from(map.values());
+}
+
+export type CohortStatusCounts = Record<EnrollmentStatus, number>;
+
+export type CohortClassBreakdown = {
+  classId: string;
+  className: string;
+  total: number;
+  counts: CohortStatusCounts;
+};
+
+export type CohortStatusSummary = {
+  courseId: string;
+  total: number;
+  counts: CohortStatusCounts;
+  byClass: CohortClassBreakdown[];
+  generatedAt: string;
+};
+
+function emptyCounts(): CohortStatusCounts {
+  return { ASSIGNED: 0, IN_PROGRESS: 0, OVERDUE: 0, COMPLETED: 0 };
+}
+
+// NOTE: deriveStatus runs 1–2 queries per audience member (completion lookup + started probe). Fine for
+// typical cohorts; batch the completion/started lookups if cohorts grow large.
+export async function getCohortStatus(courseId: string, now: Date = new Date()): Promise<CohortStatusSummary> {
+  const course = await prisma.course.findUnique({ where: { id: courseId }, select: { id: true } });
+  if (!course) throw new NotFoundError("Course", "course_not_found", "Course not found.");
+
+  const audience = await resolveCourseAudience(courseId);
+
+  const counts = emptyCounts();
+  const byClassMap = new Map<string, CohortClassBreakdown>();
+
+  for (const member of audience) {
+    const status = await deriveStatus(member.userId, courseId, member.dueAt, now);
+    counts[status] += 1;
+    if (member.classId) {
+      let bucket = byClassMap.get(member.classId);
+      if (!bucket) {
+        bucket = { classId: member.classId, className: member.className ?? member.classId, total: 0, counts: emptyCounts() };
+        byClassMap.set(member.classId, bucket);
+      }
+      bucket.counts[status] += 1;
+      bucket.total += 1;
+    }
+  }
+
+  return {
+    courseId,
+    total: audience.length,
+    counts,
+    byClass: Array.from(byClassMap.values()),
+    generatedAt: now.toISOString(),
+  };
+}

--- a/src/routes/cohortStatus.ts
+++ b/src/routes/cohortStatus.ts
@@ -1,0 +1,42 @@
+import { Router, type Request } from "express";
+import { prisma } from "../db/prisma.js";
+import { getCohortStatus } from "../modules/course/cohortStatusService.js";
+import { localizeContentText } from "../i18n/content.js";
+import { normalizeLocale } from "../i18n/locale.js";
+
+// #498: teacher/SMO cohort-status dashboard API. Mounted at /api/cohort-status; role-gated to
+// SUBJECT_MATTER_OWNER + ADMINISTRATOR + REPORT_READER (see capabilities `cohort_dashboard`).
+const cohortStatusRouter = Router();
+
+// GET /api/cohort-status/courses — published, non-archived courses for the dashboard picker.
+cohortStatusRouter.get("/courses", async (request, response, next) => {
+  try {
+    const locale = normalizeLocale(request.context?.locale) ?? "nb";
+    const courses = await prisma.course.findMany({
+      where: { publishedAt: { not: null }, archivedAt: null },
+      select: { id: true, title: true },
+      orderBy: { createdAt: "desc" },
+    });
+    response.json({
+      courses: courses.map((course) => ({
+        id: course.id,
+        title: localizeContentText(locale, course.title) ?? course.title ?? course.id,
+      })),
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/cohort-status/course/:courseId — enrollment-status counts (ASSIGNED/IN_PROGRESS/OVERDUE/
+// COMPLETED) over the course's effective audience (individual + class-expanded), plus a per-class
+// breakdown.
+cohortStatusRouter.get("/course/:courseId", async (request: Request<{ courseId: string }>, response, next) => {
+  try {
+    response.json(await getCohortStatus(request.params.courseId));
+  } catch (error) {
+    next(error);
+  }
+});
+
+export { cohortStatusRouter };

--- a/test/e2e/cohort-status.spec.ts
+++ b/test/e2e/cohort-status.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+// #498: browser e2e for the teacher/SMO cohort-status dashboard. Runs the real cohort-status.js against
+// mocked APIs — the picker → load → status-cards + per-class flow, and the «Status» sub-tab wiring.
+
+async function mockBase(page: Page, roles: string[] = ["SUBJECT_MATTER_OWNER"]) {
+  await page.route("**/participant/config", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        authMode: "mock",
+        navigation: { items: [], workspaceItems: [] },
+        identityDefaults: { contentAdmin: { userId: "smo-1", email: "smo@x.no", name: "SMO", roles } },
+        calibrationWorkspace: { accessRoles: [] },
+      }),
+    }),
+  );
+  await page.route("**/version", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "test" }) }),
+  );
+  await page.route("**/api/me", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ user: { roles }, consent: { accepted: true, currentVersion: "1.0" } }),
+    }),
+  );
+}
+
+test("cohort dashboard: pick a course → status counts + per-class breakdown, with the Status tab active", async ({ page }) => {
+  await mockBase(page);
+  await page.route("**/api/cohort-status/courses", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ courses: [{ id: "c1", title: "Kurs A" }] }) }),
+  );
+  await page.route("**/api/cohort-status/course/c1", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        courseId: "c1",
+        total: 5,
+        counts: { ASSIGNED: 2, IN_PROGRESS: 1, OVERDUE: 1, COMPLETED: 1 },
+        byClass: [{ classId: "cl1", className: "Kull 2026", total: 2, counts: { ASSIGNED: 1, IN_PROGRESS: 0, OVERDUE: 0, COMPLETED: 1 } }],
+        generatedAt: "2026-07-18T20:00:00.000Z",
+      }),
+    }),
+  );
+  await page.addInitScript(() => { try { localStorage.setItem("participant.locale", "nb"); } catch { /* ignore */ } });
+
+  await page.goto("/deltakere/status");
+
+  await expect(page.locator("h1")).toContainText("Kohort-status");
+  // The «Status» sub-tab is present and marked active; the reviewer-only tab is gated out for an SMO.
+  await expect(page.locator("#subnavStatus")).toHaveClass(/active/);
+  await expect(page.locator("#subnavReview")).toHaveCount(0);
+
+  // Empty state until a course is chosen.
+  await expect(page.locator("#cohortEmpty")).toBeVisible();
+  await expect(page.locator("#statusCards")).toBeHidden();
+
+  // Pick the course.
+  await expect(page.locator("#courseSelect option[value='c1']")).toHaveCount(1);
+  await page.locator("#courseSelect").selectOption("c1");
+
+  // Status cards render with the counts.
+  const cards = page.locator("#statusCards");
+  await expect(cards).toBeVisible();
+  await expect(cards.locator(".status-card--total .status-value")).toHaveText("5");
+  await expect(cards.locator(".status-card--assigned .status-value")).toHaveText("2");
+  await expect(cards.locator(".status-card--in_progress .status-value")).toHaveText("1");
+  await expect(cards.locator(".status-card--overdue .status-value")).toHaveText("1");
+  await expect(cards.locator(".status-card--completed .status-value")).toHaveText("1");
+
+  // Per-class breakdown row.
+  const classRow = page.locator("#byClassBody tr");
+  await expect(classRow).toHaveCount(1);
+  await expect(classRow).toContainText("Kull 2026");
+});

--- a/test/m2-cohort-status.test.ts
+++ b/test/m2-cohort-status.test.ts
@@ -1,0 +1,99 @@
+import request from "supertest";
+import { afterAll, describe, expect, it } from "vitest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+
+// #498 — teacher/SMO cohort-status dashboard API. Verifies the enrollment-status aggregate over a
+// course's effective audience (individual enrolments + class-assigned members), against native Postgres.
+
+const adminHeaders = {
+  "x-user-id": "cohort-admin-ext",
+  "x-user-email": "cohort-admin@company.com",
+  "x-user-name": "Cohort Admin",
+  "x-user-roles": "ADMINISTRATOR",
+};
+
+describe("Cohort-status dashboard API (#498)", () => {
+  const stamp = `${Date.now()}-${Math.round(performance.now())}`;
+  const userIds: string[] = [];
+  let courseId = "";
+  let classId = "";
+
+  async function makeUser(tag: string): Promise<string> {
+    const user = await prisma.user.create({
+      data: { externalId: `co-${tag}-${stamp}`, name: `CO ${tag}`, email: `co-${tag}-${stamp}@x.test` },
+      select: { id: true },
+    });
+    userIds.push(user.id);
+    return user.id;
+  }
+
+  afterAll(async () => {
+    await prisma.courseGroupAssignment.deleteMany({ where: { courseId } });
+    await prisma.classMember.deleteMany({ where: { classId } });
+    if (classId) await prisma.class.deleteMany({ where: { id: classId } });
+    await prisma.courseCompletion.deleteMany({ where: { courseId } });
+    await prisma.courseEnrollment.deleteMany({ where: { courseId } });
+    if (courseId) await prisma.course.deleteMany({ where: { id: courseId } });
+    if (userIds.length) await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+    await prisma.$disconnect();
+  });
+
+  it("counts enrollment status over individual + class-assigned audience, with a per-class breakdown", async () => {
+    const course = await prisma.course.create({
+      data: { title: JSON.stringify({ nb: "Kohortkurs", "en-GB": "Cohort course" }), publishedAt: new Date() },
+      select: { id: true },
+    });
+    courseId = course.id;
+
+    const future = new Date(Date.now() + 30 * 24 * 3600 * 1000);
+    const past = new Date(Date.now() - 30 * 24 * 3600 * 1000);
+
+    const assigned = await makeUser("assigned"); // individual, due in future, not started → ASSIGNED
+    const overdue = await makeUser("overdue"); // individual, due in past, not completed → OVERDUE
+    const completed = await makeUser("completed"); // individual, has completion → COMPLETED
+    const classMember = await makeUser("classmember"); // class-assigned, no due → ASSIGNED
+
+    await prisma.courseEnrollment.create({ data: { userId: assigned, courseId, source: "INDIVIDUAL", dueAt: future } });
+    await prisma.courseEnrollment.create({ data: { userId: overdue, courseId, source: "INDIVIDUAL", dueAt: past } });
+    await prisma.courseEnrollment.create({ data: { userId: completed, courseId, source: "INDIVIDUAL", dueAt: future } });
+    await prisma.courseCompletion.create({ data: { userId: completed, courseId, moduleSnapshotJson: "[]" } });
+
+    const klass = await prisma.class.create({
+      data: { name: `Kull ${stamp}`, kind: "MANUAL", members: { create: [{ userId: classMember }] } },
+      select: { id: true },
+    });
+    classId = klass.id;
+    await prisma.courseGroupAssignment.create({ data: { courseId, classId, dueAt: null } });
+
+    const res = await request(app).get(`/api/cohort-status/course/${courseId}`).set(adminHeaders);
+    expect(res.status).toBe(200);
+    expect(res.body.courseId).toBe(courseId);
+    expect(res.body.total).toBe(4);
+    expect(res.body.counts).toEqual({ ASSIGNED: 2, IN_PROGRESS: 0, OVERDUE: 1, COMPLETED: 1 });
+
+    // Per-class breakdown: the class member (ASSIGNED) shows under the class bucket.
+    const bucket = (res.body.byClass as Array<{ classId: string; total: number; counts: Record<string, number> }>)
+      .find((b) => b.classId === classId);
+    expect(bucket).toBeTruthy();
+    expect(bucket?.total).toBe(1);
+    expect(bucket?.counts.ASSIGNED).toBe(1);
+  });
+
+  it("lists published courses for the picker and 404s an unknown course", async () => {
+    const list = await request(app).get("/api/cohort-status/courses").set(adminHeaders);
+    expect(list.status).toBe(200);
+    const row = (list.body.courses as Array<{ id: string; title: string }>).find((c) => c.id === courseId);
+    expect(row?.title).toMatch(/Kohortkurs|Cohort course/); // localized to the request locale
+
+    const missing = await request(app).get("/api/cohort-status/course/does-not-exist").set(adminHeaders);
+    expect(missing.status).toBe(404);
+  });
+
+  it("forbids a plain PARTICIPANT (not in the dashboard roles)", async () => {
+    const res = await request(app)
+      .get(`/api/cohort-status/course/${courseId}`)
+      .set({ "x-user-id": `co-p-${stamp}`, "x-user-email": `co-p-${stamp}@x.test`, "x-user-name": "P", "x-user-roles": "PARTICIPANT" });
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
Siste «Done når»-pilar i **Epic #478** (Tier 2 LMS) — med kohort-status-dashboardet er alle pilarene levert (innhold ✓ vurdering ✓ progresjon ✓ varsling ✓ dashboard ✓). **Major-bump til 2.0.0** markerer «fra assessment-motor til kursforløp».

## Hva
Ny **«Status»**-fane under «Deltakere» (`/deltakere/status`): velg et kurs → se deltakernes enrollment-status (**Tildelt / Påbegynt / Forfalt / Fullført**) aggregert over kursets **effektive audience** (individuelle `CourseEnrollment` + klasse-tildelte medlemmer), med **per-klasse-breakdown**.

## Design (fullt writeup: `doc/design/COHORT_STATUS_DASHBOARD_498.md`)
- **Egen side, ikke `/results`** — annen status-modell (enrollment vs submission) + annen målgruppe (SMO, ikke bare ADMIN/REPORT_READER).
- **Effektiv audience**: individuell + klasse-ekspandert (MANUAL + «Alle deltakere»; ENTRA hoppes over), én rad per (bruker,kurs), presedens individuell>klasse/tidligste frist. Read-time-analog av påminnelses-jobben, kurs-scoped + uten dueAt-filter.
- **Bevisste MVP-avgrensninger** (i writeup): N+1 i `deriveStatus`, individuelle enrollments ikke aktiv-filtrert, ingen drill-down ennå.

## Endringer
- Backend: `cohortStatusService.ts` (`resolveCourseAudience` + `getCohortStatus`), `classRepository.findCourseGroupAssignmentsForCourse`, `cohortStatus.ts`-router, capability `cohort_dashboard` (SMO/ADMIN/REPORT_READER), `app.ts`-mount + `/deltakere/status`-rute.
- Frontend: `cohort-status.html`/`.js`/`.translations` (nb/nn/en), «Status»-fane i `deltakere-subnav.js` + de andre Deltakere-sidenes bar.
- Tester: integrasjon (aggregat m/individuell+klasse-ekspansjon, per-klasse, /courses-picker, 403) + e2e (picker→last→kort+per-klasse, aktiv fane, rollegating).

## Verifisering
tsc grønn; 3 integrasjonstester + 1 e2e grønne; full e2e-suite grønn (1 urelatert flaky, passerte på retry).

## Utrulling
Kun server+klient-kode, **ingen migrasjon**. **Går kun til stage foreløpig** (ikke prod).

Lukker #498. Fullfører #478 (og #442 lukket separat som del av milepælen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
