### PR TITLE
fix(security): neutralize CSV formula injection in report exports

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,25 @@
 
 This document tracks release versions and what each version includes.
 
+## 1.6.39 - 2026-07-19
+
+fix(security): nøytraliser CSV-formel-injeksjon i rapporteksport
+
+Funn fra arkitektur-gjennomgangen (`doc/design/ARCHITECTURE_REVIEW_2026-07-19.md`, CONFIRMED i Fase 4).
+`escapeCsvValue` håndterte anførselstegn/skilletegn men lot celler som starter med `=`, `+`, `-`, `@`,
+tab eller CR stå urørt. Eksportene inneholder forfatter-/deltaker-kontrollert tekst (modul-/kurstitler,
+navn), så en tittel som `=HYPERLINK(...)` kjøres som formel når en report-reader åpner CSV-en i Excel/
+Sheets (CWE-1236 → phishing/eksfiltrering fra deres maskin).
+
+- **`src/modules/reporting/csvExport.ts`:** prefiks apostrof på **string-celler** som starter med en
+  formel-trigger (spreadsheets tolker det som «tving tekst» og skjuler det). Kun string-celler, så
+  tall (f.eks. negative `-5`) og datoer forblir urørt.
+- **`test/csv-formula-injection.test.ts`:** dekker triggere, ekte `=HYPERLINK`, og at tall/datoer og
+  vanlig tekst ikke korrumperes.
+
+**Utrulling:** kun app-kode → `deploy-app.yml`. Rollback: fjern formel-guarden. **Merk:** grenet fra
+`main` (1.6.37); reversjoner ved merge avhengig av rekkefølge med #773 (2.0.0) og #775 (trust proxy).
+
 ## 1.6.37 - 2026-07-18
 
 chore(observability): #497-incident — ekstern availability-test + alert på worker-rollens /healthz

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "1.6.37",
+  "version": "1.6.39",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/reporting/csvExport.ts
+++ b/src/modules/reporting/csvExport.ts
@@ -19,12 +19,21 @@ export function toCsv(
   return [header, ...dataLines].join("\n");
 }
 
+// A cell whose text begins with one of these is executed as a formula when the CSV is opened in
+// Excel / Google Sheets (CSV formula injection, CWE-1236).
+const CSV_FORMULA_TRIGGERS = /^[=+\-@\t\r]/;
+
 function escapeCsvValue(value: unknown) {
   if (value == null) {
     return "";
   }
   const asString = value instanceof Date ? value.toISOString() : String(value);
-  const escaped = asString.replaceAll('"', '""');
+  // Neutralize formula injection for author/participant-controlled text (module/course titles, names,
+  // free-text) by prefixing an apostrophe, which spreadsheets treat as "force text" and hide. Only for
+  // string-origin cells, so numeric columns (e.g. a negative number like -5) and dates are untouched.
+  const guarded =
+    typeof value === "string" && CSV_FORMULA_TRIGGERS.test(asString) ? `'${asString}` : asString;
+  const escaped = guarded.replaceAll('"', '""');
   if (escaped.includes(",") || escaped.includes('"') || escaped.includes("\n")) {
     return `"${escaped}"`;
   }

--- a/test/csv-formula-injection.test.ts
+++ b/test/csv-formula-injection.test.ts
@@ -1,0 +1,31 @@
+import { toCsv } from "../src/modules/reporting/csvExport.js";
+
+// Guards the architecture-review finding "CSV exports allow spreadsheet formula injection": exports
+// contain author-controlled titles + participant identity fields, so a cell like =HYPERLINK(...) would
+// execute when a report reader opens the CSV in Excel/Sheets (CWE-1236).
+describe("csv formula-injection neutralization", () => {
+  it("prefixes an apostrophe on string cells that start with a formula trigger", () => {
+    for (const payload of ["=1+1", "+1", "-cmd", "@SUM(A1)", "\tx", "\rx"]) {
+      const line = toCsv([{ title: payload }], ["title"]).split("\n")[1];
+      // The rendered cell (unwrapped of any CSV quoting) must begin with the neutralizing apostrophe.
+      const cell = line.startsWith('"') ? line.slice(1) : line;
+      expect(cell.startsWith("'")).toBe(true);
+    }
+  });
+
+  it("neutralizes a real =HYPERLINK payload", () => {
+    const line = toCsv([{ title: '=HYPERLINK("http://evil","x")' }], ["title"]).split("\n")[1];
+    expect(line).toContain("'=HYPERLINK");
+  });
+
+  it("does NOT corrupt numeric or date cells (negative numbers stay numeric)", () => {
+    const line = toCsv([{ score: -5, when: new Date("2026-07-19T00:00:00.000Z") }], ["score", "when"]).split("\n")[1];
+    expect(line).toBe("-5,2026-07-19T00:00:00.000Z");
+    expect(line).not.toContain("'");
+  });
+
+  it("leaves ordinary text untouched", () => {
+    const line = toCsv([{ title: "Introduction to Safety" }], ["title"]).split("\n")[1];
+    expect(line).toBe("Introduction to Safety");
+  });
+});


### PR DESCRIPTION
Second **findings→action** item from the 2026-07-19 architecture review, **CONFIRMED** in Phase 4 cross-verification.

## Problem
`escapeCsvValue` (`src/modules/reporting/csvExport.ts`) handled quotes/delimiters but returned cells beginning with `=`, `+`, `-`, `@`, tab, or CR **unchanged**. Completion/report exports carry author-controlled module/course titles and participant identity fields, so an SMO (or any author) can name content `=HYPERLINK("http://evil","clickme")` and a report reader opening the CSV in Excel/Google Sheets executes it — phishing or outbound data exfiltration from the reader's workstation (CWE-1236).

## Fix
- Prefix an apostrophe on **string cells** whose text starts with a formula trigger (spreadsheets treat it as "force text" and hide it). Gated to `typeof value === "string"` so **numeric columns (e.g. a negative `-5`) and dates are untouched**.
- `test/csv-formula-injection.test.ts`: triggers, a real `=HYPERLINK` payload, and negatives/dates/ordinary-text pass-through.

## Verify
`tsc --noEmit` clean; 4 new tests pass.

## Deploy
App-only → `deploy-app.yml`. Rollback: remove the formula guard.

**Version note:** branched from `main` (→ 1.6.39). Reconcile at merge with #775 (trust proxy) and #773 (2.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
