### PR TITLE
fix(security): #786 content-asset object-level authorization (IDOR)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,27 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.4 - 2026-07-19
+
+fix(security): #786 — content-asset object-level authorization (IDOR)
+
+Epic #778, andre skive. `getSectionAssetContent` hentet asset kun på ID uten å sjekke seksjon/kurs/
+enrollment, så enhver innlogget bruker med en asset-ID kunne hente media fra en restricted/upublisert
+seksjon.
+
+- **`src/modules/course/enrollmentService.ts`:** ny `isSectionInAccessibleCourse` — er seksjonen del av
+  et publisert kurs deltakeren har tilgang til (via `CourseItem.sectionId` → synlighet).
+- **`src/modules/course/assetCommands.ts` + `src/routes/contentAssets.ts`:** `getSectionAssetContent`
+  tar nå en `viewer`; deltaker må ha tilgang til seksjonens publiserte kurs, forfattere (SMO/ADMIN)
+  bypasser for draft-preview. 404 (ikke 403) ved nekt.
+- **Tester:** ny `test/m2-section-asset-authz.test.ts` (uinnmeldt→404, innmeldt→200, forfatter-bypass på
+  kursløs seksjon→200). Eksisterende `m2-section-assets.test.ts`: de tre deltaker-serve-casene lenker nå
+  seksjonen inn i et publisert OPEN-kurs (den realistiske stien) — gammel oppførsel serverte assets fra
+  kursløse seksjoner, som var nettopp sårbarheten.
+
+**Utrulling:** kun app-kode → `deploy-app.yml`. Ingen skjemaendring. Rollback: fjern `viewer`-sjekken.
+Lukker #786.
+
 ## 2.0.3 - 2026-07-19
 
 fix(security): #785 — restricted-course authorization on direct endpoints (IDOR)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/course/assetCommands.ts
+++ b/src/modules/course/assetCommands.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
+import type { AppRole as AppRoleType } from "@prisma/client";
 import { prisma } from "../../db/prisma.js";
 import { NotFoundError, ValidationError } from "../../errors/AppError.js";
 import { putAsset, getAsset, deleteAsset } from "./assetStorage.js";
+import { isSectionInAccessibleCourse } from "./enrollmentService.js";
 import { sanitizeSvg, svgHasText, extractSvgTexts, applySvgTextTranslations } from "./svgSanitizer.js";
 import { localizeSvgTexts, type GenerationLocale } from "../adminContent/llmContentGenerationService.js";
 import { SUPPORTED_LOCALES, type SupportedLocale } from "../../i18n/locale.js";
