### PR TITLE
feat(auth): #787 slice 2 - ownership guard (assertContentOwnership)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,22 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.7 - 2026-07-19
+
+feat(auth): #787 skive 2 — eierskaps-guard (`assertContentOwnership`)
+
+Andre skive. **Inert** — ingenting kaller guarden enda (skive 4 kobler den på skrive-/slette-stiene), så
+ingen atferdsendring. Generaliserer den gamle single-eier `assertModuleOwnership` til multi-eier-settet.
+
+- **`src/modules/content/contentOwnershipService.ts`:** `decideOwnershipAccess` (ren beslutning: admin
+  alltid tillatt; ellers må aktør være i eier-settet; tomt sett → eierløst = admin-only), pluss
+  `listContentOwnerUserIds` + `assertContentOwnership` (kaster `ForbiddenError` `content_ownership` /
+  `content_unowned`).
+- **`test/unit/content-ownership.test.ts`:** hele tilgangs-matrisen (kjørt lokalt, ingen DB).
+
+**Utrulling:** kun ny (ubrukt) kode → `deploy-app.yml`. Ingen migrasjon, ingen atferdsendring.
+Neste skive: eier-API (`GET/POST/DELETE /owners`).
+
 ## 2.0.6 - 2026-07-19
 
 feat(auth): #787 skive 1 — `ContentOwner`-tabell + backfill (multi-eier-fundament)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/content/contentOwnershipService.ts
+++ b/src/modules/content/contentOwnershipService.ts
@@ -1,0 +1,58 @@
+// #787 slice 2: the ownership guard. Generalizes the old single-owner assertModuleOwnership to the
+// multi-owner ContentOwner set, across Course/CourseSection/Class/Module. Read-only here — nothing
+// calls it yet; slice 4 wires it onto the write/delete paths. The decision is a pure function so the
+// access matrix is unit-testable without a database.
+
+import type { AppRole as AppRoleType, ContentOwnerType } from "@prisma/client";
+import { prisma } from "../../db/prisma.js";
+import { ForbiddenError } from "../../errors/AppError.js";
+
+export type OwnershipDecision = "allow" | "unowned" | "not_owner";
+
+/**
+ * Pure ownership decision. ADMINISTRATOR always allowed (universal access). Otherwise the actor must be
+ * one of the object's owners. An object with no owners is `unowned` → admin-only until an owner is
+ * assigned (the deliberate "no frozen limbo" for backfilled Course/Section that had no createdById).
+ */
+export function decideOwnershipAccess(input: {
+  isAdmin: boolean;
+  ownerUserIds: string[];
+  actorUserId: string;
+}): OwnershipDecision {
+  if (input.isAdmin) return "allow";
+  if (input.ownerUserIds.length === 0) return "unowned";
+  return input.ownerUserIds.includes(input.actorUserId) ? "allow" : "not_owner";
+}
+
+export function listContentOwnerUserIds(
+  contentType: ContentOwnerType,
+  contentId: string,
+): Promise<string[]> {
+  return prisma.contentOwner
+    .findMany({ where: { contentType, contentId }, select: { userId: true } })
+    .then((rows) => rows.map((row) => row.userId));
+}
+
+/**
+ * Throws ForbiddenError unless the actor may modify the given content object (admin, or an owner).
+ * Gates AUTHORING only — participant read/visibility is governed elsewhere (enrollmentPolicy, #785/#786).
+ */
+export async function assertContentOwnership(input: {
+  contentType: ContentOwnerType;
+  contentId: string;
+  actorUserId: string;
+  roles: AppRoleType[];
+}): Promise<void> {
+  const isAdmin = input.roles.includes("ADMINISTRATOR");
+  // Admin short-circuits before any DB read.
+  const ownerUserIds = isAdmin ? [] : await listContentOwnerUserIds(input.contentType, input.contentId);
+  const decision = decideOwnershipAccess({ isAdmin, ownerUserIds, actorUserId: input.actorUserId });
+  if (decision === "allow") return;
+  if (decision === "unowned") {
+    throw new ForbiddenError(
+      "This content has no owner yet — only an administrator can modify it until an owner is assigned.",
+      "content_unowned",
+    );
+  }
+  throw new ForbiddenError("You can only modify content you own.", "content_ownership");
+}

--- a/test/unit/content-ownership.test.ts
+++ b/test/unit/content-ownership.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { decideOwnershipAccess } from "../../src/modules/content/contentOwnershipService.js";
+
+// #787 slice 2: pins the ownership access matrix (the pure decision the guard is built on).
+describe("decideOwnershipAccess (#787)", () => {
+  it("ADMINISTRATOR is always allowed — owner or not, owned or unowned", () => {
+    expect(decideOwnershipAccess({ isAdmin: true, ownerUserIds: [], actorUserId: "u1" })).toBe("allow");
+    expect(decideOwnershipAccess({ isAdmin: true, ownerUserIds: ["u2"], actorUserId: "u1" })).toBe("allow");
+  });
+
+  it("an owner (in the set) is allowed", () => {
+    expect(decideOwnershipAccess({ isAdmin: false, ownerUserIds: ["u1", "u2"], actorUserId: "u2" })).toBe("allow");
+  });
+
+  it("a non-owner on owned content is denied as not_owner", () => {
+    expect(decideOwnershipAccess({ isAdmin: false, ownerUserIds: ["u1"], actorUserId: "u2" })).toBe("not_owner");
+  });
+
+  it("unowned content is admin-only (unowned) for a non-admin", () => {
+    expect(decideOwnershipAccess({ isAdmin: false, ownerUserIds: [], actorUserId: "u1" })).toBe("unowned");
+  });
+});


### PR DESCRIPTION
Second slice of #787. **Inert** — nothing calls the guard yet (slice 4 wires it onto the write/delete paths), so no behavior change; safe to ship alongside slice 1.

## What
Generalizes the old single-owner `assertModuleOwnership` to the multi-owner `ContentOwner` set (Course/Section/Class/Module):
- `decideOwnershipAccess(...)` — **pure** decision: ADMINISTRATOR always allowed; otherwise the actor must be in the owner set; an empty set = `unowned` → admin-only (the deliberate no-frozen-limbo for backfilled Course/Section).
- `listContentOwnerUserIds(...)` + `assertContentOwnership(...)` — throws `ForbiddenError` (`content_ownership` / `content_unowned`).

## Verify
`tsc` clean; `test/unit/content-ownership.test.ts` pins the full access matrix and **ran locally** (4/4, no DB). New unused code only — no migration, no behavior change. Branched from `main` (→ 2.0.7).

**Next:** owner API (`GET/POST/DELETE /owners`) → wire the guard onto existing paths (the one behavior-changing slice) → owner-management UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
