### PR TITLE
feat(auth): #787 slice 5 - owner-management UI

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,24 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.10 - 2026-07-19
+
+feat(auth): #787 skive 5 — owner-forvaltnings-UI (gjenbrukbart panel, koblet på kurs-siden)
+
+Femte skive. **Inert** — eksponerer bare eier-API-et (`/api/admin/content-owners`) i UI-et; endrer ingen
+redigerings-oppførsel. Lar admins/eiere *se og forvalte* eiere (og verifisere backfill-en) **før**
+håndhevelsen (skive 4) slår inn.
+
+- **`public/static/owner-panel.js`:** gjenbrukbart panel — lister eiere, søk-og-legg-til (via
+  `/users/search`), fjern-per-eier, med human-readable feilmeldinger (siste-eier osv.). Tar container +
+  contentType + contentId, så samme komponent kan dryppes på seksjon/klasse/modul-flatene senere.
+- **`admin-content-courses.js`:** koblet inn i kurs-detaljvisningen (`#ownerPanelHost`).
+- **`shared.css`:** minimal styling. **`test/e2e/content-owner-panel.spec.ts`:** last → render → søk-legg-
+  til → fjern (mot mocket API).
+
+**Utrulling:** kun klient-kode → `deploy-app.yml`. Ingen migrasjon, ingen atferdsendring. Neste (skive 4):
+håndhevelse — koble guarden på skrive-/slette-stiene (den eneste atferdsendringen).
+
 ## 2.0.9 - 2026-07-19
 
 chore(auth): #787 — backfill kurs/seksjon-eiere fra «opprettet»-audit (før håndhevelse)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -28,6 +28,7 @@ import {
   courseItemTypeBadge,
 } from "/static/admin-content-courses-state.js";
 import { renderWorkspaceNavigationWithProfile } from "./workspace-nav.js";
+import { renderOwnerPanel } from "/static/owner-panel.js";
 
 // ---------------------------------------------------------------------------
 // i18n
