### PR TITLE
feat(auth): #787 slice 1 - ContentOwner table + backfill

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,23 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.6 - 2026-07-19
+
+feat(auth): #787 skive 1 — `ContentOwner`-tabell + backfill (multi-eier-fundament)
+
+Første skive av eierskaps-funksjonen (design: `doc/design/CONTENT_OWNERSHIP_787.md`). **Rent additivt —
+ingenting leser tabellen enda** (guard/API/UI kommer i senere skiver), så ingen atferdsendring.
+
+- **`prisma/schema.prisma` + migrasjon `20260719130000_add_content_owner`:** polymorf `ContentOwner`
+  (contentType + contentId + userId, unik per (type,innhold,bruker), FK userId→User onDelete Cascade),
+  enum `ContentOwnerType {COURSE, SECTION, CLASS, MODULE}`, `User.contentOwnerships` back-relasjon.
+- **Backfill (Q3: oppretter = første eier):** `Class.createdById` + `Module.createdById` → første eier.
+  Course/CourseSection har ingen `createdById` → forblir eierløse (admin-styrt til eier tildeles).
+- **`test/m2-content-owner.test.ts`:** modell + unikhet + cascade.
+
+**Utrulling:** additiv migrasjon (ny tabell, ingen endring på eksisterende), kjøres ved web-oppstart →
+`deploy-app.yml`. **Stage først; hvis sunn → prod.** Rollback: DROP TABLE + TYPE. Neste skive: guard.
+
 ## 2.0.5 - 2026-07-19
 
 perf(data): #800 — additive secondary indexes on hot assessment/course fact tables

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260719130000_add_content_owner/migration.sql
+++ b/prisma/migrations/20260719130000_add_content_owner/migration.sql
@@ -1,0 +1,42 @@
+-- #787 slice 1: multi-owner content ownership table + backfill. ADDITIVE — nothing reads this table
+-- yet (the guard/API/UI land in later slices), so there is no behavior change from this migration.
+
+-- CreateEnum
+CREATE TYPE "ContentOwnerType" AS ENUM ('COURSE', 'SECTION', 'CLASS', 'MODULE');
+
+-- CreateTable
+CREATE TABLE "ContentOwner" (
+    "id" TEXT NOT NULL,
+    "contentType" "ContentOwnerType" NOT NULL,
+    "contentId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "addedById" TEXT,
+    "addedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ContentOwner_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ContentOwner_contentType_contentId_userId_key" ON "ContentOwner"("contentType", "contentId", "userId");
+
+-- CreateIndex
+CREATE INDEX "ContentOwner_contentType_contentId_idx" ON "ContentOwner"("contentType", "contentId");
+
+-- CreateIndex
+CREATE INDEX "ContentOwner_userId_idx" ON "ContentOwner"("userId");
+
+-- AddForeignKey
+ALTER TABLE "ContentOwner" ADD CONSTRAINT "ContentOwner_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Backfill (Q3: creator = first owner). Class + Module have createdById → seed as first owner.
+-- Course / CourseSection have no createdById, so they intentionally remain unowned → admin-managed
+-- until an owner is assigned (the deliberate "no ingen-kan-røre limbo": unowned = admin-only, not frozen).
+INSERT INTO "ContentOwner" ("id", "contentType", "contentId", "userId", "addedById", "addedAt")
+SELECT gen_random_uuid()::text, 'CLASS'::"ContentOwnerType", "id", "createdById", NULL, CURRENT_TIMESTAMP
+FROM "Class"
+WHERE "createdById" IS NOT NULL;
+
+INSERT INTO "ContentOwner" ("id", "contentType", "contentId", "userId", "addedById", "addedAt")
+SELECT gen_random_uuid()::text, 'MODULE'::"ContentOwnerType", "id", "createdById", NULL, CURRENT_TIMESTAMP
+FROM "Module"
+WHERE "createdById" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,6 +103,7 @@ model User {
   discussionRepliesDeleted      DiscussionReply[]        @relation("DiscussionReplyDeletedBy")
   discussionSubscriptions       DiscussionSubscription[]
   agentAuthoringTokens          AgentAuthoringToken[]    @relation("AgentAuthoringTokens")
+  contentOwnerships             ContentOwner[]           @relation("ContentOwnerships")
 }
 
 // AA-3 (#651): kortlivet, scopet token for agent-orkestrerte draft-operasjoner.
@@ -810,4 +811,29 @@ model DiscussionSubscription {
 
   @@unique([threadId, userId])
   @@index([userId])
+}
+
+// #787: multi-owner content ownership. An owner *set* (not a single createdById) per content object,
+// transferable by any current owner or an ADMINISTRATOR. Polymorphic (contentType + contentId) so one
+// table + one guard covers Course/CourseSection/Class/Module. Referential cleanup of the content side is
+// application-level on delete (polymorphic, no per-type FK); the userId side has a real FK + cascade.
+model ContentOwner {
+  id          String           @id @default(cuid())
+  contentType ContentOwnerType
+  contentId   String
+  userId      String
+  addedById   String? // who granted ownership (a current owner or admin); null for migration backfill
+  addedAt     DateTime         @default(now())
+  user        User             @relation("ContentOwnerships", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([contentType, contentId, userId])
+  @@index([contentType, contentId])
+  @@index([userId])
+}
+
+enum ContentOwnerType {
+  COURSE
+  SECTION
+  CLASS
+  MODULE
 }

--- a/test/m2-content-owner.test.ts
+++ b/test/m2-content-owner.test.ts
@@ -1,0 +1,38 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { prisma } from "../src/db/prisma.js";
+
+// #787 slice 1: the ContentOwner table underpins the whole multi-owner model. No behavior reads it yet
+// (guard/API/UI come in later slices), so this just pins the model + the two constraints the later
+// slices rely on: one owner row per (contentType, contentId, userId), and cascade on user delete.
+describe("ContentOwner model (#787 slice 1)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("stores an owner, enforces uniqueness per (type, content, user), and cascades on user delete", async () => {
+    const tag = `co-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const user = await prisma.user.create({
+      data: { externalId: tag, name: "Content Owner", email: `${tag}@x.test` },
+      select: { id: true },
+    });
+    const contentId = `course-${tag}`;
+
+    const owner = await prisma.contentOwner.create({
+      data: { contentType: "COURSE", contentId, userId: user.id },
+    });
+    expect(owner.id).toBeTruthy();
+
+    // One owner row per (contentType, contentId, userId): a duplicate is rejected.
+    await expect(
+      prisma.contentOwner.create({ data: { contentType: "COURSE", contentId, userId: user.id } }),
+    ).rejects.toThrow();
+
+    // The same user CAN own a different content object / type.
+    await prisma.contentOwner.create({ data: { contentType: "MODULE", contentId, userId: user.id } });
+    expect(await prisma.contentOwner.count({ where: { userId: user.id } })).toBe(2);
+
+    // Cascade: deleting the user removes their ownership rows (userId FK onDelete: Cascade).
+    await prisma.user.delete({ where: { id: user.id } });
+    expect(await prisma.contentOwner.count({ where: { contentId } })).toBe(0);
+  });
+});


### PR DESCRIPTION
First slice of the ownership feature (#787, epic #778). Design: `doc/design/CONTENT_OWNERSHIP_787.md` (decisions Q1–Q3 locked).

## What
The multi-owner foundation — **additive only, no behavior change** (nothing reads `ContentOwner` yet; the guard/API/UI land in later slices, so this is safe to ship independently).

- **`ContentOwner`** — polymorphic (`contentType` + `contentId` + `userId`), unique per `(contentType, contentId, userId)`, `userId` FK → `User` `onDelete: Cascade`. One table + one future guard covers Course/Section/Class/Module.
- **`ContentOwnerType`** enum `{COURSE, SECTION, CLASS, MODULE}`; `User.contentOwnerships` back-relation.
- **Backfill (Q3 = creator is first owner):** `Class.createdById` + `Module.createdById` → first owner. Course/CourseSection have no `createdById`, so they intentionally stay **unowned → admin-managed** until an owner is assigned (the deliberate "no frozen limbo").
- **`test/m2-content-owner.test.ts`** — model + uniqueness + cascade.

## Risk / verify
Additive (new table + enum only; no change to existing tables/columns). `tsc` clean after `prisma generate`. CI's `verify` runs `migrate reset` (applies this migration to a fresh Postgres) + the suite. Backfill runs against empty tables in CI (0 rows) and against real data on **stage** — verified there before prod. Rollback: `DROP TABLE "ContentOwner"; DROP TYPE "ContentOwnerType";`. Migration applies at web startup → `deploy-app.yml`. Branched from `main` (→ 2.0.6).

**Next slices:** guard (`assertContentOwnership`) → owner API (`GET/POST/DELETE /owners`) → wire onto write/delete paths → owner-management UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