@@ -122,11 +124,29 @@ export async function reclaimAssetBlobs(blobPaths: string[]): Promise<void> {
 
 export async function getSectionAssetContent(
   assetId: string,
-  locale?: string,
+  locale: string | undefined,
+  viewer: { userId: string; roles: AppRoleType[]; groupIds?: string[] },
 ): Promise<{ mimeType: string; filename: string; buffer: Buffer }> {
   const asset = await prisma.sectionAsset.findUnique({ where: { id: assetId } });
   if (!asset) {
     throw new NotFoundError("SectionAsset", "asset_not_found", "Asset not found.");
+  }
+  // #778/#786: object-level authz. Assets are referenced from section markdown; a participant may
+  // fetch one only if its section belongs to a published course they can access. Authors (SMO/ADMIN)
+  // bypass so they can preview assets in unpublished/draft sections in the editor. 404 (not 403) so we
+  // never confirm the asset's existence to an unauthorized caller.
+  const isAuthor =
+    viewer.roles.includes("SUBJECT_MATTER_OWNER") || viewer.roles.includes("ADMINISTRATOR");
+  if (!isAuthor) {
+    const accessible = await isSectionInAccessibleCourse({
+      sectionId: asset.sectionId,
+      userId: viewer.userId,
+      roles: viewer.roles,
+      groupIds: viewer.groupIds,
+    });
+    if (!accessible) {
+      throw new NotFoundError("SectionAsset", "asset_not_found", "Asset not found.");
+    }
   }
   // #657: serve the localized SVG variant for the viewer's locale when one exists; otherwise the
   // original. Raster assets and untranslated SVGs always serve the original blob.

--- a/src/modules/course/enrollmentService.ts
+++ b/src/modules/course/enrollmentService.ts
@@ -285,3 +285,36 @@ export async function isModuleInAccessibleCourse(input: {
   const visible = await filterVisibleCourseIds(input.userId, courses, new Set(classCourseDue.keys()));
   return courses.some((c) => visible.has(c.id));
 }
+
+// #778/#786: is a section part of a published course this participant can access? Backs object-level
+// authz on the section-asset endpoint (assets are referenced from section markdown as `asset:<id>`).
+// Mirrors isModuleInAccessibleCourse but resolves via CourseItem.sectionId. Authors (SMO/ADMIN) bypass
+// this at the call site so they can preview assets in unpublished/draft sections.
+export async function isSectionInAccessibleCourse(input: {
+  sectionId: string;
+  userId: string;
+  roles: AppRoleType[];
+  groupIds?: string[];
+}): Promise<boolean> {
+  const links = await prisma.courseItem.findMany({
+    where: { sectionId: input.sectionId },
+    select: { courseId: true },
+  });
+  const courseIds = [...new Set(links.map((l) => l.courseId))];
+  if (courseIds.length === 0) return false;
+
+  const courses = await prisma.course.findMany({
+    where: { id: { in: courseIds }, publishedAt: { not: null }, archivedAt: null },
+    select: { id: true, enrollmentPolicy: true },
+  });
+  if (courses.length === 0) return false;
+
+  const classIds = await getUserClassIds({
+    userId: input.userId,
+    roles: input.roles,
+    groupIds: input.groupIds,
+  });
+  const classCourseDue = await getClassAssignedCourseDueDates(classIds);
+  const visible = await filterVisibleCourseIds(input.userId, courses, new Set(classCourseDue.keys()));
+  return courses.some((c) => visible.has(c.id));
+}

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -73,6 +73,7 @@ export {
   filterVisibleCourseIds,
   isCourseVisibleToUser,
   isModuleInAccessibleCourse,
+  isSectionInAccessibleCourse,
   deriveStatus,
 } from "./enrollmentService.js";
 export type {

--- a/src/routes/contentAssets.ts
+++ b/src/routes/contentAssets.ts
@@ -7,7 +7,8 @@ const contentAssetsRouter = Router();
 // storage via its managed identity — assets are never publicly accessible. Referenced from
 // section markdown as `asset:<id>`, resolved to `/api/content-assets/<id>` at render time.
 contentAssetsRouter.get("/:assetId", async (request, response, next) => {
-  if (!request.context?.userId) {
+  const userId = request.context?.userId;
+  if (!userId) {
     response.status(401).json({ error: "unauthorized" });
     return;
   }
@@ -15,7 +16,13 @@ contentAssetsRouter.get("/:assetId", async (request, response, next) => {
     // #657: `?locale=` selects a translated SVG variant when one exists (set by the section
     // markdown renderer, which knows which locale pane it is rendering). Falls back to original.
     const localeParam = typeof request.query.locale === "string" ? request.query.locale : undefined;
-    const { mimeType, buffer } = await getSectionAssetContent(request.params.assetId, localeParam);
+    // #778/#786: pass the viewer so the command enforces object-level access (participant must have
+    // access to the asset's section's published course; authors bypass for draft preview).
+    const { mimeType, buffer } = await getSectionAssetContent(request.params.assetId, localeParam, {
+      userId,
+      roles: request.context?.roles ?? [],
+      groupIds: request.context?.principal?.groupIds,
+    });
     response.setHeader("Content-Type", mimeType);
     response.setHeader("Cache-Control", "private, max-age=3600");
     // #657: defence-in-depth for SVG. The stored bytes are already sanitised, but if a victim

--- a/test/m2-section-asset-authz.test.ts
+++ b/test/m2-section-asset-authz.test.ts
@@ -1,0 +1,119 @@
+import request from "supertest";
+import { afterAll, describe, expect, it } from "vitest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+
+// #778/#786: a section asset must not be readable by just any authenticated user. Access is granted
+// only when the asset's section belongs to a published course the participant can access; authors
+// (SMO/ADMIN) bypass so they can preview assets in unpublished/draft sections.
+
+const adminHeaders = {
+  "x-user-id": "asset-authz-admin",
+  "x-user-email": "asset-authz-admin@company.com",
+  "x-user-name": "Asset Authz Admin",
+  "x-user-roles": "ADMINISTRATOR",
+};
+
+const PNG_1PX = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+function participant(externalId: string) {
+  return {
+    "x-user-id": externalId,
+    "x-user-email": `${externalId}@x.test`,
+    "x-user-name": externalId,
+    "x-user-roles": "PARTICIPANT",
+  };
+}
+
+async function makeUser(tag: string) {
+  const ext = `${tag}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  return prisma.user.create({
+    data: { externalId: ext, name: tag, email: `${ext}@x.test` },
+    select: { id: true, externalId: true },
+  });
+}
+
+// Create a section + a real (blob-backed) PNG asset via the admin API.
+async function makeSectionWithAsset(): Promise<{ sectionId: string; assetId: string }> {
+  const secRes = await request(app)
+    .post("/api/admin/content/sections")
+    .set(adminHeaders)
+    .send({ title: { nb: `authz-asset ${Date.now()}` }, bodyMarkdown: { nb: "# x" } });
+  expect(secRes.status).toBe(201);
+  const sectionId = secRes.body.section.id as string;
+  const upload = await request(app)
+    .post(`/api/admin/content/sections/${sectionId}/assets`)
+    .set(adminHeaders)
+    .attach("file", PNG_1PX, { filename: "pixel.png", contentType: "image/png" });
+  expect(upload.status).toBe(201);
+  return { sectionId, assetId: upload.body.asset.id as string };
+}
+
+async function linkToCourse(sectionId: string, enrollmentPolicy: "OPEN" | "RESTRICTED"): Promise<string> {
+  const course = await prisma.course.create({
+    data: { title: `Asset authz ${enrollmentPolicy} ${Date.now()}`, publishedAt: new Date(), enrollmentPolicy },
+    select: { id: true },
+  });
+  await prisma.courseItem.create({ data: { courseId: course.id, itemType: "SECTION", sectionId, sortOrder: 0 } });
+  return course.id;
+}
+
+async function cleanup(sectionId: string, courseId?: string) {
+  if (courseId) {
+    await prisma.courseEnrollment.deleteMany({ where: { courseId } });
+    await prisma.course.delete({ where: { id: courseId } }); // cascades CourseItem
+  }
+  await prisma.courseSection.update({ where: { id: sectionId }, data: { activeVersionId: null } });
+  await prisma.courseSectionVersion.deleteMany({ where: { sectionId } });
+  await prisma.courseSection.delete({ where: { id: sectionId } }); // cascades SectionAsset
+}
+
+describe("Section asset object-level authorization (#786)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("denies a participant not enrolled in the asset's RESTRICTED course (404)", async () => {
+    const { sectionId, assetId } = await makeSectionWithAsset();
+    const courseId = await linkToCourse(sectionId, "RESTRICTED");
+    const outsider = await makeUser("asset-outsider");
+
+    const res = await request(app).get(`/api/content-assets/${assetId}`).set(participant(outsider.externalId));
+    expect(res.status).toBe(404);
+
+    await cleanup(sectionId, courseId);
+  });
+
+  it("allows a participant enrolled in the asset's RESTRICTED course (200)", async () => {
+    const { sectionId, assetId } = await makeSectionWithAsset();
+    const courseId = await linkToCourse(sectionId, "RESTRICTED");
+    const enrolled = await makeUser("asset-enrolled");
+    await prisma.courseEnrollment.create({
+      data: { courseId, userId: enrolled.id, source: "INDIVIDUAL", assignedAt: new Date() },
+    });
+
+    const res = await request(app).get(`/api/content-assets/${assetId}`).set(participant(enrolled.externalId));
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("image/png");
+
+    await cleanup(sectionId, courseId);
+  });
+
+  it("lets an author (ADMINISTRATOR) preview an asset whose section is in NO course (draft)", async () => {
+    const { sectionId, assetId } = await makeSectionWithAsset();
+
+    // No course link at all → a participant would be denied, but the author bypass applies.
+    const denied = await makeUser("asset-draft-participant");
+    const p = await request(app).get(`/api/content-assets/${assetId}`).set(participant(denied.externalId));
+    expect(p.status).toBe(404);
+
+    const author = await request(app).get(`/api/content-assets/${assetId}`).set(adminHeaders);
+    expect(author.status).toBe(200);
+    expect(author.headers["content-type"]).toContain("image/png");
+
+    await cleanup(sectionId);
+  });
+});

--- a/test/m2-section-assets.test.ts
+++ b/test/m2-section-assets.test.ts
@@ -45,8 +45,26 @@ describe("Section asset upload + serve", () => {
     await prisma.courseSection.delete({ where: { id: sectionId } });
   }
 
-  it("uploads an image, lists it, and serves it back to a participant", async () => {
+  // #778/#786: a participant may only fetch a section asset if the section is in a published course
+  // they can access. Link an OPEN published course so the participant-serve cases stay realistic.
+  async function linkSectionToOpenCourse(sectionId: string): Promise<string> {
+    const course = await prisma.course.create({
+      data: { title: `Asset course ${Date.now()}`, publishedAt: new Date() }, // enrollmentPolicy defaults OPEN
+      select: { id: true },
+    });
+    await prisma.courseItem.create({ data: { courseId: course.id, itemType: "SECTION", sectionId, sortOrder: 0 } });
+    return course.id;
+  }
+  // Delete the course first (cascades the CourseItem) so the section is no longer Restrict-referenced.
+  async function deleteSectionAndCourse(sectionId: string, courseId: string): Promise<void> {
+    await prisma.courseCompletion.deleteMany({ where: { courseId } });
+    await prisma.course.delete({ where: { id: courseId } });
+    await deleteSectionFully(sectionId);
+  }
+
+  it("uploads an image, lists it, and serves it back to a participant in an accessible course", async () => {
     const sectionId = await createSection();
+    const courseId = await linkSectionToOpenCourse(sectionId);
 
     const upload = await request(app)
       .post(`/api/admin/content/sections/${sectionId}/assets`)
@@ -70,13 +88,14 @@ describe("Section asset upload + serve", () => {
     expect(served.headers["content-type"]).toContain("image/png");
     expect(served.body.length).toBe(PNG_1PX.length);
 
-    await deleteSectionFully(sectionId);
+    await deleteSectionAndCourse(sectionId, courseId);
   });
 
   // #657: SVG is accepted but sanitised before storage; the served bytes must be inert and the
   // serve endpoint must add hardening headers.
   it("sanitises an uploaded SVG and serves it with hardening headers", async () => {
     const sectionId = await createSection();
+    const courseId = await linkSectionToOpenCourse(sectionId);
     const dirtySvg = Buffer.from(
       `<svg xmlns="http://www.w3.org/2000/svg" width="50" height="20"><script>alert(1)</script><rect onload="x()" width="50" height="20"/><text x="2" y="12">Hei</text></svg>`,
       "utf8",
@@ -101,13 +120,14 @@ describe("Section asset upload + serve", () => {
     expect(body).not.toMatch(/onload/i);
     expect(body).toMatch(/Hei/);
 
-    await deleteSectionFully(sectionId);
+    await deleteSectionAndCourse(sectionId, courseId);
   });
 
   // #657: the explicit localize action generates a translated SVG variant per other locale; the
   // serve endpoint returns the variant for `?locale=`. LLM stub mode tags text as `[<locale>] …`.
   it("localises SVG text and serves the per-locale variant", async () => {
     const sectionId = await createSection();
+    const courseId = await linkSectionToOpenCourse(sectionId);
     const svg = Buffer.from(
       `<svg xmlns="http://www.w3.org/2000/svg" width="50" height="20"><text x="2" y="12">Start</text></svg>`,
       "utf8",
@@ -141,7 +161,7 @@ describe("Section asset upload + serve", () => {
     const english = await request(app).get(`/api/content-assets/${assetId}?locale=en-GB`).set(participantHeaders);
     expect((english.text ?? english.body.toString())).toMatch(/\[en-GB\] Start/);
 
-    await deleteSectionFully(sectionId);
+    await deleteSectionAndCourse(sectionId, courseId);
   });
 
   it("rejects a disallowed mime type", async () => {


### PR DESCRIPTION
Second slice of epic **#778**. Closes **#786**.

## Problem
`getSectionAssetContent` fetched a section asset by id with **no** section/course/enrolment check, so any authenticated user with an asset id could pull media from a **restricted or unpublished** section (`src/routes/contentAssets.ts` → `assetCommands.ts:123`).

## Fix
- **`enrollmentService.ts`** — `isSectionInAccessibleCourse`: is the section part of a published course the participant can access (mirrors the module/course visibility helpers, resolves via `CourseItem.sectionId`).
- **`assetCommands.ts` + `contentAssets.ts`** — `getSectionAssetContent` now takes a `viewer`; a participant must have access to the section's published course; **authors (SMO/ADMIN) bypass** so editor preview of draft/unpublished sections still works. **404** (not 403) on denial.

## Tests
- **New** `test/m2-section-asset-authz.test.ts`: unenrolled participant → 404; enrolled → 200; author bypass on a course-less section → 200.
- **Updated** `test/m2-section-assets.test.ts`: the three participant-serve cases now link the section into a published OPEN course — because the **old** behaviour (serving an asset from a course-less section to any participant) **was exactly the vulnerability**. The admin-only upload/mime/blob-reclaim cases are untouched.

## Safety / verify
`tsc --noEmit` clean. `CourseItem.section` is `onDelete: Restrict`, so the updated teardown deletes the course (cascades the CourseItem) before the section. No schema change. Integration tests need the Postgres test DB (Docker, unavailable locally) → verified by CI's `verify` job.

## Deploy
App-only → `deploy-app.yml`. Rollback: drop the `viewer` check. Branched from `main` (→ 2.0.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
