### PR TITLE
fix(ui): #787 owner-panel styling matches the design system

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,14 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.11 - 2026-07-19
+
+fix(ui): #787 — owner-panel styling matcher design-systemet (liten «Fjern»-knapp, design-tokens)
+
+Rettet at «Fjern» ble full-bredde (global `button { width: 100% }`-felle) + brukte ad-hoc-farger. Nå:
+design-tokens (`--color-*`, `--space-*`), `btn-secondary` + `width:auto` på knappen, ryddig rad-layout.
+Kun CSS + én klasse → `deploy-app.yml`.
+
 ## 2.0.10 - 2026-07-19
 
 feat(auth): #787 skive 5 — owner-forvaltnings-UI (gjenbrukbart panel, koblet på kurs-siden)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/owner-panel.js
+++ b/public/static/owner-panel.js
@@ -43,7 +43,7 @@ export async function renderOwnerPanel({ container, contentType, contentId, getH
             (o) => `<li class="owner-row">
         <span class="owner-name">${escapeHtml(o.name)}</span>
         <span class="owner-email">${escapeHtml(o.email)}</span>
-        <button type="button" class="owner-remove" data-user-id="${escapeHtml(o.userId)}">Fjern</button>
+        <button type="button" class="owner-remove btn-secondary" data-user-id="${escapeHtml(o.userId)}">Fjern</button>
       </li>`,
           )
           .join("")

--- a/public/static/shared.css
+++ b/public/static/shared.css
@@ -1166,15 +1166,19 @@ dialog::backdrop {
 .content-area-nav-link:hover { color: var(--color-text); }
 .content-area-nav-link.active { color: var(--color-link-active); border-bottom-color: var(--color-blue); }
 
-/* #787 slice 5: content-owner management panel (owner-panel.js) */
-.owner-list { list-style: none; padding: 0; margin: 0 0 0.75rem; }
-.owner-row { display: flex; align-items: center; gap: 0.5rem; padding: 0.35rem 0; border-bottom: 1px solid var(--border-subtle, #e5e7eb); }
-.owner-row .owner-name { font-weight: 600; }
-.owner-row .owner-email, .owner-search-results .owner-email { color: var(--text-muted, #6b7280); font-size: 0.9em; }
-.owner-remove { margin-left: auto; }
-.owner-empty { color: var(--text-muted, #6b7280); font-style: italic; padding: 0.35rem 0; }
-.owner-add { position: relative; }
+/* #787 slice 5: content-owner management panel (owner-panel.js). Uses the design tokens + shares the
+   .btn styling so it matches the rest of the workspace. The remove button MUST set width:auto to escape
+   the global `button { width: 100% }` form rule. */
+.owner-panel-title { font-size: 1rem; font-weight: 600; margin: 0 0 var(--space-1); color: var(--color-text); }
+.owner-list { list-style: none; padding: 0; margin: 0 0 var(--space-2); }
+.owner-row { display: flex; align-items: center; gap: var(--space-2); padding: 8px 0; border-bottom: 1px solid var(--color-border-soft); }
+.owner-row .owner-name { font-weight: 600; color: var(--color-text); }
+.owner-row .owner-email, .owner-search-results .owner-email { color: var(--color-text); opacity: 0.65; font-size: 0.9em; }
+.owner-remove { width: auto; margin-left: auto; flex: 0 0 auto; padding: 4px 14px; font-size: 0.85rem; }
+.owner-empty { color: var(--color-text); opacity: 0.65; font-style: italic; padding: 8px 0; }
+.owner-add { position: relative; max-width: 32rem; }
 .owner-search-input { width: 100%; box-sizing: border-box; }
-.owner-search-results { list-style: none; margin: 0.25rem 0 0; padding: 0; border: 1px solid var(--border-subtle, #e5e7eb); border-radius: 4px; max-height: 12rem; overflow-y: auto; }
-.owner-search-results li { padding: 0.4rem 0.6rem; cursor: pointer; }
-.owner-search-results li:hover { background: var(--surface-hover, #f3f4f6); }
+.owner-search-results { list-style: none; margin: 4px 0 0; padding: 0; border: 1px solid var(--color-border-soft); border-radius: 8px; max-height: 12rem; overflow-y: auto; background: var(--color-surface); }
+.owner-search-results li { padding: 8px 12px; cursor: pointer; display: flex; gap: var(--space-1); align-items: baseline; }
+.owner-search-results li:hover { background: var(--color-bg); }
+.owner-panel-loading, .owner-panel-error { color: var(--color-text); opacity: 0.7; }


### PR DESCRIPTION
Addresses QA point #1 — the owner panel didn't follow the design system.

**Root cause:** the "Fjern" button hit the global `button { width: 100% }` form rule (a known trap — there's already a comment about it in `shared.css`), so it rendered as a huge full-width block; the panel also used ad-hoc colours.

**Fix:** design tokens (`--color-*`, `--space-*`), the shared `.btn-secondary` class on the button + `width: auto` to escape the global rule, tidy row layout (name / muted email / small right-aligned Fjern), and a proper search-results dropdown. → 2.0.11.

Existing owner-panel e2e still passes. Other QA points (owner on module/section surfaces, calibration semantics, the advanced-editor drift) are handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
