### PR TITLE
fix(privacy): #806 — ikke lagre person-PII (e-post) i evig-lagret audit-metadata

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,28 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.1.3 - 2026-07-19
+
+fix(privacy): #806 — slutt å skrive person-PII (e-post) i evig-lagret audit-metadata (GDPR)
+
+Pseudonymisering skrubber User-raden, men audit-metadata beholdt original e-post i evig-lagrede
+AuditEvent-rader → en «pseudonymisert» brukers e-post var fortsatt direkte søkbar (bryter
+u-lenkbarhet). Forward-fix — nye hendelser lagrer kun stabil id, ikke e-post/navn:
+
+- **recertification_reminder_sent/failed** (`recertificationService.ts`): fjernet `recipientEmail`
+  fra metadata; beholder `userId` (+ certificationId, moduleId, kanal, leveringsstatus). E-posten
+  brukes fortsatt til å SENDE påminnelsen — den persisteres bare ikke.
+- **org_sync_record_failed** (`orgSyncService.ts`): fjernet `email` fra metadata; `externalId`
+  identifiserer den feilede posten uten PII (matcher allerede den deklarerte metadata-typen).
+
+Operasjonell logg (`console.log`, begrenset oppbevaring) beholder e-post for leveringsfeilsøking —
+ikke den evig-lagrede audit-tabellen. Historisk skrubb av eksisterende rader er egen sak (henger
+sammen med payloadHash-invalidering, #D2/#806-oppfølger). Ingen leser e-post ut av audit-metadata,
+så ingen lese-side påvirkes.
+
+Tester: unit-assertions på at recert-metadata ikke har recipientEmail/recipientName. tsc + berørte
+unit-suiter grønne. Backend-only.
+
 ## 2.1.2 - 2026-07-19
 
 fix(ui): QA runde 6 — ekte slank eier-stripe, forklart bestått-avvik, klasse-rader i stedet for chips

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/certification/recertificationService.ts
+++ b/src/modules/certification/recertificationService.ts
@@ -194,9 +194,12 @@ export async function runRecertificationReminderSchedule(input?: { asOf?: Date }
         : auditActions.certification.recertificationReminderFailed,
       actorId: undefined,
       metadata: {
+        // #806 (GDPR): store userId only, never email/name, in indefinitely-retained audit metadata.
+        // The email is still used to SEND the reminder above — it is just not persisted here, so a
+        // pseudonymized user's email is not left searchable in AuditEvent.metadataJson. Resolve
+        // recipient details from userId at read time if ever needed.
         certificationId: certification.id,
         userId: certification.user.id,
-        recipientEmail: certification.user.email,
         moduleId: certification.module.id,
         reminderDaysBefore: matchedReminderDay,
         asOfDate,

--- a/src/modules/orgSync/orgSyncService.ts
+++ b/src/modules/orgSync/orgSyncService.ts
@@ -80,9 +80,11 @@ export async function applyOrgDeltaSync(input: ApplyOrgDeltaSyncInput) {
         action: auditActions.orgSync.recordFailed,
         actorId: input.actorId,
         metadata: {
+          // #806 (GDPR): externalId identifies the failed record without persisting the email into
+          // indefinitely-retained audit metadata. (Email is still in the operational log above, which
+          // has bounded retention.)
           source: input.source,
           externalId: record.externalId,
-          email: record.email,
           reason,
         },
       });

--- a/src/observability/auditEvents.ts
+++ b/src/observability/auditEvents.ts
@@ -289,15 +289,16 @@ export type AuditMetadataByAction = {
     moduleId: string;
     decisionId: string;
   }>;
+  // #806 (GDPR): recipient PII (email/name) must NOT be persisted in indefinitely-retained audit
+  // metadata — store userId only and resolve details at read time. Other fields (moduleId, channel,
+  // reminderDaysBefore, asOfDate, expiryDate, delivered, failureReason) are also recorded by the writer.
   [auditActions.certification.recertificationReminderSent]: EventMetadata<{
     certificationId: string;
     userId: string;
-    recipientEmail: string;
   }>;
   [auditActions.certification.recertificationReminderFailed]: EventMetadata<{
     certificationId: string;
     userId: string;
-    recipientEmail: string;
   }>;
   [auditActions.certification.participantNotificationSent]: EventMetadata<{
     channel: string;

--- a/test/m2-recertification-flow.test.ts
+++ b/test/m2-recertification-flow.test.ts
@@ -120,11 +120,15 @@ describe("Recertification status and reminders", () => {
       where: {
         entityType: "certification_status",
         action: "recertification_reminder_sent",
-        metadataJson: {
-          contains: participantHeaders["x-user-email"],
-        },
       },
     });
     expect(reminderAuditEvents.length).toBeGreaterThan(0);
+    // #806 (GDPR): the reminder audit must record the event but NOT persist the recipient's email in
+    // indefinitely-retained metadata — it should carry userId only, so a pseudonymized user stays
+    // un-linkable. (The email is still used to send the reminder and appears in the live report above.)
+    for (const event of reminderAuditEvents) {
+      expect(event.metadataJson).not.toContain(participantHeaders["x-user-email"]);
+      expect(event.metadataJson).toContain("userId");
+    }
   });
 });

