### PR TITLE
fix(ui): QA r7 — slankere status-rad + full-bredde seksjon-editor (bundles, ingen egen deploy)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,21 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.1.4 - 2026-07-19
+
+fix(ui): QA runde 7 — to forenklinger på modul-/seksjon-editorene (bundlet, ikke egen deploy)
+
+- **Slankere status-linje** (QA #1): fjernet de redundante «Modul» (modulnavnet står i modul-kortet) og
+  «Språk» (finnes i språk-velgeren) fra status-raden på begge modul-editorene. Rad viser nå «Du redigerer
+  · Live nå · Endringer · Preview viser» på én linje.
+- **Seksjon-editor bruker full bredde** (QA #2): fjernet 720px-taket på `.section-editor` slik at
+  Markdown- og Forhåndsvisning-kolonnene deler hele sidebredden 50/50 (målt 542px hver, var ~350).
+  Enkelt-kolonne-feltene (tittel + språk-faner) er fortsatt kappet på 720px.
+
+Verifisert visuelt lokalt før commit (målte kolonnebredder + status-rad-etiketter + skjermbilder).
+Berørte kontrakt-/e2e-tester oppdatert (status-rad-parity, rename-e2e verifiseres via patch-body).
+106 e2e + 61 kontraktstester grønne.
+
 ## 2.1.3 - 2026-07-19
 
 fix(privacy): #806 — slutt å skrive person-PII (e-post) i evig-lagret audit-metadata (GDPR)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content-advanced.html
+++ b/public/admin-content-advanced.html
@@ -239,12 +239,9 @@
       </div>
     </div>
 
+    <!-- QA r7 #1: dropped the redundant «Modul» (shown in the module card) and «Språk» (in the locale
+         picker) items from the status rail. -->
     <div id="stateRail" class="state-rail" hidden aria-label="Modulstatus">
-      <div class="state-rail-item">
-        <span class="state-rail-label" data-i18n="stateRail.label.module">Modul</span>
-        <span id="srModuleName" class="state-rail-value">—</span>
-      </div>
-      <span class="state-rail-sep" aria-hidden="true">·</span>
       <div class="state-rail-item">
         <span class="state-rail-label" data-i18n="stateRail.label.editing">Du redigerer</span>
         <span id="srEditing"></span>
@@ -263,11 +260,6 @@
       <div class="state-rail-item">
         <span class="state-rail-label" data-i18n="stateRail.label.preview">Preview viser</span>
         <span id="srPreview"></span>
-      </div>
-      <span class="state-rail-sep" aria-hidden="true">·</span>
-      <div class="state-rail-item">
-        <span class="state-rail-label" data-i18n="stateRail.label.language">Språk</span>
-        <span id="srLang" class="state-rail-value"></span>
       </div>
     </div>
 

--- a/public/admin-content-sections.html
+++ b/public/admin-content-sections.html
@@ -76,7 +76,11 @@
       .sections-table .col-actions { white-space: nowrap; }
 
       /* Editor */
-      .section-editor { max-width: 720px; }
+      /* QA r7 #2: let the editor fill the page width so the Markdown/Preview columns are a true 50/50
+         split of the available width (they were 50/50 of a 720px cap). Constrain only the single-column
+         fields so the title input doesn't stretch uncomfortably wide. */
+      .section-editor { max-width: none; }
+      .section-editor > .editor-field, .section-editor > .lang-tabs { max-width: 720px; }
       .editor-field { margin-bottom: var(--space-2); }
       .editor-field label { display: block; font-size: 13px; font-weight: 600; margin-bottom: 4px; }
       .editor-field input[type="text"] { width: 100%; padding: 8px; border: 1px solid var(--color-border-soft); border-radius: var(--radius-btn); font-size: 14px; }

--- a/public/admin-content.html
+++ b/public/admin-content.html
@@ -374,12 +374,9 @@
         </div>
       </div>
 
+      <!-- QA r7 #1: dropped the redundant «Modul» (shown in the module card) and «Språk» (in the locale
+           picker) items from the status rail. -->
       <div id="stateRail" class="state-rail" hidden aria-label="Modulstatus">
-        <div class="state-rail-item">
-          <span class="state-rail-label" data-i18n="stateRail.label.module">Modul</span>
-          <span id="srModuleName" class="state-rail-value">—</span>
-        </div>
-        <span class="state-rail-sep" aria-hidden="true">·</span>
         <div class="state-rail-item">
           <span class="state-rail-label" data-i18n="stateRail.label.editing">Du redigerer</span>
           <span id="srEditing"></span>
@@ -398,11 +395,6 @@
         <div class="state-rail-item">
           <span class="state-rail-label" data-i18n="stateRail.label.preview">Preview viser</span>
           <span id="srPreview"></span>
-        </div>
-        <span class="state-rail-sep" aria-hidden="true">·</span>
-        <div class="state-rail-item">
-          <span class="state-rail-label" data-i18n="stateRail.label.language">Språk</span>
-          <span id="srLang" class="state-rail-value"></span>
         </div>
       </div>
 

