### PR TITLE
fix(security): #785 restricted-course authorization on direct endpoints (IDOR)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,26 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.3 - 2026-07-19
+
+fix(security): #785 — restricted-course authorization on direct endpoints (IDOR)
+
+Arkitektur-gjennomgangens topp-prioritet (epic #778). Kurs-LISTE-endepunktet filtrerte RESTRICTED-kurs
+på enrollment/klasse-synlighet, men de direkte endepunktene (detalj, seksjonsinnhold, marker-lest) gated
+kun på `publishedAt` — så en innlogget, uinnmeldt deltaker med en RESTRICTED kurs-ID kunne lese hele
+sekvensen + seksjonsinnhold og skrive lese-progresjon.
+
+- **`src/modules/course/enrollmentService.ts`:** ny `isCourseVisibleToUser` — enkelt-kurs-synlighet
+  (OPEN kortslutter; RESTRICTED krever enrollment ELLER klasse-tildeling), speiler liste-logikken.
+- **`src/routes/courses.ts`:** guard på `GET /:courseId`, `GET /:courseId/sections/:sectionId`, og
+  `POST /:courseId/sections/:sectionId/read` — 404 (ikke 403) når ikke synlig.
+- **`test/m2-course-restricted-visibility.test.ts`:** uinnmeldt → 404 ×3 (og ingen lese-rad skrevet);
+  innmeldt → 200/200/204; OPEN uendret (200).
+
+**Utrulling:** kun app-kode → `deploy-app.yml`. Ingen skjemaendring. Rollback: fjern guardene.
+`enrollmentPolicy` defaulter til OPEN, så eksisterende kurs er upåvirket. Lukker #785. (#786 asset-IDOR
+kommer som egen PR — bredere test-endring.)
+
 ## 2.0.2 - 2026-07-19
 
 fix(security): nøytraliser CSV-formel-injeksjon i rapporteksport

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/course/enrollmentService.ts
+++ b/src/modules/course/enrollmentService.ts
@@ -230,6 +230,30 @@ export async function filterVisibleCourseIds(
   return visible;
 }
 
+/**
+ * #778/#785: single-course visibility guard for the direct course endpoints (detail / section
+ * content / mark-read). The course LIST endpoint filters by `filterVisibleCourseIds`, but the direct
+ * endpoints gated only on `publishedAt`, so an unenrolled participant with a RESTRICTED course id
+ * could read its content. This mirrors the list logic for one already-fetched course. OPEN
+ * short-circuits (no class/enrolment lookups); RESTRICTED requires an enrolment OR class assignment.
+ */
+export async function isCourseVisibleToUser(input: {
+  course: { id: string; enrollmentPolicy: string };
+  userId: string;
+  roles: AppRoleType[];
+  groupIds?: string[];
+}): Promise<boolean> {
+  if (input.course.enrollmentPolicy === "OPEN") return true;
+  const classIds = await getUserClassIds({
+    userId: input.userId,
+    roles: input.roles,
+    groupIds: input.groupIds,
+  });
+  const classCourseDue = await getClassAssignedCourseDueDates(classIds);
+  const visible = await filterVisibleCourseIds(input.userId, [input.course], new Set(classCourseDue.keys()));
+  return visible.has(input.course.id);
+}
+
 // #495-follow-up (PARTICIPANT_COURSE_ONLY): er modulen del av et publisert kurs som brukeren har
 // tilgang til? Brukes til å gate frittstående modul-innlevering for deltakere — modul tatt via
 // course player passerer (modulen ligger jo i et tilgjengelig kurs).

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -71,6 +71,7 @@ export {
   listUserEnrollments,
   listCourseEnrollments,
   filterVisibleCourseIds,
+  isCourseVisibleToUser,
   isModuleInAccessibleCourse,
   deriveStatus,
 } from "./enrollmentService.js";

