### PR TITLE
fix: #787 QA r2 — owner-panel på modul-avansert + klasse; kompakt GDPR-varsel

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,27 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.14 - 2026-07-19
+
+fix(auth): #787 QA runde 2 — owner-panel på de faktisk manglende flatene + kompakt GDPR-varsel
+
+QA-runde 1 (2.0.13) trodde modul-avansert var dekket, men **avansert-editoren kjører `admin-content.js`**
+(egen `updateStateRail`), ikke samtale-shellen (`admin-content-shell.js`) — så owner-panelet ble aldri
+rendret der. Denne runden fikser de tre gjenstående flatene, hver bevist med en Playwright-e2e som
+driver den ekte front-end-JS-en:
+
+- **Modul-avansert** (`admin-content.js`): owner-panel rendres nå fra `setSelectedModule` inn i
+  `#moduleOwnerPanelHost` (én gang per modul-id), uavhengig av om modul-status er ferdig hentet. QA #1.
+- **Klasse** (`admin-content-classes.js`): owner-panel i `openClass`-detaljvisningen — klasser var aldri
+  koblet for eierskap. QA #2.
+- **Seksjon**: e2e bekrefter at editor-visningen allerede rendrer panelet for eksisterende seksjoner
+  (åpne en seksjon via `?id=`); panelet vises i editoren, ikke i liste-visningen. QA #3.
+- **GDPR-varsel**: gjort kompakt (én linje, mindre skrift, lettere ramme) på begge modul-editorene så
+  det ikke dominerer arbeidsflaten. QA #5 (plassering/størrelse).
+
+Ny e2e: `test/e2e/content-owner-surfaces.spec.ts` (3 tester). Ingen regresjon i de 55 berørte
+admin-content-e2e-ene.
+
 ## 2.0.13 - 2026-07-19
 
 feat(auth): #787 QA #2/#4 — owner-panel på modul- + seksjon-flatene

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-advanced.html
+++ b/public/admin-content-advanced.html
@@ -292,11 +292,9 @@
       </details>
     </section>
 
-    <div role="note" style="border:1px solid #f5c37f;background:#fffbf0;border-radius:var(--radius-card);padding:var(--space-1) var(--space-2);margin-top:var(--space-2);margin-bottom:var(--space-2)">
-      <strong data-i18n="adminContent.privacy.warning.title">Special category data risk</strong>
-      <p class="small" style="margin-top:4px;color:var(--color-meta)" data-i18n="adminContent.privacy.warning.body">
-        Participants may include health information, political views, or other special category data in free-text submissions.
-      </p>
+    <div role="note" style="display:flex;gap:8px;align-items:baseline;border:1px solid #f0d9b5;background:#fffdf7;border-radius:var(--radius-card);padding:6px 10px;margin:var(--space-1) 0;font-size:12px;line-height:1.4;color:var(--color-meta)">
+      <span aria-hidden="true">⚠️</span>
+      <span><strong style="color:var(--color-text);font-weight:600" data-i18n="adminContent.privacy.warning.title">Special category data risk</strong> — <span data-i18n="adminContent.privacy.warning.body">Participants may include health information, political views, or other special category data in free-text submissions.</span></span>
     </div>
 
     <div class="content-tab-nav" role="tablist">

--- a/public/admin-content.html
+++ b/public/admin-content.html
@@ -389,11 +389,9 @@
       <!-- #787: content-owner management for the loaded module -->
       <div id="moduleOwnerPanelHost" class="card" hidden style="margin-top:var(--space-2)"></div>
 