@@ -1428,6 +1429,8 @@ async function renderDetailView(courseId) {
     </div>
     <div class="detail-layout">
 
+      <div class="detail-section" id="ownerPanelHost"></div>
+
       <div class="detail-section">
         <h2 class="detail-section-title">Kursdetaljer</h2>
 
@@ -1517,6 +1520,11 @@ async function renderDetailView(courseId) {
 
   renderModuleList();
   initDetailEventListeners(courseId);
+  // #787 slice 5: content-owner management for this course.
+  const ownerHost = document.getElementById("ownerPanelHost");
+  if (ownerHost) {
+    renderOwnerPanel({ container: ownerHost, contentType: "COURSE", contentId: courseId, getHeaders }).catch(() => {});
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/public/static/owner-panel.js
+++ b/public/static/owner-panel.js
@@ -1,0 +1,136 @@
+// #787 slice 5: reusable content-owner management panel. Renders the current owner set + a search-to-
+// add box + per-owner remove, calling /api/admin/content-owners. Drop into any content surface with a
+// container element, the contentType (COURSE|SECTION|CLASS|MODULE), the contentId, and the page's
+// getHeaders. Inert with respect to editing — this only manages who owns the object (enforcement is a
+// separate concern wired onto the write/delete paths).
+
+import { apiFetch } from "/static/api-client.js";
+import { escapeHtml } from "/static/html-escape.js";
+import { showToast } from "/static/toast.js";
+
+function ownersPath(contentType, contentId) {
+  return `/api/admin/content-owners/${contentType}/${encodeURIComponent(contentId)}`;
+}
+
+// Turn apiFetch's `"<status>: <json>"` error into the server's human message when present.
+function errorMessage(error, fallback) {
+  const raw = error instanceof Error ? error.message : "";
+  const match = raw.match(/^\d+:\s*(\{.*\})$/);
+  if (match) {
+    try {
+      const parsed = JSON.parse(match[1]);
+      if (parsed && typeof parsed.message === "string") return parsed.message;
+    } catch {
+      /* ignore */
+    }
+  }
+  return fallback;
+}
+
+export async function renderOwnerPanel({ container, contentType, contentId, getHeaders }) {
+  let owners = [];
+  container.innerHTML = `<div class="owner-panel"><p class="owner-panel-loading">Laster eiere…</p></div>`;
+
+  async function load() {
+    const data = await apiFetch(ownersPath(contentType, contentId), getHeaders);
+    owners = Array.isArray(data.owners) ? data.owners : [];
+  }
+
+  function paint() {
+    const rows = owners.length
+      ? owners
+          .map(
+            (o) => `<li class="owner-row">
+        <span class="owner-name">${escapeHtml(o.name)}</span>
+        <span class="owner-email">${escapeHtml(o.email)}</span>
+        <button type="button" class="owner-remove" data-user-id="${escapeHtml(o.userId)}">Fjern</button>
+      </li>`,
+          )
+          .join("")
+      : `<li class="owner-empty">Ingen eiere ennå — kun administrator kan redigere til en eier tildeles.</li>`;
+    container.innerHTML = `
+      <div class="owner-panel">
+        <h3 class="owner-panel-title">Eiere</h3>
+        <ul class="owner-list">${rows}</ul>
+        <div class="owner-add">
+          <input type="text" class="owner-search-input" placeholder="Søk navn/e-post for å legge til eier…" aria-label="Søk etter eier" autocomplete="off" />
+          <ul class="owner-search-results" hidden></ul>
+        </div>
+      </div>`;
+    wire();
+  }
+
+  function wire() {
+    for (const btn of container.querySelectorAll(".owner-remove")) {
+      btn.addEventListener("click", () => removeOwner(btn.dataset.userId));
+    }
+    const input = container.querySelector(".owner-search-input");
+    const results = container.querySelector(".owner-search-results");
+    let timer;
+    input?.addEventListener("input", () => {
+      clearTimeout(timer);
+      const q = input.value.trim();
+      if (q.length < 2) {
+        results.hidden = true;
+        results.innerHTML = "";
+        return;
+      }
+      timer = setTimeout(() => search(q, results), 250);
+    });
+    results?.addEventListener("click", (event) => {
+      const li = event.target.closest("li[data-user-id]");
+      if (li) addOwner(li.dataset.userId);
+    });
+  }
+
+  async function search(q, results) {
+    try {
+      const data = await apiFetch(`/api/admin/content/users/search?q=${encodeURIComponent(q)}`, getHeaders);
+      const matches = (Array.isArray(data.users) ? data.users : []).filter((u) => !owners.some((o) => o.userId === u.id));
+      results.innerHTML = matches.length
+        ? matches
+            .map(
+              (u) => `<li data-user-id="${escapeHtml(u.id)}"><span class="owner-name">${escapeHtml(u.name)}</span> <span class="owner-email">${escapeHtml(u.email)}</span></li>`,
+            )
+            .join("")
+        : `<li class="owner-empty">Ingen treff.</li>`;
+      results.hidden = false;
+    } catch {
+      results.hidden = true;
+    }
+  }
+
+  async function addOwner(userId) {
+    try {
+      const data = await apiFetch(ownersPath(contentType, contentId), getHeaders, {
+        method: "POST",
+        body: JSON.stringify({ userId }),
+      });
+      owners = Array.isArray(data.owners) ? data.owners : owners;
+      showToast("Eier lagt til.");
+      paint();
+    } catch (error) {
+      showToast(errorMessage(error, "Kunne ikke legge til eier."), "error");
+    }
+  }
+
+  async function removeOwner(userId) {
+    try {
+      const data = await apiFetch(`${ownersPath(contentType, contentId)}/${encodeURIComponent(userId)}`, getHeaders, {
+        method: "DELETE",
+      });
+      owners = Array.isArray(data.owners) ? data.owners : owners;
+      showToast("Eier fjernet.");
+      paint();
+    } catch (error) {
+      showToast(errorMessage(error, "Kunne ikke fjerne eier."), "error");
+    }
+  }
+
+  try {
+    await load();
+    paint();
+  } catch {
+    container.innerHTML = `<div class="owner-panel"><p class="owner-panel-error">Kunne ikke laste eiere.</p></div>`;
+  }
+}

--- a/public/static/shared.css
+++ b/public/static/shared.css
@@ -1165,3 +1165,16 @@ dialog::backdrop {
 .content-area-nav-link { padding: 10px var(--space-2); font-size: 14px; font-weight: 600; color: var(--color-meta); text-decoration: none; border-bottom: 2px solid transparent; margin-bottom: -2px; white-space: nowrap; }
 .content-area-nav-link:hover { color: var(--color-text); }
 .content-area-nav-link.active { color: var(--color-link-active); border-bottom-color: var(--color-blue); }
+
+/* #787 slice 5: content-owner management panel (owner-panel.js) */
+.owner-list { list-style: none; padding: 0; margin: 0 0 0.75rem; }
+.owner-row { display: flex; align-items: center; gap: 0.5rem; padding: 0.35rem 0; border-bottom: 1px solid var(--border-subtle, #e5e7eb); }
+.owner-row .owner-name { font-weight: 600; }
+.owner-row .owner-email, .owner-search-results .owner-email { color: var(--text-muted, #6b7280); font-size: 0.9em; }
+.owner-remove { margin-left: auto; }
+.owner-empty { color: var(--text-muted, #6b7280); font-style: italic; padding: 0.35rem 0; }
+.owner-add { position: relative; }
+.owner-search-input { width: 100%; box-sizing: border-box; }
+.owner-search-results { list-style: none; margin: 0.25rem 0 0; padding: 0; border: 1px solid var(--border-subtle, #e5e7eb); border-radius: 4px; max-height: 12rem; overflow-y: auto; }
+.owner-search-results li { padding: 0.4rem 0.6rem; cursor: pointer; }
+.owner-search-results li:hover { background: var(--surface-hover, #f3f4f6); }

--- a/test/e2e/content-owner-panel.spec.ts
+++ b/test/e2e/content-owner-panel.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect, type Route } from "@playwright/test";
+import { mockCommonApis } from "./admin-content-helpers.js";
+
+// #787 slice 5: the owner-management panel on the course detail page. Runs the real owner-panel.js
+// against mocked owner + user-search APIs — load → render → search-add → remove.
+test("course owner panel: lists, adds via search, and removes owners", async ({ page }) => {
+  await mockCommonApis(page, {
+    courses: [{ id: "course-1", title: { nb: "Kurs" }, certificationLevel: "basic", moduleCount: 0, modules: [] }],
+    libraryModules: [],
+  });
+
+  let owners = [{ userId: "u1", name: "Alice Owner", email: "alice@x.no", addedAt: "2026-07-19T00:00:00.000Z" }];
+
+  await page.route("**/api/admin/content-owners/COURSE/course-1", async (route: Route) => {
+    const method = route.request().method();
+    if (method === "GET") {
+      return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ owners }) });
+    }
+    if (method === "POST") {
+      const { userId } = JSON.parse(route.request().postData() ?? "{}");
+      owners = [...owners, { userId, name: "Bob New", email: "bob@x.no", addedAt: "2026-07-19T01:00:00.000Z" }];
+      return route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ owners }) });
+    }
+    return route.fallback();
+  });
+  await page.route("**/api/admin/content-owners/COURSE/course-1/*", async (route: Route) => {
+    if (route.request().method() !== "DELETE") return route.fallback();
+    const removed = decodeURIComponent(route.request().url().split("/").pop() ?? "");
+    owners = owners.filter((o) => o.userId !== removed);
+    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ owners }) });
+  });
+  await page.route("**/api/admin/content/users/search**", async (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ users: [{ id: "u2", name: "Bob New", email: "bob@x.no" }] }),
+    }),
+  );
+
+  await page.addInitScript(() => { try { localStorage.setItem("participant.locale", "nb"); } catch { /* ignore */ } });
+  await page.goto("/admin-content/courses/course-1");
+
+  // Panel renders with the initial owner.
+  const panel = page.locator("#ownerPanelHost .owner-panel");
+  await expect(panel).toBeVisible();
+  await expect(panel.locator(".owner-row")).toHaveCount(1);
+  await expect(panel.locator(".owner-name").first()).toHaveText("Alice Owner");
+
+  // Search for and add a co-owner.
+  await panel.locator(".owner-search-input").fill("bob");
+  const result = panel.locator(".owner-search-results li[data-user-id='u2']");
+  await expect(result).toBeVisible();
+  await result.click();
+  await expect(panel.locator(".owner-row")).toHaveCount(2);
+
+  // Remove the original owner; the co-owner remains.
+  await panel.locator(".owner-remove[data-user-id='u1']").click();
+  await expect(panel.locator(".owner-row")).toHaveCount(1);
+  await expect(panel.locator(".owner-name").first()).toHaveText("Bob New");
+});


### PR DESCRIPTION
Fifth slice of #787. **Inert** — exposes the owner API in the UI; no editing-behavior change. Lets admins/owners **see and manage owners** (and visually verify the backfill) *before* enforcement (slice 4) lands.

## What
- **`public/static/owner-panel.js`** — a reusable panel: lists current owners, search-and-add (via `/api/admin/content/users/search`), per-owner remove, with human-readable errors (last-owner protection etc.). Generic over `contentType` so the same component drops onto the section/class/module surfaces in a fast follow-up.
- **`admin-content-courses.js`** — wired into the course detail view (`#ownerPanelHost`).
- **`shared.css`** — minimal styling.
- **`test/e2e/content-owner-panel.spec.ts`** — load → render → search-add → remove against a mocked API (Playwright, CI).

## Verify
Client-layer feature → covered by the Playwright e2e (CI). I can't reach stage over HTTP from here, so the visual/UX pass is yours on stage. Branched from `main` (→ 2.0.10).

**Next (slice 4):** wire `assertContentOwnership` onto the write/delete paths — the one behavior-changing slice, promoted to prod only after content is confirmed owned (per the prod plan). The owner panel here is the tool to confirm/fix ownership first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
