### PR TITLE
fix(#813): unhandled rejection restarter prosessen (web + parser)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,21 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.2.2 - 2026-07-20
+
+fix(#813): unhandled promise rejection restarter nå prosessen (web + parser)
+
+`unhandledRejection`-handleren logget bare og lot prosessen kjøre videre — en defekt som rejecter etter
+delvis mutasjon etterlot en upålitelig prosess som fortsatt serverte/planla arbeid. Nå logges + graceful-
+shutdown med exit≠0 (som `uncaughtException`), så App Service restarter en ren prosess. Håndterte
+domene-feil når aldri hit.
+
+- `src/process/processErrorHandlers.ts`: `logUnhandledRejection` tar nå `gracefulShutdown` og kaller
+  `gracefulShutdown(1)`.
+- `scripts/runtime/parserStartup.mjs`: parser-worker `unhandledRejection` gjør nå `process.exit(1)`.
+
+Test oppdatert (asserterer shutdown ved unhandled rejection). Backend-only.
+
 ## 2.2.1 - 2026-07-20
 
 feat(#843): historisk audit-PII-skrubb (re-seal, approach A) — backend + maintenance-script

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/scripts/runtime/parserStartup.mjs
+++ b/scripts/runtime/parserStartup.mjs
@@ -26,7 +26,10 @@ function writeStartupLog(level, message, error) {
 }
 
 process.on("unhandledRejection", (error) => {
+  // #813: exit non-zero so App Service restarts a clean parser process — an unhandled rejection means a
+  // defect escaped handling and the process can no longer be trusted (was: log-only, left running).
   writeStartupLog("ERROR", "Unhandled promise rejection during parser startup/runtime.", error);
+  process.exit(1);
 });
 
 process.on("uncaughtException", (error) => {

--- a/src/process/processErrorHandlers.ts
+++ b/src/process/processErrorHandlers.ts
@@ -3,7 +3,11 @@ import { operationalEvents } from "../observability/operationalEvents.js";
 
 export type GracefulShutdown = (exitCode?: number) => void;
 
-export function logUnhandledRejection(reason: unknown) {
+// #813: an unhandled rejection means a defect escaped all handling — the process may have partially
+// mutated state and can no longer be trusted to serve/schedule reliably. Log, then graceful-shutdown
+// with a non-zero exit so App Service restarts a clean process (same treatment as an uncaught exception;
+// handled domain failures never reach here). Node would otherwise leave the process running.
+export function logUnhandledRejection(reason: unknown, gracefulShutdown: GracefulShutdown) {
   logOperationalEvent(
     operationalEvents.process.unhandledRejection,
     {
@@ -12,6 +16,7 @@ export function logUnhandledRejection(reason: unknown) {
     },
     "error",
   );
+  gracefulShutdown(1);
 }
 
 export function logUncaughtException(error: unknown, gracefulShutdown: GracefulShutdown) {
@@ -28,7 +33,7 @@ export function logUncaughtException(error: unknown, gracefulShutdown: GracefulS
 
 export function registerProcessErrorHandlers(gracefulShutdown: GracefulShutdown) {
   const handleUnhandledRejection = (reason: unknown) => {
-    logUnhandledRejection(reason);
+    logUnhandledRejection(reason, gracefulShutdown);
   };
   const handleUncaughtException = (error: unknown) => {
     logUncaughtException(error, gracefulShutdown);

--- a/test/process-error-handlers.test.ts
+++ b/test/process-error-handlers.test.ts
@@ -11,11 +11,11 @@ afterEach(() => {
 });
 
 describe("process error handlers", () => {
-  it("logs unhandled rejections with structured metadata", async () => {
+  it("logs unhandled rejections and requests shutdown (#813)", async () => {
     const { logUnhandledRejection } = await import("../src/process/processErrorHandlers.js");
-
+    const gracefulShutdown = vi.fn();
     const error = new Error("worker tick failed");
-    logUnhandledRejection(error);
+    logUnhandledRejection(error, gracefulShutdown);
 
     expect(logOperationalEvent).toHaveBeenCalledWith(
       "unhandled_rejection",
@@ -25,6 +25,8 @@ describe("process error handlers", () => {
       }),
       "error",
     );
+    // #813: an unhandled rejection must exit non-zero so App Service restarts a clean process.
+    expect(gracefulShutdown).toHaveBeenCalledWith(1);
   });
 
   it("logs uncaught exceptions and requests shutdown", async () => {


### PR DESCRIPTION
## #813 — unhandled promise rejection lot prosessen kjøre videre

`unhandledRejection`-handleren logget bare; en defekt som rejecter etter delvis mutasjon etterlot en upålitelig prosess som fortsatt serverte/planla arbeid. `uncaughtException` gjorde allerede graceful-shutdown — nå gjør `unhandledRejection` det samme.

- **Web** (`processErrorHandlers.ts`): logg + `gracefulShutdown(1)` → drain + exit≠0 → App Service restarter rent.
- **Parser** (`parserStartup.mjs`): `process.exit(1)`.
- Håndterte domene-feil (caught) når aldri denne handleren.

Test oppdatert (asserterer shutdown). tsc + process-error-tester grønne. Backend-only, ingen migrasjon. Bumper 2.2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
