### PR TITLE
feat(auth): #787 slice 3 - owner-management API

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,28 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.8 - 2026-07-19
+
+feat(auth): #787 skive 3 — eier-forvaltnings-API (`/api/admin/content-owners`)
+
+Tredje skive. **Nye endepunkter** (ingen eksisterende oppførsel endres):
+- `GET /:contentType/:contentId` — list eiere (med navn/e-post)
+- `POST /:contentType/:contentId` `{ userId }` — legg til med-eier (idempotent)
+- `DELETE /:contentType/:contentId/:userId` — fjern eier (siste-eier-beskyttet)
+
+To-lags authz: mount krever `admin_content` (SMO/ADMIN), og hver handler kaller `assertContentOwnership`
+så bare en eier (eller admin) av *det* objektet kan forvalte dets eiere. Siste-eier kan ikke fjernes av
+ikke-admin (hindrer foreldreløst innhold); admin kan (→ eierløst = admin-styrt). Alle mutasjoner
+audit-logges (`content_owner_added`/`_removed`).
+
+- **`src/routes/contentOwners.ts`** (Zod-validert), mount i `app.ts`, `src/modules/content/
+  contentOwnershipService.ts` (add/remove/list), audit-actions/entity-type i `auditEvents.ts`.
+- **`test/m2-content-owners-api.test.ts`:** eier + admin forvalter; ikke-eier blokkert; siste-eier
+  beskyttet; eierløst → admin-only. Agent-tokens blokkeres (global `enforceAgentTokenScope`).
+
+**Utrulling:** kun nye endepunkter → `deploy-app.yml`. Ingen migrasjon. Neste (skive 4): koble guarden
+på eksisterende skrive-/slette-stier (den eneste atferdsendringen — grundig stage-QA der).
+
 ## 2.0.7 - 2026-07-19
 
 feat(auth): #787 skive 2 — eierskaps-guard (`assertContentOwnership`)

