### PR TITLE
feat(#843): historisk audit-PII-skrubb (re-seal, approach A)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,23 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.2.1 - 2026-07-20
+
+feat(#843): historisk audit-PII-skrubb (re-seal, approach A) — backend + maintenance-script
+
+Oppfølger til #806-forward-fixen. Rydder e-post ut av EKSISTERENDE evig-lagrede audit-rader:
+
+- **`scrubHistoricalAuditPii()`** (`src/services/auditPiiScrub.ts`): for hver mål-handling
+  (recertification_reminder_sent/failed → recipientEmail, org_sync_record_failed → email) fjernes
+  feltet fra metadataJson, `payloadHash` rekomputeres over den rensede raden (seglet forblir konsistent),
+  og én auditbar `audit_metadata_scrubbed`-hendelse (kun antall, ingen PII) skrives. Idempotent — en
+  skrubbet rad velges ikke på nytt.
+- **Script** `scripts/maintenance/scrub-audit-pii.ts` (`npm run maint:scrub-audit-pii`) for å kjøre
+  skrubben mot valgt env. **Kjøres IKKE automatisk** — en bevisst maintenance-handling.
+
+Ny integrasjonstest `m2-audit-pii-scrub.test.ts`: e-post fjernet, hash re-seglet (matcher fersk sha256),
+rene rader urørt, skrubb-hendelse logget, idempotent. Verifisert lokalt mot Postgres.
+
 ## 2.2.0 - 2026-07-20
 
 feat(#787 slice 4b): eierskaps-HÅNDHEVING på innholds-skrivestier (ATFERDSENDRING)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",
@@ -9,6 +9,7 @@
     "dev:local": "dotenv -e .env.postgres.local -- tsx watch src/index.ts",
     "skill:package": "node scripts/package-authoring-skill.mjs",
     "dev:seed:consent": "dotenv -e .env.postgres.local -- tsx scripts/dev/seed-mock-consent.ts",
+    "maint:scrub-audit-pii": "tsx scripts/maintenance/scrub-audit-pii.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node scripts/runtime/startup.mjs",
     "postgres:setup": "node scripts/postgres/localSetup.mjs setup",

--- a/scripts/maintenance/scrub-audit-pii.ts
+++ b/scripts/maintenance/scrub-audit-pii.ts
@@ -1,0 +1,26 @@
+/**
+ * #843 (#806 follow-up): one-time historical scrub of person-PII (email) from indefinitely-retained
+ * audit metadata. Approach A (re-seal): removes the PII field, recomputes each row's payloadHash, and
+ * records an auditable `audit_metadata_scrubbed` event. Idempotent — safe to re-run (a scrubbed row is
+ * skipped).
+ *
+ * Runs against whatever DATABASE_URL is in the environment, so target the intended env explicitly:
+ *   dotenv -e .env.<env> -- tsx scripts/maintenance/scrub-audit-pii.ts
+ * On Azure, run via the app's DATABASE_URL. Verify afterwards that no target action's metadata still
+ * contains the field (the test m2-audit-pii-scrub covers the mechanics).
+ */
+import { scrubHistoricalAuditPii } from "../../src/services/auditPiiScrub.js";
+import { prisma } from "../../src/db/prisma.js";
+
+async function main() {
+  const result = await scrubHistoricalAuditPii();
+  // Structured, PII-free output for the operator log.
+  console.log(JSON.stringify({ event: "audit_pii_scrub_complete", scrubbed: result.scrubbed }));
+}
+
+main()
+  .catch((error) => {
+    console.error("audit_pii_scrub_failed", error);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/observability/auditEvents.ts
+++ b/src/observability/auditEvents.ts
@@ -24,6 +24,7 @@ export const auditEntityTypes = {
   submission: "submission",
   user: "user",
   contentOwner: "content_owner",
+  audit: "audit",
 } as const;
 
 export type AuditEntityType = NestedValue<typeof auditEntityTypes>;
@@ -144,6 +145,10 @@ export const auditActions = {
   orgSync: {
     recordFailed: "org_sync_record_failed",
     completed: "org_sync_completed",
+  },
+  audit: {
+    // #843/#806: records a historical PII scrub of audit metadata (re-seal approach A). No PII itself.
+    metadataScrubbed: "audit_metadata_scrubbed",
   },
   submission: {
     created: "submission_created",
@@ -416,6 +421,11 @@ export type AuditMetadataByAction = {
   [auditActions.manualReview.superseded]: EventMetadata<{
     newSubmissionId: string;
     supersededAt: string;
+  }>;
+  [auditActions.audit.metadataScrubbed]: EventMetadata<{
+    scrubbedCount: number;
+    actions: string[];
+    fields: string[];
   }>;
   [auditActions.orgSync.recordFailed]: EventMetadata<{
     source: string;

--- a/src/services/auditPiiScrub.ts
+++ b/src/services/auditPiiScrub.ts
@@ -1,0 +1,72 @@
+import { prisma } from "../db/prisma.js";
+import { sha256 } from "../utils/hash.js";
+import { recordAuditEvent } from "./auditService.js";
+import { auditActions, auditEntityTypes } from "../observability/auditEvents.js";
+
+// #843 (#806 follow-up): historical scrub of person-PII (email) from indefinitely-retained audit
+// metadata. The #806 forward-fix stopped NEW rows from carrying email; this cleans the existing ones.
+//
+// Approach A (re-seal, chosen by product owner): remove the PII field from metadataJson, recompute
+// payloadHash over the cleaned row so the tamper-evidence seal stays internally consistent (hash matches
+// content), and record ONE auditable `audit_metadata_scrubbed` event (count only, no PII) as the trail.
+// We lose the ability to cryptographically prove a scrubbed row's PRE-scrub content — deliberately,
+// because that content was the PII being deleted.
+//
+// Idempotent: a scrubbed row no longer contains the field, so re-runs select nothing.
+
+// The retained actions that embedded person-PII (the #806/#4b forward-fix sites) → the metadata key to
+// remove. Keep in sync with any future field added to (then removed from) retained audit metadata.
+const SCRUB_TARGETS: ReadonlyArray<{ action: string; field: string }> = [
+  { action: auditActions.certification.recertificationReminderSent, field: "recipientEmail" },
+  { action: auditActions.certification.recertificationReminderFailed, field: "recipientEmail" },
+  { action: auditActions.orgSync.recordFailed, field: "email" },
+];
+
+export async function scrubHistoricalAuditPii(actorId?: string): Promise<{ scrubbed: number }> {
+  let scrubbed = 0;
+
+  for (const { action, field } of SCRUB_TARGETS) {
+    // Only rows that still carry the field — makes the pass both efficient and idempotent.
+    const rows = await prisma.auditEvent.findMany({
+      where: { action, metadataJson: { contains: `"${field}"` } },
+      select: { id: true, entityType: true, entityId: true, action: true, metadataJson: true },
+    });
+
+    for (const row of rows) {
+      let metadata: Record<string, unknown>;
+      try {
+        metadata = JSON.parse(row.metadataJson) as Record<string, unknown>;
+      } catch {
+        continue; // unparseable metadata — leave it untouched rather than risk corrupting the row
+      }
+      if (!(field in metadata)) continue; // substring match false-positive (field inside a value)
+
+      delete metadata[field];
+      // Re-stringify preserves the remaining keys' original insertion order, so the recomputed hash
+      // matches what a fresh recordAuditEvent would produce for the scrubbed metadata.
+      const newMetadataJson = JSON.stringify(metadata);
+      const payloadHash = sha256(`${row.entityType}:${row.entityId}:${row.action}:${newMetadataJson}`);
+      await prisma.auditEvent.update({
+        where: { id: row.id },
+        data: { metadataJson: newMetadataJson, payloadHash },
+      });
+      scrubbed += 1;
+    }
+  }
+
+  if (scrubbed > 0) {
+    await recordAuditEvent({
+      entityType: auditEntityTypes.audit,
+      entityId: "audit-pii-scrub",
+      action: auditActions.audit.metadataScrubbed,
+      actorId,
+      metadata: {
+        scrubbedCount: scrubbed,
+        actions: [...new Set(SCRUB_TARGETS.map((t) => t.action))],
+        fields: [...new Set(SCRUB_TARGETS.map((t) => t.field))],
+      },
+    });
+  }
+
+  return { scrubbed };
+}

--- a/test/m2-audit-pii-scrub.test.ts
+++ b/test/m2-audit-pii-scrub.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { prisma } from "../src/db/prisma.js";
+import { sha256 } from "../src/utils/hash.js";
+import { scrubHistoricalAuditPii } from "../src/services/auditPiiScrub.js";
+
+// #843 (#806 follow-up): historical audit-PII scrub, approach A (re-seal). Verifies a legacy row with an
+// embedded email is cleaned, the payloadHash is recomputed to stay consistent, an auditable scrub event
+// is recorded, non-PII rows are untouched, and the pass is idempotent.
+
+function seedAudit(entityType: string, entityId: string, action: string, metadata: Record<string, unknown>) {
+  const metadataJson = JSON.stringify(metadata);
+  return prisma.auditEvent.create({
+    data: { entityType, entityId, action, metadataJson, payloadHash: sha256(`${entityType}:${entityId}:${action}:${metadataJson}`) },
+    select: { id: true },
+  });
+}
+
+describe("historical audit-PII scrub (#843, re-seal)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("removes email, re-seals the hash, records a scrub event, and is idempotent", async () => {
+    const tag = `scrub-${Date.now()}`;
+    // Two legacy rows carrying person-PII, plus one clean row that must be left untouched.
+    const recert = await seedAudit("certification_status", `${tag}-cert`, "recertification_reminder_sent", {
+      certificationId: `${tag}-cert`, userId: `${tag}-u`, recipientEmail: "leak@x.test",
+    });
+    const orgFail = await seedAudit("org_sync", `${tag}-run`, "org_sync_record_failed", {
+      source: "entra", externalId: `${tag}-ext`, email: "leak2@x.test", reason: "conflict",
+    });
+    const clean = await seedAudit("certification_status", `${tag}-clean`, "recertification_reminder_sent", {
+      certificationId: `${tag}-clean`, userId: `${tag}-u2`,
+    });
+    const cleanBefore = await prisma.auditEvent.findUniqueOrThrow({ where: { id: clean.id } });
+
+    const result = await scrubHistoricalAuditPii();
+    expect(result.scrubbed).toBeGreaterThanOrEqual(2);
+
+    const recertAfter = await prisma.auditEvent.findUniqueOrThrow({ where: { id: recert.id } });
+    expect(recertAfter.metadataJson).not.toContain("recipientEmail");
+    expect(recertAfter.metadataJson).not.toContain("leak@x.test");
+    expect(recertAfter.metadataJson).toContain("userId");
+    // Re-sealed: the stored hash matches a fresh hash of the scrubbed content.
+    expect(recertAfter.payloadHash).toBe(sha256(`${recertAfter.entityType}:${recertAfter.entityId}:${recertAfter.action}:${recertAfter.metadataJson}`));
+
+    const orgAfter = await prisma.auditEvent.findUniqueOrThrow({ where: { id: orgFail.id } });
+    expect(orgAfter.metadataJson).not.toContain("leak2@x.test");
+    expect(orgAfter.metadataJson).toContain("externalId");
+
+    // The clean row is byte-for-byte untouched.
+    const cleanAfter = await prisma.auditEvent.findUniqueOrThrow({ where: { id: clean.id } });
+    expect(cleanAfter.metadataJson).toBe(cleanBefore.metadataJson);
+    expect(cleanAfter.payloadHash).toBe(cleanBefore.payloadHash);
+
+    // An auditable scrub event was recorded (no PII).
+    const scrubEvent = await prisma.auditEvent.findFirst({ where: { action: "audit_metadata_scrubbed" }, orderBy: { timestamp: "desc" } });
+    expect(scrubEvent).toBeTruthy();
+    const scrubMeta = JSON.parse(scrubEvent!.metadataJson) as { scrubbedCount: number };
+    expect(scrubMeta.scrubbedCount).toBeGreaterThanOrEqual(2);
+    expect(scrubEvent!.metadataJson).not.toContain("leak");
+
+    // Idempotent: a second pass finds nothing left to scrub.
+    expect((await scrubHistoricalAuditPii()).scrubbed).toBe(0);
+  });
+});


### PR DESCRIPTION
## #843 (#806-oppfølger) — historisk audit-PII-skrubb

Rydder e-post ut av EKSISTERENDE evig-lagrede audit-rader (forward-fixen #806 stoppet nye). Approach A (re-seal), besluttet av produkteier.

- **`scrubHistoricalAuditPii()`**: fjerner PII-feltet (recert-reminders → recipientEmail, org_sync_record_failed → email), **rekomputerer payloadHash** over den rensede raden (seglet forblir konsistent), og skriver én auditbar `audit_metadata_scrubbed`-hendelse (kun antall). Idempotent.
- **Script** `npm run maint:scrub-audit-pii` — **kjøres IKKE automatisk**, en bevisst maintenance-handling mot valgt env.

## Verifisert lokalt mot Postgres
Ny `m2-audit-pii-scrub.test.ts`: e-post fjernet, hash re-seglet (matcher fersk sha256), rene rader byte-for-byte urørt, skrubb-hendelse logget uten PII, idempotent (andre kjøring = 0). Full suite grønn: 806 unit + 388 integrasjon.

Backend-only, ingen migrasjon, ingen atferdsendring ved deploy (script kjøres manuelt). Bumper 2.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
