### PR TITLE
fix(#787): hide edit/lifecycle actions for non-owners + «Mine kurs» for all roles

### DIFF
--- a/doc/DOMAIN_LIFECYCLE.md
+++ b/doc/DOMAIN_LIFECYCLE.md
@@ -235,6 +235,17 @@ Current application roles:
 - a claimed appeal should only be resolved by the same handler unless an admin intervenes
 - participants cannot alter historical decisions directly
 
+### Content ownership (#787) — authoring guard + list annotation
+
+Course/Section/Class/Module authoring mutations are gated by `requireContentOwnership` →
+`assertContentOwnership` (`decideOwnershipAccess`): `ADMINISTRATOR` bypasses; an owner (a `ContentOwner`
+row) is allowed; content with no owner is admin-only (`content_unowned`); any other non-owner is blocked
+(`content_ownership`). To keep the UI honest, the four admin list endpoints (`GET /api/admin/content/{courses,sections,classes,modules/library}`)
+annotate each row with **`canManage`** — the batch equivalent of the same decision (`listManageableContentIds`:
+admin ⇒ all; non-admin ⇒ only rows they own). The front-end hides edit/lifecycle actions (and the editor
+entry points) when `canManage=false`, showing a read-only marker instead, so a non-owner never sees a
+button the guard would 403. Read/copy actions (export, duplicate) stay available.
+
 ## Domain Invariants
 
 The key invariants that should stay true:

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,27 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.2.4 - 2026-07-23
+
+fix(#787): skjul rediger/livssyklus-handlinger for ikke-eiere + vis «Mine kurs» for alle roller (QA)
+
+To QA-oppfølginger på eierskaps-håndhevingen (#787):
+
+1. **Listene speiler nå eierskaps-vakta.** Kurs-, seksjon-, modul- og klasse-listene annoterer hver rad
+   med `canManage` (= admin eller eier — samme regel som `requireContentOwnership`), og frontend skjuler
+   Rediger/Publiser/Avpubliser/Arkiver/Gjenopprett/Slett (og editor-inngangene) når `canManage=false`.
+   En dempet «Skrivebeskyttet»-markør vises i stedet. Tidligere fikk en ikke-eier opp knappene og ble
+   først stoppet ved lagring (403). Lese-/kopi-handlinger (Eksporter, Dupliser) beholdes.
+   - Backend: ny batch-hjelper `listManageableContentIds` + `canManage` i de fire liste-endepunktene.
+   - Frontend: gating i `admin-content-{sections,courses,library,classes}.js` + `.row-readonly-note`-stil.
+2. **«Mine kurs» er nå synlig for alle roller** (tom `requiredRoles`). En ren SUBJECT_MATTER_OWNER fikk
+   tidligere et skjult meny-punkt mens `/participant` var nåbar via URL. Siden viser kun den publiserte
+   modulkatalogen (`participantFacing=true`, ingen utkast/admin-data), så nav matcher nå faktisk tilgang.
+
+Tester: 811 unit + DOM + integrasjon grønne; ny e2e beviser at rediger/livssyklus skjules for
+`canManage:false` og vises for `true`; ny regresjonsvakt på at «Mine kurs» er synlig for alle roller.
+Kun kode (ingen infra) — deploy via `deploy-app.yml`.
+
 ## 2.2.3 - 2026-07-20
 
 fix(#816): bind body-digest + nonce i parser-worker HMAC (replay-herding)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-classes.js
+++ b/public/static/admin-content-classes.js
@@ -96,6 +96,9 @@ function renderClassesTable() {
     const archived = !!c.archivedAt;
     const systemBadge = c.isSystem ? `<span class="system-badge">System</span>` : "";
     const statusBadge = archived ? ` <span class="status-badge status-badge--archived">Arkivert</span>` : "";
+    // #787 slice 5: eier/admin styrer om Administrer/Arkiver-handlingene vises (speiler eierskaps-vakta).
+    // Systemklasser er ueide → bare admin forvalter dem, som før.
+    const canManage = c.canManage !== false;
     let action = "";
     if (!c.isSystem) {
       action = archived
@@ -110,8 +113,9 @@ function renderClassesTable() {
       <td>${c._count?.courseAssignments ?? 0}</td>
       <td class="col-actions">
         <div class="row-actions">
-          <button class="row-action-btn" data-action="open" data-id="${escapeHtml(c.id)}">Administrer</button>
-          ${action}
+          ${canManage
+            ? `<button class="row-action-btn" data-action="open" data-id="${escapeHtml(c.id)}">Administrer</button>${action}`
+            : `<span class="row-readonly-note" title="Bare en eier eller administrator kan endre denne klassen.">Skrivebeskyttet</span>`}
         </div>
       </td>
     </tr>`;

--- a/public/static/admin-content-courses-state.js
+++ b/public/static/admin-content-courses-state.js
@@ -42,5 +42,7 @@ export function deriveCourseListRows(courses, { localizeTitle, formatDate }) {
     publishedAt: course.publishedAt ?? null,
     archivedAt: course.archivedAt ?? null,
     inProgressCount: course.inProgressCount ?? 0,
+    // #787 slice 5: may the viewer manage this course (admin or owner)? Absent (older payload) ⇒ true.
+    canManage: course.canManage !== false,
   }));
 }

--- a/public/static/admin-content-courses.js
+++ b/public/static/admin-content-courses.js
@@ -549,6 +549,8 @@ async function renderListView() {
     const status = courseStatus(course);
     const cid = escapeHtml(course.courseId);
     const ctitle = escapeHtml(course.title);
+    // #787 slice 5: eier/admin styrer om rediger/livssyklus-handlingene vises (speiler eierskaps-vakta).
+    const canManage = course.canManage !== false;
     // #705: samme handlings-rekkefølge som modul/seksjon — Publiser⇄Avpubliser, Arkiver⇄Gjenopprett.
     const publishToggle = canPublishCourse(course)
       ? `<button class="row-action-btn" data-action="publish" data-course-id="${cid}">Publiser</button>`
@@ -575,11 +577,12 @@ async function renderListView() {
       <td class="col-updated">${escapeHtml(course.updatedLabel)}</td>
       <td class="col-actions">
         <div class="row-actions">
-          <a href="/admin-content/courses/${encodeURIComponent(course.courseId)}" class="row-action-btn">Rediger</a>
-          ${publishToggle}
+          ${canManage ? `<a href="/admin-content/courses/${encodeURIComponent(course.courseId)}" class="row-action-btn">Rediger</a>` : ""}
+          ${canManage ? publishToggle : ""}
           <button class="row-action-btn" data-action="export" data-course-id="${cid}" data-course-title="${ctitle}">Eksporter</button>
-          ${archiveToggleBtn}
-          ${cascadeDeleteBtn}
+          ${canManage ? archiveToggleBtn : ""}
+          ${canManage ? cascadeDeleteBtn : ""}
+          ${canManage ? "" : `<span class="row-readonly-note" title="Bare en eier eller administrator kan endre dette kurset.">Skrivebeskyttet</span>`}
         </div>
       </td>
     </tr>`;

--- a/public/static/admin-content-library.js
+++ b/public/static/admin-content-library.js
@@ -279,6 +279,9 @@ function renderLibrary() {
     const openConvUrl = `/admin-content/module/${encodeURIComponent(m.id)}/conversation`;
     const openAdvUrl = `/admin-content/module/${encodeURIComponent(m.id)}/advanced`;
     const isArchived = m.status === "archived";
+    // #787 slice 5: eier/admin styrer om redigerings-/livssyklus-handlingene vises (speiler eierskaps-
+    // vakta). Dupliser/Eksporter beholdes — de er lese-/kopi-handlinger som ikke vaktes av eierskap.
+    const canManage = m.canManage !== false;
 
     const courseCountCell = m.courseCount > 0
       ? `<button class="course-count-btn" data-module-id="${escapeHtml(m.id)}" aria-label="${m.courseCount} kurs">${m.courseCount}</button>`
@@ -305,12 +308,13 @@ function renderLibrary() {
       <td class="col-updated">${formatDate(m.updatedAt)}</td>
       <td class="col-actions">
         <div class="row-actions">
-          <a href="${openConvUrl}" class="row-action-btn">Åpne i Samtale</a>
-          <a href="${openAdvUrl}" class="row-action-btn">Åpne i Avansert</a>
+          ${canManage ? `<a href="${openConvUrl}" class="row-action-btn">Åpne i Samtale</a>` : ""}
+          ${canManage ? `<a href="${openAdvUrl}" class="row-action-btn">Åpne i Avansert</a>` : ""}
           <button class="row-action-btn" data-action="duplicate" data-module-id="${escapeHtml(m.id)}">Dupliser</button>
           <button class="row-action-btn" data-action="export" data-module-id="${escapeHtml(m.id)}" data-module-title="${escapeHtml(m.title ?? m.id)}">Eksporter</button>
-          ${unpublishAction}
-          ${archiveAction}
+          ${canManage ? unpublishAction : ""}
+          ${canManage ? archiveAction : ""}
+          ${canManage ? "" : `<span class="row-readonly-note" title="Bare en eier eller administrator kan endre denne modulen.">Skrivebeskyttet</span>`}
         </div>
       </td>
     </tr>`;

--- a/public/static/admin-content-sections.js
+++ b/public/static/admin-content-sections.js
@@ -37,6 +37,7 @@ const LABELS = {
     published: "Section published.", unpublished: "Section unpublished.",
     archived: "Section archived.", restored: "Section restored.", confirmArchive: "Archive this section?",
     colUpdated: "Last changed", edit: "Edit", del: "Delete", empty: "No sections yet.",
+    readonly: "Read-only", readonlyHint: "Only an owner or an administrator can change this section.",
     back: "← Back", titleLabel: "Title", markdown: "Markdown", preview: "Preview",
     save: "Save new version", saved: "Section saved.", deleted: "Section deleted.",
     confirmDelete: "Delete this section?", loadError: "Could not load sections.",
@@ -56,6 +57,7 @@ const LABELS = {
     published: "Seksjon publisert.", unpublished: "Seksjon avpublisert.",
     archived: "Seksjon arkivert.", restored: "Seksjon gjenopprettet.", confirmArchive: "Arkivere denne seksjonen?",
     colUpdated: "Sist endret", edit: "Rediger", del: "Slett", empty: "Ingen seksjoner ennå.",
+    readonly: "Skrivebeskyttet", readonlyHint: "Bare en eier eller administrator kan endre denne seksjonen.",
     back: "← Tilbake", titleLabel: "Tittel", markdown: "Markdown", preview: "Forhåndsvisning",
     save: "Lagre ny versjon", saved: "Seksjon lagret.", deleted: "Seksjon slettet.",
     confirmDelete: "Slette denne seksjonen?", loadError: "Kunne ikke laste seksjoner.",
@@ -75,6 +77,7 @@ const LABELS = {
     published: "Seksjon publisert.", unpublished: "Seksjon avpublisert.",
     archived: "Seksjon arkivert.", restored: "Seksjon gjenoppretta.", confirmArchive: "Arkivere denne seksjonen?",
     colUpdated: "Sist endra", edit: "Rediger", del: "Slett", empty: "Ingen seksjonar enno.",
+    readonly: "Skrivebeskytta", readonlyHint: "Berre ein eigar eller administrator kan endre denne seksjonen.",
     back: "← Tilbake", titleLabel: "Tittel", markdown: "Markdown", preview: "Førehandsvising",
     save: "Lagre ny versjon", saved: "Seksjon lagra.", deleted: "Seksjon sletta.",
     confirmDelete: "Slette denne seksjonen?", loadError: "Kunne ikkje laste seksjonar.",
@@ -287,6 +290,9 @@ async function renderListView() {
   const rows = visible.map((s) => {
     const status = sectionStatus(s);
     const id = escapeHtml(s.id);
+    // #787 slice 5: skjul rediger/livssyklus-handlingene for innhold brukeren ikke eier (og ikke er admin
+    // for) — samme regel som eierskaps-vakta, så vi ikke viser knapper som gir 403 ved lagring.
+    const canManage = s.canManage !== false;
     // #705-UX: Slett vises kun for arkiverte elementer (terminal steg etter arkivering).
     const lifecycle = status === "archived"
       ? `<button class="row-action-btn" data-action="restore" data-id="${id}">${escapeHtml(L("restore"))}</button>
@@ -308,8 +314,10 @@ async function renderListView() {
       <td style="white-space:nowrap">${escapeHtml(new Date(s.updatedAt).toLocaleDateString(currentLocale))}</td>
       <td class="col-actions">
         <div class="row-actions">
-          <button class="row-action-btn" data-action="edit" data-id="${id}">${escapeHtml(L("edit"))}</button>
-          ${lifecycle}
+          ${canManage
+            ? `<button class="row-action-btn" data-action="edit" data-id="${id}">${escapeHtml(L("edit"))}</button>
+          ${lifecycle}`
+            : `<span class="row-readonly-note" title="${escapeHtml(L("readonlyHint"))}">${escapeHtml(L("readonly"))}</span>`}
         </div>
       </td>
     </tr>`;

--- a/public/static/shared.css
+++ b/public/static/shared.css
@@ -1114,6 +1114,12 @@ dialog::backdrop {
 .row-action-btn:hover { background: var(--color-row-hover); border-color: var(--color-link-hover-border); }
 .row-action-btn.destructive { color: var(--color-error); border-color: #f5c0bb; }
 .row-action-btn.destructive:hover { background: #fdf0ef; }
+/* #787 slice 5: nøytral «Skrivebeskyttet»-markør når brukeren verken eier innholdet eller er admin —
+   samme høyde som knappene så radene ikke hopper, men tydelig ikke-interaktiv (dempet, hjelpe-markør). */
+.row-readonly-note {
+  display: inline-flex; align-items: center; min-height: 28px; padding: 0 4px;
+  font-size: 12px; color: var(--color-meta); font-style: italic; cursor: help; white-space: nowrap;
+}
 
 /* #705-UX(A): felles filter-piller (Alle/Aktive/Publiserte/Arkiverte) på tvers av admin-listene,
    samme uttrykk som modul-bibliotekets .library-filter-btn. */

--- a/src/config/capabilities.ts
+++ b/src/config/capabilities.ts
@@ -157,10 +157,14 @@ export function buildWorkspaceNavigationItems(calibrationAccessRoles: AppRoleTyp
       // #767: «Mine kurs» — deltakerens egen kurs-arbeidsflate. «Fullførte» er ikke lenger et eget
       // toppmeny-punkt; den nås via undernavigasjonen (Pågående | Fullførte) rendret av
       // public/static/mine-kurs-subnav.js på /participant og /participant/completed.
+      // #787 QA: synlig for ALLE roller (tom requiredRoles). Deltaker-arbeidsflaten viser kun den
+      // publiserte modulkatalogen (participantFacing=true → ingen utkast/admin-data) og er uansett nåbar
+      // via URL for enhver innlogget bruker. Tidligere manglet f.eks. en ren SUBJECT_MATTER_OWNER punktet
+      // og fikk en usammenhengende meny (skjult punkt, men nåbar side) — nå matcher nav faktisk tilgang.
       id: "participant",
       path: "/participant",
       labelKey: "nav.participant",
-      requiredRoles: [AppRole.PARTICIPANT, AppRole.ADMINISTRATOR, AppRole.REVIEWER],
+      requiredRoles: [],
     },
     {
       id: "admin-content",

--- a/src/modules/adminContent/adminContentQueries.ts
+++ b/src/modules/adminContent/adminContentQueries.ts
@@ -29,7 +29,11 @@ function deriveLibraryStatus(module: {
   return "published";
 }
 
-export async function listLibraryModules(locale: SupportedLocale = "en-GB", viewerUserId?: string) {
+export async function listLibraryModules(
+  locale: SupportedLocale = "en-GB",
+  viewerUserId?: string,
+  viewerIsAdmin = false,
+) {
   const modules = await adminContentRepository.listLibraryModules();
   // #787/#836: annotate each module with whether the viewer owns it, so the quality/calibration picker
   // can default to "my modules". Only queried when a viewer id is supplied (unauthenticated → all false).
@@ -46,6 +50,9 @@ export async function listLibraryModules(locale: SupportedLocale = "en-GB", view
     activeVersionNo: module.activeVersion?.versionNo ?? null,
     latestVersionNo: module.versions[0]?.versionNo ?? null,
     ownedByMe: ownedIds.has(module.id),
+    // #787 slice 5: admin manages all; a non-admin manages only modules they own (unowned → admin-only).
+    // Same rule as the ownership guard, so the library hides the edit/lifecycle actions that would 403.
+    canManage: viewerIsAdmin || ownedIds.has(module.id),
     courseCount: module._count.courseItems,
     courses: module.courseItems.map((ci) => ({
       id: ci.course.id,

--- a/src/modules/content/contentOwnershipService.ts
+++ b/src/modules/content/contentOwnershipService.ts
@@ -36,6 +36,28 @@ export function listContentOwnerUserIds(
 }
 
 /**
+ * #787 slice 5 (list UX): batch version of the ownership decision for list views. Returns the subset of
+ * `contentIds` the actor may manage (edit / publish / archive / delete) — exactly the ids where
+ * assertContentOwnership would NOT throw. Same rule as decideOwnershipAccess: an ADMINISTRATOR manages
+ * all; a non-admin manages only the ids they own (unowned → not manageable). Lets a list endpoint annotate
+ * each row with `canManage`, so the UI can hide the action buttons the server would otherwise 403 on save.
+ */
+export async function listManageableContentIds(input: {
+  contentType: ContentOwnerType;
+  contentIds: string[];
+  actorUserId: string;
+  roles: string[];
+}): Promise<Set<string>> {
+  if (input.roles.includes("ADMINISTRATOR")) return new Set(input.contentIds);
+  if (input.contentIds.length === 0 || !input.actorUserId) return new Set();
+  const rows = await prisma.contentOwner.findMany({
+    where: { contentType: input.contentType, contentId: { in: input.contentIds }, userId: input.actorUserId },
+    select: { contentId: true },
+  });
+  return new Set(rows.map((r) => r.contentId));
+}
+
+/**
  * Throws ForbiddenError unless the actor may modify the given content object (admin, or an owner).
  * Gates AUTHORING only — participant read/visibility is governed elsewhere (enrollmentPolicy, #785/#786).
  */

--- a/src/modules/course/courseReadModels.ts
+++ b/src/modules/course/courseReadModels.ts
@@ -52,6 +52,9 @@ export interface AdminCourseListItem {
   archivedAt: string | null;
   // #705-UX(F): antall deltakere som er midt i kurset (påbegynt, ikke fullført).
   inProgressCount: number;
+  // #787 slice 5: may the viewer manage this course (admin, or an owner)? Drives whether the list shows
+  // the edit/lifecycle actions — mirrors the ownership guard so we don't render buttons that 403.
+  canManage: boolean;
 }
 
 export interface AdminCourseDetail {

--- a/src/routes/adminClasses.ts
+++ b/src/routes/adminClasses.ts
@@ -1,5 +1,6 @@
 import { Router, type Request } from "express";
 import { requireContentOwnership } from "./requireContentOwnership.js";
+import { listManageableContentIds } from "../modules/content/contentOwnershipService.js";
 import { z } from "zod";
 import {
   createClass,
@@ -25,9 +26,19 @@ const createClassSchema = z.object({
 const addMemberSchema = z.object({ userId: z.string().min(1) });
 const assignCourseSchema = z.object({ courseId: z.string().min(1), dueAt: z.string().datetime().nullish() });
 
-adminClassesRouter.get("/", async (_request, response, next) => {
+adminClassesRouter.get("/", async (request, response, next) => {
   try {
-    response.json({ classes: await listClasses() });
+    const classes = await listClasses();
+    // #787 slice 5: annotate each class with whether the viewer may manage it (admin or owner), so the
+    // list hides the archive/restore/manage actions the ownership guard would 403 on. System classes are
+    // unowned, so only an administrator manages them — which is the existing behaviour.
+    const manageable = await listManageableContentIds({
+      contentType: "CLASS",
+      contentIds: classes.map((c) => c.id),
+      actorUserId: request.context?.userId ?? "",
+      roles: request.context?.roles ?? [],
+    });
+    response.json({ classes: classes.map((c) => ({ ...c, canManage: manageable.has(c.id) })) });
   } catch (error) {
     next(error);
   }

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -239,7 +239,11 @@ adminContentRouter.post("/modules", async (request, response) => {
 adminContentRouter.get("/modules/library", async (request, response) => {
   const locale = (request.query.locale as string) || request.context?.locale || "en-GB";
   try {
-    const modules = await listLibraryModules(locale as Parameters<typeof listLibraryModules>[0], request.context?.userId);
+    const modules = await listLibraryModules(
+      locale as Parameters<typeof listLibraryModules>[0],
+      request.context?.userId,
+      request.context?.roles?.includes("ADMINISTRATOR") ?? false,
+    );
     response.json({ modules });
   } catch {
     response.status(500).json({ error: "list_library_failed" });

--- a/src/routes/adminCourses.ts
+++ b/src/routes/adminCourses.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { requireContentOwnership } from "./requireContentOwnership.js";
+import { listManageableContentIds } from "../modules/content/contentOwnershipService.js";
 import { z } from "zod";
 import {
   createCourse,
@@ -130,13 +131,21 @@ adminCoursesRouter.post("/localize-copy", generateLimiter, async (request, respo
   }
 });
 
-adminCoursesRouter.get("/", async (_request, response, next) => {
+adminCoursesRouter.get("/", async (request, response, next) => {
   try {
     const courses = await courseRepository.listCourses();
     // #705-UX(F): vis antall påbegynte-ufullførte deltakere per kurs (samme signal som G3-vakta).
     const inProgressCounts = await Promise.all(
       courses.map((c) => countCourseInProgressParticipants(c.id)),
     );
+    // #787 slice 5: hvilke kurs kan innlogget bruker forvalte (admin eller eier)? Styrer om lista viser
+    // rediger/livssyklus-handlingene — speiler eierskaps-vakta så vi ikke rendrer knapper som gir 403.
+    const manageable = await listManageableContentIds({
+      contentType: "COURSE",
+      contentIds: courses.map((c) => c.id),
+      actorUserId: request.context?.userId ?? "",
+      roles: request.context?.roles ?? [],
+    });
     const items: AdminCourseListItem[] = courses.map((c, i) => ({
       id: c.id,
       title: c.title,
@@ -147,6 +156,7 @@ adminCoursesRouter.get("/", async (_request, response, next) => {
       publishedAt: c.publishedAt?.toISOString() ?? null,
       archivedAt: c.archivedAt?.toISOString() ?? null,
       inProgressCount: inProgressCounts[i],
+      canManage: manageable.has(c.id),
     }));
     response.json({ courses: items });
   } catch (error) {

--- a/src/routes/adminSections.ts
+++ b/src/routes/adminSections.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type RequestHandler } from "express";
 import { requireContentOwnership } from "./requireContentOwnership.js";
+import { listManageableContentIds } from "../modules/content/contentOwnershipService.js";
 import multer from "multer";
 import { z } from "zod";
 import {
@@ -182,11 +183,19 @@ adminSectionsRouter.post("/localize", generateLimiter, async (request, response,
   }
 });
 
-adminSectionsRouter.get("/", async (_request, response, next) => {
+adminSectionsRouter.get("/", async (request, response, next) => {
   try {
     const sections = await listSections();
     // #705-UX(G): «Brukt i kurs»-kolonne med popover (likt modul-biblioteket).
     const coursesBySection = await findCoursesForSections(sections.map((s) => s.id));
+    // #787 slice 5: annotate each row with whether the viewer may manage it, so the list can hide the
+    // edit/lifecycle actions the ownership guard would 403 on (mirrors requireContentOwnership exactly).
+    const manageable = await listManageableContentIds({
+      contentType: "SECTION",
+      contentIds: sections.map((s) => s.id),
+      actorUserId: request.context?.userId ?? "",
+      roles: request.context?.roles ?? [],
+    });
     response.json({
       sections: sections.map((s) => {
         const courses = coursesBySection.get(s.id) ?? [];
@@ -200,6 +209,7 @@ adminSectionsRouter.get("/", async (_request, response, next) => {
           archivedAt: s.archivedAt?.toISOString() ?? null,
           courseCount: courses.length,
           courses,
+          canManage: manageable.has(s.id),
         };
       }),
     });

--- a/test/e2e/content-owner-surfaces.spec.ts
+++ b/test/e2e/content-owner-surfaces.spec.ts
@@ -90,6 +90,33 @@ test("klasse: owner panel renders in the class detail view", async ({ page }) =>
   await expect(panel.locator(".owner-compact-names")).toContainText("Alice Owner");
 });
 
+// #787 slice 5 — the section LIST hides edit/lifecycle actions for rows the viewer can't manage
+// (canManage:false), so a non-owner never sees a button the server would 403 on save. Drives the real
+// admin-content-sections.js list render with a mixed owned/not-owned payload.
+test("seksjon-liste: edit/lifecycle hidden for canManage:false, shown for canManage:true", async ({ page }) => {
+  await page.route("**/participant/config", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ authMode: "mock", navigation: { items: [], workspaceItems: [] }, identityDefaults: { userId: "c1", email: "c@x.no", name: "C", roles: ["SUBJECT_MATTER_OWNER"] } }) }));
+  await page.route("**/version", (route: Route) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "e2e" }) }));
+  await page.route("**/api/me", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ user: { id: "c1", email: "c@x.no", name: "C", roles: ["SUBJECT_MATTER_OWNER"] }, consent: { accepted: true }, pendingDeletion: null }) }));
+  await page.route("**/api/admin/content/sections", (route: Route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ sections: [
+      { id: "sec-mine", title: { nb: "Min seksjon", nn: "", "en-GB": "" }, activeVersionId: "v1", versionNo: 1, updatedAt: "2026-07-20T00:00:00.000Z", archivedAt: null, courseCount: 0, courses: [], canManage: true },
+      { id: "sec-theirs", title: { nb: "Andres seksjon", nn: "", "en-GB": "" }, activeVersionId: "v1", versionNo: 1, updatedAt: "2026-07-20T00:00:00.000Z", archivedAt: null, courseCount: 0, courses: [], canManage: false },
+    ] }) }));
+
+  await page.goto("/admin-content/sections");
+
+  // Owned row: edit + lifecycle present.
+  await expect(page.locator('[data-action="edit"][data-id="sec-mine"]')).toBeVisible();
+  await expect(page.locator('[data-action="unpublish"][data-id="sec-mine"]')).toBeVisible();
+  // Not-owned row: no edit, no lifecycle — a read-only marker instead.
+  await expect(page.locator('[data-action="edit"][data-id="sec-theirs"]')).toHaveCount(0);
+  await expect(page.locator('[data-action="unpublish"][data-id="sec-theirs"]')).toHaveCount(0);
+  await expect(page.locator(".row-readonly-note")).toHaveCount(1);
+  await expect(page.locator(".row-readonly-note")).toHaveText("Skrivebeskyttet");
+});
+
 // QA #3 — the standalone section editor (admin-content-sections.js), reachable directly via ?id=.
 test("seksjon: owner panel renders in the section editor for an existing section", async ({ page }) => {
   await page.route("**/participant/config", (route: Route) =>

--- a/test/m2-content-ownership-enforcement.test.ts
+++ b/test/m2-content-ownership-enforcement.test.ts
@@ -54,4 +54,42 @@ describe("content ownership enforcement (#787 slice 4b)", () => {
 
     expect([200, 204]).toContain((await request(app).delete(`/api/admin/content/classes/${id}`).set(smoA)).status);
   });
+
+  // #787 slice 5 (list UX): the list endpoints annotate each row with `canManage` so the UI hides the
+  // edit/lifecycle actions the guard above would 403 on. Owner + admin ⇒ true; a non-owner SMO ⇒ false.
+  const canManageOf = (rows: Array<{ id: string; canManage?: boolean }>, id: string) =>
+    rows.find((r) => r.id === id)?.canManage;
+
+  it("SECTION list: canManage true for owner+admin, false for non-owner", async () => {
+    const create = await request(app).post("/api/admin/content/sections").set(smoA).send({ title: L("Mng section"), bodyMarkdown: "# S" });
+    const id = create.body.section.id as string;
+    expect(canManageOf((await request(app).get("/api/admin/content/sections").set(smoA)).body.sections, id)).toBe(true);
+    expect(canManageOf((await request(app).get("/api/admin/content/sections").set(smoB)).body.sections, id)).toBe(false);
+    expect(canManageOf((await request(app).get("/api/admin/content/sections").set(admin)).body.sections, id)).toBe(true);
+  });
+
+  it("COURSE list: canManage true for owner+admin, false for non-owner", async () => {
+    const create = await request(app).post("/api/admin/content/courses").set(smoA).send({ title: L("Mng course") });
+    const id = create.body.course.id as string;
+    expect(canManageOf((await request(app).get("/api/admin/content/courses").set(smoA)).body.courses, id)).toBe(true);
+    expect(canManageOf((await request(app).get("/api/admin/content/courses").set(smoB)).body.courses, id)).toBe(false);
+    expect(canManageOf((await request(app).get("/api/admin/content/courses").set(admin)).body.courses, id)).toBe(true);
+  });
+
+  it("CLASS list: canManage true for owner+admin, false for non-owner", async () => {
+    const create = await request(app).post("/api/admin/content/classes").set(smoA).send({ name: `Mng-${Date.now()}` });
+    const id = create.body.class.id as string;
+    expect(canManageOf((await request(app).get("/api/admin/content/classes").set(smoA)).body.classes, id)).toBe(true);
+    expect(canManageOf((await request(app).get("/api/admin/content/classes").set(smoB)).body.classes, id)).toBe(false);
+    expect(canManageOf((await request(app).get("/api/admin/content/classes").set(admin)).body.classes, id)).toBe(true);
+  });
+
+  it("MODULE library: canManage true for owner+admin, false for non-owner", async () => {
+    const create = await request(app).post("/api/admin/content/modules").set(smoA).send({ title: L(`Mng module ${Date.now()}`) });
+    expect(create.status).toBe(201);
+    const id = create.body.module.id as string;
+    expect(canManageOf((await request(app).get("/api/admin/content/modules/library").set(smoA)).body.modules, id)).toBe(true);
+    expect(canManageOf((await request(app).get("/api/admin/content/modules/library").set(smoB)).body.modules, id)).toBe(false);
+    expect(canManageOf((await request(app).get("/api/admin/content/modules/library").set(admin)).body.modules, id)).toBe(true);
+  });
 });

--- a/test/participant-console-config.test.ts
+++ b/test/participant-console-config.test.ts
@@ -3,6 +3,13 @@ import { app } from "../src/app.js";
 import { buildWorkspaceNavigationItems } from "../src/config/capabilities.js";
 
 describe("participant console runtime config", () => {
+  // #787 QA: «Mine kurs» must be visible to EVERY role (empty requiredRoles) — a pure SUBJECT_MATTER_OWNER
+  // previously got a hidden nav item while the page stayed reachable by URL. Guards that regression.
+  it("«Mine kurs» nav item is visible to all roles (empty requiredRoles)", () => {
+    const participant = buildWorkspaceNavigationItems([]).find((i) => i.id === "participant");
+    expect(participant?.requiredRoles).toEqual([]);
+  });
+
   it("returns runtime config with role presets and auth metadata", async () => {
     const response = await request(app).get("/participant/config");
 

--- a/test/unit/admin-content-courses-state.test.js
+++ b/test/unit/admin-content-courses-state.test.js
@@ -58,6 +58,7 @@ describe("admin content courses state helpers", () => {
         publishedAt: null,
         archivedAt: null,
         inProgressCount: 0,
+        canManage: true,
       },
       {
         courseId: "course-2",
@@ -68,8 +69,22 @@ describe("admin content courses state helpers", () => {
         publishedAt: "2026-03-02T08:15:00.000Z",
         archivedAt: null,
         inProgressCount: 0,
+        canManage: true,
       },
     ]);
+  });
+
+  // #787 slice 5: canManage passes through — absent ⇒ true (older payload / admin), explicit false ⇒ false.
+  it("deriveCourseListRows carries canManage (false only when explicitly false)", () => {
+    const rows = deriveCourseListRows(
+      [
+        { id: "owned", title: {}, canManage: true },
+        { id: "not-owned", title: {}, canManage: false },
+        { id: "legacy", title: {} },
+      ],
+      { localizeTitle: () => "", formatDate: () => "" },
+    );
+    expect(rows.map((r) => r.canManage)).toEqual([true, false, true]);
   });
 
   // #524 (U3): the course-builder mixed module/section list — reorder + type-badge logic.


### PR DESCRIPTION
## QA follow-ups on #787 (from stage 2.2.3 testing)

Two refinements to the ownership-enforcement UX.

### 1. Lists mirror the ownership guard (`canManage`)
A non-owner used to see **Rediger / Publiser / Avpubliser / Arkiver / Gjenopprett / Slett** on content they don't own, and was only stopped at save (403). Now the four admin list endpoints annotate each row with **`canManage`** — the batch equivalent of `decideOwnershipAccess` (new `listManageableContentIds`: admin ⇒ all; non-admin ⇒ only rows they own, same rule as `requireContentOwnership`). The front-end hides the edit/lifecycle actions and editor entry points when `canManage=false`, showing a muted **«Skrivebeskyttet»** marker. Read/copy actions (Eksporter, Dupliser) stay.

Surfaces covered: **Kurs, Seksjoner, Moduler, Klasser**.

### 2. «Mine kurs» nav visible to all roles
A pure `SUBJECT_MATTER_OWNER` got a hidden **Mine kurs** item while `/participant` stayed reachable by URL. The page shows only the published catalog (`participantFacing=true`, no draft/admin data), so the item is now visible to all roles (empty `requiredRoles`) — nav matches actual access. No data-scope change.

## Tests
- Integration: `canManage` true for owner+admin / false for non-owner on all four list endpoints.
- E2e: list gating — edit/lifecycle hidden for `canManage:false`, shown for `true` (`content-owner-surfaces.spec.ts`).
- Regression guard: «Mine kurs» visible to all roles.
- Full local run: **tsc 0 · 811 unit · 5 DOM · 393 integration · 4 e2e** green.

Code-only (no infra) → deploy via `deploy-app.yml`. Version **2.2.4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
