### PR TITLE
feat(#787 slice 4a): tildel skaper som eier ved oppretting + catch-up backfill (inert)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,26 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.1.5 - 2026-07-20
+
+feat(#787 slice 4a): tildel skaper som eier ved oppretting (INERT) + catch-up backfill
+
+Forberedelse til eierskaps-håndheving (4b). **Ingen atferdsendring** — populerer bare ContentOwner.
+
+- **Oppretting tildeler eier:** `createCourse`/`createSection`/`createClass`/`createModule` skriver nå en
+  ContentOwner-rad for skaperen (Q3: eneste initielle eier), idempotent + auditert, hoppes over uten aktor
+  (system/seed → admin-forvaltet). Lagt i service-laget så alle opprettings-stier dekkes.
+- **Catch-up backfill** (`20260720120000_backfill_content_owner_gap`): idempotent (NOT EXISTS) seeding av
+  ContentOwner for innhold opprettet etter de opprinnelige backfillene (2.0.6/2.0.9) som mangler eier-rad
+  — Class/Module fra createdById, Course/Section fra created-audit. Hindrer at eksisterende innhold blir
+  «unowned» (admin-only) når 4b lander.
+
+Hvorfor først: håndheving alene ville låst skapere ute av eget nytt innhold. 4a er den trygge grunnmuren;
+4b (assertContentOwnership-vakter, 403 for ikke-eiere) er den bevisste atferdsendringen.
+
+Ny integrasjonstest `m2-content-owner-assignment.test.ts` (alle fire typer + unowned-uten-aktor); migrasjon
+verifisert via lokal `migrate reset`. Backend-only.
+
 ## 2.1.4 - 2026-07-19
 
 fix(ui): QA runde 7 — to forenklinger på modul-/seksjon-editorene (bundlet, ikke egen deploy)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260720120000_backfill_content_owner_gap/migration.sql
+++ b/prisma/migrations/20260720120000_backfill_content_owner_gap/migration.sql
@@ -1,0 +1,56 @@
+-- #787 slice 4a: catch-up backfill of ContentOwner. The original backfills (20260719130000 for
+-- Class/Module from createdById, 20260719140000 for Course/Section from the created-audit actor) ran
+-- once. Content created BETWEEN those migrations and slice 4a's create-time assignment has no
+-- ContentOwner row. This re-runs the same seeding idempotently so that when 4b enforcement lands, no
+-- existing content is left unowned (which would lock its creator out → admin-only).
+--
+-- Data-only. Idempotent (NOT EXISTS guard on every insert). 0 rows in CI (empty tables). Content with
+-- no createdById / no created-audit stays UNOWNED → admin-managed (the deliberate no-frozen-limbo).
+
+-- Class → creator from createdById
+INSERT INTO "ContentOwner" ("id", "contentType", "contentId", "userId", "addedById", "addedAt")
+SELECT gen_random_uuid()::text, 'CLASS'::"ContentOwnerType", c."id", c."createdById", NULL, CURRENT_TIMESTAMP
+FROM "Class" c
+WHERE c."createdById" IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM "ContentOwner" co WHERE co."contentType" = 'CLASS' AND co."contentId" = c."id"
+  );
+
+-- Module → creator from createdById
+INSERT INTO "ContentOwner" ("id", "contentType", "contentId", "userId", "addedById", "addedAt")
+SELECT gen_random_uuid()::text, 'MODULE'::"ContentOwnerType", m."id", m."createdById", NULL, CURRENT_TIMESTAMP
+FROM "Module" m
+WHERE m."createdById" IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM "ContentOwner" co WHERE co."contentType" = 'MODULE' AND co."contentId" = m."id"
+  );
+
+-- Course → creator from the earliest course_created AuditEvent actor
+INSERT INTO "ContentOwner" ("id", "contentType", "contentId", "userId", "addedById", "addedAt")
+SELECT gen_random_uuid()::text, 'COURSE'::"ContentOwnerType", c."id", ae."actorId", NULL, CURRENT_TIMESTAMP
+FROM "Course" c
+CROSS JOIN LATERAL (
+    SELECT "actorId"
+    FROM "AuditEvent"
+    WHERE "action" = 'course_created' AND "entityId" = c."id" AND "actorId" IS NOT NULL
+    ORDER BY "timestamp" ASC
+    LIMIT 1
+) ae
+WHERE NOT EXISTS (
+    SELECT 1 FROM "ContentOwner" co WHERE co."contentType" = 'COURSE' AND co."contentId" = c."id"
+);
+
+-- CourseSection → creator from the earliest section_created AuditEvent actor
+INSERT INTO "ContentOwner" ("id", "contentType", "contentId", "userId", "addedById", "addedAt")
+SELECT gen_random_uuid()::text, 'SECTION'::"ContentOwnerType", s."id", ae."actorId", NULL, CURRENT_TIMESTAMP
+FROM "CourseSection" s
+CROSS JOIN LATERAL (
+    SELECT "actorId"
+    FROM "AuditEvent"
+    WHERE "action" = 'section_created' AND "entityId" = s."id" AND "actorId" IS NOT NULL
+    ORDER BY "timestamp" ASC
+    LIMIT 1
+) ae
+WHERE NOT EXISTS (
+    SELECT 1 FROM "ContentOwner" co WHERE co."contentType" = 'SECTION' AND co."contentId" = s."id"
+);

