### PR TITLE
feat(auth): #787 QA #2/#4 - owner panel on module + section surfaces

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,19 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.13 - 2026-07-19
+
+feat(auth): #787 QA #2/#4 — owner-panel på modul- + seksjon-flatene
+
+Kobler det gjenbrukbare owner-panelet (samme som kurs) inn på de resterende innholds-flatene:
+- **Seksjon-editor** (`admin-content-sections.js`): panel for eksisterende seksjoner (nye har ingen id enda).
+- **Modul-arbeidsflate** (`admin-content-shell.js` + `admin-content.html` + `admin-content-advanced.html`):
+  panel under «Modulstatus»-raden når en modul er lastet — dekker BÅDE samtale- og avansert-modus (begge
+  bruker samme shell/`updateStateRail`). Rendres én gang per modul (guardet), skjules når ingen modul.
+
+Inert (eksponerer bare eier-API-et). Panel-logikken er e2e-dekket (kurs-spec); wiringen er mekanisk +
+syntaks-verifisert, og eksisterende admin-content-e2e-specs fanger side-brudd. → `deploy-app.yml`.
+
 ## 2.0.12 - 2026-07-19
 
 fix(auth): #787 QA #6 — eiere er lesbare for enhver SMO/admin (panelet vises på innhold du ikke eier)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-advanced.html
+++ b/public/admin-content-advanced.html
@@ -249,6 +249,9 @@
       </div>
     </div>
 
+    <!-- #787: content-owner management for the loaded module -->
+    <div id="moduleOwnerPanelHost" class="card" hidden style="margin-top:var(--space-2)"></div>
+
     <div class="module-workspace-header">
       <div style="display:flex; align-items:baseline; gap:var(--space-2); flex-wrap:wrap;">
         <h1 id="moduleWorkspaceTitle" data-i18n="adminContentPage.title" style="margin:0">Content Setup Workspace</h1>

--- a/public/admin-content.html
+++ b/public/admin-content.html
@@ -386,6 +386,9 @@
         </div>
       </div>
 
+      <!-- #787: content-owner management for the loaded module -->
+      <div id="moduleOwnerPanelHost" class="card" hidden style="margin-top:var(--space-2)"></div>
+
       <div role="note" style="border:1px solid #f5c37f;background:#fffbf0;border-radius:var(--radius-card);padding:var(--space-1) var(--space-2);margin-top:var(--space-2);margin-bottom:var(--space-2)">
         <strong data-i18n="adminContent.privacy.warning.title">Special category data risk</strong>
         <p class="small" style="margin-top:4px;color:var(--color-meta)" data-i18n="adminContent.privacy.warning.body">

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -9,6 +9,7 @@ import { resolveWorkspaceNavigationItems } from "/static/participant-console-sta
 import { renderWorkspaceNavigationWithProfile } from "./workspace-nav.js";
 import { showToast } from "/static/toast.js";
 import { lifecycleStatusBadge } from "/static/content-status-badge.js";
+import { renderOwnerPanel } from "/static/owner-panel.js";
 import {
   SECTION_EDITOR_LOCALES,
   nonEmptyLocales,
@@ -432,6 +433,7 @@ async function renderEditorView(sectionId) {
         <button type="button" id="sectionLifecycleBtn" class="btn btn-secondary" style="width:auto;display:none"></button>
         <span class="editor-status" id="editorStatus"></span>
       </div>
+      ${sectionId ? `<div id="ownerPanelHost" style="margin-top:var(--space-3);border-top:1px solid var(--color-border-soft);padding-top:var(--space-2)"></div>` : ""}
     </div>`;
 
   document.getElementById("backLink")?.addEventListener("click", (e) => { e.preventDefault(); goTo("list"); });
@@ -457,6 +459,11 @@ async function renderEditorView(sectionId) {
   document.getElementById("sectionLifecycleBtn")?.addEventListener("click", toggleSectionLifecycle);
   refreshSectionLifecycleUI();
   refreshPreview();
+  // #787: content-owner management for an existing section (new sections have no id yet).
+  if (sectionId) {
+    const ownerHost = document.getElementById("ownerPanelHost");
+    if (ownerHost) renderOwnerPanel({ container: ownerHost, contentType: "SECTION", contentId: sectionId, getHeaders }).catch(() => {});
+  }
 }
 
 // #705: status i editoren (samme vokabular som modul) + Publiser/Avpubliser-knapp. Seksjoner

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -29,6 +29,7 @@ import {
 } from "/static/admin-content-shell-state.js";
 import { buildAdminContentAdvancedUrl } from "/static/admin-content-handoff-routes.js";
 import { deriveModuleStatusChains } from "/static/module-status-logic.js";
+import { renderOwnerPanel } from "/static/owner-panel.js";
 import {
   buildExternalLlmAuthoringPrompt,
   parseExternalLlmJson,
@@ -1138,6 +1139,19 @@ function updateStateRail() {
   if (!stateRail) return;
   const hasModule = !!selectedModuleId;
   stateRail.hidden = !hasModule;
+  // #787: content-owner panel for the loaded module. Render once per module (guard on the last id) so
+  // the frequent updateStateRail calls don't re-fetch/reset it; hide when no module is loaded.
+  const ownerHost = document.getElementById("moduleOwnerPanelHost");
+  if (ownerHost) {
+    if (!hasModule) {
+      ownerHost.hidden = true;
+      ownerHost.dataset.moduleId = "";
+    } else if (ownerHost.dataset.moduleId !== selectedModuleId) {
+      ownerHost.dataset.moduleId = selectedModuleId;
+      ownerHost.hidden = false;
+      renderOwnerPanel({ container: ownerHost, contentType: "MODULE", contentId: selectedModuleId, getHeaders }).catch(() => {});
+    }
+  }
   if (!hasModule) return;
 
   const chains = bundle ? deriveModuleStatusChains(bundle) : null;


### PR DESCRIPTION
Addresses QA #2 (no owner in module UI) + #4 (no owner in sections). Wires the reusable owner panel (already e2e-verified on courses) onto the remaining content surfaces.

## What
- **Section editor** (`admin-content-sections.js`) — owner panel below the editor for **existing** sections (new sections have no id until saved).
- **Module workspace** (`admin-content-shell.js` + `admin-content.html` + `admin-content-advanced.html`) — owner panel under the "Modulstatus" rail when a module is loaded. Rendered **once per module** (guarded on the last id so the frequent `updateStateRail` calls don't reset it), hidden when no module. Covers **both** conversational and advanced modes (both load the same shell — this also gives the advanced editor the panel, partially touching QA #3's ownership aspect).

## Verify
Inert (exposes the owner API only; no editing-behavior change). The panel logic is e2e-covered by the course spec; the wiring is mechanical + `node --check` syntax-verified; existing admin-content e2e specs load these pages so a JS break would fail CI. → 2.0.13, `deploy-app.yml`.

**Remaining #787:** #5 (calibration shows which modules you can calibrate) folds into the enforcement slice; slice 4 enforcement is the one behavior-changing step; #3 advanced-editor drift beyond ownership is #818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