--- a/src/routes/courses.ts
+++ b/src/routes/courses.ts
@@ -8,6 +8,7 @@ import {
   listUserEnrollments,
   selfEnroll,
   filterVisibleCourseIds,
+  isCourseVisibleToUser,
   getUserClassIds,
   getClassAssignedCourseDueDates,
   deriveStatus,
@@ -221,6 +222,11 @@ coursesRouter.get("/:courseId", async (request, response, next) => {
     if (!course || !course.publishedAt || course.archivedAt) {
       throw new NotFoundError("Course", "course_not_found", "Course not found.");
     }
+    // #778/#785: RESTRICTED courses are visible only to enrolled/class-assigned users. Gate the direct
+    // detail endpoint the same way the list endpoint does; 404 (not 403) so we don't confirm existence.
+    if (!(await isCourseVisibleToUser({ course, userId, roles: request.context?.roles ?? [], groupIds: request.context?.principal?.groupIds }))) {
+      throw new NotFoundError("Course", "course_not_found", "Course not found.");
+    }
 
     const moduleIds = course.modules.map((cm) => cm.moduleId);
     const [certStatuses, passedCount, latestSubmissions] = await Promise.all([
@@ -336,6 +342,10 @@ coursesRouter.get("/:courseId/sections/:sectionId", async (request, response, ne
     if (!course || !course.publishedAt || course.archivedAt) {
       throw new NotFoundError("Course", "course_not_found", "Course not found.");
     }
+    // #778/#785: gate RESTRICTED-course section content on enrolment/class visibility.
+    if (!(await isCourseVisibleToUser({ course, userId, roles: request.context?.roles ?? [], groupIds: request.context?.principal?.groupIds }))) {
+      throw new NotFoundError("Course", "course_not_found", "Course not found.");
+    }
     const courseItems = await courseRepository.findCourseItems(course.id);
     const belongs = courseItems.some(
       (item) => item.itemType === "SECTION" && item.sectionId === request.params.sectionId,
@@ -365,6 +375,10 @@ coursesRouter.post("/:courseId/sections/:sectionId/read", async (request, respon
   try {
     const course = await courseRepository.findCourseById(request.params.courseId);
     if (!course || !course.publishedAt || course.archivedAt) {
+      throw new NotFoundError("Course", "course_not_found", "Course not found.");
+    }
+    // #778/#785: gate RESTRICTED-course read-progress writes on enrolment/class visibility.
+    if (!(await isCourseVisibleToUser({ course, userId, roles: request.context?.roles ?? [], groupIds: request.context?.principal?.groupIds }))) {
       throw new NotFoundError("Course", "course_not_found", "Course not found.");
     }
     const courseItems = await courseRepository.findCourseItems(course.id);

--- a/test/m2-course-restricted-visibility.test.ts
+++ b/test/m2-course-restricted-visibility.test.ts
@@ -1,0 +1,103 @@
+import request from "supertest";
+import { afterAll, describe, expect, it } from "vitest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+
+// #778/#785: the course LIST endpoint filters RESTRICTED courses by enrolment/class visibility, but
+// the direct detail / section-content / mark-read endpoints previously gated only on `publishedAt`.
+// An authenticated but unenrolled participant with a RESTRICTED course id could therefore read the
+// full sequence + section content and write read-progress. These tests pin the guard.
+
+function headers(externalId: string) {
+  return {
+    "x-user-id": externalId,
+    "x-user-email": `${externalId}@company.com`,
+    "x-user-name": externalId,
+    "x-user-roles": "PARTICIPANT",
+  };
+}
+
+async function makeUser(tag: string) {
+  const ext = `${tag}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  const user = await prisma.user.create({
+    data: { externalId: ext, name: tag, email: `${ext}@x.test` },
+    select: { id: true, externalId: true },
+  });
+  return user;
+}
+
+async function makeCourseWithSection(enrollmentPolicy: "OPEN" | "RESTRICTED") {
+  const course = await prisma.course.create({
+    data: { title: `Visibility ${enrollmentPolicy} ${Date.now()}`, publishedAt: new Date(), enrollmentPolicy },
+    select: { id: true },
+  });
+  const section = await prisma.courseSection.create({
+    data: { title: JSON.stringify({ "en-GB": "Secret section" }) },
+    select: { id: true },
+  });
+  const version = await prisma.courseSectionVersion.create({
+    data: { sectionId: section.id, versionNo: 1, bodyMarkdown: JSON.stringify({ "en-GB": "Secret body." }), publishedAt: new Date() },
+    select: { id: true },
+  });
+  await prisma.courseSection.update({ where: { id: section.id }, data: { activeVersionId: version.id } });
+  await prisma.courseItem.create({ data: { courseId: course.id, itemType: "SECTION", sectionId: section.id, sortOrder: 0 } });
+  return { courseId: course.id, sectionId: section.id };
+}
+
+async function cleanup(courseId: string, sectionId: string) {
+  await prisma.courseEnrollment.deleteMany({ where: { courseId } });
+  await prisma.courseCompletion.deleteMany({ where: { courseId } });
+  await prisma.course.delete({ where: { id: courseId } }); // cascades courseItems
+  await prisma.courseSection.update({ where: { id: sectionId }, data: { activeVersionId: null } });
+  await prisma.courseSectionVersion.deleteMany({ where: { sectionId } });
+  await prisma.courseSection.delete({ where: { id: sectionId } });
+}
+
+describe("RESTRICTED course direct-endpoint visibility (#785)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("denies an unenrolled participant on detail, section content, and mark-read (404)", async () => {
+    const { courseId, sectionId } = await makeCourseWithSection("RESTRICTED");
+    const outsider = await makeUser("outsider");
+    const h = headers(outsider.externalId);
+
+    const detail = await request(app).get(`/api/courses/${courseId}`).set(h);
+    expect(detail.status).toBe(404);
+    const section = await request(app).get(`/api/courses/${courseId}/sections/${sectionId}`).set(h);
+    expect(section.status).toBe(404);
+    const read = await request(app).post(`/api/courses/${courseId}/sections/${sectionId}/read`).set(h);
+    expect(read.status).toBe(404);
+
+    // The read must NOT have been recorded (the guard runs before markSectionRead).
+    expect(await prisma.courseSectionRead.count({ where: { userId: outsider.id, courseId } })).toBe(0);
+    await cleanup(courseId, sectionId);
+  });
+
+  it("allows an enrolled participant on all three (200/200/204)", async () => {
+    const { courseId, sectionId } = await makeCourseWithSection("RESTRICTED");
+    const enrolled = await makeUser("enrolled");
+    await prisma.courseEnrollment.create({
+      data: { courseId, userId: enrolled.id, source: "INDIVIDUAL", assignedAt: new Date() },
+    });
+    const h = headers(enrolled.externalId);
+
+    expect((await request(app).get(`/api/courses/${courseId}`).set(h)).status).toBe(200);
+    const section = await request(app).get(`/api/courses/${courseId}/sections/${sectionId}`).set(h);
+    expect(section.status).toBe(200);
+    expect(section.body.html).toContain("Secret body");
+    expect((await request(app).post(`/api/courses/${courseId}/sections/${sectionId}/read`).set(h)).status).toBe(204);
+    await cleanup(courseId, sectionId);
+  });
+
+  it("does not affect OPEN courses — an unenrolled participant still gets 200", async () => {
+    const { courseId, sectionId } = await makeCourseWithSection("OPEN");
+    const anyone = await makeUser("open-viewer");
+    const h = headers(anyone.externalId);
+
+    expect((await request(app).get(`/api/courses/${courseId}`).set(h)).status).toBe(200);
+    expect((await request(app).get(`/api/courses/${courseId}/sections/${sectionId}`).set(h)).status).toBe(200);
+    await cleanup(courseId, sectionId);
+  });
+});


### PR DESCRIPTION
First code fix from the architecture-review backlog — epic **#778** (object-level access control), the reconciled #1 priority. Closes **#785**.

## Problem
The course **list** endpoint filters RESTRICTED courses by enrolment/class visibility (`filterVisibleCourseIds`), but the **direct** endpoints gated only on `publishedAt`. An authenticated but unenrolled participant with a RESTRICTED course id could read the full sequence + section content and write read-progress (`src/routes/courses.ts:210, 327, 359`).

## Fix
- **`enrollmentService.ts`** — new `isCourseVisibleToUser`: single-course visibility mirroring the list logic. OPEN short-circuits (no extra queries); RESTRICTED requires an enrolment **or** a class assignment.
- **`courses.ts`** — guard `GET /:courseId`, `GET /:courseId/sections/:sectionId`, `POST /:courseId/sections/:sectionId/read`; **404** (not 403) so existence isn't confirmed.
- **`test/m2-course-restricted-visibility.test.ts`** — unenrolled → 404 ×3 (+ no read row written); enrolled → 200/200/204; OPEN unchanged → 200.

## Safety / verify
`tsc --noEmit` clean. `enrollmentPolicy` **defaults to OPEN**, so every existing course and test is unaffected (verified: existing course tests create OPEN courses). The new integration test needs the Postgres test DB (Docker), which isn't available in my local env — it runs in CI's `verify` job.

## Deploy
App-only → `deploy-app.yml`. No schema change. Rollback: remove the guards. Branched from `main` (→ 2.0.3).

**#786 (asset IDOR)** in the same epic follows as its own PR — it changes shared asset-serving behavior encoded in existing tests (sections are `onDelete: Restrict` from course items), so it needs more careful test surgery and shouldn't ride with this clean fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