-      <div role="note" style="border:1px solid #f5c37f;background:#fffbf0;border-radius:var(--radius-card);padding:var(--space-1) var(--space-2);margin-top:var(--space-2);margin-bottom:var(--space-2)">
-        <strong data-i18n="adminContent.privacy.warning.title">Special category data risk</strong>
-        <p class="small" style="margin-top:4px;color:var(--color-meta)" data-i18n="adminContent.privacy.warning.body">
-          Participants may include health information, political views, or other special category data in free-text submissions.
-        </p>
+      <div role="note" style="display:flex;gap:8px;align-items:baseline;border:1px solid #f0d9b5;background:#fffdf7;border-radius:var(--radius-card);padding:6px 10px;margin:var(--space-1) 0;font-size:12px;line-height:1.4;color:var(--color-meta)">
+        <span aria-hidden="true">⚠️</span>
+        <span><strong style="color:var(--color-text);font-weight:600" data-i18n="adminContent.privacy.warning.title">Special category data risk</strong> — <span data-i18n="adminContent.privacy.warning.body">Participants may include health information, political views, or other special category data in free-text submissions.</span></span>
       </div>
 
       <div class="module-workspace-header">

--- a/public/admin-content.js
+++ b/public/admin-content.js
@@ -25,6 +25,7 @@ import {
   buildAdminContentConversationUrl,
   resolveConversationModuleId,
 } from "/static/admin-content-handoff-routes.js";
