### PR TITLE
fix(ui): #787 QA r4 — skjul Avansert dobbel-meny; kompakt eier-panel

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,21 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.0.16 - 2026-07-19
+
+fix(ui): #787 QA runde 4 — fjern dobbel-meny i Avansert + kompakt eier-panel
+
+- **Dobbel meny i Avansert** (QA #1): den nye innholds-sub-nav-en (2.0.15) kolliderte med Avansert-editorens
+  gamle interne fane-rad (Moduler/Kurs/Kalibrering). De interne fanene er utdatert — Kurs og Kalibrering
+  har egne ruter nådd via topp-nav-en. Fane-raden skjules nå (`display:none`), så Avansert er rent
+  modul-editoren. (Konsoliderer også bort Avansert sin kalibrerings-fane, jf. #836.)
+- **Kompakt eier-panel** (QA #2): «Eiere» er nå en slank én-linje som standard («Eiere: Navn A, Navn B»)
+  med en «Rediger»-lenke; hele legg-til/fjern-UI-et utvides kun ved behov. Eierskap vises ofte, endres
+  sjelden — panelet tar nå minimalt med plass til det faktisk skal endres.
+
+e2e (`content-owner-surfaces` + `content-owner-panel`) oppdatert for kompakt-standard (verifiser kompakt
+visning, utvid for administrasjon). 44 berørte specs grønne.
+
 ## 2.0.15 - 2026-07-19
 
 fix(ui): #787 QA runde 3 — konsistens på innholds-flatene (tittel, sub-nav, eier-plassering)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-advanced.html
+++ b/public/admin-content-advanced.html
@@ -303,7 +303,12 @@
       <span><strong style="color:var(--color-text);font-weight:600" data-i18n="adminContent.privacy.warning.title">Special category data risk</strong> — <span data-i18n="adminContent.privacy.warning.body">Participants may include health information, political views, or other special category data in free-text submissions.</span></span>
     </div>
 
-    <div class="content-tab-nav" role="tablist">
+    <!-- #787 QA r4: the legacy in-page content tabs (Moduler/Kurs/Kalibrering) duplicated the new
+         content-area sub-nav at the top. Kurs and Kalibrering now live on their own routes reached via
+         that sub-nav, so the Avansert page is purely the module editor. Bar kept in DOM (its ids are
+         referenced by admin-content.js) but hidden — inline display:none beats the .content-tab-nav
+         flex rule (a plain [hidden] would lose the cascade). -->
+    <div class="content-tab-nav" role="tablist" style="display:none">
       <button type="button" id="tabModuler" role="tab" class="content-tab active" aria-selected="true" data-i18n="adminContent.tab.modules">Moduler</button>
       <button type="button" id="tabKurs" role="tab" class="content-tab" aria-selected="false" data-i18n="adminContent.tab.courses">Kurs</button>
       <button type="button" id="tabKalibrering" role="tab" class="content-tab" aria-selected="false" data-i18n="nav.calibration">Kalibrering</button>

--- a/public/static/owner-panel.js
+++ b/public/static/owner-panel.js
@@ -30,6 +30,9 @@ function errorMessage(error, fallback) {
 export async function renderOwnerPanel({ container, contentType, contentId, getHeaders }) {
   let owners = [];
   let canManage = false; // only owners/admin may change owners; everyone with access can view
+  // Ownership is mostly read, rarely edited — so the panel is a compact one-line summary by default and
+  // only expands into the full add/remove UI when the user chooses to edit.
+  let expanded = false;
   container.innerHTML = `<div class="owner-panel"><p class="owner-panel-loading">Laster eiere…</p></div>`;
 
   async function load() {
@@ -39,6 +42,10 @@ export async function renderOwnerPanel({ container, contentType, contentId, getH
   }
 
   function paint() {
+    if (!expanded) {
+      paintCompact();
+      return;
+    }
     const rows = owners.length
       ? owners
           .map(
@@ -58,14 +65,39 @@ export async function renderOwnerPanel({ container, contentType, contentId, getH
       : "";
     container.innerHTML = `
       <div class="owner-panel">
-        <h3 class="owner-panel-title">Eiere</h3>
+        <div class="owner-panel-head">
+          <h3 class="owner-panel-title">Eiere</h3>
+          <button type="button" class="owner-collapse">Ferdig</button>
+        </div>
         <ul class="owner-list">${rows}</ul>
         ${addBox}
       </div>`;
     wire();
   }
 
+  // Compact default: "Eiere: Name A, Name B" on one line, plus an inline "Rediger" affordance for
+  // those who can manage. Keeps the panel to a slim strip since it's shown far more than edited.
+  function paintCompact() {
+    const names = owners.length
+      ? owners.map((o) => escapeHtml(o.name)).join(", ")
+      : `<span class="owner-none">Ingen eiere ennå</span>`;
+    container.innerHTML = `
+      <div class="owner-panel owner-panel--compact">
+        <span class="owner-compact-label">Eiere</span>
+        <span class="owner-compact-names">${names}</span>
+        ${canManage ? `<button type="button" class="owner-edit-toggle">Rediger</button>` : ""}
+      </div>`;
+    container.querySelector(".owner-edit-toggle")?.addEventListener("click", () => {
+      expanded = true;
+      paint();
+    });
+  }
+
   function wire() {
+    container.querySelector(".owner-collapse")?.addEventListener("click", () => {
+      expanded = false;
+      paint();
+    });
     for (const btn of container.querySelectorAll(".owner-remove")) {
       btn.addEventListener("click", () => removeOwner(btn.dataset.userId));
     }

--- a/public/static/shared.css
+++ b/public/static/shared.css
@@ -1182,3 +1182,14 @@ dialog::backdrop {
 .owner-search-results li { padding: 8px 12px; cursor: pointer; display: flex; gap: var(--space-1); align-items: baseline; }
 .owner-search-results li:hover { background: var(--color-bg); }
 .owner-panel-loading, .owner-panel-error { color: var(--color-text); opacity: 0.7; }
+/* #787 QA r4: compact-by-default owner panel — a slim one-line summary that expands to the full
+   add/remove UI only on demand. Ownership is shown far more than it is edited. */
+.owner-panel--compact { display: flex; align-items: baseline; gap: var(--space-1); flex-wrap: wrap; }
+.owner-compact-label { font-size: 0.72rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--color-meta); }
+.owner-compact-names { color: var(--color-text); font-weight: 600; flex: 1 1 auto; min-width: 0; }
+.owner-compact-names .owner-none { font-weight: 400; font-style: italic; opacity: 0.65; }
+.owner-edit-toggle, .owner-collapse { width: auto; flex: 0 0 auto; background: none; border: 0; padding: 2px 4px;
+  color: var(--color-link-active, var(--color-blue)); font-size: 0.85rem; font-weight: 600; cursor: pointer; }
+.owner-edit-toggle:hover, .owner-collapse:hover { text-decoration: underline; }
+.owner-panel-head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2); }
+.owner-panel-head .owner-panel-title { margin: 0; }

--- a/test/e2e/content-owner-panel.spec.ts
+++ b/test/e2e/content-owner-panel.spec.ts
@@ -40,9 +40,11 @@ test("course owner panel: lists, adds via search, and removes owners", async ({ 
   await page.addInitScript(() => { try { localStorage.setItem("participant.locale", "nb"); } catch { /* ignore */ } });
   await page.goto("/admin-content/courses/course-1");
 
-  // Panel renders with the initial owner.
+  // Panel renders compact with the initial owner; expand to manage.
   const panel = page.locator("#ownerPanelHost .owner-panel");
   await expect(panel).toBeVisible();
+  await expect(panel.locator(".owner-compact-names")).toContainText("Alice Owner");
+  await panel.locator(".owner-edit-toggle").click();
   await expect(panel.locator(".owner-row")).toHaveCount(1);
   await expect(panel.locator(".owner-name").first()).toHaveText("Alice Owner");
 
@@ -80,8 +82,9 @@ test("owner panel is read-only when the viewer cannot manage owners", async ({ p
 
   const panel = page.locator("#ownerPanelHost .owner-panel");
   await expect(panel).toBeVisible();
-  await expect(panel.locator(".owner-name").first()).toHaveText("Someone Else");
-  // No management controls for a non-owner viewer.
+  await expect(panel.locator(".owner-compact-names")).toContainText("Someone Else");
+  // No edit affordance and no management controls for a non-owner viewer.
+  await expect(panel.locator(".owner-edit-toggle")).toHaveCount(0);
   await expect(panel.locator(".owner-remove")).toHaveCount(0);
   await expect(panel.locator(".owner-search-input")).toHaveCount(0);
 });

--- a/test/e2e/content-owner-surfaces.spec.ts
+++ b/test/e2e/content-owner-surfaces.spec.ts
@@ -50,6 +50,9 @@ test("modul-avansert: owner panel renders in the module state-rail host", async 
 
   const panel = page.locator("#moduleOwnerPanelHost .owner-panel");
   await expect(panel).toBeVisible();
+  // QA r4: compact by default — owner name shown inline, full list only after expanding.
+  await expect(panel.locator(".owner-compact-names")).toContainText("Alice Owner");
+  await panel.locator(".owner-edit-toggle").click();
   await expect(panel.locator(".owner-row")).toHaveCount(1);
   await expect(panel.locator(".owner-name").first()).toHaveText("Alice Owner");
 
@@ -84,8 +87,7 @@ test("klasse: owner panel renders in the class detail view", async ({ page }) =>
 
   const panel = page.locator("#classOwnerPanelHost .owner-panel");
   await expect(panel).toBeVisible();
-  await expect(panel.locator(".owner-row")).toHaveCount(1);
-  await expect(panel.locator(".owner-name").first()).toHaveText("Alice Owner");
+  await expect(panel.locator(".owner-compact-names")).toContainText("Alice Owner");
 });
 
 // QA #3 — the standalone section editor (admin-content-sections.js), reachable directly via ?id=.
@@ -105,6 +107,5 @@ test("seksjon: owner panel renders in the section editor for an existing section
 
   const panel = page.locator("#ownerPanelHost .owner-panel");
   await expect(panel).toBeVisible();
-  await expect(panel.locator(".owner-row")).toHaveCount(1);
-  await expect(panel.locator(".owner-name").first()).toHaveText("Alice Owner");
+  await expect(panel.locator(".owner-compact-names")).toContainText("Alice Owner");
 });


### PR DESCRIPTION
## QA runde 4

1. **Dobbel meny i Avansert** (#1): 2.0.15-sub-nav-en kolliderte med Avansert-editorens gamle interne fane-rad (Moduler/Kurs/Kalibrering). Fane-raden er utdatert — Kurs/Kalibrering har egne ruter via topp-nav-en — så den skjules. Avansert er nå rent modul-editoren (konsoliderer også bort Avansert sin kalibrerings-fane, jf. #836).
2. **Kompakt eier-panel** (#2): «Eiere» er nå en slank én-linje som standard med «Rediger»-lenke; full legg-til/fjern-UI utvides kun ved behov. «Vises ofte, endres sjelden.»

## Tester

`owner-panel.js` fikk expanded-state + `paintCompact()`. Begge owner-e2e-suitene oppdatert til kompakt-standard (verifiser kompakt visning; utvid via «Rediger» for administrasjon; read-only-viewer får ingen «Rediger»). 44 berørte specs grønne.

Kun statisk front-end + doc. Bumper 2.0.16. Til stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
