### PR TITLE
fix(security): set trust proxy so anonymous rate limiting isn't one shared bucket

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,23 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.38 - 2026-07-19
+
+fix(security): sett `trust proxy` — hindre at anonym IP-basert rate-limiting kollapser til én delt bøtte
+
+Funn fra arkitektur-gjennomgangen (`doc/design/ARCHITECTURE_REVIEW_2026-07-19.md`). Rate-limiterne
+(`src/middleware/rateLimiting.ts`) nøkler anonyme kall på `req.ip`. Uten `trust proxy` bak Azure App
+Services front-end blir `req.ip` proxy-ens IP — lik for alle — så alle anonyme klienter deler én bøtte,
+og én støyende klient gir `429` til alle andre anonyme deltakere (selv-påført throttle).
+
+- **`src/app.ts`:** `app.set("trust proxy", 1)` — stol på nøyaktig ett proxy-hopp, så `req.ip` løses
+  fra `X-Forwarded-For` til den reelle klienten. `1` (ikke `true`) hindrer at en klient spoofer XFF.
+- **`test/trust-proxy.test.ts`:** guard-test som feiler hvis innstillingen fjernes.
+
+**Utrulling:** kun app-kode → `deploy-app.yml`. Lavrisiko atferdsendring (påvirker `req.ip`-utledning
+for logging + rate-limit-nøkkel). Rollback: fjern linja. **Merk:** grenet fra `main` (1.6.37); hvis
+2.0.0 (#773) merges først, reversjoner denne til 2.0.1 ved merge.
+
 ## 1.6.37 - 2026-07-18
 
 chore(observability): #497-incident — ekstern availability-test + alert på worker-rollens /healthz

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.37",
+  "version": "1.6.38",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/app.ts
+++ b/src/app.ts
@@ -32,6 +32,13 @@ import { calibrationRouter } from "./routes/calibration.js";
 import { queueCountsRouter } from "./routes/queueCounts.js";
 
 const app = express();
+// Azure App Service terminates TLS at a single front-end hop and forwards the real client IP in
+// X-Forwarded-For. Trust exactly that one hop so req.ip resolves to the client instead of the proxy.
+// Without this, every anonymous request shares one proxy-side req.ip, collapsing the IP-keyed rate
+// limiters (rateLimiting.ts resolveRateLimitKey falls back to req.ip for unauthenticated callers)
+// into a single shared bucket — one noisy client 429s all other anonymous participants. Trust 1 hop
+// (not `true`) so a client cannot spoof X-Forwarded-For to forge its key.
+app.set("trust proxy", 1);
 const participantConsoleRuntimeConfig = getParticipantConsoleRuntimeConfig();
 const publicRootPath = path.resolve(process.cwd(), "public");
 const publicStaticPath = path.resolve(publicRootPath, "static");

--- a/test/trust-proxy.test.ts
+++ b/test/trust-proxy.test.ts
@@ -1,0 +1,12 @@
+import { app } from "../src/app.js";
+
+// Guards the fix for the architecture-review finding "no `trust proxy` set → IP-keyed rate limiting
+// collapses all anonymous clients into one bucket behind Azure's front end". The rate limiters
+// (src/middleware/rateLimiting.ts) key anonymous callers by req.ip; behind Azure App Service that
+// only resolves to the real client when Express is told to trust exactly one proxy hop. If a future
+// refactor drops this, anonymous rate limiting silently becomes a single shared bucket again.
+describe("trust proxy", () => {
+  it("trusts exactly one proxy hop so req.ip resolves from X-Forwarded-For (not the front-end IP)", () => {
+    expect(app.get("trust proxy")).toBe(1);
+  });
+});


### PR DESCRIPTION
First **findings→action** item from the 2026-07-19 architecture review (`doc/design/ARCHITECTURE_REVIEW_2026-07-19.md`), a quick win independently found by both Claude (verified) and adjacent to Codex's rate-limit findings.

## Problem
`src/middleware/rateLimiting.ts` keys anonymous callers by `req.ip`. Behind Azure App Service's front end, **without `trust proxy`**, `req.ip` is the proxy's IP — identical for every client — so all anonymous hits to `/participant/config`, `/certificate-background`, etc. share **one** 120/min bucket. A single page-load fan-out or one noisy client returns `429` to every other anonymous participant (a self-inflicted throttle). `express-rate-limit@7` also raises `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` in exactly this misconfiguration.

## Fix
- `src/app.ts`: `app.set("trust proxy", 1)` — trust exactly one hop so `req.ip` resolves from `X-Forwarded-For` to the real client. `1` (not `true`) prevents a client from spoofing `X-Forwarded-For` to forge its rate-limit key.
- `test/trust-proxy.test.ts`: guard test that fails if the setting is dropped.

## Verify
`tsc --noEmit` clean; new test passes.

## Deploy
App-only → `deploy-app.yml`. Low-risk behavior change (affects `req.ip` derivation for logging + rate-limit key). Rollback: remove the line.

**Version note:** branched from `main` (1.6.37 → 1.6.38). #773 (2.0.0) is a larger pending release; if it merges first, rebase this to 2.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