+import { renderOwnerPanel } from "/static/owner-panel.js";
 
 const translations = Object.fromEntries(
   supportedLocales.map((locale) => [
@@ -1742,6 +1743,27 @@ function setSelectedModule(nextModuleId, syncInput = true) {
   renderCalibrationModuleOptions();
   renderModuleMeta();
   renderModuleStatus();
+  renderModuleOwnerPanel();
+}
+
+// #787: content-owner panel for the loaded module in the Avansert editor. The Avansert page runs THIS
+// file (admin-content.js), which has its own state-rail code separate from the conversational shell —
+// so the shell's owner-panel wiring never applied here. Render into the static host once per module id
+// (guarded on dataset), driven by setSelectedModule so it appears as soon as a module is loaded,
+// independent of whether module status has finished fetching.
+function renderModuleOwnerPanel() {
+  const ownerHost = document.getElementById("moduleOwnerPanelHost");
+  if (!ownerHost) return;
+  if (!selectedModuleId) {
+    ownerHost.hidden = true;
+    ownerHost.dataset.moduleId = "";
+    ownerHost.innerHTML = "";
+    return;
+  }
+  if (ownerHost.dataset.moduleId === selectedModuleId) return;
+  ownerHost.dataset.moduleId = selectedModuleId;
+  ownerHost.hidden = false;
+  renderOwnerPanel({ container: ownerHost, contentType: "MODULE", contentId: selectedModuleId, getHeaders: headers }).catch(() => {});
 }
 
 function resolveModuleIdOrThrow() {

--- a/public/static/admin-content-classes.js
+++ b/public/static/admin-content-classes.js
@@ -4,6 +4,7 @@ import { resolveWorkspaceNavigationItems } from "/static/participant-console-sta
 import { renderWorkspaceNavigationWithProfile } from "./workspace-nav.js";
 import { showToast } from "/static/toast.js";
 import { supportedLocales, localeLabels, translations as adminContentTranslations } from "/static/i18n/admin-content-translations.js";
+import { renderOwnerPanel } from "/static/owner-panel.js";
 
 // #645/CL-3: admin UI for classes (cohorts) — list, create, manage members, assign courses.
 
@@ -294,8 +295,13 @@ async function openClass(id) {
         <button id="assignCourseBtn" class="btn btn-secondary" style="width:auto">Tildel kurs</button>
       </div>
       <p style="font-size:12px;color:var(--color-meta);margin:6px 0 0">Fristen brukes til automatiske påminnelser til deltakerne (frist nærmer seg / forfalt).</p>
-    </div>`;
+    </div>
+    <div class="detail-section" id="classOwnerPanelHost"></div>`;
   document.getElementById("backToClasses").addEventListener("click", renderListView);
+
+  // #787: content-owner management for the class.
+  const ownerHost = document.getElementById("classOwnerPanelHost");
+  if (ownerHost) renderOwnerPanel({ container: ownerHost, contentType: "CLASS", contentId: id, getHeaders }).catch(() => {});
 
   // Member add via search.
   const searchInput = document.getElementById("studentSearch");

--- a/test/e2e/content-owner-surfaces.spec.ts
+++ b/test/e2e/content-owner-surfaces.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+import { mockCommonApis, buildMockModuleExport } from "./admin-content-helpers.js";
+
+// #787 QA round 2: the owner-management panel must render on EVERY content surface, not just the course
+// detail. Round 1 shipped the panel into the conversational shell's state rail, but three surfaces run
+// DIFFERENT front-end files and were missed:
+//   - modul-avansert  → admin-content.js         (its own updateStateRail, no owner wiring) — QA #1
+//   - klasse-detalj   → admin-content-classes.js (openClass detail)                          — QA #2
+//   - seksjon-editor  → admin-content-sections.js(renderEditorView, existing section only)   — QA #3
+// These tests drive the REAL front-end JS for each page (static server + mocked APIs) and assert the
+// panel renders with its owner — the client-layer proof that would have caught the missed surfaces.
+
+const OWNERS = [{ userId: "u1", name: "Alice Owner", email: "alice@x.no", addedAt: "2026-07-19T00:00:00.000Z" }];
+
+/** Mock the two-verb owner API for one (type,id) so the panel loads with a manageable owner set. */
+async function mockOwnerApi(page: Page, contentType: string, contentId: string) {
+  let owners = [...OWNERS];
+  await page.route(`**/api/admin/content-owners/${contentType}/${contentId}`, async (route: Route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ owners, canManage: true }) });
+    }
+    if (route.request().method() === "POST") {
+      const { userId } = JSON.parse(route.request().postData() ?? "{}");
+      owners = [...owners, { userId, name: "Bob New", email: "bob@x.no", addedAt: "2026-07-19T01:00:00.000Z" }];
+      return route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ owners }) });
+    }
+    return route.fallback();
+  });
+  await page.route(`**/api/admin/content-owners/${contentType}/${contentId}/*`, async (route: Route) => {
+    if (route.request().method() !== "DELETE") return route.fallback();
+    const removed = decodeURIComponent(route.request().url().split("/").pop() ?? "");
+    owners = owners.filter((o) => o.userId !== removed);
+    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ owners }) });
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => { try { localStorage.setItem("participant.locale", "nb"); } catch { /* ignore */ } });
+});
+
+// QA #1 — the Avansert editor (admin-content.js) is a separate surface from the conversational shell.
+test("modul-avansert: owner panel renders in the module state-rail host", async ({ page }) => {
+  await mockCommonApis(page, {
+    modules: [{ id: "module-1", title: "Trade unions" }],
+    moduleExports: { "module-1": buildMockModuleExport({ id: "module-1", title: "Trade unions", moduleVersionId: "module-1-version-1" }) },
+  });
+  await mockOwnerApi(page, "MODULE", "module-1");
+
+  await page.goto("/admin-content/module/module-1/advanced");
+
+  const panel = page.locator("#moduleOwnerPanelHost .owner-panel");
+  await expect(panel).toBeVisible();
+  await expect(panel.locator(".owner-row")).toHaveCount(1);
+  await expect(panel.locator(".owner-name").first()).toHaveText("Alice Owner");
+});
+
+// QA #2 — classes were never wired for ownership; the panel goes in the openClass detail view.
+test("klasse: owner panel renders in the class detail view", async ({ page }) => {
+  await page.route("**/participant/config", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ authMode: "mock", navigation: { items: [], workspaceItems: [] }, identityDefaults: { userId: "c1", email: "c@x.no", name: "C", roles: ["ADMINISTRATOR"] } }) }));
+  await page.route("**/version", (route: Route) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "e2e" }) }));
+  await page.route("**/api/me", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ user: { id: "c1", email: "c@x.no", name: "C", roles: ["ADMINISTRATOR"] }, consent: { accepted: true }, pendingDeletion: null }) }));
+  await page.route("**/api/admin/content/classes", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ classes: [{ id: "cls-1", name: "Kull 2026", isSystem: false, _count: { members: 0, courseAssignments: 0 } }] }) }));
+  await page.route("**/api/admin/content/classes/*/members", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ members: [] }) }));
+  await page.route("**/api/admin/content/classes/*/courses", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ courses: [] }) }));
+  await page.route("**/api/admin/content/courses", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ courses: [] }) }));
+  await mockOwnerApi(page, "CLASS", "cls-1");
+
+  await page.goto("/deltakere/klasser");
+  await page.locator('[data-action="open"][data-id="cls-1"]').click();
+
+  const panel = page.locator("#classOwnerPanelHost .owner-panel");
+  await expect(panel).toBeVisible();
+  await expect(panel.locator(".owner-row")).toHaveCount(1);
+  await expect(panel.locator(".owner-name").first()).toHaveText("Alice Owner");
+});
+
+// QA #3 — the standalone section editor (admin-content-sections.js), reachable directly via ?id=.
+test("seksjon: owner panel renders in the section editor for an existing section", async ({ page }) => {
+  await page.route("**/participant/config", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ authMode: "mock", navigation: { items: [], workspaceItems: [] }, identityDefaults: { userId: "c1", email: "c@x.no", name: "C", roles: ["SUBJECT_MATTER_OWNER"] } }) }));
+  await page.route("**/version", (route: Route) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "e2e" }) }));
+  await page.route("**/api/me", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ user: { id: "c1", email: "c@x.no", name: "C", roles: ["SUBJECT_MATTER_OWNER"] }, consent: { accepted: true }, pendingDeletion: null }) }));
+  await page.route("**/api/admin/content/sections/preview", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ html: "<p>preview</p>" }) }));
+  await page.route("**/api/admin/content/sections/sec-1", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ section: { id: "sec-1", title: { nb: "Innledning", nn: "", "en-GB": "" }, bodyMarkdown: { nb: "Tekst", nn: "", "en-GB": "" }, activeVersionId: "v1", archivedAt: null } }) }));
+  await mockOwnerApi(page, "SECTION", "sec-1");
+
+  await page.goto("/admin-content/sections?id=sec-1");
+
+  const panel = page.locator("#ownerPanelHost .owner-panel");
+  await expect(panel).toBeVisible();
+  await expect(panel.locator(".owner-row")).toHaveCount(1);
+  await expect(panel.locator(".owner-name").first()).toHaveText("Alice Owner");
+});


