### PR TITLE
perf(data): #800 additive secondary indexes on hot fact tables

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,24 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.5 - 2026-07-19
+
+perf(data): #800 — additive secondary indexes on hot assessment/course fact tables
+
+Første migrasjon fra arkitektur-gjennomgangen (epic #780). MCQAttempt/MCQResponse/LLMEvaluation/
+CourseCompletion/CertificationStatus hadde ingen sekundær-indekser; foreign keys lager ikke disse
+automatisk, så hot-spørringer (last en innleverings MCQ-forsøk/-svar/LLM-evalueringer; kurs-fullførings-
+tellinger per kurs; sertifiserings-tellinger per modul/status) skannet voksende barn-tabeller.
+
+- **`prisma/schema.prisma` + migrasjon `20260719120000_add_hot_table_indexes`:** 5 additive indekser —
+  `MCQAttempt(submissionId, completedAt)`, `MCQResponse(mcqAttemptId)`, `LLMEvaluation(submissionId,
+  createdAt)`, `CertificationStatus(moduleId, status)`, `CourseCompletion(courseId, completedAt)`.
+
+**Utrulling:** additiv DB-migrasjon (ingen data-/atferdsendring). Migrasjonen kjøres ved web-oppstart
+(`prisma migrate deploy` i `startup.mjs`), så **`deploy-app.yml`** holder — ingen Bicep-endring. Additivt
+→ rekkefølge web/worker er uproblematisk. **Stage først; hvis sunn → prod.** Tabellene er små, så
+CREATE INDEX er umiddelbar (bruk CONCURRENTLY i fremtidig migrasjon hvis de vokser). Rollback: DROP INDEX.
+
 ## 2.0.4 - 2026-07-19
 
 fix(security): #786 — content-asset object-level authorization (IDOR)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260719120000_add_hot_table_indexes/migration.sql
+++ b/prisma/migrations/20260719120000_add_hot_table_indexes/migration.sql
@@ -1,0 +1,20 @@
+-- #800: additive secondary indexes on hot assessment/course fact tables that previously had none.
+-- These match hot query paths (load a submission's MCQ attempts/responses/LLM evaluations; course
+-- completion counts by course; certification totals by module/status). Additive only — no data change,
+-- no behavior change. Tables are small in current environments so a plain CREATE INDEX is instant; use
+-- CREATE INDEX CONCURRENTLY in a future migration if any of these grows large enough to matter.
+
+-- CreateIndex
+CREATE INDEX "MCQAttempt_submissionId_completedAt_idx" ON "MCQAttempt"("submissionId", "completedAt");
+
+-- CreateIndex
+CREATE INDEX "MCQResponse_mcqAttemptId_idx" ON "MCQResponse"("mcqAttemptId");
+
+-- CreateIndex
+CREATE INDEX "LLMEvaluation_submissionId_createdAt_idx" ON "LLMEvaluation"("submissionId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "CertificationStatus_moduleId_status_idx" ON "CertificationStatus"("moduleId", "status");
+
+-- CreateIndex
+CREATE INDEX "CourseCompletion_courseId_completedAt_idx" ON "CourseCompletion"("courseId", "completedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -316,6 +316,8 @@ model MCQAttempt {
   submission      Submission    @relation(fields: [submissionId], references: [id], onDelete: Restrict)
   mcqSetVersion   MCQSetVersion @relation(fields: [mcqSetVersionId], references: [id], onDelete: Restrict)
   responses       MCQResponse[]
+
+  @@index([submissionId, completedAt])
 }
 
 model MCQResponse {
@@ -327,6 +329,8 @@ model MCQResponse {
   createdAt      DateTime    @default(now())
   mcqAttempt     MCQAttempt  @relation(fields: [mcqAttemptId], references: [id], onDelete: Restrict)
   question       MCQQuestion @relation(fields: [questionId], references: [id], onDelete: Restrict)
+
+  @@index([mcqAttemptId])
 }
 
 model RubricVersion {
@@ -381,6 +385,8 @@ model LLMEvaluation {
   submission              Submission            @relation(fields: [submissionId], references: [id], onDelete: Restrict)
   moduleVersion           ModuleVersion         @relation(fields: [moduleVersionId], references: [id], onDelete: Restrict)
   promptTemplateVersion   PromptTemplateVersion @relation(fields: [promptTemplateVersionId], references: [id], onDelete: Restrict)
+
+  @@index([submissionId, createdAt])
 }
 
 model AssessmentDecision {
@@ -464,6 +470,7 @@ model CertificationStatus {
   latestDecision         AssessmentDecision @relation(fields: [latestDecisionId], references: [id], onDelete: Restrict)
 
   @@unique([userId, moduleId])
+  @@index([moduleId, status])
 }
 
 model AuditEvent {
@@ -535,6 +542,7 @@ model CourseCompletion {
   course             Course   @relation(fields: [courseId], references: [id], onDelete: Restrict)
 
   @@unique([userId, courseId])
+  @@index([courseId, completedAt])
 }
 
 // #496/EN-1: assignment of a course to a participant (individual, department, or self-enrollment),


### PR DESCRIPTION
First **migration** from the architecture-review backlog (epic #780) — deliberately the lowest-risk one, to validate the CI → stage → prod migration pipeline before the bigger schema changes (#787, #806).

## What
5 additive secondary indexes on fact tables that had **none** (FKs don't create them), matching hot query paths:
- `MCQAttempt(submissionId, completedAt)`
- `MCQResponse(mcqAttemptId)`
- `LLMEvaluation(submissionId, createdAt)`
- `CertificationStatus(moduleId, status)`
- `CourseCompletion(courseId, completedAt)`

## Risk
**Additive only** — no data change, no behavior change, no dropped/renamed columns. Migration applies at web startup (`prisma migrate deploy`). Tables are small in all environments today, so `CREATE INDEX` is instant. Rollback: `DROP INDEX`.

## Verify
`tsc` clean. CI's `verify` job runs `prisma migrate reset` (applies this migration to a fresh Postgres) + the full suite — that's the real validation. Then: **stage first**, confirm `/healthz` + smoke, then promote to prod.

Hand-authored migration (no local Docker) matching Prisma's `migrate dev` output; CI + stage are the safety net (per the agreed approach). Branched from `main` (→ 2.0.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
