### PR TITLE
chore(auth): #787 backfill course/section owners from created audit

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,21 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.9 - 2026-07-19
+
+chore(auth): #787 — backfill kurs/seksjon-eiere fra «opprettet»-audit (før håndhevelse)
+
+Forberedelse til eierskaps-håndhevelsen (skive 4). Kurs/seksjoner mangler `createdById`, så uten dette
+ville de vært eierløse → admin-only når håndhevelsen slår inn. Denne data-migrasjonen utleder eier fra
+den tidligste `course_created`/`section_created` audit-eventens aktør.
+
+- **Migrasjon `20260719140000_backfill_course_section_owners`:** INSERT eier per kurs/seksjon fra audit-
+  aktør (ikke-null actorId ⇒ gyldig User, siden actor-FK er SetNull). Idempotent (NOT EXISTS). Innhold
+  uten «created»-audit forblir eierløst (admin-styrt) — bevisst.
+
+**Utrulling:** data-only migrasjon (kun INSERT i `ContentOwner`), kjøres ved oppstart → `deploy-app.yml`.
+Kjører mot tomme tabeller i CI (0 rader), mot ekte data på stage/prod. **Stage først.** Neste: håndhevelse.
+
 ## 2.0.8 - 2026-07-19
 
 feat(auth): #787 skive 3 — eier-forvaltnings-API (`/api/admin/content-owners`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260719140000_backfill_course_section_owners/migration.sql
+++ b/prisma/migrations/20260719140000_backfill_course_section_owners/migration.sql
@@ -1,0 +1,41 @@
+-- #787: backfill Course/CourseSection owners from the "created" audit event's actor, so that
+-- ownership enforcement (a later slice) does not leave existing content admin-only. Course/Section have
+-- no createdById column (unlike Class/Module, already backfilled in 20260719130000), so the creator is
+-- recovered from the earliest course_created / section_created AuditEvent. A non-null AuditEvent.actorId
+-- always references a live User (actor FK is onDelete: SetNull), so the ContentOwner.userId FK holds.
+--
+-- Data-only migration. Idempotent (NOT EXISTS guard). Content with no "created" audit stays UNOWNED →
+-- admin-managed until an owner is assigned (the deliberate no-frozen-limbo). Runs against empty tables
+-- in CI (0 rows) and against real data on stage/prod.
+
+-- CreateOwners: Course
+INSERT INTO "ContentOwner" ("id", "contentType", "contentId", "userId", "addedById", "addedAt")
+SELECT gen_random_uuid()::text, 'COURSE'::"ContentOwnerType", c."id", ae."actorId", NULL, CURRENT_TIMESTAMP
+FROM "Course" c
+CROSS JOIN LATERAL (
+    SELECT "actorId"
+    FROM "AuditEvent"
+    WHERE "action" = 'course_created' AND "entityId" = c."id" AND "actorId" IS NOT NULL
+    ORDER BY "timestamp" ASC
+    LIMIT 1
+) ae
+WHERE NOT EXISTS (
+    SELECT 1 FROM "ContentOwner" co
+    WHERE co."contentType" = 'COURSE' AND co."contentId" = c."id"
+);
+
+-- CreateOwners: CourseSection
+INSERT INTO "ContentOwner" ("id", "contentType", "contentId", "userId", "addedById", "addedAt")
+SELECT gen_random_uuid()::text, 'SECTION'::"ContentOwnerType", s."id", ae."actorId", NULL, CURRENT_TIMESTAMP
+FROM "CourseSection" s
+CROSS JOIN LATERAL (
+    SELECT "actorId"
+    FROM "AuditEvent"
+    WHERE "action" = 'section_created' AND "entityId" = s."id" AND "actorId" IS NOT NULL
+    ORDER BY "timestamp" ASC
+    LIMIT 1
+) ae
+WHERE NOT EXISTS (
+    SELECT 1 FROM "ContentOwner" co
+    WHERE co."contentType" = 'SECTION' AND co."contentId" = s."id"
+);


### PR DESCRIPTION
Prepares for ownership enforcement (per the decision: **auto-backfill from audit, then enforce**). Course/CourseSection have no `createdById` (unlike Class/Module, already backfilled), so without this they'd be **unowned → admin-only** the moment enforcement lands. This recovers the creator from the earliest `course_created` / `section_created` audit event.

## What
Data-only migration `20260719140000_backfill_course_section_owners`: `INSERT` one owner per Course/Section from the earliest matching audit event's `actorId`. A non-null `AuditEvent.actorId` always references a live `User` (actor FK is `onDelete: SetNull`), so the `ContentOwner.userId` FK holds. **Idempotent** (`NOT EXISTS` guard). Content with no "created" audit **stays unowned** → admin-managed (the deliberate no-frozen-limbo).

## Verify
Runs against empty tables in CI (0 rows, but the SQL still executes so wrong table/column names would fail `migrate reset`) and against **real data on stage** — the actual backfill test. Transactional/fail-closed: a bad backfill rolls back the migration and reds the deploy. Branched from `main` (→ 2.0.9).

**Next:** slice 4 — wire `assertContentOwnership` onto the write/delete paths (now that existing content is mostly owned) + slice 5 UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