--- a/doc/route-map.md
+++ b/doc/route-map.md
@@ -62,6 +62,7 @@ URLs; only Klasser moved (from `/admin-content/classes`).
 | `/api/cohort-status` | SMO / Admin / Report reader | Cohort enrollment-status aggregate per course (#498) |
 | `/api/appeals` | Appeal Handler / Admin | Appeal queue and resolution |
 | `/api/admin/content` | SMO / Admin | Module, course, and learning-section content management |
+| `/api/admin/content-owners` | SMO / Admin (+ per-object owner check) | Manage the owner set of a content object — `GET/POST/DELETE /:contentType/:contentId[/:userId]` (#787) |
 | `/api/admin/platform` | Admin | Platform administration |
 | `/participant/config` | Public (rate-limited) | Participant console bootstrap config |
 | `/healthz` | Public | Health check (no version info) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,7 @@ import { appealsRouter } from "./routes/appeals.js";
 import { reportsRouter } from "./routes/reports.js";
 import { cohortStatusRouter } from "./routes/cohortStatus.js";
 import { adminContentRouter } from "./routes/adminContent.js";
+import { contentOwnersRouter } from "./routes/contentOwners.js";
 import { adminModulesRouter } from "./routes/adminModules.js";
 import { adminPlatformRouter } from "./routes/adminPlatform.js";
 import { orgSyncRouter } from "./routes/orgSync.js";
@@ -237,6 +238,10 @@ app.use(
   calibrationRouter,
 );
 app.use("/api/admin/content", requireAnyRole(rolesFor("admin_content")), adminContentRouter);
+// #787: owner-set management. Distinct sibling path (not nested under /api/admin/content) so it doesn't
+// collide with adminContentRouter. Content-admin capability (SMO/ADMIN) to reach it; each handler then
+// calls assertContentOwnership so only an owner (or admin) of the specific object can manage its owners.
+app.use("/api/admin/content-owners", requireAnyRole(rolesFor("admin_content")), contentOwnersRouter);
 app.use("/api/admin/modules", requireAnyRole(rolesFor("admin_modules")), adminModulesRouter);
 app.use("/api/admin/platform", requireAnyRole(rolesFor("admin_platform")), adminPlatformRouter);
 app.use("/api/admin/sync/org", requireAnyRole(rolesFor("admin_sync_org")), orgSyncRouter);

--- a/src/modules/content/contentOwnershipService.ts
+++ b/src/modules/content/contentOwnershipService.ts
@@ -5,7 +5,9 @@
 
 import type { AppRole as AppRoleType, ContentOwnerType } from "@prisma/client";
 import { prisma } from "../../db/prisma.js";
-import { ForbiddenError } from "../../errors/AppError.js";
+import { ForbiddenError, NotFoundError } from "../../errors/AppError.js";
+import { recordAuditEvent } from "../../services/auditService.js";
+import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
 
 export type OwnershipDecision = "allow" | "unowned" | "not_owner";
 
@@ -55,4 +57,96 @@ export async function assertContentOwnership(input: {
     );
   }
   throw new ForbiddenError("You can only modify content you own.", "content_ownership");
+}
+
+// --- #787 slice 3: owner-set management (used by the owners API). Managing owners is itself an
+// owner-or-admin action (the route calls assertContentOwnership first). ---
+
+export interface ContentOwnerView {
+  userId: string;
+  name: string;
+  email: string;
+  addedAt: string;
+}
+
+export async function listContentOwners(
+  contentType: ContentOwnerType,
+  contentId: string,
+): Promise<ContentOwnerView[]> {
+  const rows = await prisma.contentOwner.findMany({
+    where: { contentType, contentId },
+    select: { userId: true, addedAt: true, user: { select: { name: true, email: true } } },
+    orderBy: { addedAt: "asc" },
+  });
+  return rows.map((r) => ({ userId: r.userId, name: r.user.name, email: r.user.email, addedAt: r.addedAt.toISOString() }));
+}
+
+// Idempotent: adding an existing owner is a no-op (unique constraint). Audited.
+export async function addContentOwner(input: {
+  contentType: ContentOwnerType;
+  contentId: string;
+  ownerUserId: string;
+  actorUserId: string;
+}): Promise<void> {
+  const user = await prisma.user.findUnique({ where: { id: input.ownerUserId }, select: { id: true } });
+  if (!user) {
+    throw new NotFoundError("User", "user_not_found", "That user does not exist.");
+  }
+  const existing = await prisma.contentOwner.findUnique({
+    where: {
+      contentType_contentId_userId: {
+        contentType: input.contentType,
+        contentId: input.contentId,
+        userId: input.ownerUserId,
+      },
+    },
+    select: { id: true },
+  });
+  if (existing) return; // already an owner
+  const owner = await prisma.contentOwner.create({
+    data: {
+      contentType: input.contentType,
+      contentId: input.contentId,
+      userId: input.ownerUserId,
+      addedById: input.actorUserId,
+    },
+  });
+  await recordAuditEvent({
+    entityType: auditEntityTypes.contentOwner,
+    entityId: owner.id,
+    action: auditActions.contentOwner.added,
+    actorId: input.actorUserId,
+    metadata: { contentType: input.contentType, contentId: input.contentId, ownerUserId: input.ownerUserId },
+  });
+}
+
+// Last-owner protection: a non-admin cannot remove the final owner (would orphan the content). An
+// administrator may (it becomes unowned → admin-managed until reassigned). Audited.
+export async function removeContentOwner(input: {
+  contentType: ContentOwnerType;
+  contentId: string;
+  ownerUserId: string;
+  actorUserId: string;
+  isAdmin: boolean;
+}): Promise<void> {
+  const ownerIds = await listContentOwnerUserIds(input.contentType, input.contentId);
+  if (!ownerIds.includes(input.ownerUserId)) {
+    throw new NotFoundError("ContentOwner", "owner_not_found", "That user is not an owner of this content.");
+  }
+  if (ownerIds.length === 1 && !input.isAdmin) {
+    throw new ForbiddenError(
+      "You cannot remove the last owner. Add another owner first, or ask an administrator.",
+      "last_owner",
+    );
+  }
+  await prisma.contentOwner.deleteMany({
+    where: { contentType: input.contentType, contentId: input.contentId, userId: input.ownerUserId },
+  });
+  await recordAuditEvent({
+    entityType: auditEntityTypes.contentOwner,
+    entityId: `${input.contentType}:${input.contentId}:${input.ownerUserId}`,
+    action: auditActions.contentOwner.removed,
+    actorId: input.actorUserId,
+    metadata: { contentType: input.contentType, contentId: input.contentId, ownerUserId: input.ownerUserId },
+  });
 }

--- a/src/observability/auditEvents.ts
+++ b/src/observability/auditEvents.ts
@@ -23,6 +23,7 @@ export const auditEntityTypes = {
   promptTemplateVersion: "prompt_template_version",
   submission: "submission",
   user: "user",
+  contentOwner: "content_owner",
 } as const;
 
 export type AuditEntityType = NestedValue<typeof auditEntityTypes>;
@@ -72,6 +73,10 @@ export const auditActions = {
   agentAuthoring: {
     tokenIssued: "agent_authoring_token_issued",
     tokenRevoked: "agent_authoring_token_revoked",
+  },
+  contentOwner: {
+    added: "content_owner_added",
+    removed: "content_owner_removed",
   },
   course: {
     created: "course_created",
@@ -434,6 +439,16 @@ export type AuditMetadataByAction = {
     trigger: string;
     cancelledJobCount: number;
     pseudonymizedAt: string;
+  }>;
+  [auditActions.contentOwner.added]: EventMetadata<{
+    contentType: string;
+    contentId: string;
+    ownerUserId: string;
+  }>;
+  [auditActions.contentOwner.removed]: EventMetadata<{
+    contentType: string;
+    contentId: string;
+    ownerUserId: string;
   }>;
 };
 

--- a/src/routes/contentOwners.ts
+++ b/src/routes/contentOwners.ts
@@ -1,0 +1,83 @@
+import { Router, type Response } from "express";
+import { z } from "zod";
+import type { ContentOwnerType } from "@prisma/client";
+import {
+  assertContentOwnership,
+  listContentOwners,
+  addContentOwner,
+  removeContentOwner,
+} from "../modules/content/contentOwnershipService.js";
+import { AppError } from "../errors/AppError.js";
+
+// #787 slice 3: manage the owner set of a content object. Two layers of authz: the mount requires the
+// content-admin capability (SMO/ADMIN), and each handler additionally calls assertContentOwnership so
+// only an owner (or admin) of THIS object can see/change its owners. Generic over content type so one
+// router serves Course/CourseSection/Class/Module.
+
+const contentOwnersRouter = Router();
+
+const contentTypeSchema = z.enum(["COURSE", "SECTION", "CLASS", "MODULE"]);
+const addBodySchema = z.object({ userId: z.string().min(1) });
+
+function sendAppError(response: Response, error: unknown): boolean {
+  if (error instanceof AppError) {
+    response.status(error.httpStatus).json({ error: error.code, message: error.message });
+    return true;
+  }
+  return false;
+}
+
+contentOwnersRouter.get("/:contentType/:contentId", async (request, response, next) => {
+  const userId = request.context?.userId;
+  if (!userId) return void response.status(401).json({ error: "unauthorized" });
+  const type = contentTypeSchema.safeParse(request.params.contentType);
+  if (!type.success) return void response.status(400).json({ error: "invalid_content_type" });
+  const contentType = type.data as ContentOwnerType;
+  try {
+    await assertContentOwnership({ contentType, contentId: request.params.contentId, actorUserId: userId, roles: request.context?.roles ?? [] });
+    response.json({ owners: await listContentOwners(contentType, request.params.contentId) });
+  } catch (error) {
+    if (!sendAppError(response, error)) next(error);
+  }
+});
+
+contentOwnersRouter.post("/:contentType/:contentId", async (request, response, next) => {
+  const userId = request.context?.userId;
+  if (!userId) return void response.status(401).json({ error: "unauthorized" });
+  const type = contentTypeSchema.safeParse(request.params.contentType);
+  if (!type.success) return void response.status(400).json({ error: "invalid_content_type" });
+  const body = addBodySchema.safeParse(request.body);
+  if (!body.success) return void response.status(400).json({ error: "invalid_body", message: "userId is required." });
+  const contentType = type.data as ContentOwnerType;
+  try {
+    await assertContentOwnership({ contentType, contentId: request.params.contentId, actorUserId: userId, roles: request.context?.roles ?? [] });
+    await addContentOwner({ contentType, contentId: request.params.contentId, ownerUserId: body.data.userId, actorUserId: userId });
+    response.status(201).json({ owners: await listContentOwners(contentType, request.params.contentId) });
+  } catch (error) {
+    if (!sendAppError(response, error)) next(error);
+  }
+});
+
+contentOwnersRouter.delete("/:contentType/:contentId/:ownerUserId", async (request, response, next) => {
+  const userId = request.context?.userId;
+  if (!userId) return void response.status(401).json({ error: "unauthorized" });
+  const type = contentTypeSchema.safeParse(request.params.contentType);
+  if (!type.success) return void response.status(400).json({ error: "invalid_content_type" });
+  const contentType = type.data as ContentOwnerType;
+  const roles = request.context?.roles ?? [];
+  try {
+    await assertContentOwnership({ contentType, contentId: request.params.contentId, actorUserId: userId, roles });
+    await removeContentOwner({
+      contentType,
+      contentId: request.params.contentId,
+      ownerUserId: request.params.ownerUserId,
+      actorUserId: userId,
+      isAdmin: roles.includes("ADMINISTRATOR"),
+    });
+    response.json({ owners: await listContentOwners(contentType, request.params.contentId) });
+  } catch (error) {
+    if (!sendAppError(response, error)) next(error);
+  }
+});
+
+export { contentOwnersRouter };

--- a/test/m2-content-owners-api.test.ts
+++ b/test/m2-content-owners-api.test.ts
@@ -1,0 +1,82 @@
+import request from "supertest";
+import { afterAll, describe, expect, it } from "vitest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+
+// #787 slice 3: owner-set management API. Two-layer authz (content-admin capability to reach it, then
+// per-object ownership), plus last-owner protection. contentId is polymorphic (no FK) so we use a
+// synthetic id — the ownership logic doesn't require the content row to exist.
+
+function smo(externalId: string) {
+  return {
+    "x-user-id": externalId,
+    "x-user-email": `${externalId}@x.test`,
+    "x-user-name": externalId,
+    "x-user-roles": "SUBJECT_MATTER_OWNER",
+  };
+}
+function admin(externalId: string) {
+  return { ...smo(externalId), "x-user-roles": "ADMINISTRATOR" };
+}
+
+async function makeUser(tag: string) {
+  const ext = `${tag}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  return prisma.user.create({
+    data: { externalId: ext, name: tag, email: `${ext}@x.test` },
+    select: { id: true, externalId: true },
+  });
+}
+
+describe("content-owners API (#787)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("owner + admin can manage owners; non-owner is blocked; last owner is protected", async () => {
+    const a = await makeUser("owner-a");
+    const b = await makeUser("owner-b");
+    const adminUser = await makeUser("owner-admin");
+    const contentId = `course-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    // Seed A as the initial owner.
+    await prisma.contentOwner.create({ data: { contentType: "COURSE", contentId, userId: a.id } });
+
+    // Owner A can list.
+    const listA = await request(app).get(`/api/admin/content-owners/COURSE/${contentId}`).set(smo(a.externalId));
+    expect(listA.status).toBe(200);
+    expect((listA.body.owners as Array<{ userId: string }>).map((o) => o.userId)).toEqual([a.id]);
+
+    // Non-owner B (has SMO capability but doesn't own this object) is blocked.
+    const listB = await request(app).get(`/api/admin/content-owners/COURSE/${contentId}`).set(smo(b.externalId));
+    expect(listB.status).toBe(403);
+    expect(listB.body.error).toBe("content_ownership");
+
+    // Owner A adds B as a co-owner.
+    const add = await request(app).post(`/api/admin/content-owners/COURSE/${contentId}`).set(smo(a.externalId)).send({ userId: b.id });
+    expect(add.status).toBe(201);
+    expect((add.body.owners as Array<{ userId: string }>).map((o) => o.userId).sort()).toEqual([a.id, b.id].sort());
+
+    // Now B (a co-owner) can act. B removes A.
+    const removeA = await request(app).delete(`/api/admin/content-owners/COURSE/${contentId}/${a.id}`).set(smo(b.externalId));
+    expect(removeA.status).toBe(200);
+    expect((removeA.body.owners as Array<{ userId: string }>).map((o) => o.userId)).toEqual([b.id]);
+
+    // B is now the last owner — B (non-admin) cannot remove the last owner.
+    const removeLast = await request(app).delete(`/api/admin/content-owners/COURSE/${contentId}/${b.id}`).set(smo(b.externalId));
+    expect(removeLast.status).toBe(403);
+    expect(removeLast.body.error).toBe("last_owner");
+
+    // An admin CAN remove the last owner (content becomes unowned → admin-managed).
+    const adminRemove = await request(app).delete(`/api/admin/content-owners/COURSE/${contentId}/${b.id}`).set(admin(adminUser.externalId));
+    expect(adminRemove.status).toBe(200);
+    expect(adminRemove.body.owners).toEqual([]);
+
+    // Unowned now: a non-admin SMO is blocked (content_unowned); admin can still add an owner.
+    const smoUnowned = await request(app).get(`/api/admin/content-owners/COURSE/${contentId}`).set(smo(a.externalId));
+    expect(smoUnowned.status).toBe(403);
+    expect(smoUnowned.body.error).toBe("content_unowned");
+    const adminAdd = await request(app).post(`/api/admin/content-owners/COURSE/${contentId}`).set(admin(adminUser.externalId)).send({ userId: a.id });
+    expect(adminAdd.status).toBe(201);
+
+    await prisma.contentOwner.deleteMany({ where: { contentId } });
+  });
+});