### PR DESCRIPTION
## Hva

QA-runde 2 på #787 owner-panel-utrullingen. Runde 1 (2.0.13) **antok** at modul-avansert var dekket, men avansert-editoren kjører `admin-content.js` (egen `updateStateRail`), **ikke** samtale-shellen (`admin-content-shell.js`) — så owner-panelet ble aldri rendret der. Denne runden dekker de tre gjenstående flatene, hver bevist med Playwright-e2e mot den ekte front-end-JS-en.

## Fikser (QA runde 2)

| # | Flate | Rot-årsak | Fix |
|---|-------|-----------|-----|
| 1 | **Modul-avansert** | `admin-content.js` har sin egen `updateStateRail` uten owner-wiring | Render fra `setSelectedModule` → `#moduleOwnerPanelHost`, én gang per modul-id, uavhengig av status-fetch |
| 2 | **Klasse** | Klasser var aldri koblet for eierskap | Owner-panel i `openClass`-detaljen |
| 3 | **Seksjon** | (Ingen bug) | E2e bekrefter at editor-visningen alt rendrer for eksisterende seksjoner — panelet vises når du **åpner** en seksjon, ikke i lista |
| 5 | **GDPR-varsel** | For dominerende | Kompakt én-linjes notis på begge modul-editorene |

## Tester

Ny `test/e2e/content-owner-surfaces.spec.ts` — 3 tester som driver modul-avansert, klasse og seksjon-editor mot mocket owner-API og asserter at `.owner-panel` rendrer med eier. Alle grønne. De 55 berørte admin-content-e2e-ene passerer uendret (ingen regresjon).

## Utrulling

Kun statisk front-end (public/*.js/.html) + doc. Ingen infra/DB/migrasjon. Bumper til 2.0.14. Deployes til **stage** for QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