--- a/src/modules/adminContent/adminContentCommands.ts
+++ b/src/modules/adminContent/adminContentCommands.ts
@@ -8,6 +8,7 @@ import type { AssessmentMode } from "@prisma/client";
 import { localizedTextCodec, type LocalizedText, type LocalizedTextObject } from "../../codecs/localizedTextCodec.js";
 import { NotFoundError } from "../../errors/AppError.js";
 import { assertModuleNotInAnyCourse } from "../course/contentLifecycle.js";
+import { addContentOwner } from "../content/contentOwnershipService.js";
 import {
   generateModuleRubric,
   type AssessmentBlueprint,
@@ -115,6 +116,13 @@ export async function createModule(input: CreateModuleInput) {
       validTo: module.validTo?.toISOString() ?? null,
     },
   });
+
+  // #787 slice 4a: creator becomes sole initial owner. Modules already set createdById and the backfill
+  // populated ContentOwner from it, but new modules need an explicit row so 4b enforcement (which reads
+  // ContentOwner, not createdById) recognises the creator. Inert until 4b. Idempotent + audited.
+  if (input.actorId) {
+    await addContentOwner({ contentType: "MODULE", contentId: module.id, ownerUserId: input.actorId, actorUserId: input.actorId });
+  }
 
   return module;
 }

--- a/src/modules/course/classService.ts
+++ b/src/modules/course/classService.ts
@@ -6,6 +6,7 @@ import { localizeContentText } from "../../i18n/content.js";
 import { sendCourseAssignmentNotification } from "../certification/participantNotificationService.js";
 import { classRepository, SYSTEM_ALL_PARTICIPANTS_CLASS_ID } from "./classRepository.js";
 import { isClassEntraLinkingEnabled } from "./classConfig.js";
+import { addContentOwner } from "../content/contentOwnershipService.js";
 
 // #645/CL-2: class (cohort) business logic — CRUD + membership + course assignment + dynamic
 // membership evaluation. Course→class assignment is dynamic: a participant is assigned a course if
@@ -28,6 +29,10 @@ export async function createClass(input: { name: string; description?: string | 
     actorId: actorId ?? undefined,
     metadata: { classId: created.id, name },
   });
+  // #787 slice 4a: creator becomes sole initial owner (inert until 4b enforcement).
+  if (actorId) {
+    await addContentOwner({ contentType: "CLASS", contentId: created.id, ownerUserId: actorId, actorUserId: actorId });
+  }
   return created;
 }
 

--- a/src/modules/course/courseCommands.ts
+++ b/src/modules/course/courseCommands.ts
@@ -4,6 +4,7 @@ import { NotFoundError, ValidationError } from "../../errors/AppError.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes, agentAuthoringAuditMetadata, type AgentAuthoringContext } from "../../observability/auditEvents.js";
 import { assertCourseHasNoInProgressParticipants } from "./contentLifecycle.js";
+import { addContentOwner } from "../content/contentOwnershipService.js";
 
 export async function createCourse(input: {
   title: string;
@@ -32,6 +33,13 @@ export async function createCourse(input: {
     actorId: input.actorId,
     metadata: { courseId: course.id, ...agentAuthoringAuditMetadata(input.agent) },
   });
+
+  // #787 slice 4a: the creator becomes the sole initial owner (Q3 decision). Inert until enforcement
+  // (slice 4b) — this only populates ContentOwner so creators aren't locked out once guards land.
+  // Idempotent + audited. Skipped when there's no actor (system/seed creation stays admin-managed).
+  if (input.actorId) {
+    await addContentOwner({ contentType: "COURSE", contentId: course.id, ownerUserId: input.actorId, actorUserId: input.actorId });
+  }
 
   return course;
 }

--- a/src/modules/course/sectionCommands.ts
+++ b/src/modules/course/sectionCommands.ts
@@ -5,6 +5,7 @@ import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes, agentAuthoringAuditMetadata, type AgentAuthoringContext } from "../../observability/auditEvents.js";
 import { assertSectionNotInAnyCourse } from "./contentLifecycle.js";
 import { importSectionAssets, collectSectionAssetBlobPaths, reclaimAssetBlobs } from "./assetCommands.js";
+import { addContentOwner } from "../content/contentOwnershipService.js";
 
 // #763 (Layer B): the agent section-create route inlines figures/images (base64), so the JSON body
 // can exceed the 5 MB global parser. Sized to cover a handful of SVG figures + localized variants
@@ -87,6 +88,10 @@ export async function createSection(input: {
       ...agentAuthoringAuditMetadata(input.agent),
     },
   });