--- a/test/admin-content-state-rail.test.js
+++ b/test/admin-content-state-rail.test.js
@@ -179,17 +179,21 @@ describe("state rail HTML structure", () => {
         expect(html).toContain('aria-label=');
       });
 
-      it("has all four state rail value slots", () => {
+      // QA r7 #1: «Modul» (srModuleName) and «Språk» (srLang) were dropped from the rail as redundant
+      // (module name is in the module card; language in the locale picker).
+      it("has the state rail value slots", () => {
         html = readFile(page);
-        expect(html).toContain('id="srModuleName"');
+        expect(html).not.toContain('id="srModuleName"');
         expect(html).toContain('id="srEditing"');
         expect(html).toContain('id="srLive"');
         expect(html).toContain('id="srChanges"');
+        expect(html).toContain('id="srPreview"');
       });
 
       it("has i18n keys on state rail labels", () => {
         html = readFile(page);
-        expect(html).toContain('data-i18n="stateRail.label.module"');
+        expect(html).not.toContain('data-i18n="stateRail.label.module"');
+        expect(html).not.toContain('data-i18n="stateRail.label.language"');
         expect(html).toContain('data-i18n="stateRail.label.editing"');
         expect(html).toContain('data-i18n="stateRail.label.live"');
         expect(html).toContain('data-i18n="stateRail.label.changes"');

--- a/test/admin-content-ui-contracts.test.js
+++ b/test/admin-content-ui-contracts.test.js
@@ -28,14 +28,13 @@ describe("admin content workspace UI contracts", () => {
   it("keeps state-rail parity between conversational and advanced module workspaces", () => {
     const shellHtml = readFile("public/admin-content.html");
     const advancedHtml = readFile("public/admin-content-advanced.html");
+    // QA r7 #1: srModuleName + srLang were removed as redundant; parity is on the remaining slots.
     const ids = [
       "stateRail",
-      "srModuleName",
       "srEditing",
       "srLive",
       "srChanges",
       "srPreview",
-      "srLang",
     ];
 
     for (const id of ids) {

--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -628,7 +628,8 @@ test.describe("admin content browser coverage", () => {
 
     await expect.poll(() => state.lastTitlePatchBody?.title?.nb).toBe("Fagforeninger");
     await expect(state.lastTitlePatchBody?.title?.["en-GB"]).toContain("[en-GB]");
-    await expect(page.locator("#srModuleName")).toHaveText("Fagforeninger");
+    // QA r7 #1: the module name was removed from the status rail (redundant with the module card).
+    // The rename is verified by the title-patch body above.
   });
 
   test("chat revision can rename the module title through a bounded free-text instruction", async ({ page }) => {
@@ -680,12 +681,11 @@ test.describe("admin content browser coverage", () => {
 
     await expect(page.getByText('I will update the module title to "Trade union dialogue" and refresh the localized variants.')).toBeVisible();
     await expect.poll(() => state.lastDraftLocalizationBody?.title).toBe("Trade union dialogue");
-    await expect(page.locator("#srModuleName")).toHaveText("Trade union dialogue");
 
     await clickEnabledButton(page, /Save draft|Lagre utkast/);
 
+    // QA r7 #1: module name removed from the status rail; rename verified via the localization + patch bodies.
     await expect.poll(() => state.lastTitlePatchBody?.title?.["en-GB"]).toBe("Trade union dialogue");
-    await expect(page.locator("#srModuleName")).toHaveText("Trade union dialogue");
   });
 
   test("direct edit keeps MCQ visible and editable through translation and save", async ({ page }) => {


### PR DESCRIPTION
## QA runde 7 — to små forenklinger (bundles med neste leveranse)

1. **Status-rad slankere** (#1): fjernet redundante «Modul» (modulnavnet er i modul-kortet) + «Språk» (i språk-velgeren) fra status-raden på begge modul-editorene. Nå: `Du redigerer · Live nå · Endringer · Preview viser` på én linje.
2. **Seksjon-editor full bredde** (#2): `.editor-cols` var alt 1fr 1fr, men `.section-editor { max-width: 720px }` kappet hele editoren — så 50/50-splitten var av 720px, ikke sidebredden. Fjernet taket → kolonnene er nå **542px hver** (målt, var ~350). Tittel/språk-faner beholder 720px-kappet.

## Verifisering (visuelt lokalt før commit)
Rendret begge flatene headless, målte status-rad-etikettene (`Du redigerer/Live nå/Endringer/Preview viser`, ingen Modul/Språk) + kolonnebreddene (542/542), og inspiserte skjermbilder.

## Tester
Berørte kontrakt-/e2e oppdatert: status-rad-parity (srModuleName/srLang fjernet), rename-e2e verifiseres nå via patch-body (status-rad viser ikke lenger navnet). 106 e2e + 61 kontrakt grønne. Kun statisk front-end + doc. Bump 2.1.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