### PR DESCRIPTION
Third slice of #787. **New endpoints only** — no existing behavior changes, safe to ship alongside slices 1–2.

## What — `/api/admin/content-owners`
- `GET /:contentType/:contentId` — list owners (with name/email)
- `POST /:contentType/:contentId` `{ userId }` — add a co-owner (idempotent)
- `DELETE /:contentType/:contentId/:userId` — remove an owner (last-owner protected)

## Authorization (two layers)
1. **Mount** requires the `admin_content` capability (SMO/ADMIN) to reach it.
2. Each handler calls **`assertContentOwnership`** so only an owner (or admin) of *that* object can see/change its owners.

**Last-owner protection:** a non-admin cannot remove the final owner (would orphan the content); an admin can (→ unowned = admin-managed). All mutations are **audited** (`content_owner_added`/`_removed`). Agent tokens are blocked by the global `enforceAgentTokenScope` (owner-management isn't allow-listed).

## Verify
`tsc` clean. `test/m2-content-owners-api.test.ts` covers owner/admin manage, non-owner 403, last-owner 403, unowned → admin-only — runs in CI (needs the Postgres test DB). Branched from `main` (→ 2.0.8).

**Next (slice 4):** wire `assertContentOwnership` onto the existing course/section/class/module write+delete paths — the one behavior-changing slice, with careful stage QA. Then slice 5: the owner-management UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
