### PR TITLE
fix(ui): #787 QA r3 — modul-tittel, sub-nav på modul-editorer, eier øverst overalt

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,24 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.15 - 2026-07-19
+
+fix(ui): #787 QA runde 3 — konsistens på innholds-flatene (tittel, sub-nav, eier-plassering)
+
+- **Modul-editor-titler** (QA #1/#2): «Innholdsarbeidsrom» (samtale) og «Arbeidsflate for innholdsoppsett»
+  (avansert) → **«Modul»** (som Kurs/Klasse bruker innholdstype-navnet). Redigeringsmodus vises allerede
+  av Samtale/Avansert-bryteren, og modulnavnet av state-rail-en.
+- **Innholds-sub-nav** (QA #3): begge modul-editorene får nå samme topp-meny som Kurs/Seksjoner
+  (Kurs · Moduler · Seksjoner · Kalibrering), med «Moduler» aktiv. Kalibrering-lenken er rolle-gated
+  likt de andre sidene (både samtale-shell og avansert).
+- **Eier-plassering** (QA #4): «Eiere» står nå **øverst** på alle fire flatene. Kurs og Modul var alt
+  øverst; Seksjon og Klasse flyttet fra bunn til topp for konsistens.
+
+Kalibrering (QA #5) tas som eget interaksjons-design-spor (#836) — ikke i denne releasen.
+
+Ny e2e-dekning i `content-owner-surfaces.spec.ts` (sub-nav aktiv-state + tittel på avansert). Ingen
+regresjon i de 61 berørte admin-content-e2e-ene.
+
 ## 2.0.14 - 2026-07-19
 
 fix(auth): #787 QA runde 2 — owner-panel på de faktisk manglende flatene + kompakt GDPR-varsel

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-advanced.html
+++ b/public/admin-content-advanced.html
@@ -217,6 +217,12 @@
         <select id="localeSelect" class="locale-select-compact"></select>
       </div>
     </div>
+    <nav id="contentAreaNav" class="content-area-nav" aria-label="Innholdsadministrasjon">
+      <a href="/admin-content/courses" class="content-area-nav-link" id="navKurs">Kurs</a>
+      <a href="/admin-content" class="content-area-nav-link active" id="navModuler">Moduler</a>
+      <a href="/admin-content/sections" class="content-area-nav-link" id="navSeksjoner">Seksjoner</a>
+      <a href="/admin-content/calibration" class="content-area-nav-link" id="navKalibrering" hidden>Kalibrering</a>
+    </nav>
     <div id="stateRail" class="state-rail" hidden aria-label="Modulstatus">
       <div class="state-rail-item">
         <span class="state-rail-label" data-i18n="stateRail.label.module">Modul</span>

--- a/public/admin-content.html
+++ b/public/admin-content.html
@@ -354,6 +354,13 @@
         </div>
       </div>
 
+      <nav id="contentAreaNav" class="content-area-nav" aria-label="Innholdsadministrasjon">
+        <a href="/admin-content/courses" class="content-area-nav-link" id="navKurs">Kurs</a>
+        <a href="/admin-content" class="content-area-nav-link active" id="navModuler">Moduler</a>
+        <a href="/admin-content/sections" class="content-area-nav-link" id="navSeksjoner">Seksjoner</a>
+        <a href="/admin-content/calibration" class="content-area-nav-link" id="navKalibrering" hidden>Kalibrering</a>
+      </nav>
+
       <div id="stateRail" class="state-rail" hidden aria-label="Modulstatus">
         <div class="state-rail-item">
           <span class="state-rail-label" data-i18n="stateRail.label.module">Modul</span>

--- a/public/admin-content.js
+++ b/public/admin-content.js
@@ -1505,6 +1505,10 @@ function renderCalibrationTabVisibility() {
 
   const visible = canAccessCalibrationTab();
   tabKalibrering.hidden = !visible;
+  // #787 QA r3: the content-area sub-nav's Kalibrering link is role-gated the same way (parity with the
+  // courses/sections pages) so the Avansert editor shows the same top menu.
+  const navKalibrering = document.getElementById("navKalibrering");
+  if (navKalibrering) navKalibrering.hidden = !visible;
   if (calibrationTab) {
     calibrationTab.hidden = !visible || activeContentTab !== "calibration";
   }

--- a/public/i18n/admin-content-translations.js
+++ b/public/i18n/admin-content-translations.js
@@ -9,7 +9,7 @@ export const localeLabels = baseLocaleLabels;
 
 const adminContentBase = {
   "nav.profile": "Profile",
-  "adminContentPage.title": "Content Setup Workspace",
+  "adminContentPage.title": "Module",
   "adminContentPage.chatLink": "Back to conversational editor",
   "adminContentPage.subtitle": "Define module content and scoring rules in a guided sequence.",
   "adminContentPage.versionLabel": "Version:",
@@ -384,7 +384,7 @@ const adminContentBase = {
   "adminContent.courses.dialog.save": "Save",
 
   // ── Conversational shell (admin-content-shell.js) ─────────────────────────
-  "shell.page.title": "Content Workspace",
+  "shell.page.title": "Module",
   "shell.page.advancedLink": "Advanced editor \u2197",
   "shell.idle.prompt": "What would you like to do?",
   "shell.idle.openExisting": "Open existing module",
@@ -771,7 +771,7 @@ const adminContentBase = {
 };
 const nbOverrides = {
   "nav.profile": "Profil",
-  "adminContentPage.title": "Arbeidsflate for innholdsoppsett",
+  "adminContentPage.title": "Modul",
   "adminContentPage.chatLink": "Tilbake til samtaledrevet editor",
   "adminContentPage.subtitle": "Definer modulinnhold og vurderingsregler i en tydelig rekkefølge.",
   "adminContentPage.versionLabel": "Versjon:",
@@ -1162,7 +1162,7 @@ const nbOverrides = {
 };
 const nnOverrides = {
   "nav.profile": "Profil",
-  "adminContentPage.title": "Arbeidsflate for innhaldsoppsett",
+  "adminContentPage.title": "Modul",
   "adminContentPage.chatLink": "Tilbake til samtaledriven editor",
   "adminContentPage.subtitle": "Definer modulinnhald og vurderingsreglar i ei tydeleg rekkjefølgje.",
   "adminContentPage.versionLabel": "Versjon:",
@@ -1570,7 +1570,7 @@ const adminContentLateOverrides = {
     "adminContent.help.moduleVersionIds": "ID-er fylles automatisk n\u00e5r du lagrer steg 5-8.",
 
     // ── Conversational shell ─────────────────────────────────────────────────
-    "shell.page.title": "Innholdsarbeidsrom",
+    "shell.page.title": "Modul",
     "shell.page.advancedLink": "Avansert redigering \u2197",
     "shell.idle.prompt": "Hva vil du gj\u00f8re?",
     "shell.idle.openExisting": "\u00c5pne eksisterende modul",
@@ -1987,7 +1987,7 @@ const adminContentLateOverrides = {
     "adminContent.help.moduleVersionIds": "ID-ar blir fylte automatisk n\u00e5r du lagrar steg 5-8.",
 
     // ── Conversational shell ─────────────────────────────────────────────────
-    "shell.page.title": "Innhaldsarbeidsrom",
+    "shell.page.title": "Modul",
     "shell.page.advancedLink": "Avansert redigering \u2197",
     "shell.idle.prompt": "Kva vil du gj\u00f8re?",
     "shell.idle.openExisting": "Opne eksisterande modul",

--- a/public/static/admin-content-classes.js
+++ b/public/static/admin-content-classes.js
@@ -275,6 +275,7 @@ async function openClass(id) {
   pageContent.innerHTML = `
     <a class="back-link" id="backToClasses">← Tilbake til klasser</a>
     <div class="page-header"><h1>Klasse</h1></div>
+    <div class="detail-section" id="classOwnerPanelHost"></div>
     <div class="detail-section">
       <h2>Studenter (${members.length})</h2>
       <div class="chip-row" id="memberChips">${memberChips || `<span style="color:var(--color-meta);font-size:13px">Ingen studenter ennå.</span>`}</div>
@@ -295,8 +296,7 @@ async function openClass(id) {
         <button id="assignCourseBtn" class="btn btn-secondary" style="width:auto">Tildel kurs</button>
       </div>
       <p style="font-size:12px;color:var(--color-meta);margin:6px 0 0">Fristen brukes til automatiske påminnelser til deltakerne (frist nærmer seg / forfalt).</p>
-    </div>
-    <div class="detail-section" id="classOwnerPanelHost"></div>`;
+    </div>`;
   document.getElementById("backToClasses").addEventListener("click", renderListView);
 
   // #787: content-owner management for the class.

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -405,6 +405,7 @@ async function renderEditorView(sectionId) {
       <a href="#" class="back-link" id="backLink">${escapeHtml(L("back"))}</a>
       <span id="sectionStatusBadge"></span>
     </div>
+    ${sectionId ? `<div id="ownerPanelHost" class="card" style="margin-bottom:var(--space-2)"></div>` : ""}
     <div class="section-editor">
       <div class="lang-tabs" id="langTabs">
         ${EDITOR_LOCALES.map((loc) => `<button type="button" class="lang-tab${loc === editing.editLocale ? " active" : ""}" data-locale="${loc}">${escapeHtml(localeLabels[loc] ?? loc)}</button>`).join("")}
@@ -433,7 +434,6 @@ async function renderEditorView(sectionId) {
         <button type="button" id="sectionLifecycleBtn" class="btn btn-secondary" style="width:auto;display:none"></button>
         <span class="editor-status" id="editorStatus"></span>
       </div>
-      ${sectionId ? `<div id="ownerPanelHost" style="margin-top:var(--space-3);border-top:1px solid var(--color-border-soft);padding-top:var(--space-2)"></div>` : ""}
     </div>`;
 
   document.getElementById("backLink")?.addEventListener("click", (e) => { e.preventDefault(); goTo("list"); });

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -4681,6 +4681,14 @@ function renderWorkspaceNavigation() {
     items,
     buildLabel: (item) => t(item.labelKey) || item.id,
   });
+  // #787 QA r3: role-gate the content-area sub-nav's Kalibrering link (same accessRoles as the
+  // calibration workspace) so the Samtale editor shows the same top menu as courses/sections.
+  const navKalibrering = document.getElementById("navKalibrering");
+  if (navKalibrering) {
+    const calibrationRoles = ["SUBJECT_MATTER_OWNER", "ADMINISTRATOR"];
+    const current = new Set(activeUserRoles.length ? activeUserRoles : (participantRuntimeConfig.identityDefaults?.roles ?? []));
+    navKalibrering.hidden = !calibrationRoles.some((role) => current.has(role));
+  }
 }
 
 // Translates static text that lives in the HTML source (not rendered by chat flow).

--- a/test/e2e/content-owner-surfaces.spec.ts
+++ b/test/e2e/content-owner-surfaces.spec.ts
@@ -52,6 +52,14 @@ test("modul-avansert: owner panel renders in the module state-rail host", async 
   await expect(panel).toBeVisible();
   await expect(panel.locator(".owner-row")).toHaveCount(1);
   await expect(panel.locator(".owner-name").first()).toHaveText("Alice Owner");
+
+  // QA r3 #3: the Avansert editor shows the same content-area sub-nav as Kurs/Seksjoner, with Moduler active.
+  const nav = page.locator("#contentAreaNav");
+  await expect(nav.locator("#navModuler")).toHaveClass(/active/);
+  await expect(nav.locator("#navKurs")).toBeVisible();
+  await expect(nav.locator("#navSeksjoner")).toBeVisible();
+  // QA r3 #1/#2: the page title is now "Modul", not the old vague workspace label.
+  await expect(page.locator("#moduleWorkspaceTitle")).toHaveText("Modul");
 });
 
 // QA #2 — classes were never wired for ownership; the panel goes in the openClass detail view.


### PR DESCRIPTION
## Hva (QA runde 3, forts. #787)

Konsistens-fikser på innholds-flatene etter produkteier-QA:

1. **Modul-editor-titler** (#1/#2): «Innholdsarbeidsrom» / «Arbeidsflate for innholdsoppsett» → **«Modul»** (samme innholdstype-navn-mønster som Kurs/Klasse). Modus vises av Samtale/Avansert-bryteren; modulnavnet av state-rail-en.
2. **Innholds-sub-nav** (#3): begge modul-editorene får samme topp-meny som Kurs/Seksjoner (Kurs · Moduler · Seksjoner · Kalibrering, «Moduler» aktiv). Kalibrering-lenken rolle-gated likt de andre (shell + avansert).
3. **Eier-plassering** (#4): «Eiere» øverst på alle fire flatene — Seksjon + Klasse flyttet fra bunn til topp (Kurs/Modul var alt øverst).

Kalibrering (#5) = eget interaksjons-design-spor (#836).

## Tester

`content-owner-surfaces.spec.ts` utvidet: asserterer sub-nav aktiv-state + «Modul»-tittel på avansert, og at eier-panelet fortsatt rendrer på alle flatene etter flyttingen. 61 berørte admin-content-e2e-er grønne (ingen regresjon).

## Utrulling

Kun statisk front-end + i18n + doc. Ingen infra/DB. Bumper 2.0.15. Til **stage** for QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
