### PR TITLE
fix(auth): #787 QA #6 - owners readable by any content-admin

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,17 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.12 - 2026-07-19
+
+fix(auth): #787 QA #6 — eiere er lesbare for enhver SMO/admin (panelet vises på innhold du ikke eier)
+
+GET-eiere var gated på eierskap, så åpnet du et kurs du ikke eide fikk owner-panelet 403 og viste ikke.
+Nå: enhver content-admin kan SE eiere (transparens); kun eier/admin kan ENDRE (POST/DELETE gated).
+GET returnerer `canManage` så UI-en skjuler legg-til/fjern for ikke-eiere.
+
+- `contentOwners.ts`: GET capability-gated + `canManage`. `owner-panel.js`: skjul kontroller når
+  `!canManage`. Tester (integrasjon + e2e read-only) oppdatert.
+
 ## 2.0.11 - 2026-07-19
 
 fix(ui): #787 — owner-panel styling matcher design-systemet (liten «Fjern»-knapp, design-tokens)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/owner-panel.js
+++ b/public/static/owner-panel.js
@@ -29,11 +29,13 @@ function errorMessage(error, fallback) {
 
 export async function renderOwnerPanel({ container, contentType, contentId, getHeaders }) {
   let owners = [];
+  let canManage = false; // only owners/admin may change owners; everyone with access can view
   container.innerHTML = `<div class="owner-panel"><p class="owner-panel-loading">Laster eiere…</p></div>`;
 
   async function load() {
     const data = await apiFetch(ownersPath(contentType, contentId), getHeaders);
     owners = Array.isArray(data.owners) ? data.owners : [];
+    canManage = data.canManage === true;
   }
 
   function paint() {
@@ -43,19 +45,22 @@ export async function renderOwnerPanel({ container, contentType, contentId, getH
             (o) => `<li class="owner-row">
         <span class="owner-name">${escapeHtml(o.name)}</span>
         <span class="owner-email">${escapeHtml(o.email)}</span>
-        <button type="button" class="owner-remove btn-secondary" data-user-id="${escapeHtml(o.userId)}">Fjern</button>
+        ${canManage ? `<button type="button" class="owner-remove btn-secondary" data-user-id="${escapeHtml(o.userId)}">Fjern</button>` : ""}
       </li>`,
           )
           .join("")
       : `<li class="owner-empty">Ingen eiere ennå — kun administrator kan redigere til en eier tildeles.</li>`;
+    const addBox = canManage
+      ? `<div class="owner-add">
+          <input type="text" class="owner-search-input" placeholder="Søk navn/e-post for å legge til eier…" aria-label="Søk etter eier" autocomplete="off" />
+          <ul class="owner-search-results" hidden></ul>
+        </div>`
+      : "";
     container.innerHTML = `
       <div class="owner-panel">
         <h3 class="owner-panel-title">Eiere</h3>
         <ul class="owner-list">${rows}</ul>
-        <div class="owner-add">
-          <input type="text" class="owner-search-input" placeholder="Søk navn/e-post for å legge til eier…" aria-label="Søk etter eier" autocomplete="off" />
-          <ul class="owner-search-results" hidden></ul>
-        </div>
+        ${addBox}
       </div>`;
     wire();
   }

--- a/src/routes/contentOwners.ts
+++ b/src/routes/contentOwners.ts
@@ -33,9 +33,14 @@ contentOwnersRouter.get("/:contentType/:contentId", async (request, response, ne
   const type = contentTypeSchema.safeParse(request.params.contentType);
   if (!type.success) return void response.status(400).json({ error: "invalid_content_type" });
   const contentType = type.data as ContentOwnerType;
+  const roles = request.context?.roles ?? [];
   try {
-    await assertContentOwnership({ contentType, contentId: request.params.contentId, actorUserId: userId, roles: request.context?.roles ?? [] });
-    response.json({ owners: await listContentOwners(contentType, request.params.contentId) });
+    // #787 QA: any content-admin (the mount already requires SMO/ADMIN) may VIEW the owners for
+    // transparency — the panel must render on content you don't own too. Only an owner or admin may
+    // CHANGE owners (POST/DELETE stay ownership-gated). `canManage` tells the UI whether to show controls.
+    const owners = await listContentOwners(contentType, request.params.contentId);
+    const canManage = roles.includes("ADMINISTRATOR") || owners.some((o) => o.userId === userId);
+    response.json({ owners, canManage });
   } catch (error) {
     if (!sendAppError(response, error)) next(error);
   }

--- a/test/e2e/content-owner-panel.spec.ts
+++ b/test/e2e/content-owner-panel.spec.ts
@@ -14,7 +14,7 @@ test("course owner panel: lists, adds via search, and removes owners", async ({ 
   await page.route("**/api/admin/content-owners/COURSE/course-1", async (route: Route) => {
     const method = route.request().method();
     if (method === "GET") {
-      return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ owners }) });
+      return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ owners, canManage: true }) });
     }
     if (method === "POST") {
       const { userId } = JSON.parse(route.request().postData() ?? "{}");
@@ -57,4 +57,31 @@ test("course owner panel: lists, adds via search, and removes owners", async ({ 
   await panel.locator(".owner-remove[data-user-id='u1']").click();
   await expect(panel.locator(".owner-row")).toHaveCount(1);
   await expect(panel.locator(".owner-name").first()).toHaveText("Bob New");
+});
+
+// #787 QA #6: a content-admin who is NOT an owner (and not admin) still sees the owners (transparency),
+// but gets no add/remove controls (canManage=false). This is what makes the panel render on content you
+// don't own — previously the ownership-gated GET returned 403 and the panel failed to render.
+test("owner panel is read-only when the viewer cannot manage owners", async ({ page }) => {
+  await mockCommonApis(page, {
+    courses: [{ id: "course-2", title: { nb: "Kurs" }, certificationLevel: "basic", moduleCount: 0, modules: [] }],
+    libraryModules: [],
+  });
+  await page.route("**/api/admin/content-owners/COURSE/course-2", async (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ owners: [{ userId: "u9", name: "Someone Else", email: "else@x.no", addedAt: "2026-07-19T00:00:00.000Z" }], canManage: false }),
+    }),
+  );
+
+  await page.addInitScript(() => { try { localStorage.setItem("participant.locale", "nb"); } catch { /* ignore */ } });
+  await page.goto("/admin-content/courses/course-2");
+
+  const panel = page.locator("#ownerPanelHost .owner-panel");
+  await expect(panel).toBeVisible();
+  await expect(panel.locator(".owner-name").first()).toHaveText("Someone Else");
+  // No management controls for a non-owner viewer.
+  await expect(panel.locator(".owner-remove")).toHaveCount(0);
+  await expect(panel.locator(".owner-search-input")).toHaveCount(0);
 });

--- a/test/m2-content-owners-api.test.ts
+++ b/test/m2-content-owners-api.test.ts
@@ -44,11 +44,15 @@ describe("content-owners API (#787)", () => {
     const listA = await request(app).get(`/api/admin/content-owners/COURSE/${contentId}`).set(smo(a.externalId));
     expect(listA.status).toBe(200);
     expect((listA.body.owners as Array<{ userId: string }>).map((o) => o.userId)).toEqual([a.id]);
+    expect(listA.body.canManage).toBe(true); // A owns it
 
-    // Non-owner B (has SMO capability but doesn't own this object) is blocked.
+    // Non-owner B can VIEW owners (transparency, canManage=false) but cannot mutate them.
     const listB = await request(app).get(`/api/admin/content-owners/COURSE/${contentId}`).set(smo(b.externalId));
-    expect(listB.status).toBe(403);
-    expect(listB.body.error).toBe("content_ownership");
+    expect(listB.status).toBe(200);
+    expect(listB.body.canManage).toBe(false);
+    const bAdd = await request(app).post(`/api/admin/content-owners/COURSE/${contentId}`).set(smo(b.externalId)).send({ userId: b.id });
+    expect(bAdd.status).toBe(403);
+    expect(bAdd.body.error).toBe("content_ownership");
 
     // Owner A adds B as a co-owner.
     const add = await request(app).post(`/api/admin/content-owners/COURSE/${contentId}`).set(smo(a.externalId)).send({ userId: b.id });
@@ -70,10 +74,14 @@ describe("content-owners API (#787)", () => {
     expect(adminRemove.status).toBe(200);
     expect(adminRemove.body.owners).toEqual([]);
 
-    // Unowned now: a non-admin SMO is blocked (content_unowned); admin can still add an owner.
+    // Unowned now: any SMO can still VIEW (empty owners, canManage=false); mutating is admin-only.
     const smoUnowned = await request(app).get(`/api/admin/content-owners/COURSE/${contentId}`).set(smo(a.externalId));
-    expect(smoUnowned.status).toBe(403);
-    expect(smoUnowned.body.error).toBe("content_unowned");
+    expect(smoUnowned.status).toBe(200);
+    expect(smoUnowned.body.owners).toEqual([]);
+    expect(smoUnowned.body.canManage).toBe(false);
+    const smoAddUnowned = await request(app).post(`/api/admin/content-owners/COURSE/${contentId}`).set(smo(a.externalId)).send({ userId: a.id });
+    expect(smoAddUnowned.status).toBe(403);
+    expect(smoAddUnowned.body.error).toBe("content_unowned");
     const adminAdd = await request(app).post(`/api/admin/content-owners/COURSE/${contentId}`).set(admin(adminUser.externalId)).send({ userId: a.id });
     expect(adminAdd.status).toBe(201);
 


### PR DESCRIPTION
Addresses QA point #6 ("course detail didn't show it"). Likely root cause: `GET owners` was gated by `assertContentOwnership`, so opening content you **don't own** returned 403 and the panel silently failed to render (it only worked on content you own — hence screenshot 1 showed it, on your own course).

## Fix
- **`contentOwners.ts` GET** — dropped the ownership gate (the mount still requires the `admin_content` capability, so it's SMO/ADMIN only). Any content-admin may now **VIEW** owners (transparency). **POST/DELETE stay ownership-gated** — only an owner or admin may change owners. GET returns `canManage` (admin, or you're an owner).
- **`owner-panel.js`** — hides the add-search box + per-owner remove buttons when `canManage` is false, so a non-owner viewer sees the owner list read-only.
- **Tests** — integration (non-owner now 200-readable + `canManage:false`, mutations still 403) + a new read-only e2e case.

→ 2.0.12. `tsc` clean.

**Still open from QA:** #2/#4 (wire the panel onto module + section editors) as the next focused change; #5 (calibration shows which modules you can calibrate) folds into the enforcement slice; #3 (advanced-editor drift) tracked as #818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