--- a/test/unit/recertification-service.test.ts
+++ b/test/unit/recertification-service.test.ts
@@ -307,5 +307,14 @@ describe("recertification service", () => {
         action: "recertification_reminder_sent",
       }),
     );
+
+    // #806 (GDPR): recipient PII (email/name) must NOT be persisted in indefinitely-retained audit
+    // metadata — only userId, which stays un-linkable after pseudonymization scrubs the User row.
+    const auditCall = (recordAuditEvent as unknown as { mock: { calls: Array<[{ action: string; metadata: Record<string, unknown> }]> } }).mock.calls.find(
+      (c) => c[0]?.action === "recertification_reminder_sent",
+    );
+    expect(auditCall?.[0]?.metadata).toMatchObject({ certificationId: "cert-1", userId: "user-1" });
+    expect(auditCall?.[0]?.metadata).not.toHaveProperty("recipientEmail");
+    expect(auditCall?.[0]?.metadata).not.toHaveProperty("recipientName");
   });
 });


### PR DESCRIPTION
## #806 (GDPR, CONFIRMED architecture-review-funn)

Pseudonymisering skrubber User-raden, men `AuditEvent.metadataJson` beholdt original e-post i evig-lagrede rader → en «pseudonymisert» brukers e-post var fortsatt direkte søkbar (bryter u-lenkbarhet).

**Forward-fix — nye hendelser lagrer stabil id, ikke PII:**
- `recertification_reminder_sent/failed`: fjernet `recipientEmail` fra audit-metadata (beholder `userId`, certificationId, moduleId, kanal, status). E-post brukes fortsatt til å SENDE.
- `org_sync_record_failed`: fjernet `email`; `externalId` identifiserer posten (matcher allerede deklarert metadata-type).

Kartla hele overflaten først: dette er de **eneste to** stedene person-PII nådde audit-metadata (appeal/assessment `recipientEmail` er send-payloads, ikke audit). Ingen leser e-post ut av audit → ingen lese-side påvirkes. Operasjonell `console.log` (begrenset oppbevaring) beholder e-post for leveringsfeilsøking.

**Utenfor scope (egen oppfølger):** historisk skrubb av eksisterende audit-rader — henger sammen med at endring av `metadataJson` invaliderer `payloadHash` (#D2). Egen sak opprettes.

## Tester
Unit-assertions: recert-reminder-metadata har verken `recipientEmail` eller `recipientName`. tsc + berørte unit-suiter grønne. Backend-only, ingen infra/DB. Bump 2.1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
