### PR TITLE
fix(#816): bind body-digest + nonce i parser-worker HMAC (anti-replay)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,23 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.2.3 - 2026-07-20
+
+fix(#816): bind body-digest + nonce i parser-worker HMAC (replay-herding)
+
+Klienten signerte kun `timestamp:method:path`, så en observert gyldig `POST /parse`-signatur kunne
+replayes i 60s med vilkårlig body. Nå signeres en kanonisk verdi som binder **SHA-256 av body + en
+tilfeldig nonce**, og worker avviser gjensette nonces innen vinduet.
+
+- **Delt modul** `src/parser/parserHmac.ts`: kanonisk melding + signering + nonce-cache — brukt av BÅDE
+  klient og worker, så de aldri kan drifte fra hverandre.
+- Klient (`parserWorkerClient.ts`): signerer body + `X-Parser-Nonce`.
+- Worker (`parserApp.ts`): fanger rå body (`express.json` verify), verifiserer body-digest, avviser
+  manglende/replayet nonce. Begge sider deployes atomisk (samme kodebase).
+
+Unit-test beviser klient↔worker-symmetri + at bytt-body/nonce ikke verifiserer + nonce-cache-oppførsel.
+810 unit + 388 integrasjon grønne. Backend-only, intern service-auth (ingen bruker-vendt endring).
+
 ## 2.2.2 - 2026-07-20
 
 fix(#813): unhandled promise rejection restarter nå prosessen (web + parser)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/clients/parserWorkerClient.ts
+++ b/src/clients/parserWorkerClient.ts
@@ -1,5 +1,6 @@
-import { createHmac, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { env } from "../config/env.js";
+import { signParserRequest } from "../parser/parserHmac.js";
 import {
   extractSourceMaterialText,
   type SourceMaterialExtractionInput,
@@ -39,13 +40,16 @@ function purgeLocalJobs(): void {
   }
 }
 
-function signRequest(method: string, path: string): Record<string, string> {
+// #816: sign the body digest + a per-request nonce (not just timestamp:method:path), so an observed
+// signature can't be replayed with a different body, and the worker can reject repeated nonces.
+function signRequest(method: string, path: string, body: string): Record<string, string> {
   const timestamp = Math.floor(Date.now() / 1000);
-  const message = `${timestamp}:${method.toUpperCase()}:${path}`;
-  const signature = createHmac("sha256", env.PARSER_WORKER_AUTH_KEY!).update(message).digest("hex");
+  const nonce = randomUUID();
+  const signature = signParserRequest(env.PARSER_WORKER_AUTH_KEY!, { timestamp, method, path, body, nonce });
   return {
     "X-Parser-Auth": `hmac-sha256 ${signature}`,
     "X-Parser-Timestamp": String(timestamp),
+    "X-Parser-Nonce": nonce,
     "Content-Type": "application/json",
   };
 }
@@ -56,10 +60,11 @@ export async function submitParseJob(input: SourceMaterialExtractionInput): Prom
   }
 
   const path = "/parse";
+  const body = JSON.stringify(input);
   const response = await fetch(`${env.PARSER_WORKER_URL}${path}`, {
     method: "POST",
-    headers: signRequest("POST", path),
-    body: JSON.stringify(input),
+    headers: signRequest("POST", path, body),
+    body,
   });
 
   if (!response.ok) {
@@ -79,7 +84,7 @@ export async function getParsedResult(jobId: string): Promise<ParseJobStatus | n
   const path = `/parse/${encodeURIComponent(jobId)}`;
   const response = await fetch(`${env.PARSER_WORKER_URL}${path}`, {
     method: "GET",
-    headers: signRequest("GET", path),
+    headers: signRequest("GET", path, ""),
   });
 
   if (response.status === 404) return null;

--- a/src/parser/parserHmac.ts
+++ b/src/parser/parserHmac.ts
@@ -1,0 +1,53 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { sha256 } from "../utils/hash.js";
+
+// #816: shared HMAC signing for the web↔parser-worker channel. Both the client (parserWorkerClient) and
+// the worker (parserApp) build the canonical message HERE, so they can never drift — the previous
+// signature covered only `timestamp:method:path`, which let an observed POST /parse signature be
+// replayed for 60s with an arbitrary body. The canonical value now binds the SHA-256 of the body and a
+// per-request nonce; the worker additionally rejects seen nonces within the replay window.
+
+export interface ParserSignatureInput {
+  timestamp: number;
+  method: string;
+  path: string;
+  body: string; // exact request-body string ("" for bodyless GETs)
+  nonce: string;
+}
+
+export function parserCanonicalMessage(input: ParserSignatureInput): string {
+  return `${input.timestamp}:${input.method.toUpperCase()}:${input.path}:${sha256(input.body)}:${input.nonce}`;
+}
+
+export function signParserRequest(key: string, input: ParserSignatureInput): string {
+  return createHmac("sha256", key).update(parserCanonicalMessage(input)).digest("hex");
+}
+
+// Constant-time comparison of two hex signatures.
+export function parserSignaturesMatch(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "hex");
+  const bBuf = Buffer.from(b, "hex");
+  return aBuf.length === bBuf.length && timingSafeEqual(aBuf, bBuf);
+}
+
+// In-memory nonce replay cache. A nonce may be accepted once within the window; a second use inside the
+// window is a replay. Entries self-expire so the map stays bounded to ~one replay-window of traffic.
+export class NonceReplayCache {
+  private readonly seen = new Map<string, number>(); // nonce -> expiry (epoch seconds)
+
+  constructor(private readonly windowSeconds: number) {}
+
+  // Returns true if the nonce is fresh (and records it); false if it was already seen in-window.
+  checkAndRecord(nonce: string, nowSeconds: number): boolean {
+    this.purge(nowSeconds);
+    if (this.seen.has(nonce)) return false;
+    this.seen.set(nonce, nowSeconds + this.windowSeconds);
+    return true;
+  }
+
+  private purge(nowSeconds: number): void {
+    for (const [nonce, expiry] of this.seen) {
+      if (expiry <= nowSeconds) this.seen.delete(nonce);
+    }
+  }
+}

--- a/src/parserApp.ts
+++ b/src/parserApp.ts
@@ -1,7 +1,8 @@
 import "dotenv/config";
 import express from "express";
-import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { z } from "zod";
+import { signParserRequest, parserSignaturesMatch, NonceReplayCache } from "./parser/parserHmac.js";
 import {
   extractSourceMaterialText,
   detectSourceMaterialFormat,
@@ -87,19 +88,38 @@ function hmacAuthMiddleware(
   }
   const signature = authHeader.slice(spaceIdx + 1);
 
-  const message = `${timestamp}:${req.method.toUpperCase()}:${req.path}`;
-  const expected = createHmac("sha256", parserEnv.PARSER_WORKER_AUTH_KEY).update(message).digest("hex");
+  // #816: require a nonce, and verify the signature over the body digest too, so a captured signature
+  // can't be replayed with a different body.
+  const nonceHeader = req.headers["x-parser-nonce"];
+  if (typeof nonceHeader !== "string" || !nonceHeader) {
+    res.status(401).json({ error: "missing_nonce" });
+    return;
+  }
 
-  const sigBuf = Buffer.from(signature, "hex");
-  const expBuf = Buffer.from(expected, "hex");
+  const body = (req as express.Request & { rawBody?: string }).rawBody ?? "";
+  const expected = signParserRequest(parserEnv.PARSER_WORKER_AUTH_KEY, {
+    timestamp,
+    method: req.method,
+    path: req.path,
+    body,
+    nonce: nonceHeader,
+  });
 
-  if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) {
+  if (!parserSignaturesMatch(signature, expected)) {
     res.status(401).json({ error: "invalid_signature" });
+    return;
+  }
+
+  // Reject a nonce already seen within the replay window (belt-and-suspenders with the body binding).
+  if (!nonceCache.checkAndRecord(nonceHeader, now)) {
+    res.status(401).json({ error: "replayed_nonce" });
     return;
   }
 
   next();
 }
+
+const nonceCache = new NonceReplayCache(REPLAY_WINDOW_SECONDS);
 
 const parseRequestSchema = z.object({
   fileName: z.string().min(1),
@@ -113,7 +133,16 @@ const parserApp = express();
 // file after the per-file cap was raised to 10 MB (#479 Slice A) — the cap was raised in the
 // extraction service and main app, but this separate service's limit was missed. Deriving from the
 // shared constant prevents that drift.
-parserApp.use(express.json({ limit: SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES }));
+parserApp.use(
+  express.json({
+    limit: SOURCE_MATERIAL_UPLOAD_BODY_LIMIT_BYTES,
+    // #816: capture the exact raw body so hmacAuthMiddleware can verify the signed body digest against
+    // the bytes actually received (not a re-serialization, which could differ).
+    verify: (req, _res, buf) => {
+      (req as express.Request & { rawBody?: string }).rawBody = buf.toString("utf8");
+    },
+  }),
+);
 
 // Health endpoint — no auth (used by Azure App Service probes)
 parserApp.get("/health", (_req, res) => {

--- a/test/unit/parser-hmac.test.ts
+++ b/test/unit/parser-hmac.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { signParserRequest, parserSignaturesMatch, NonceReplayCache } from "../../src/parser/parserHmac.js";
+
+// #816: the client (parserWorkerClient) signs and the worker (parserApp) verifies using this SAME
+// module, so these tests double as the cross-service symmetry proof — a valid client signature verifies,
+// a different body/nonce does not, and repeated nonces are rejected within the window.
+
+const KEY = "test-parser-key";
+
+describe("parser HMAC replay hardening (#816)", () => {
+  it("a signature over the same (timestamp, method, path, body, nonce) verifies (client↔worker symmetry)", () => {
+    const input = { timestamp: 1000, method: "POST", path: "/parse", body: JSON.stringify({ fileName: "a.pdf", contentBase64: "abc" }), nonce: "n1" };
+    const clientSig = signParserRequest(KEY, input);
+    const workerSig = signParserRequest(KEY, { ...input }); // worker recomputes from the received request
+    expect(parserSignaturesMatch(clientSig, workerSig)).toBe(true);
+  });
+
+  it("a captured signature does NOT verify against a different body (replay-with-different-body blocked)", () => {
+    const base = { timestamp: 1000, method: "POST", path: "/parse", nonce: "n1" };
+    const captured = signParserRequest(KEY, { ...base, body: '{"a":1}' });
+    const forgedWorkerSig = signParserRequest(KEY, { ...base, body: '{"a":2}' }); // worker sees the swapped body
+    expect(parserSignaturesMatch(captured, forgedWorkerSig)).toBe(false);
+  });
+
+  it("the nonce is bound into the signature", () => {
+    const base = { timestamp: 1000, method: "POST", path: "/parse", body: "" };
+    expect(parserSignaturesMatch(signParserRequest(KEY, { ...base, nonce: "n1" }), signParserRequest(KEY, { ...base, nonce: "n2" }))).toBe(false);
+  });
+
+  it("the nonce cache accepts a nonce once, rejects an in-window replay, and lets it expire", () => {
+    const cache = new NonceReplayCache(60);
+    expect(cache.checkAndRecord("n1", 1000)).toBe(true); // first use
+    expect(cache.checkAndRecord("n1", 1030)).toBe(false); // replay within the 60s window
+    expect(cache.checkAndRecord("n2", 1030)).toBe(true); // a different nonce is fine
+    expect(cache.checkAndRecord("n1", 1061)).toBe(true); // past the window → expired, fresh again
+  });
+});


### PR DESCRIPTION
## #816 — parser-worker HMAC replay-herding

Klienten signerte kun `timestamp:method:path`; en observert `POST /parse`-signatur kunne replayes i 60s med vilkårlig body (ingen body-digest, ingen nonce).

**Fix:** kanonisk signert verdi binder nå **SHA-256(body) + tilfeldig nonce**; worker avviser gjensette nonces innen vinduet.
- Delt `src/parser/parserHmac.ts` (kanonisk melding + sign + nonce-cache) brukt av **både** klient og worker → kan ikke drifte.
- Worker fanger rå body via `express.json` `verify` og verifiserer digest mot mottatte bytes.
- Begge sider deployes atomisk (samme kodebase).

**Verifisert:** unit-test beviser klient↔worker-symmetri (gyldig signatur verifiserer), at bytt-body/nonce IKKE verifiserer, og nonce-cache (aksepter én gang → avvis replay → utløp). 810 unit + 388 integrasjon grønne. Intern service-auth, ingen bruker-vendt endring. Bumper 2.2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