+  // #787 slice 4a: creator becomes sole initial owner (inert until 4b enforcement).
+  if (input.actorId) {
+    await addContentOwner({ contentType: "SECTION", contentId: created.id, ownerUserId: input.actorId, actorUserId: input.actorId });
+  }
   return created;
 }
 

--- a/test/m2-content-owner-assignment.test.ts
+++ b/test/m2-content-owner-assignment.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { prisma } from "../src/db/prisma.js";
+import { createCourse } from "../src/modules/course/courseCommands.js";
+import { createSection } from "../src/modules/course/sectionCommands.js";
+import { createClass } from "../src/modules/course/classService.js";
+import { createModule } from "../src/modules/adminContent/adminContentCommands.js";
+
+// #787 slice 4a: content creation assigns the creator as the sole initial owner (Q3). This is inert
+// (nothing enforces ownership until 4b), but it MUST populate ContentOwner so creators aren't locked
+// out once 4b enforcement (which reads ContentOwner) lands. Verifies all four content types + that a
+// missing actor leaves the object unowned (system/seed creation → admin-managed).
+
+async function makeActor(tag: string) {
+  const ext = `${tag}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  return prisma.user.create({ data: { externalId: ext, name: tag, email: `${ext}@x.test` }, select: { id: true } });
+}
+
+async function ownerIds(contentType: "COURSE" | "SECTION" | "CLASS" | "MODULE", contentId: string) {
+  const rows = await prisma.contentOwner.findMany({ where: { contentType, contentId }, select: { userId: true } });
+  return rows.map((r) => r.userId);
+}
+
+describe("content creation assigns the creator as owner (#787 slice 4a)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("course/section/class/module: creator gets a ContentOwner row", async () => {
+    const actor = await makeActor("creator");
+
+    const course = await createCourse({ title: "T", actorId: actor.id });
+    expect(await ownerIds("COURSE", course.id)).toEqual([actor.id]);
+
+    const section = await createSection({ title: "S", bodyMarkdown: "# S", actorId: actor.id });
+    expect(await ownerIds("SECTION", section.id)).toEqual([actor.id]);
+
+    const klass = await createClass({ name: `Kull-${Date.now()}` }, actor.id);
+    expect(await ownerIds("CLASS", klass.id)).toEqual([actor.id]);
+
+    const module = await createModule({ title: "M", actorId: actor.id });
+    expect(await ownerIds("MODULE", module.id)).toEqual([actor.id]);
+  });
+
+  it("creation without an actor leaves the object unowned (admin-managed)", async () => {
+    const course = await createCourse({ title: "No actor" });
+    expect(await ownerIds("COURSE", course.id)).toEqual([]);
+  });
+});

--- a/test/unit/admin-content-service.test.ts
+++ b/test/unit/admin-content-service.test.ts
@@ -54,6 +54,12 @@ vi.mock("../../src/services/auditService.js", () => ({
   recordAuditEvent,
 }));
 
+// #787 slice 4a: createModule now assigns the creator as owner (addContentOwner → prisma.contentOwner).
+// This unit test mocks the repository/prisma, so stub the ownership side-effect out.
+vi.mock("../../src/modules/content/contentOwnershipService.js", () => ({
+  addContentOwner: vi.fn(),
+}));
+
 vi.mock("../../src/config/benchmarkExamples.js", () => ({
   getBenchmarkExamplesConfig: () => ({
     maxExamplesPerVersion: 3,


### PR DESCRIPTION
## #787 slice 4a — eierskaps-grunnmur (INERT, ingen atferdsendring)

Forberedelse til håndheving (4b). Populerer bare ContentOwner; ingenting håndhever eierskap ennå.

**Hvorfor 4a først:** håndheving alene ville låst skapere ute — nyopprettet innhold uten eier-rad blir «unowned» → kun admin kan redigere. Så tildeling-ved-oppretting MÅ på plass før 4b.

### Endringer
- **Oppretting tildeler eier** (service-laget, dekker alle stier: POST, import, localize-copy, agent-authoring): `createCourse`/`createSection`/`createClass`/`createModule` skriver en ContentOwner-rad for skaperen (Q3: eneste initielle eier). Idempotent + auditert. Hoppes over uten aktor (system/seed → admin-forvaltet).
- **Catch-up backfill** `20260720120000_backfill_content_owner_gap`: idempotent (NOT EXISTS) seeding for innhold opprettet etter de opprinnelige backfillene (2.0.6/2.0.9) som mangler eier-rad. Class/Module fra createdById, Course/Section fra created-audit. 0 rader i CI.

### Verifisering
Lokal `prisma migrate reset` bekrefter at migrasjonen anvendes rent (samme som CI). Ny integrasjonstest `m2-content-owner-assignment.test.ts` — alle fire innholdstyper får eier, og oppretting uten aktor forblir unowned — kjørt lokalt mot Postgres, grønn.

### Utrulling
Backend + én additiv data-migrasjon. Inert → trygt å deploye. Bumper 2.1.5. Neste: 4b (assertContentOwnership-vakter — den bevisste 403-atferdsendringen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
