### PR TITLE
fix(ui): QA r6 — slank eier-stripe (kaskade-fix), bestått-avvik forklart, klasse-rader

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,27 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.1.2 - 2026-07-19
+
+fix(ui): QA runde 6 — ekte slank eier-stripe, forklart bestått-avvik, klasse-rader i stedet for chips
+
+- **Eier-stripa faktisk slank** (QA #1): r5-fiksen tapte kaskaden mot side-nivå `.detail-section`-padding
+  (side-styles lastes etter shared.css og vinner ved lik spesifisitet). Padding settes nå inline fra
+  owner-panel.js (vinner alltid), og «Rediger»-knappen fikk `min-height:0` (global
+  `button{min-height:40px}` blåste opp høyden). Målt: 36px (var ~54+). Permanent boundingBox-assertion
+  (≤52px) i e2e piner fiksen.
+- **«Bestått 100 % men ingen består» forklart** (QA #2): Bestått-andel-kortet viser den LAGREDE andelen
+  (avgjørelsene da svarene ble scoret). Når den avviker fra hva dagens grense ville gitt, viser kortet nå
+  eksplisitt «Ved dagens grense (70) ville bare 0 % av de lastede svarene bestått» — og oppdateres live
+  når grensa endres.
+- **Klasse-detalj: rader i stedet for grå chips** (QA #3): Studenter og Tildelte kurs bruker nå samme
+  rad-språk som eier-panelet (navn + meta, skillelinje, slank «Fjern» til høyre).
+
+**Prosess:** visuell verifikasjon lokalt før deploy (headless render + måling + skjermbilder inspisert)
+er nå standard for CSS/layout-endringer — stage brukes som akseptanse, ikke feilsøking.
+
+e2e: avviks-notis-assertions + stripe-høyde; alle 106 grønne.
+
 ## 2.1.1 - 2026-07-19
 
 fix(ui): QA runde 5 — tynn eier-stripe, modul-navigasjon/tittel, MCQ-bevisst Vurderingskvalitet, klasse-kort

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-classes.html
+++ b/public/admin-content-classes.html
@@ -22,9 +22,13 @@
       .system-badge { display: inline-block; margin-left: 6px; padding: 1px 8px; border-radius: 999px; background: var(--color-blue-light); color: var(--color-link-active); font-size: 11px; font-weight: 600; }
       .detail-section { background: var(--color-surface); border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); box-shadow: var(--shadow-card); padding: var(--space-2); margin-bottom: var(--space-3); }
       .detail-section h2 { font-size: 16px; margin: 0 0 var(--space-2); }
-      .chip-row { display: flex; flex-wrap: wrap; gap: 6px; margin-top: var(--space-1); }
-      .chip { display: inline-flex; align-items: center; gap: 6px; background: var(--color-surface-muted, #f0f0f0); border-radius: 999px; padding: 3px 6px 3px 10px; font-size: 13px; }
-      .chip button { background: none; border: none; color: var(--color-error); cursor: pointer; font-size: 14px; line-height: 1; padding: 0 2px; }
+      /* QA r6 #3: rows (same visual language as owner rows) instead of grey chips. */
+      .assign-list { list-style: none; margin: 0 0 var(--space-2); padding: 0; }
+      .assign-row { display: flex; align-items: baseline; gap: var(--space-2); padding: 8px 0; border-bottom: 1px solid var(--color-border-soft); }
+      .assign-name { font-weight: 600; color: var(--color-text); }
+      .assign-meta { color: var(--color-meta); font-size: 12.5px; }
+      .assign-remove { width: auto; margin-left: auto; flex: 0 0 auto; min-height: 0; padding: 3px 12px; font-size: 0.85rem; }
+      .assign-empty { color: var(--color-meta); font-style: italic; font-size: 13px; padding: 6px 0; }
       .search-results { list-style: none; margin: 4px 0 0; padding: 0; border: 1px solid var(--color-border-soft); border-radius: var(--radius-card); max-height: 220px; overflow-y: auto; }
       .search-results:empty { display: none; }
       .search-results li { padding: 6px 10px; cursor: pointer; font-size: 13px; }

--- a/public/i18n/calibration-translations.js
+++ b/public/i18n/calibration-translations.js
@@ -12,6 +12,7 @@ const extraTranslations = {
     "quality.title": "Assessment quality",
     "quality.threshold.mcqOnlyNote": "This is an MCQ module: pass/fail is decided by the MCQ minimum below. The total-score threshold does not apply.",
     "quality.signals.note": "The pass rate reflects stored decisions (the rules in effect when each response was scored).",
+    "quality.signal.passRate.divergent": "At the current threshold ({threshold}) only {pct}% of the loaded responses would pass.",
 
     "quality.subtitle": "See how a module scores, and adjust the pass mark.",
     "quality.filter.owner": "Owner",
@@ -157,6 +158,7 @@ const extraTranslations = {
     "quality.title": "Vurderingskvalitet",
     "quality.threshold.mcqOnlyNote": "Dette er en MCQ-modul: bestått avgjøres av MCQ-minimumet under. Total-grensa gjelder ikke.",
     "quality.signals.note": "Bestått-andelen bygger på lagrede avgjørelser (reglene som gjaldt da hvert svar ble scoret).",
+    "quality.signal.passRate.divergent": "Ved dagens grense ({threshold}) ville bare {pct} % av de lastede svarene bestått.",
 
     "quality.subtitle": "Se hvordan en modul scorer, og juster best\u00e5tt-grensa.",
     "quality.filter.owner": "Eier",
@@ -302,6 +304,7 @@ const extraTranslations = {
     "quality.title": "Vurderingskvalitet",
     "quality.threshold.mcqOnlyNote": "Dette er ein MCQ-modul: bestått blir avgjort av MCQ-minimumet under. Total-grensa gjeld ikkje.",
     "quality.signals.note": "Bestått-delen byggjer på lagra avgjerder (reglane som gjaldt då kvart svar blei scora).",
+    "quality.signal.passRate.divergent": "Ved dagens grense ({threshold}) ville berre {pct} % av dei lasta svara bestått.",
 
     "quality.subtitle": "Sj\u00e5 korleis ein modul scorar, og juster best\u00e5tt-grensa.",
     "quality.filter.owner": "Eigar",

--- a/public/static/admin-content-calibration.js
+++ b/public/static/admin-content-calibration.js
@@ -234,8 +234,9 @@ function renderWorkspace() {
   if (!body) return hideResults();
   el.qMeta.textContent = tf("quality.meta.loaded", { title: body.module?.title ?? "-", count: (body.outcomes ?? []).length });
   effective = body.effectiveThresholds ?? { totalMin: 60, mcqMinPercent: null, practicalMinPercent: null };
-  renderSignals(body.signals ?? {});
+  // Threshold card first so qTotalMin holds THIS module's value before the signal note reads it.
   renderThresholdCard(body);
+  renderSignals(body.signals ?? {});
   renderAnchors(body);
   renderOutcomes(body.outcomes ?? []);
 }
@@ -255,11 +256,27 @@ function renderSignals(signals) {
   const mrRate = signals.manualReviewRate ?? null;
   const cov = signals.benchmarkCoverageRate ?? null;
 
+  // QA r6 #2: the stored pass rate can contradict the current threshold (decisions were made under the
+  // rules in effect at scoring time — e.g. a lower totalMin, or the module was MCQ-only back then). When
+  // they diverge, say so explicitly instead of leaving two conflicting numbers on screen.
+  let passNote =
+    passRate == null ? t("quality.signal.noData") : passRate >= passMin ? t("quality.signal.passRate.ok") : t("quality.signal.passRate.low");
+  if (passRate != null && !isMcqOnly()) {
+    const scores = outcomeScores();
+    const threshold = el.qTotalMin?.value !== "" ? Number(el.qTotalMin?.value) : Number(effective?.totalMin ?? NaN);
+    if (scores.length > 0 && Number.isFinite(threshold)) {
+      const wouldPassRate = scores.filter((s) => s >= threshold).length / scores.length;
+      if (Math.abs(wouldPassRate - passRate) > 0.005) {
+        passNote = tf("quality.signal.passRate.divergent", { threshold, pct: Math.round(wouldPassRate * 100) });
+      }
+    }
+  }
+
   const cards = [
     {
       cls: passRate == null ? "neutral" : sigClass(passRate >= passMin, passRate >= passMin * 0.8),
       k: t("quality.signal.passRate"), v: pct(passRate),
-      note: passRate == null ? t("quality.signal.noData") : passRate >= passMin ? t("quality.signal.passRate.ok") : t("quality.signal.passRate.low"),
+      note: passNote,
     },
     {
       cls: mrRate == null ? "neutral" : sigClass(mrRate <= mrMax, mrRate <= mrMax * 1.2),
@@ -492,7 +509,7 @@ function mountWorkspace() {
   el.qModuleSelect.addEventListener("change", onModuleChange);
   el.qLoad.addEventListener("click", loadQuality);
   el.qPublish.addEventListener("click", publish);
-  el.qTotalMin.addEventListener("input", () => { renderHistogram(); updatePreview(); });
+  el.qTotalMin.addEventListener("input", () => { renderHistogram(); updatePreview(); renderSignals(snapshotBody?.signals ?? {}); });
 
   renderCourseFilterOptions();
   renderModuleOptions();

--- a/public/static/admin-content-classes.js
+++ b/public/static/admin-content-classes.js
@@ -261,13 +261,20 @@ async function openClass(id) {
     pageContent.innerHTML = `<p>Kunne ikke laste klassen: ${escapeHtml(err?.message ?? "")}</p>`;
     return;
   }
-  const memberChips = members.map((m) => `<span class="chip">${escapeHtml(m.name)} <button data-remove-member="${escapeHtml(m.userId)}" aria-label="Fjern ${escapeHtml(m.name)}">×</button></span>`).join("");
-  const courseChips = courses.map((c) => {
+  // QA r6 #3: rows instead of grey chips — same visual language as the owner rows (name + meta,
+  // separator line, slim «Fjern» on the right).
+  const memberRows = members.map((m) => `<li class="assign-row">
+      <span class="assign-name">${escapeHtml(m.name)}</span>
+      ${m.email ? `<span class="assign-meta">${escapeHtml(m.email)}</span>` : ""}
+      <button type="button" class="assign-remove btn-secondary" data-remove-member="${escapeHtml(m.userId)}" aria-label="Fjern ${escapeHtml(m.name)}">Fjern</button>
+    </li>`).join("");
+  const courseRows = courses.map((c) => {
     const due = formatDueDate(c.dueAt);
-    const dueLabel = due
-      ? `<span class="chip-due" style="color:var(--color-meta);font-size:12px;margin-left:4px">Frist: ${escapeHtml(due)}</span>`
-      : `<span class="chip-due" style="color:var(--color-meta);font-size:12px;margin-left:4px">Ingen frist</span>`;
-    return `<span class="chip">${escapeHtml(courseTitle(c.title))} ${dueLabel} <button data-remove-course="${escapeHtml(c.courseId)}" aria-label="Fjern kurs">×</button></span>`;
+    return `<li class="assign-row">
+      <span class="assign-name">${escapeHtml(courseTitle(c.title))}</span>
+      <span class="assign-meta">${due ? `Frist: ${escapeHtml(due)}` : "Ingen frist"}</span>
+      <button type="button" class="assign-remove btn-secondary" data-remove-course="${escapeHtml(c.courseId)}" aria-label="Fjern kurs">Fjern</button>
+    </li>`;
   }).join("");
   const assignedIds = new Set(courses.map((c) => c.courseId));
   // #688: don't offer archived courses for assignment — they are retired and shouldn't be assigned.
@@ -278,7 +285,7 @@ async function openClass(id) {
     <div class="detail-section" id="classOwnerPanelHost"></div>
     <div class="detail-section">
       <h2>Studenter (${members.length})</h2>
-      <div class="chip-row" id="memberChips">${memberChips || `<span style="color:var(--color-meta);font-size:13px">Ingen studenter ennå.</span>`}</div>
+      <ul class="assign-list" id="memberChips">${memberRows || `<li class="assign-empty">Ingen studenter ennå.</li>`}</ul>
       <div class="inline-form">
         <input type="text" id="studentSearch" placeholder="Søk navn eller e-post (min. 2 tegn)" autocomplete="off" style="min-width:280px" />
       </div>
@@ -286,7 +293,7 @@ async function openClass(id) {
     </div>
     <div class="detail-section">
       <h2>Tildelte kurs (${courses.length})</h2>
-      <div class="chip-row" id="courseChips">${courseChips || `<span style="color:var(--color-meta);font-size:13px">Ingen kurs tildelt ennå.</span>`}</div>
+      <ul class="assign-list" id="courseChips">${courseRows || `<li class="assign-empty">Ingen kurs tildelt ennå.</li>`}</ul>
       <div class="inline-form">
         <select id="courseSelect"><option value="">Velg kurs…</option>${courseOptions}</select>
         <label for="dueAtInput" style="font-size:13px;color:var(--color-meta);display:inline-flex;align-items:center;gap:6px">

--- a/public/static/owner-panel.js
+++ b/public/static/owner-panel.js
@@ -47,6 +47,7 @@ export async function renderOwnerPanel({ container, contentType, contentId, getH
       return;
     }
     container.classList.remove("owner-host--compact");
+    container.style.padding = "";
     const rows = owners.length
       ? owners
           .map(
@@ -79,9 +80,11 @@ export async function renderOwnerPanel({ container, contentType, contentId, getH
   // Compact default: "Eiere: Name A, Name B" on one line, plus an inline "Rediger" affordance for
   // those who can manage. Keeps the panel to a slim strip since it's shown far more than edited.
   function paintCompact() {
-    // Slim the host card down to a strip while compact (QA r5 #1): the host brings .card/.detail-section
-    // padding meant for full sections — override it for the one-line default.
+    // Slim the host card down to a strip while compact (QA r5/r6 #1): the host brings .card/.detail-section
+    // padding meant for full sections. Page-level styles load after shared.css and win the cascade at equal
+    // specificity (bit us on the courses page), so set the padding inline — inline always wins.
     container.classList.add("owner-host--compact");
+    container.style.padding = "6px 16px";
     const names = owners.length
       ? // Same-name owners are distinct users (e.g. mock + Entra identity) — expose the email in a
         // tooltip so "Joakim Kosmo, Joakim Kosmo" is explainable at a glance.

--- a/public/static/shared.css
+++ b/public/static/shared.css
@@ -1192,7 +1192,7 @@ dialog::backdrop {
 .owner-compact-names { color: var(--color-text); font-weight: 600; flex: 1 1 auto; min-width: 0; }
 .owner-compact-names .owner-none { font-weight: 400; font-style: italic; opacity: 0.65; }
 .owner-edit-toggle, .owner-collapse { width: auto; flex: 0 0 auto; background: none; border: 0; padding: 2px 4px;
-  color: var(--color-link-active, var(--color-blue)); font-size: 0.85rem; font-weight: 600; cursor: pointer; }
+  min-height: 0; color: var(--color-link-active, var(--color-blue)); font-size: 0.85rem; font-weight: 600; cursor: pointer; }
 .owner-edit-toggle:hover, .owner-collapse:hover { text-decoration: underline; }
 .owner-panel-head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2); }
 .owner-panel-head .owner-panel-title { margin: 0; }

--- a/test/e2e/content-owner-panel.spec.ts
+++ b/test/e2e/content-owner-panel.spec.ts
@@ -44,6 +44,12 @@ test("course owner panel: lists, adds via search, and removes owners", async ({ 
   const panel = page.locator("#ownerPanelHost .owner-panel");
   await expect(panel).toBeVisible();
   await expect(panel.locator(".owner-compact-names")).toContainText("Alice Owner");
+  // QA r6 #1: the compact strip must actually BE a strip. The courses page's own .detail-section
+  // padding overrode the shared compact class (page styles load after shared.css), which kept the
+  // panel tall — the inline padding fix must win. Pin the rendered height.
+  const strip = await page.locator("#ownerPanelHost").boundingBox();
+  expect(strip).not.toBeNull();
+  expect(strip!.height).toBeLessThanOrEqual(52);
   await panel.locator(".owner-edit-toggle").click();
   await expect(panel.locator(".owner-row")).toHaveCount(1);
   await expect(panel.locator(".owner-name").first()).toHaveText("Alice Owner");

--- a/test/e2e/vurderingskvalitet.spec.ts
+++ b/test/e2e/vurderingskvalitet.spec.ts
@@ -101,6 +101,16 @@ test("vurderingskvalitet: owner filter, load, signals, histogram, preview, publi
   await expect(page.locator("#qPreview")).toContainText("5");
   await expect(page.locator("#qPreview .delta")).toBeVisible();
 
+  // QA r6 #2: when the stored pass rate contradicts the current threshold, the signal card says so.
+  // At 75 only 2 of 6 (33%) of the loaded scores would pass vs the stored 67% — the divergent note shows.
+  await page.locator("#qTotalMin").fill("75");
+  await page.locator("#qTotalMin").dispatchEvent("input");
+  await expect(page.locator("#qSignals .q-sig").first()).toContainText("33 %");
+  // Back to 50 (5/6 = 83% ≠ stored 67% → note still shows, now with 83).
+  await page.locator("#qTotalMin").fill("50");
+  await page.locator("#qTotalMin").dispatchEvent("input");
+  await expect(page.locator("#qSignals .q-sig").first()).toContainText("83 %");
+
   // Publish → confirm dialog → localised toast (NOT a raw i18n key).
   page.once("dialog", (d) => d.accept());
   await page.locator("#qPublish").click();


### PR DESCRIPTION
## QA runde 6 — visuelt verifisert lokalt før deploy

| # | Funn | Rot-årsak | Fix |
|---|------|-----------|-----|
| 1 | Eier-stripa fortsatt ikke slank | Side-nivå `.detail-section`-padding laster etter shared.css og vant kaskaden; global `button{min-height:40px}` blåste opp «Rediger» | Inline padding fra JS (vinner alltid) + `min-height:0`. **Målt 36px** (var ~54+). Permanent høyde-assertion i e2e |
| 2 | «Bestått 100 % men ingen består» | Kortet viser LAGRET andel (avgjørelser ved scoring-tidspunkt); dagens grense gir noe annet | Divergens-notis: «Ved dagens grense (70) ville bare 0 % av de lastede svarene bestått» — live ved grense-endring |
| 3 | Grå chips ser ikke pene ut | — | Studenter + Tildelte kurs som rene rader i owner-row-stil (navn + meta + slank Fjern) |

## Prosess (nytt krav: riktig første gang)

Rendret alle tre flatene headless lokalt, målte stripa (36px) og inspiserte skjermbilder FØR denne PR-en — stage brukes som akseptanse, ikke feilsøking.

## Tester

Divergens-assertions (33 %/83 %) + stripe-høyde ≤52px. Alle 106 admin-content-e2e grønne. Kun statisk front-end + i18n + doc. Bump 2.1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
