### PR TITLE
fix(ui): QA r5 — eier-stripe, modul-navigasjon, MCQ-bevisst Vurderingskvalitet, klasse-kort

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,26 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.1.1 - 2026-07-19
+
+fix(ui): QA runde 5 — tynn eier-stripe, modul-navigasjon/tittel, MCQ-bevisst Vurderingskvalitet, klasse-kort
+
+- **Eier-stripa vesentlig tynnere** (QA #1): verts-kortet slankes til en stripe i kompakt modus
+  (`.owner-host--compact`, 6px padding). Navn får e-post-tooltip (to eiere med samme navn er to ulike
+  brukere, f.eks. mock- + Entra-identitet).
+- **«← Tilbake til modulliste»** (QA #2): begge modul-editorene har nå back-link øverst, som Kurs.
+- **Tittel-plassering** (QA #3): back-link + «Modul»-tittel (+ Samtale/Avansert-bryter) står nå øverst
+  under sub-nav-en — før status-rail, eiere og GDPR-notis — i stedet for strandet midt på siden.
+- **Vurderingskvalitet er modus-bevisst** (QA #4): for **MCQ-moduler** avgjøres bestått av MCQ-prosenten
+  (mcqMinPercent, standard 70) — lagret totalScore er MCQ-en skalert inn i vektings-båndet sitt, så
+  total-histogrammet/grensa var misvisende («Bestått 100 %» men søyle under grensa). MCQ-moduler viser nå
+  MCQ-minimum-regelen med forklarende notis; histogram/total/preview skjules. Publisering beholder
+  totalMin uendret og sender redigert mcqMinPercent. Signal-kortet fikk også en notis om at bestått-andelen
+  bygger på lagrede avgjørelser (reglene ved scoring-tidspunkt).
+- **Klasse-kort med hvit bakgrunn** (QA #5): `.detail-section` på klasse-siden fikk surface-bakgrunn + skygge.
+
+e2e: ny MCQ-only-test i `vurderingskvalitet.spec.ts`; alle 106 admin-content-e2e grønne.
+
 ## 2.1.0 - 2026-07-19
 
 feat(quality): #836 «Vurderingskvalitet» — rebrand + konsolidering av kalibrering

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-advanced.html
+++ b/public/admin-content-advanced.html
@@ -223,6 +223,22 @@
       <a href="/admin-content/sections" class="content-area-nav-link" id="navSeksjoner">Seksjoner</a>
       <a href="/admin-content/calibration" class="content-area-nav-link" id="navKalibrering" hidden>Vurderingskvalitet</a>
     </nav>
+
+    <!-- QA r5 #2/#3: mirror the Kurs page — back-link + page title at the top, before status/owners. -->
+    <div class="page-header-back" style="margin-bottom:var(--space-1)">
+      <a href="/admin-content" class="back-link">← Tilbake til modulliste</a>
+    </div>
+    <div class="module-workspace-header">
+      <div style="display:flex; align-items:baseline; gap:var(--space-2); flex-wrap:wrap;">
+        <h1 id="moduleWorkspaceTitle" data-i18n="adminContentPage.title" style="margin:0">Modul</h1>
+        <button id="advPreviewToggleBtn" type="button" class="adv-preview-toggle" data-i18n="advPreview.toggle.open" aria-pressed="false">Vis forhåndsvisning</button>
+      </div>
+      <div class="module-mode-switch" role="group" aria-label="Redigeringsmodus">
+        <button class="module-mode-btn" id="modeSwitchConversation" data-i18n="workspace.mode.conversation" aria-pressed="false">Samtale</button>
+        <button class="module-mode-btn active" id="modeSwitchAdvanced" data-i18n="workspace.mode.advanced" aria-pressed="true">Avansert</button>
+      </div>
+    </div>
+
     <div id="stateRail" class="state-rail" hidden aria-label="Modulstatus">
       <div class="state-rail-item">
         <span class="state-rail-label" data-i18n="stateRail.label.module">Modul</span>
@@ -257,18 +273,6 @@
 
     <!-- #787: content-owner management for the loaded module -->
     <div id="moduleOwnerPanelHost" class="card" hidden style="margin-top:var(--space-2)"></div>
-
-    <div class="module-workspace-header">
-      <div style="display:flex; align-items:baseline; gap:var(--space-2); flex-wrap:wrap;">
-        <h1 id="moduleWorkspaceTitle" data-i18n="adminContentPage.title" style="margin:0">Content Setup Workspace</h1>
-        <button id="advPreviewToggleBtn" type="button" class="adv-preview-toggle" data-i18n="advPreview.toggle.open" aria-pressed="false">Vis forhåndsvisning</button>
-      </div>
-      <div class="module-mode-switch" role="group" aria-label="Redigeringsmodus">
-        <button class="module-mode-btn" id="modeSwitchConversation" data-i18n="workspace.mode.conversation" aria-pressed="false">Samtale</button>
-        <button class="module-mode-btn active" id="modeSwitchAdvanced" data-i18n="workspace.mode.advanced" aria-pressed="true">Avansert</button>
-      </div>
-    </div>
-    <p class="small" data-i18n="adminContentPage.subtitle">Define module content and scoring rules in a guided sequence.</p>
 
     <div id="advWorkspaceLayout" class="adv-workspace-layout">
     <div id="advEditorContent">

--- a/public/admin-content-calibration.html
+++ b/public/admin-content-calibration.html
@@ -143,17 +143,21 @@
         <!-- Signals -->
         <section class="card" id="qSignalsCard" hidden>
           <h2 data-i18n="quality.signals.title">Kvalitetssignaler</h2>
+          <p class="small" data-i18n="quality.signals.note">Bestått-andelen bygger på de lagrede avgjørelsene (reglene som gjaldt da hvert svar ble scoret).</p>
           <div class="q-signals" id="qSignals"></div>
         </section>
 
         <!-- Score distribution + threshold -->
         <section class="card" id="qThresholdCard" hidden>
-          <h2 data-i18n="quality.distribution.title">Poengfordeling</h2>
-          <p class="small" data-i18n="quality.distribution.subtitle">Blå søyler består ved valgt grense. Juster grensa for å se effekten.</p>
-          <div class="q-hist-bars" id="qHistogram"></div>
-          <div class="q-hist-x"><span>0</span><span>25</span><span>50</span><span>75</span><span>100</span></div>
+          <div id="qDistBlock">
+            <h2 data-i18n="quality.distribution.title">Poengfordeling</h2>
+            <p class="small" data-i18n="quality.distribution.subtitle">Blå søyler består ved valgt grense. Juster grensa for å se effekten.</p>
+            <div class="q-hist-bars" id="qHistogram"></div>
+            <div class="q-hist-x"><span>0</span><span>25</span><span>50</span><span>75</span><span>100</span></div>
+          </div>
 
           <h3 style="margin:var(--space-3) 0 var(--space-1);font-size:15px" data-i18n="quality.threshold.title">Bestått-grense</h3>
+          <p class="small" id="qModeNote" hidden></p>
           <div class="q-thr-grid">
             <div class="q-thr-field">
               <label for="qTotalMin" data-i18n="quality.threshold.totalMin">Total (min av 100)</label>

--- a/public/admin-content-classes.html
+++ b/public/admin-content-classes.html
@@ -20,7 +20,7 @@
       .classes-table .col-actions { white-space: nowrap; }
       /* #705-UX: .row-action-btn + .row-actions arves fra shared.css (felles utseende på tvers). */
       .system-badge { display: inline-block; margin-left: 6px; padding: 1px 8px; border-radius: 999px; background: var(--color-blue-light); color: var(--color-link-active); font-size: 11px; font-weight: 600; }
-      .detail-section { border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); padding: var(--space-2); margin-bottom: var(--space-3); }
+      .detail-section { background: var(--color-surface); border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); box-shadow: var(--shadow-card); padding: var(--space-2); margin-bottom: var(--space-3); }
       .detail-section h2 { font-size: 16px; margin: 0 0 var(--space-2); }
       .chip-row { display: flex; flex-wrap: wrap; gap: 6px; margin-top: var(--space-1); }
       .chip { display: inline-flex; align-items: center; gap: 6px; background: var(--color-surface-muted, #f0f0f0); border-radius: 999px; padding: 3px 6px 3px 10px; font-size: 13px; }

--- a/public/admin-content.html
+++ b/public/admin-content.html
@@ -354,12 +354,25 @@
         </div>
       </div>
 
+      <!-- QA r5 #2/#3: back-link + page title first, mirroring the Kurs page. Header markup moved up
+           from below the GDPR notice; the old position left the H1 stranded mid-page. -->
       <nav id="contentAreaNav" class="content-area-nav" aria-label="Innholdsadministrasjon">
         <a href="/admin-content/courses" class="content-area-nav-link" id="navKurs">Kurs</a>
         <a href="/admin-content" class="content-area-nav-link active" id="navModuler">Moduler</a>
         <a href="/admin-content/sections" class="content-area-nav-link" id="navSeksjoner">Seksjoner</a>
         <a href="/admin-content/calibration" class="content-area-nav-link" id="navKalibrering" hidden>Vurderingskvalitet</a>
       </nav>
+
+      <div class="page-header-back" style="margin-bottom:var(--space-1)">
+        <a href="/admin-content" class="back-link">← Tilbake til modulliste</a>
+      </div>
+      <div class="module-workspace-header">
+        <h1 id="moduleWorkspaceTitle" style="margin:0; font-size:22px" data-i18n="shell.page.title">Modul</h1>
+        <div class="module-mode-switch" role="group" aria-label="Redigeringsmodus">
+          <button class="module-mode-btn active" id="modeSwitchConversation" data-i18n="workspace.mode.conversation" aria-pressed="true">Samtale</button>
+          <button class="module-mode-btn" id="modeSwitchAdvanced" data-i18n="workspace.mode.advanced" aria-pressed="false">Avansert</button>
+        </div>
+      </div>
 
       <div id="stateRail" class="state-rail" hidden aria-label="Modulstatus">
         <div class="state-rail-item">
@@ -399,14 +412,6 @@
       <div role="note" style="display:flex;gap:8px;align-items:baseline;border:1px solid #f0d9b5;background:#fffdf7;border-radius:var(--radius-card);padding:6px 10px;margin:var(--space-1) 0;font-size:12px;line-height:1.4;color:var(--color-meta)">
         <span aria-hidden="true">⚠️</span>
         <span><strong style="color:var(--color-text);font-weight:600" data-i18n="adminContent.privacy.warning.title">Special category data risk</strong> — <span data-i18n="adminContent.privacy.warning.body">Participants may include health information, political views, or other special category data in free-text submissions.</span></span>
-      </div>
-
-      <div class="module-workspace-header">
-        <h1 id="moduleWorkspaceTitle" style="margin:0; font-size:22px" data-i18n="shell.page.title">Content Workspace</h1>
-        <div class="module-mode-switch" role="group" aria-label="Redigeringsmodus">
-          <button class="module-mode-btn active" id="modeSwitchConversation" data-i18n="workspace.mode.conversation" aria-pressed="true">Samtale</button>
-          <button class="module-mode-btn" id="modeSwitchAdvanced" data-i18n="workspace.mode.advanced" aria-pressed="false">Avansert</button>
-        </div>
       </div>
 
       <div class="workspace-shell">

--- a/public/i18n/calibration-translations.js
+++ b/public/i18n/calibration-translations.js
@@ -10,6 +10,9 @@ export const localeLabels = baseLocaleLabels;
 const extraTranslations = {
   "en-GB": {
     "quality.title": "Assessment quality",
+    "quality.threshold.mcqOnlyNote": "This is an MCQ module: pass/fail is decided by the MCQ minimum below. The total-score threshold does not apply.",
+    "quality.signals.note": "The pass rate reflects stored decisions (the rules in effect when each response was scored).",
+
     "quality.subtitle": "See how a module scores, and adjust the pass mark.",
     "quality.filter.owner": "Owner",
     "quality.filter.owner.mine": "My modules",
@@ -152,6 +155,9 @@ const extraTranslations = {
   },
   nb: {
     "quality.title": "Vurderingskvalitet",
+    "quality.threshold.mcqOnlyNote": "Dette er en MCQ-modul: bestått avgjøres av MCQ-minimumet under. Total-grensa gjelder ikke.",
+    "quality.signals.note": "Bestått-andelen bygger på lagrede avgjørelser (reglene som gjaldt da hvert svar ble scoret).",
+
     "quality.subtitle": "Se hvordan en modul scorer, og juster best\u00e5tt-grensa.",
     "quality.filter.owner": "Eier",
     "quality.filter.owner.mine": "Mine moduler",
@@ -294,6 +300,9 @@ const extraTranslations = {
   },
   nn: {
     "quality.title": "Vurderingskvalitet",
+    "quality.threshold.mcqOnlyNote": "Dette er ein MCQ-modul: bestått blir avgjort av MCQ-minimumet under. Total-grensa gjeld ikkje.",
+    "quality.signals.note": "Bestått-delen byggjer på lagra avgjerder (reglane som gjaldt då kvart svar blei scora).",
+
     "quality.subtitle": "Sj\u00e5 korleis ein modul scorar, og juster best\u00e5tt-grensa.",
     "quality.filter.owner": "Eigar",
     "quality.filter.owner.mine": "Mine modular",

--- a/public/static/admin-content-calibration.js
+++ b/public/static/admin-content-calibration.js
@@ -92,6 +92,10 @@ let ownerFilter = "mine"; // "mine" | "all"
 let courseFilter = ""; // courseId or ""
 let snapshotBody = null;
 let effective = null; // effectiveThresholds from the last snapshot
+// QA r5 #4: the pass rule depends on the module's assessment mode. For MCQ_ONLY modules pass/fail is
+// decided by the MCQ percentage (mcqMinPercent, default 70) — totalScore is the MCQ score scaled into
+// its weighting band, so the 0–100 total-histogram/threshold view is misleading and must be replaced.
+let currentAssessmentMode = null;
 
 function resolveContentAdminDefaults() {
   const defaults = participantRuntimeConfig?.identityDefaults?.contentAdmin;
@@ -165,10 +169,15 @@ async function onModuleChange() {
     el.qOwnPill.textContent = mod.ownedByMe ? t("quality.pill.owned") : t("quality.pill.notOwned");
     el.qOwnPill.classList.toggle("notmine", !mod.ownedByMe);
   }
-  // Populate the version dropdown from the module export (versions carry versionNo + id).
+  // Populate the version dropdown from the module export (versions carry versionNo + id), and capture
+  // the module's assessment mode (active version's, else newest) for the mode-aware threshold card.
+  currentAssessmentMode = null;
   try {
     const data = await apiFetch(`/api/admin/content/modules/${encodeURIComponent(moduleId)}/export`, getHeaders);
     const versions = data?.moduleExport?.versions ?? [];
+    const activeVersionId = data?.moduleExport?.module?.activeVersionId ?? null;
+    const modeVersion = versions.find((v) => v.id === activeVersionId) ?? versions[0];
+    currentAssessmentMode = modeVersion?.assessmentMode ?? null;
     for (const v of versions) {
       const opt = document.createElement("option");
       opt.value = v.id;
@@ -276,21 +285,44 @@ function outcomeScores() {
     .filter((s) => typeof s === "number" && Number.isFinite(s));
 }
 
+function isMcqOnly() {
+  return currentAssessmentMode === "MCQ_ONLY";
+}
+
 function renderThresholdCard(body) {
   el.qTotalMin.value = String(effective.totalMin ?? 60);
-  // Contextual sub-gates: only show when the module's policy actually uses them.
-  const showMcq = effective.mcqMinPercent != null;
-  const showPractical = effective.practicalMinPercent != null;
-  el.qMcqField.hidden = !showMcq;
-  el.qPracticalField.hidden = !showPractical;
-  if (showMcq) el.qMcqMin.value = String(effective.mcqMinPercent);
-  if (showPractical) el.qPracticalMin.value = String(effective.practicalMinPercent);
+  const mcqOnly = isMcqOnly();
+
+  if (mcqOnly) {
+    // MCQ-only: pass/fail is decided by the MCQ percentage. Hide the misleading total-score
+    // histogram/threshold/preview and expose the one rule that actually applies.
+    el.qDistBlock.hidden = true;
+    el.qPreview.hidden = true;
+    el.qTotalMin.closest(".q-thr-field").hidden = true;
+    el.qMcqField.hidden = false;
+    el.qMcqMin.value = String(effective.mcqMinPercent ?? 70);
+    el.qPracticalField.hidden = true;
+    el.qModeNote.hidden = false;
+    el.qModeNote.textContent = t("quality.threshold.mcqOnlyNote");
+  } else {
+    el.qDistBlock.hidden = false;
+    el.qPreview.hidden = false;
+    el.qTotalMin.closest(".q-thr-field").hidden = false;
+    el.qModeNote.hidden = true;
+    // Contextual sub-gates: only show when the module's policy actually uses them.
+    const showMcq = effective.mcqMinPercent != null;
+    const showPractical = effective.practicalMinPercent != null;
+    el.qMcqField.hidden = !showMcq;
+    el.qPracticalField.hidden = !showPractical;
+    if (showMcq) el.qMcqMin.value = String(effective.mcqMinPercent);
+    if (showPractical) el.qPracticalMin.value = String(effective.practicalMinPercent);
+    renderHistogram();
+    updatePreview();
+  }
 
   el.qThresholdSource.textContent =
     effective.source === "module_policy" ? t("quality.threshold.source.module") : t("quality.threshold.source.global");
 
-  renderHistogram();
-  updatePreview();
   el.qPublish.disabled = false;
   el.qThresholdCard.hidden = false;
 }
@@ -394,7 +426,8 @@ async function publish() {
     showToast(t("quality.errors.moduleRequired"), "error");
     return;
   }
-  const totalMin = Number(el.qTotalMin.value);
+  // MCQ-only modules keep their (unused) totalMin unchanged — the edited rule is mcqMinPercent.
+  const totalMin = isMcqOnly() ? Number(effective?.totalMin ?? 60) : Number(el.qTotalMin.value);
   if (!Number.isFinite(totalMin) || totalMin < 0 || totalMin > 100) {
     showToast(t("quality.errors.totalMinRange"), "error");
     return;
@@ -434,7 +467,7 @@ function mountWorkspace() {
   el = {};
   for (const id of [
     "qOwnerSeg", "qCourseFilter", "qModuleSelect", "qVersionSelect", "qModuleCount", "qLoad", "qOwnPill", "qMeta",
-    "qSignalsCard", "qSignals", "qThresholdCard", "qHistogram", "qTotalMin", "qMcqField", "qMcqMin",
+    "qSignalsCard", "qSignals", "qThresholdCard", "qDistBlock", "qModeNote", "qHistogram", "qTotalMin", "qMcqField", "qMcqMin",
     "qPracticalField", "qPracticalMin", "qPreview", "qThresholdSource", "qPublish",
     "qAnchorCard", "qAnchorSummary", "qAnchorLink", "qOutcomesCard", "qOutcomesBody",
   ]) el[id] = document.getElementById(id);

--- a/public/static/owner-panel.js
+++ b/public/static/owner-panel.js
@@ -46,6 +46,7 @@ export async function renderOwnerPanel({ container, contentType, contentId, getH
       paintCompact();
       return;
     }
+    container.classList.remove("owner-host--compact");
     const rows = owners.length
       ? owners
           .map(
@@ -78,8 +79,13 @@ export async function renderOwnerPanel({ container, contentType, contentId, getH
   // Compact default: "Eiere: Name A, Name B" on one line, plus an inline "Rediger" affordance for
   // those who can manage. Keeps the panel to a slim strip since it's shown far more than edited.
   function paintCompact() {
+    // Slim the host card down to a strip while compact (QA r5 #1): the host brings .card/.detail-section
+    // padding meant for full sections — override it for the one-line default.
+    container.classList.add("owner-host--compact");
     const names = owners.length
-      ? owners.map((o) => escapeHtml(o.name)).join(", ")
+      ? // Same-name owners are distinct users (e.g. mock + Entra identity) — expose the email in a
+        // tooltip so "Joakim Kosmo, Joakim Kosmo" is explainable at a glance.
+        owners.map((o) => `<span title="${escapeHtml(o.email)}">${escapeHtml(o.name)}</span>`).join(", ")
       : `<span class="owner-none">Ingen eiere ennå</span>`;
     container.innerHTML = `
       <div class="owner-panel owner-panel--compact">

--- a/public/static/shared.css
+++ b/public/static/shared.css
@@ -1184,6 +1184,9 @@ dialog::backdrop {
 .owner-panel-loading, .owner-panel-error { color: var(--color-text); opacity: 0.7; }
 /* #787 QA r4: compact-by-default owner panel — a slim one-line summary that expands to the full
    add/remove UI only on demand. Ownership is shown far more than it is edited. */
+/* QA r5 #1: the host (.card/.detail-section) carries section-sized padding; slim it to a strip while
+   the panel is compact. owner-panel.js toggles this class with the expanded state. */
+.owner-host--compact { padding: 6px var(--space-2); margin-bottom: var(--space-1); }
 .owner-panel--compact { display: flex; align-items: baseline; gap: var(--space-1); flex-wrap: wrap; }
 .owner-compact-label { font-size: 0.72rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--color-meta); }
 .owner-compact-names { color: var(--color-text); font-weight: 600; flex: 1 1 auto; min-width: 0; }

--- a/test/e2e/vurderingskvalitet.spec.ts
+++ b/test/e2e/vurderingskvalitet.spec.ts
@@ -115,3 +115,41 @@ test("vurderingskvalitet: no access shows the access-denied state", async ({ pag
   await expect(page.locator(".access-denied-title")).toBeVisible();
   await expect(page.locator("#qModuleSelect")).toHaveCount(0);
 });
+
+// QA r5 #4: for MCQ_ONLY modules pass/fail is decided by the MCQ percentage — totalScore is the MCQ
+// score scaled into its weighting band, so the total-score histogram/threshold view is misleading.
+// The card must swap to the MCQ-minimum rule and publish must keep totalMin unchanged.
+test("vurderingskvalitet: MCQ-only module shows the MCQ rule instead of the total histogram", async ({ page }) => {
+  await mockBase(page, ["SUBJECT_MATTER_OWNER"]);
+  // Override the export: active version is MCQ_ONLY.
+  await page.route("**/api/admin/content/modules/*/export", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ moduleExport: {
+      module: { activeVersionId: "v4" },
+      versions: [{ id: "v4", versionNo: 4, publishedAt: "2026-07-19T00:00:00.000Z", assessmentMode: "MCQ_ONLY" }],
+    } }) }));
+  await page.route(/\/api\/calibration\/workspace\?/, (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(snapshot(60)) }));
+  let publishBody: any = null;
+  await page.route("**/api/calibration/workspace/publish-thresholds", (route: Route) => {
+    publishBody = JSON.parse(route.request().postData() ?? "{}");
+    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true }) });
+  });
+
+  await page.goto("/admin-content/calibration");
+  await page.locator("#qModuleSelect").selectOption("mod-own");
+  await page.locator("#qLoad").click();
+
+  // Distribution/total hidden; MCQ rule shown with the explanatory note.
+  await expect(page.locator("#qModeNote")).toBeVisible();
+  await expect(page.locator("#qDistBlock")).toBeHidden();
+  await expect(page.locator("#qMcqField")).toBeVisible();
+  await expect(page.locator("#qTotalMin")).toBeHidden();
+
+  // Publish keeps totalMin at the effective value and sends the edited MCQ minimum.
+  await page.locator("#qMcqMin").fill("80");
+  page.once("dialog", (d) => d.accept());
+  await page.locator("#qPublish").click();
+  await expect(page.locator(".toast, #toast, [role='status']").first()).toContainText(/publisert/i);
+  expect(publishBody.totalMin).toBe(60);
+  expect(publishBody.mcqMinPercent).toBe(80);
+});


### PR DESCRIPTION
## QA runde 5

| # | Funn | Fix |
|---|------|-----|
| 1 | Eiere kan gjøres vesentlig tynnere | Verts-kortet slankes til en stripe i kompakt modus (`.owner-host--compact`); e-post-tooltip på navn (like navn = to ulike brukere, mock + Entra) |
| 2 | Modul mangler «tilbake til liste» | «← Tilbake til modulliste» øverst på begge modul-editorene (som Kurs) |
| 3 | Tittel-plassering | Back-link + «Modul»-tittel + Samtale/Avansert-bryter øverst under sub-nav-en; header var strandet under GDPR-notisen |
| 4 | «Bestått 100 %» men søyle under grensa | Rot-årsak: MCQ-modul — bestått avgjøres av MCQ-prosent; lagret totalScore er MCQ skalert i vektings-bånd (100 % × 0,3 ≈ 30), så total-histogrammet var misvisende. Flata er nå modus-bevisst: MCQ-moduler viser MCQ-minimum-regelen + notis; histogram/total/preview skjules; publish beholder totalMin og sender mcqMinPercent. + notis om at bestått-andel bygger på lagrede avgjørelser |
| 5 | Klasse-kort uten hvit bakgrunn | `.detail-section` fikk surface-bakgrunn + skygge |

## Tester

Ny MCQ-only-e2e i `vurderingskvalitet.spec.ts` (modus-bytte + publish-payload). Alle 106 admin-content-e2e grønne. Kun statisk front-end + i18n + doc. Bumper 2.1.1. Til stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
