### PR TITLE
M5 worker reliability: #809 (health 503 on stuck) + #810 (drain on shutdown) + #812 (external-call deadlines)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,33 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.2.5 - 2026-07-23
+
+M5 stabilization — worker reliability cluster (#809 + #810 + #812)
+
+Three related fixes so a stuck background loop is detected, survived, and prevented. All code-only
+(no infra), deployed as one bundle.
+
+- **#809 — worker health returns 503 when a loop is stuck (liveness ≠ readiness).** The worker
+  `/healthz` returned a hardcoded 200 regardless of monitor state, so a permanently stuck loop was
+  invisible to Azure's probe and the container was never auto-replaced. New pure
+  `evaluateWorkerHealth` with per-monitor thresholds derived from each monitor's own interval (the six
+  span 4s..24h): **wedged** (in-flight tick running > interval×3) or **stalled** (no success within
+  interval×3), both floored at 60s so short-interval monitors / warm-up don't flap. Each monitor
+  exposes `health()` (adds `tickStartedAt`); `getStatus()` unchanged. Worker `healthCheckPath=/healthz`
+  is already wired in bicep, so Azure now auto-restarts a stuck worker.
+- **#810 — graceful shutdown drains in-flight work.** `gracefulShutdown` stopped scheduling but didn't
+  wait for a tick already running, so shutdown could kill work mid-flight. It now drains (bounded 10s;
+  Azure allows ~30s before SIGKILL) before exiting; a wedged tick can't block the exit.
+- **#812 — deadlines + bounded retries on ACS email and Microsoft Graph.** Node's fetch has no default
+  timeout and the ACS poller waits indefinitely, so a hung dependency could wedge a tick. New
+  `src/clients/externalCall.ts`: `withTimeout` bounds the ACS send (30s, no retry — audit-deduped
+  re-run avoids double-send) and Graph token; `fetchWithDeadlineAndRetry` gives the idempotent Graph
+  GETs a 15s per-attempt deadline + backoff retry.
+
+Tests: 18 new (health evaluator wedged/stalled/disabled/grace/floor/aggregate, in-flight snapshot,
+drain idle/settle/wedged, external-call timeout + retry + abort). tsc 0 · 829 unit · 393 integration.
+
 ## 2.2.4 - 2026-07-23
 
 fix(#787): skjul rediger/livssyklus-handlinger for ikke-eiere + vis «Mine kurs» for alle roller (QA)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/clients/externalCall.ts
+++ b/src/clients/externalCall.ts
@@ -1,0 +1,86 @@
+// #812: external calls (ACS email, Microsoft Graph) had no deadlines. Node's global fetch has NO
+// default timeout, and the ACS SDK's pollUntilDone() polls until the service responds — so a slow or
+// unresponsive dependency could block a worker tick indefinitely, wedging the loop (the failure #809
+// makes visible and #810 has to force past on shutdown). This module bounds those calls in time.
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export class ExternalCallTimeoutError extends Error {
+  constructor(label: string, ms: number) {
+    super(`External call '${label}' exceeded its ${ms}ms deadline`);
+    this.name = "ExternalCallTimeoutError";
+  }
+}
+
+/**
+ * Bound a promise that offers no native cancellation (e.g. an SDK poller). On timeout we stop awaiting
+ * and reject; the underlying operation may still complete server-side, so this must only wrap
+ * operations that are IDEMPOTENT or dedup-guarded by the caller (a retry/re-run must not double-effect).
+ */
+export async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new ExternalCallTimeoutError(label, ms)), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+const DEFAULT_RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+const BACKOFF_MAX_MS = 8_000;
+
+function backoffMs(attempt: number): number {
+  // attempt is 1-based; exponential (1s, 2s, 4s…) capped, with jitter to avoid synchronized retries.
+  const exponential = Math.min(1_000 * 2 ** (attempt - 1), BACKOFF_MAX_MS);
+  return Math.round(exponential * (0.5 + Math.random() * 0.5));
+}
+
+export interface FetchWithDeadlineOptions {
+  timeoutMs: number;
+  label: string;
+  maxAttempts?: number;
+  retryableStatuses?: Set<number>;
+  onRetry?: (info: { attempt: number; maxAttempts: number; reason: string }) => void;
+}
+
+/**
+ * fetch() with an abort-based per-attempt deadline plus bounded retry with backoff. A hung request is
+ * aborted at `timeoutMs` (turning into an ExternalCallTimeoutError on the final attempt); transient
+ * failures (network error / 429 / 5xx) are retried. ONLY for IDEMPOTENT requests (typically GET): a
+ * retry re-issues the request, so running it more than once must be safe.
+ */
+export async function fetchWithDeadlineAndRetry(
+  url: string,
+  init: RequestInit,
+  opts: FetchWithDeadlineOptions,
+): Promise<Response> {
+  const maxAttempts = opts.maxAttempts ?? 3;
+  const retryable = opts.retryableStatuses ?? DEFAULT_RETRYABLE_STATUSES;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
+    try {
+      const response = await fetch(url, { ...init, signal: controller.signal });
+      if (response.ok || !retryable.has(response.status)) return response;
+      if (attempt === maxAttempts) return response; // out of budget — hand the last failing response back
+      opts.onRetry?.({ attempt, maxAttempts, reason: `status ${response.status}` });
+    } catch (error) {
+      // An abort surfaces as an AbortError — normalize it to a clear deadline error on the last attempt.
+      const isAbort = error instanceof Error && error.name === "AbortError";
+      lastError = isAbort ? new ExternalCallTimeoutError(opts.label, opts.timeoutMs) : error;
+      if (attempt === maxAttempts) throw lastError;
+      opts.onRetry?.({ attempt, maxAttempts, reason: error instanceof Error ? error.message : String(error) });
+    } finally {
+      clearTimeout(timer);
+    }
+    await sleep(backoffMs(attempt));
+  }
+
+  // Unreachable in practice (the loop returns/throws on the final attempt), but keeps the type total.
+  throw lastError instanceof Error ? lastError : new Error(`fetch '${opts.label}' failed`);
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -63,6 +63,10 @@ const envSchema = z.object({
   // #690: how often the scheduled Entra user sync runs (worker). Default 24h. Only active when
   // ENTRA_USER_SYNC_GROUP_ID is set.
   ENTRA_USER_SYNC_INTERVAL_MS: z.coerce.number().int().positive().default(86_400_000),
+  // #812: per-request deadline for Microsoft Graph calls (token + group-member pages). Node's fetch has
+  // no default timeout, so a hung Graph response would wedge the Entra sync tick. Idempotent GETs, so
+  // the fetch is retried with backoff on timeout/5xx/429.
+  ENTRA_GRAPH_TIMEOUT_MS: z.coerce.number().int().positive().default(15_000),
   MOCK_DEFAULT_USER_ID: z.string().default("dev-user-1"),
   MOCK_DEFAULT_EMAIL: z.string().email().default("dev.user@company.com"),
   MOCK_DEFAULT_NAME: z.string().default("Dev User"),
@@ -99,6 +103,9 @@ const envSchema = z.object({
     z.string().url().optional(),
   ),
   PARTICIPANT_NOTIFICATION_WEBHOOK_TIMEOUT_MS: z.coerce.number().int().positive().default(5000),
+  // #812: deadline for an ACS email send (beginSend + pollUntilDone). Without it a slow/unresponsive
+  // ACS could block a worker tick (course reminders, recert, appeal SLA) indefinitely → wedged loop.
+  ACS_EMAIL_SEND_TIMEOUT_MS: z.coerce.number().int().positive().default(30_000),
   // #497: daglig bakgrunnsjobb for kurs-frist-påminnelser. Kjører kun i worker-rollen når
   // varselkanalen er aktiv (PARTICIPANT_NOTIFICATION_CHANNEL !== "disabled").
   COURSE_REMINDER_INTERVAL_MS: z.coerce.number().int().positive().default(86_400_000),

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { PseudonymizationMonitor } from "./modules/user/PseudonymizationMonitor.
 import { AuditRetentionMonitor } from "./modules/retention/AuditRetentionMonitor.js";
 import { EntraUserSyncMonitor } from "./modules/orgSync/EntraUserSyncMonitor.js";
 import { CourseReminderMonitor } from "./modules/course/CourseReminderMonitor.js";
-import { evaluateWorkerHealth, type MonitorHealthSnapshot } from "./observability/workerHealth.js";
+import { evaluateWorkerHealth, drainInFlightTicks, type MonitorHealthSnapshot } from "./observability/workerHealth.js";
 
 export function resolveProcessRoleFlags(role: string) {
   return {
@@ -29,18 +29,33 @@ const auditRetentionMonitor = startWorkers ? new AuditRetentionMonitor() : null;
 const entraUserSyncMonitor = startWorkers ? new EntraUserSyncMonitor() : null;
 const courseReminderMonitor = startWorkers ? new CourseReminderMonitor() : null;
 
-const gracefulShutdown = (exitCode = 0) => {
+const backgroundMonitors = [
+  assessmentWorker,
+  appealSlaMonitor,
+  pseudonymizationMonitor,
+  auditRetentionMonitor,
+  entraUserSyncMonitor,
+  courseReminderMonitor,
+];
+
+// #810: on shutdown, stop scheduling AND drain any in-flight tick before exiting, so we don't kill work
+// mid-flight (e.g. an assessment job being processed). Bounded so a wedged loop (#809) can't block the
+// exit — Azure allows ~30 s before SIGKILL, so 10 s of drain is safe headroom.
+const SHUTDOWN_DRAIN_TIMEOUT_MS = 10_000;
+
+const gracefulShutdown = async (exitCode = 0) => {
   if (shuttingDown) {
     return;
   }
 
   shuttingDown = true;
-  appealSlaMonitor?.stop();
-  assessmentWorker?.stop();
-  pseudonymizationMonitor?.stop();
-  auditRetentionMonitor?.stop();
-  entraUserSyncMonitor?.stop();
-  courseReminderMonitor?.stop();
+  for (const monitor of backgroundMonitors) monitor?.stop();
+
+  const drained = await drainInFlightTicks(backgroundMonitors, SHUTDOWN_DRAIN_TIMEOUT_MS);
+  if (!drained) {
+    // eslint-disable-next-line no-console
+    console.warn(`[#810] shutdown drain timed out after ${SHUTDOWN_DRAIN_TIMEOUT_MS}ms; a tick was still in flight`);
+  }
 
   if (!server) {
     process.exit(exitCode);
@@ -71,14 +86,9 @@ async function startServer() {
     // container. A hardcoded 200 previously hid a stuck loop from the probe. `startedAt` is the grace
     // reference for monitors that haven't completed their first cycle yet.
     server = http.createServer((_req, res) => {
-      const snapshots: MonitorHealthSnapshot[] = [
-        assessmentWorker?.health(),
-        appealSlaMonitor?.health(),
-        pseudonymizationMonitor?.health(),
-        auditRetentionMonitor?.health(),
-        entraUserSyncMonitor?.health(),
-        courseReminderMonitor?.health(),
-      ].filter((s): s is MonitorHealthSnapshot => Boolean(s));
+      const snapshots: MonitorHealthSnapshot[] = backgroundMonitors
+        .map((m) => m?.health())
+        .filter((s): s is MonitorHealthSnapshot => Boolean(s));
 
       const report = evaluateWorkerHealth(snapshots, new Date(), startedAt);
       res.writeHead(report.healthy ? 200 : 503, { "content-type": "application/json" });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { PseudonymizationMonitor } from "./modules/user/PseudonymizationMonitor.
 import { AuditRetentionMonitor } from "./modules/retention/AuditRetentionMonitor.js";
 import { EntraUserSyncMonitor } from "./modules/orgSync/EntraUserSyncMonitor.js";
 import { CourseReminderMonitor } from "./modules/course/CourseReminderMonitor.js";
+import { evaluateWorkerHealth, type MonitorHealthSnapshot } from "./observability/workerHealth.js";
 
 export function resolveProcessRoleFlags(role: string) {
   return {
@@ -64,21 +65,28 @@ async function startServer() {
       console.log(`a2-assessment-platform listening on port ${env.PORT} [role=${env.PROCESS_ROLE}]`);
     });
   } else {
-    // Worker-only mode: bind health endpoint so Azure App Service keeps the process alive
+    // Worker-only mode: bind the health endpoint Azure App Service probes. #809: this is READINESS, not
+    // just liveness — the endpoint returns 503 when a background loop is permanently stuck (a wedged
+    // in-flight tick, or no successful cycle within its staleness window), so the platform restarts the
+    // container. A hardcoded 200 previously hid a stuck loop from the probe. `startedAt` is the grace
+    // reference for monitors that haven't completed their first cycle yet.
     server = http.createServer((_req, res) => {
-      res.writeHead(200, { "content-type": "application/json" });
+      const snapshots: MonitorHealthSnapshot[] = [
+        assessmentWorker?.health(),
+        appealSlaMonitor?.health(),
+        pseudonymizationMonitor?.health(),
+        auditRetentionMonitor?.health(),
+        entraUserSyncMonitor?.health(),
+        courseReminderMonitor?.health(),
+      ].filter((s): s is MonitorHealthSnapshot => Boolean(s));
+
+      const report = evaluateWorkerHealth(snapshots, new Date(), startedAt);
+      res.writeHead(report.healthy ? 200 : 503, { "content-type": "application/json" });
       res.end(JSON.stringify({
-        status: "ok",
+        status: report.healthy ? "ok" : "degraded",
         role: env.PROCESS_ROLE,
         startedAt: startedAt.toISOString(),
-        workers: {
-          assessmentWorker: assessmentWorker?.getStatus() ?? null,
-          appealSlaMonitor: appealSlaMonitor?.getStatus() ?? null,
-          pseudonymizationMonitor: pseudonymizationMonitor?.getStatus() ?? null,
-          auditRetentionMonitor: auditRetentionMonitor?.getStatus() ?? null,
-          entraUserSyncMonitor: entraUserSyncMonitor?.getStatus() ?? null,
-          courseReminderMonitor: courseReminderMonitor?.getStatus() ?? null,
-        },
+        health: report,
       }));
     }).listen(env.PORT, () => {
       // eslint-disable-next-line no-console

--- a/src/modules/appeal/AppealSlaMonitor.ts
+++ b/src/modules/appeal/AppealSlaMonitor.ts
@@ -1,4 +1,5 @@
 import { env } from "../../config/env.js";
+import type { MonitorHealthSnapshot } from "../../observability/workerHealth.js";
 import { runAppealSlaMonitorNow, type AppealSlaMonitorSnapshot } from "./appealSlaMonitorService.js";
 
 type AppealSlaMonitorRunner = () => Promise<AppealSlaMonitorSnapshot>;
@@ -10,6 +11,7 @@ export type AppealSlaMonitorStatus = {
 export class AppealSlaMonitor {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
+  private tickStartedAt: Date | null = null;
   private lastCycleAt: Date | null = null;
 
   constructor(
@@ -45,12 +47,26 @@ export class AppealSlaMonitor {
     return { lastCycleAt: this.lastCycleAt?.toISOString() ?? null };
   }
 
+  // #809: standardized snapshot for the worker readiness check. Always enabled while workers run.
+  health(): MonitorHealthSnapshot {
+    return {
+      name: "appealSlaMonitor",
+      enabled: true,
+      intervalMs: this.pollIntervalMs,
+      running: this.running,
+      tickStartedAt: this.tickStartedAt?.toISOString() ?? null,
+      lastCycleAt: this.lastCycleAt?.toISOString() ?? null,
+      lastError: null,
+    };
+  }
+
   private async tick() {
     if (this.running) {
       return;
     }
 
     this.running = true;
+    this.tickStartedAt = new Date();
     try {
       await this.runMonitor();
       this.lastCycleAt = new Date();
@@ -60,6 +76,7 @@ export class AppealSlaMonitor {
       console.warn(`[appeal-sla] monitor tick failed: ${error instanceof Error ? error.message : String(error)}`);
     } finally {
       this.running = false;
+      this.tickStartedAt = null;
     }
   }
 }

--- a/src/modules/assessment/AssessmentWorker.ts
+++ b/src/modules/assessment/AssessmentWorker.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { env } from "../../config/env.js";
+import type { MonitorHealthSnapshot } from "../../observability/workerHealth.js";
 import { processNextJob } from "./assessmentJobService.js";
 
 type AssessmentWorkerRunner = () => Promise<boolean>;
@@ -12,6 +13,7 @@ export type AssessmentWorkerStatus = {
 export class AssessmentWorker {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
+  private tickStartedAt: Date | null = null;
   private lastCycleAt: Date | null = null;
   readonly instanceId: string;
 
@@ -54,12 +56,26 @@ export class AssessmentWorker {
     };
   }
 
+  // #809: standardized snapshot for the worker readiness check. Always enabled while workers run.
+  health(): MonitorHealthSnapshot {
+    return {
+      name: "assessmentWorker",
+      enabled: true,
+      intervalMs: this.pollIntervalMs,
+      running: this.running,
+      tickStartedAt: this.tickStartedAt?.toISOString() ?? null,
+      lastCycleAt: this.lastCycleAt?.toISOString() ?? null,
+      lastError: null,
+    };
+  }
+
   private async tick() {
     if (this.running) {
       return;
     }
 
     this.running = true;
+    this.tickStartedAt = new Date();
     try {
       await this.runJob();
       this.lastCycleAt = new Date();
@@ -68,6 +84,7 @@ export class AssessmentWorker {
       // Suppress here so the void-fired tick does not become an unhandled rejection.
     } finally {
       this.running = false;
+      this.tickStartedAt = null;
     }
   }
 }

--- a/src/modules/certification/participantNotificationService.ts
+++ b/src/modules/certification/participantNotificationService.ts
@@ -1,6 +1,7 @@
 import { EmailClient } from "@azure/communication-email";
 import type { AppealStatus } from "@prisma/client";
 import { env } from "../../config/env.js";
+import { withTimeout } from "../../clients/externalCall.js";
 import type { SupportedLocale } from "../../i18n/locale.js";
 import { getAppealNotificationMessage, getAssessmentResultNotificationMessage } from "../../i18n/notificationMessages.js";
 import { logOperationalEvent } from "../../observability/operationalLog.js";
@@ -194,8 +195,18 @@ export async function sendViaAcs(input: {
   };
 
   try {
-    const poller = await emailClient.beginSend(message);
-    const result = await poller.pollUntilDone();
+    // #812: bound the whole send (beginSend + pollUntilDone) so a slow/unresponsive ACS can't wedge the
+    // calling worker tick. No retry here — a re-send after a timeout could duplicate the email; the
+    // scheduled monitors re-run on their next cycle and are audit-deduped, so a dropped send is recovered
+    // safely without risking a double-send.
+    const result = await withTimeout(
+      (async () => {
+        const poller = await emailClient.beginSend(message);
+        return poller.pollUntilDone();
+      })(),
+      env.ACS_EMAIL_SEND_TIMEOUT_MS,
+      "acs_email_send",
+    );
 
     if (result.status === "Succeeded") {
       logOperationalEvent(operationalEvents.certification.participantNotificationSent, {

--- a/src/modules/course/CourseReminderMonitor.ts
+++ b/src/modules/course/CourseReminderMonitor.ts
@@ -1,4 +1,5 @@
 import { env } from "../../config/env.js";
+import type { MonitorHealthSnapshot } from "../../observability/workerHealth.js";
 import { runCourseReminderSchedule } from "./courseReminderService.js";
 
 // #497: scheduled background job that sends course due-date reminders (due-soon + overdue) to
@@ -16,6 +17,7 @@ export type CourseReminderMonitorStatus = {
 export class CourseReminderMonitor {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
+  private tickStartedAt: Date | null = null;
   private lastCycleAt: Date | null = null;
   private lastError: string | null = null;
   private lastSummary: unknown | null = null;
@@ -54,9 +56,23 @@ export class CourseReminderMonitor {
     };
   }
 
+  // #809: standardized snapshot for the worker readiness check.
+  health(): MonitorHealthSnapshot {
+    return {
+      name: "courseReminderMonitor",
+      enabled: this.enabled,
+      intervalMs: this.pollIntervalMs,
+      running: this.running,
+      tickStartedAt: this.tickStartedAt?.toISOString() ?? null,
+      lastCycleAt: this.lastCycleAt?.toISOString() ?? null,
+      lastError: this.lastError,
+    };
+  }
+
   private async tick() {
     if (this.running || !this.enabled) return;
     this.running = true;
+    this.tickStartedAt = new Date();
     try {
       this.lastSummary = await this.runSchedule();
       this.lastCycleAt = new Date();
@@ -66,6 +82,7 @@ export class CourseReminderMonitor {
       console.warn(`[#497] Course reminder schedule failed: ${this.lastError}`);
     } finally {
       this.running = false;
+      this.tickStartedAt = null;
     }
   }
 }

--- a/src/modules/orgSync/EntraUserSyncMonitor.ts
+++ b/src/modules/orgSync/EntraUserSyncMonitor.ts
@@ -1,4 +1,5 @@
 import { env } from "../../config/env.js";
+import type { MonitorHealthSnapshot } from "../../observability/workerHealth.js";
 import { syncEntraUsersFromGroup } from "./entraUserSyncService.js";
 
 // #690: scheduled background sync of the configured Entra group's members into the platform's user
@@ -16,6 +17,7 @@ const SYSTEM_ACTOR = "system_entra_user_sync";
 export class EntraUserSyncMonitor {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
+  private tickStartedAt: Date | null = null;
   private lastCycleAt: Date | null = null;
   private lastError: string | null = null;
 
@@ -48,9 +50,23 @@ export class EntraUserSyncMonitor {
     };
   }
 
+  // #809: standardized snapshot for the worker readiness check.
+  health(): MonitorHealthSnapshot {
+    return {
+      name: "entraUserSyncMonitor",
+      enabled: Boolean(env.ENTRA_USER_SYNC_GROUP_ID),
+      intervalMs: this.pollIntervalMs,
+      running: this.running,
+      tickStartedAt: this.tickStartedAt?.toISOString() ?? null,
+      lastCycleAt: this.lastCycleAt?.toISOString() ?? null,
+      lastError: this.lastError,
+    };
+  }
+
   private async tick() {
     if (this.running || !env.ENTRA_USER_SYNC_GROUP_ID) return;
     this.running = true;
+    this.tickStartedAt = new Date();
     try {
       await this.runSync(SYSTEM_ACTOR);
       this.lastCycleAt = new Date();
@@ -60,6 +76,7 @@ export class EntraUserSyncMonitor {
       console.warn(`[#690] Entra user sync failed: ${this.lastError}`);
     } finally {
       this.running = false;
+      this.tickStartedAt = null;
     }
   }
 }

--- a/src/modules/orgSync/entraUserSyncService.ts
+++ b/src/modules/orgSync/entraUserSyncService.ts
@@ -1,6 +1,7 @@
 import { DefaultAzureCredential } from "@azure/identity";
 import { env } from "../../config/env.js";
 import { ValidationError } from "../../errors/AppError.js";
+import { fetchWithDeadlineAndRetry, withTimeout } from "../../clients/externalCall.js";
 import { applyOrgDeltaSync } from "./orgSyncService.js";
 
 // #690: import the members of a configured Entra group (e.g. "Alle i A-2 Norge", ~61 employees) into
@@ -52,7 +53,12 @@ export function mapGraphMemberToOrgSyncRecord(member: GraphMember): EntraUserSyn
 }
 
 async function getGraphToken(): Promise<string> {
-  const token = await new DefaultAzureCredential().getToken(GRAPH_SCOPE);
+  // #812: token acquisition (IMDS / managed identity) can hang — bound it so it can't wedge the sync tick.
+  const token = await withTimeout(
+    new DefaultAzureCredential().getToken(GRAPH_SCOPE),
+    env.ENTRA_GRAPH_TIMEOUT_MS,
+    "graph_token",
+  );
   if (!token?.token) throw new Error("Could not acquire a Microsoft Graph token (managed identity).");
   return token.token;
 }
@@ -63,7 +69,13 @@ async function fetchAllGroupMembers(groupId: string, accessToken: string): Promi
     `${GRAPH_BASE}/groups/${encodeURIComponent(groupId)}/members` +
     `?$select=id,displayName,mail,userPrincipalName,department,accountEnabled&$top=100`;
   while (url) {
-    const response = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+    // #812: idempotent GET → per-request deadline + bounded retry with backoff, so a hung or transiently
+    // failing Graph page can't wedge the Entra sync tick.
+    const response = await fetchWithDeadlineAndRetry(
+      url,
+      { headers: { Authorization: `Bearer ${accessToken}` } },
+      { timeoutMs: env.ENTRA_GRAPH_TIMEOUT_MS, label: "graph_group_members" },
+    );
     if (!response.ok) {
       const body = await response.text().catch(() => "");
       throw new Error(`Graph group members request failed (${response.status}): ${body.slice(0, 300)}`);

--- a/src/modules/retention/AuditRetentionMonitor.ts
+++ b/src/modules/retention/AuditRetentionMonitor.ts
@@ -1,3 +1,4 @@
+import type { MonitorHealthSnapshot } from "../../observability/workerHealth.js";
 import { runAuditRetentionScan, type AuditRetentionResult } from "./auditRetentionService.js";
 
 type ScanRunner = () => Promise<AuditRetentionResult>;
@@ -13,6 +14,7 @@ export type AuditRetentionMonitorStatus = {
 export class AuditRetentionMonitor {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
+  private tickStartedAt: Date | null = null;
   private lastCycleAt: Date | null = null;
 
   constructor(
@@ -42,9 +44,23 @@ export class AuditRetentionMonitor {
     return { lastCycleAt: this.lastCycleAt?.toISOString() ?? null };
   }
 
+  // #809: standardized snapshot for the worker readiness check. Always enabled while workers run.
+  health(): MonitorHealthSnapshot {
+    return {
+      name: "auditRetentionMonitor",
+      enabled: true,
+      intervalMs: this.pollIntervalMs,
+      running: this.running,
+      tickStartedAt: this.tickStartedAt?.toISOString() ?? null,
+      lastCycleAt: this.lastCycleAt?.toISOString() ?? null,
+      lastError: null,
+    };
+  }
+
   private async tick() {
     if (this.running) return;
     this.running = true;
+    this.tickStartedAt = new Date();
     try {
       await this.runScan();
       this.lastCycleAt = new Date();
@@ -53,6 +69,7 @@ export class AuditRetentionMonitor {
       console.warn(`[audit-retention] monitor tick failed: ${error instanceof Error ? error.message : String(error)}`);
     } finally {
       this.running = false;
+      this.tickStartedAt = null;
     }
   }
 }

--- a/src/modules/user/PseudonymizationMonitor.ts
+++ b/src/modules/user/PseudonymizationMonitor.ts
@@ -1,3 +1,4 @@
+import type { MonitorHealthSnapshot } from "../../observability/workerHealth.js";
 import { runPseudonymizationScan, type PseudonymizationScanResult } from "./pseudonymizationScanner.js";
 
 type ScanRunner = () => Promise<PseudonymizationScanResult>;
@@ -16,6 +17,7 @@ export type PseudonymizationMonitorStatus = {
 export class PseudonymizationMonitor {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
+  private tickStartedAt: Date | null = null;
   private lastCycleAt: Date | null = null;
 
   constructor(
@@ -51,12 +53,26 @@ export class PseudonymizationMonitor {
     return { lastCycleAt: this.lastCycleAt?.toISOString() ?? null };
   }
 
+  // #809: standardized snapshot for the worker readiness check. Always enabled while workers run.
+  health(): MonitorHealthSnapshot {
+    return {
+      name: "pseudonymizationMonitor",
+      enabled: true,
+      intervalMs: this.pollIntervalMs,
+      running: this.running,
+      tickStartedAt: this.tickStartedAt?.toISOString() ?? null,
+      lastCycleAt: this.lastCycleAt?.toISOString() ?? null,
+      lastError: null,
+    };
+  }
+
   private async tick() {
     if (this.running) {
       return;
     }
 
     this.running = true;
+    this.tickStartedAt = new Date();
     try {
       await this.runScan();
       this.lastCycleAt = new Date();
@@ -65,6 +81,7 @@ export class PseudonymizationMonitor {
       console.warn(`[pseudonymization] monitor tick failed: ${error instanceof Error ? error.message : String(error)}`);
     } finally {
       this.running = false;
+      this.tickStartedAt = null;
     }
   }
 }

--- a/src/observability/workerHealth.ts
+++ b/src/observability/workerHealth.ts
@@ -121,3 +121,27 @@ export function evaluateWorkerHealth(
     monitors,
   };
 }
+
+// #810: graceful shutdown must not kill an in-flight tick mid-work — a half-processed assessment job or
+// a partial sync should be allowed to finish. After the timers are stopped (no new ticks), poll each
+// monitor's `running` flag until every in-flight tick has settled, bounded by `timeoutMs` so a wedged
+// loop (the #809 case) can't block shutdown forever. Returns true if fully drained, false if it timed out
+// (the caller then force-exits, which is correct — a wedged tick is not going to finish).
+export interface DrainableMonitor {
+  health(): { running: boolean };
+}
+
+export async function drainInFlightTicks(
+  monitors: Array<DrainableMonitor | null | undefined>,
+  timeoutMs: number,
+  nowMs: () => number = () => Date.now(),
+  sleep: (ms: number) => Promise<void> = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  pollMs = 25,
+): Promise<boolean> {
+  const deadline = nowMs() + timeoutMs;
+  const anyRunning = () => monitors.some((m) => m?.health().running === true);
+  while (anyRunning() && nowMs() < deadline) {
+    await sleep(pollMs);
+  }
+  return !anyRunning();
+}

--- a/src/observability/workerHealth.ts
+++ b/src/observability/workerHealth.ts
@@ -1,0 +1,123 @@
+// #809: liveness ≠ readiness for the worker process. The worker health endpoint used to return a
+// hardcoded HTTP 200 with each monitor's status embedded in the body — so a permanently STUCK loop
+// (a wedged in-flight tick that never completes, or a loop whose last successful cycle is long past)
+// was invisible to Azure App Service's health probe, and the container was never restarted.
+//
+// This module is the pure, dependency-free decision: given each monitor's health snapshot and the
+// current time, decide whether the worker is READY (all enabled loops are making progress) or STUCK.
+// The endpoint turns an unhealthy verdict into a 503 so the platform restarts the container.
+//
+// Thresholds are per-monitor and derived from each monitor's own interval, because the six monitors
+// span 4 s (assessment poller) to 24 h (Entra sync, course reminders): a single global threshold would
+// either false-trip the fast poller or never catch the slow ones. Generous factors + absolute floors
+// keep a transient error or a slow first cycle from flapping the container (cf. the #497 startup
+// connection-storm incident — restarts are not free).
+
+export interface MonitorHealthSnapshot {
+  /** Stable key for logs/telemetry, e.g. "assessmentWorker". */
+  name: string;
+  /** A monitor that is not configured to run (e.g. Entra sync without a group id) is never "stuck". */
+  enabled: boolean;
+  /** The loop's scheduling interval in ms — the basis for its staleness/wedge windows. */
+  intervalMs: number;
+  /** True while a tick is in flight. */
+  running: boolean;
+  /** ISO timestamp of when the in-flight tick started (null when not running) — detects a wedged tick. */
+  tickStartedAt: string | null;
+  /** ISO timestamp of the last SUCCESSFUL cycle (null before the first success). */
+  lastCycleAt: string | null;
+  /** Last error message, if the most recent tick failed. Informational — does not by itself mark unhealthy. */
+  lastError: string | null;
+}
+
+export type MonitorHealthReason = "ok" | "disabled" | "wedged" | "stalled";
+
+export interface MonitorVerdict {
+  name: string;
+  enabled: boolean;
+  healthy: boolean;
+  reason: MonitorHealthReason;
+  /** ms since the last successful cycle (or since process start if none yet); null when disabled. */
+  staleMs: number | null;
+  /** ms the current tick has been running; null when idle or disabled. */
+  runningMs: number | null;
+}
+
+export interface WorkerHealthReport {
+  healthy: boolean;
+  checkedAt: string;
+  monitors: MonitorVerdict[];
+}
+
+export interface WorkerHealthThresholds {
+  /** A monitor is "stalled" if no successful cycle within intervalMs × this (floored). */
+  staleFactor: number;
+  /** A monitor is "wedged" if a single tick runs longer than intervalMs × this (floored). */
+  wedgeFactor: number;
+  /** Lower bound on the stale window, so short-interval monitors get a grace period. */
+  minStaleFloorMs: number;
+  /** Lower bound on the wedge window, so a brief-but-legitimate slow tick isn't called wedged. */
+  minWedgeFloorMs: number;
+}
+
+// Factor 3 + 60 s floors: the 4 s assessment poller tolerates ~60 s of no progress before "stalled"
+// (a poller stuck for a minute is genuinely stuck); the 24 h monitors tolerate 72 h. A tick running
+// past the same window is "wedged". These are deliberately forgiving — the goal is catching a
+// PERMANENT stick, not policing latency.
+export const DEFAULT_WORKER_HEALTH_THRESHOLDS: WorkerHealthThresholds = {
+  staleFactor: 3,
+  wedgeFactor: 3,
+  minStaleFloorMs: 60_000,
+  minWedgeFloorMs: 60_000,
+};
+
+function parseIso(value: string | null): number | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/**
+ * Pure readiness decision. `processStartedAt` is the reference point for a monitor that has not yet
+ * completed its first cycle — it gets a grace window measured from process start, not treated as
+ * instantly stale. Disabled monitors are always healthy (they aren't supposed to be ticking).
+ */
+export function evaluateWorkerHealth(
+  snapshots: MonitorHealthSnapshot[],
+  now: Date,
+  processStartedAt: Date,
+  thresholds: WorkerHealthThresholds = DEFAULT_WORKER_HEALTH_THRESHOLDS,
+): WorkerHealthReport {
+  const nowMs = now.getTime();
+  const startMs = processStartedAt.getTime();
+
+  const monitors = snapshots.map((s): MonitorVerdict => {
+    if (!s.enabled) {
+      return { name: s.name, enabled: false, healthy: true, reason: "disabled", staleMs: null, runningMs: null };
+    }
+
+    const wedgeWindow = Math.max(s.intervalMs * thresholds.wedgeFactor, thresholds.minWedgeFloorMs);
+    const staleWindow = Math.max(s.intervalMs * thresholds.staleFactor, thresholds.minStaleFloorMs);
+
+    const tickStartedMs = parseIso(s.tickStartedAt);
+    const runningMs = s.running && tickStartedMs !== null ? nowMs - tickStartedMs : null;
+    if (runningMs !== null && runningMs > wedgeWindow) {
+      return { name: s.name, enabled: true, healthy: false, reason: "wedged", staleMs: null, runningMs };
+    }
+
+    // No success yet → measure the grace window from process start.
+    const referenceMs = parseIso(s.lastCycleAt) ?? startMs;
+    const staleMs = nowMs - referenceMs;
+    if (staleMs > staleWindow) {
+      return { name: s.name, enabled: true, healthy: false, reason: "stalled", staleMs, runningMs };
+    }
+
+    return { name: s.name, enabled: true, healthy: true, reason: "ok", staleMs, runningMs };
+  });
+
+  return {
+    healthy: monitors.every((m) => m.healthy),
+    checkedAt: now.toISOString(),
+    monitors,
+  };
+}

--- a/src/process/processErrorHandlers.ts
+++ b/src/process/processErrorHandlers.ts
@@ -1,7 +1,9 @@
 import { logOperationalEvent } from "../observability/operationalLog.js";
 import { operationalEvents } from "../observability/operationalEvents.js";
 
-export type GracefulShutdown = (exitCode?: number) => void;
+// #810: gracefulShutdown is async (it drains in-flight worker ticks before exiting). Error handlers
+// fire-and-forget it — they don't await — so a void-or-Promise return type keeps both callers valid.
+export type GracefulShutdown = (exitCode?: number) => void | Promise<void>;
 
 // #813: an unhandled rejection means a defect escaped all handling — the process may have partially
 // mutated state and can no longer be trusted to serve/schedule reliably. Log, then graceful-shutdown

--- a/test/unit/external-call.test.ts
+++ b/test/unit/external-call.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  withTimeout,
+  fetchWithDeadlineAndRetry,
+  ExternalCallTimeoutError,
+} from "../../src/clients/externalCall.js";
+
+// #812: external calls (ACS email, Microsoft Graph) must be bounded in time so a hung dependency can't
+// wedge a worker loop. These tests pin the deadline + bounded-retry behaviour.
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("withTimeout (#812)", () => {
+  it("resolves with the value when the promise settles before the deadline", async () => {
+    await expect(withTimeout(Promise.resolve(42), 1_000, "fast")).resolves.toBe(42);
+  });
+
+  it("rejects with ExternalCallTimeoutError when the deadline passes", async () => {
+    vi.useFakeTimers();
+    const never = new Promise<never>(() => {});
+    const pending = withTimeout(never, 100, "slow");
+    const assertion = expect(pending).rejects.toBeInstanceOf(ExternalCallTimeoutError);
+    await vi.advanceTimersByTimeAsync(150);
+    await assertion;
+  });
+});
+
+describe("fetchWithDeadlineAndRetry (#812)", () => {
+  it("returns immediately on a 2xx (single attempt)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await fetchWithDeadlineAndRetry("https://x", {}, { timeoutMs: 1_000, label: "t" });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry a non-retryable 4xx", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("", { status: 400 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await fetchWithDeadlineAndRetry("https://x", {}, { timeoutMs: 1_000, label: "t" });
+    expect(res.status).toBe(400);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transient 503 with backoff, then returns the eventual 200", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("", { status: 503 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const pending = fetchWithDeadlineAndRetry("https://x", {}, { timeoutMs: 1_000, label: "t", maxAttempts: 3 });
+    await vi.advanceTimersByTimeAsync(5_000); // let the backoff elapse
+    const res = await pending;
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts a hung request at the deadline and surfaces a timeout on the final attempt", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockImplementation((_url: string, init: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => {
+          const err = new Error("The operation was aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const pending = fetchWithDeadlineAndRetry("https://x", {}, { timeoutMs: 100, label: "hung", maxAttempts: 1 });
+    const assertion = expect(pending).rejects.toBeInstanceOf(ExternalCallTimeoutError);
+    await vi.advanceTimersByTimeAsync(150);
+    await assertion;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/worker-health.test.ts
+++ b/test/unit/worker-health.test.ts
@@ -8,6 +8,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { PseudonymizationMonitor } from "../../src/modules/user/PseudonymizationMonitor.js";
 import { AuditRetentionMonitor } from "../../src/modules/retention/AuditRetentionMonitor.js";
+import { AssessmentWorker } from "../../src/modules/assessment/AssessmentWorker.js";
+import {
+  evaluateWorkerHealth,
+  type MonitorHealthSnapshot,
+} from "../../src/observability/workerHealth.js";
 
 describe("PseudonymizationMonitor.getStatus", () => {
   it("returns null lastCycleAt before first tick", () => {
@@ -36,5 +41,115 @@ describe("AuditRetentionMonitor.getStatus", () => {
     await Promise.resolve();
     monitor.stop();
     expect(monitor.getStatus().lastCycleAt).not.toBeNull();
+  });
+});
+
+// #809: readiness decision — worker health must report 503 when a loop is permanently stuck.
+describe("evaluateWorkerHealth (#809)", () => {
+  const NOW = new Date("2026-07-23T12:00:00.000Z");
+  const nowMs = NOW.getTime();
+  const START = new Date(nowMs - 60_000); // process started 1 min ago
+  const iso = (msAgo: number) => new Date(nowMs - msAgo).toISOString();
+  const snap = (o: Partial<MonitorHealthSnapshot>): MonitorHealthSnapshot => ({
+    name: "m",
+    enabled: true,
+    intervalMs: 600_000, // 10 min
+    running: false,
+    tickStartedAt: null,
+    lastCycleAt: null,
+    lastError: null,
+    ...o,
+  });
+
+  it("healthy when every enabled monitor completed a recent cycle", () => {
+    const report = evaluateWorkerHealth([snap({ lastCycleAt: iso(60_000) })], NOW, START);
+    expect(report.healthy).toBe(true);
+    expect(report.monitors[0].reason).toBe("ok");
+  });
+
+  it("a disabled monitor is always healthy (never 'stuck'), even with no cycle ever", () => {
+    const report = evaluateWorkerHealth([snap({ enabled: false, lastCycleAt: null })], NOW, START);
+    expect(report.healthy).toBe(true);
+    expect(report.monitors[0].reason).toBe("disabled");
+  });
+
+  it("WEDGED: an in-flight tick running past intervalMs × factor → unhealthy 503", () => {
+    // intervalMs 10min → wedge window 30min; tick started 40min ago and still running.
+    const report = evaluateWorkerHealth(
+      [snap({ running: true, tickStartedAt: iso(40 * 60_000) })],
+      NOW,
+      START,
+    );
+    expect(report.healthy).toBe(false);
+    expect(report.monitors[0].reason).toBe("wedged");
+  });
+
+  it("STALLED: no successful cycle within the staleness window → unhealthy 503", () => {
+    // intervalMs 10min → stale window 30min; last success 40min ago.
+    const report = evaluateWorkerHealth([snap({ lastCycleAt: iso(40 * 60_000) })], NOW, START);
+    expect(report.healthy).toBe(false);
+    expect(report.monitors[0].reason).toBe("stalled");
+  });
+
+  it("startup grace: a monitor with no cycle yet is healthy within the window from process start", () => {
+    // Never ticked, but process only started 1 min ago and interval is 10 min → not stale.
+    const report = evaluateWorkerHealth([snap({ lastCycleAt: null })], NOW, START);
+    expect(report.healthy).toBe(true);
+    expect(report.monitors[0].reason).toBe("ok");
+  });
+
+  it("a 24h monitor is not 'stalled' one hour after its last cycle", () => {
+    const report = evaluateWorkerHealth(
+      [snap({ intervalMs: 86_400_000, lastCycleAt: iso(60 * 60_000) })],
+      NOW,
+      START,
+    );
+    expect(report.healthy).toBe(true);
+  });
+
+  it("the absolute floor protects a 4s poller from a slow-but-fine 30s gap, but 90s is stalled", () => {
+    const fresh = evaluateWorkerHealth([snap({ intervalMs: 4_000, lastCycleAt: iso(30_000) })], NOW, START);
+    expect(fresh.healthy).toBe(true); // 30s < 60s floor
+    const stalled = evaluateWorkerHealth([snap({ intervalMs: 4_000, lastCycleAt: iso(90_000) })], NOW, START);
+    expect(stalled.healthy).toBe(false); // 90s > 60s floor
+    expect(stalled.monitors[0].reason).toBe("stalled");
+  });
+
+  it("one unhealthy monitor makes the whole worker unhealthy (all must be ready)", () => {
+    const report = evaluateWorkerHealth(
+      [snap({ lastCycleAt: iso(60_000) }), snap({ name: "stuck", lastCycleAt: iso(40 * 60_000) })],
+      NOW,
+      START,
+    );
+    expect(report.healthy).toBe(false);
+    expect(report.monitors.find((m) => m.name === "stuck")?.healthy).toBe(false);
+  });
+});
+
+// #809: the monitor's health() snapshot must expose the in-flight tick so a wedge is detectable.
+describe("monitor.health() exposes in-flight tick state (#809)", () => {
+  it("reports running + tickStartedAt while a tick is in progress, cleared after", async () => {
+    let release!: () => void;
+    const gate = new Promise<boolean>((resolve) => {
+      release = () => resolve(true);
+    });
+    const worker = new AssessmentWorker(10_000, () => gate);
+    worker.start(); // fires the first tick synchronously up to the awaited runJob
+    await Promise.resolve();
+
+    const inflight = worker.health();
+    expect(inflight.running).toBe(true);
+    expect(inflight.tickStartedAt).not.toBeNull();
+    expect(inflight.name).toBe("assessmentWorker");
+
+    release();
+    await gate;
+    await Promise.resolve(); // let the finally block run
+    worker.stop();
+
+    const settled = worker.health();
+    expect(settled.running).toBe(false);
+    expect(settled.tickStartedAt).toBeNull();
+    expect(settled.lastCycleAt).not.toBeNull();
   });
 });

--- a/test/unit/worker-health.test.ts
+++ b/test/unit/worker-health.test.ts
@@ -11,6 +11,7 @@ import { AuditRetentionMonitor } from "../../src/modules/retention/AuditRetentio
 import { AssessmentWorker } from "../../src/modules/assessment/AssessmentWorker.js";
 import {
   evaluateWorkerHealth,
+  drainInFlightTicks,
   type MonitorHealthSnapshot,
 } from "../../src/observability/workerHealth.js";
 
@@ -151,5 +152,33 @@ describe("monitor.health() exposes in-flight tick state (#809)", () => {
     expect(settled.running).toBe(false);
     expect(settled.tickStartedAt).toBeNull();
     expect(settled.lastCycleAt).not.toBeNull();
+  });
+});
+
+// #810: graceful shutdown drains in-flight ticks (bounded) before exiting.
+describe("drainInFlightTicks (#810)", () => {
+  it("resolves drained=true immediately when nothing is running", async () => {
+    const idle = { health: () => ({ running: false }) };
+    expect(await drainInFlightTicks([idle, null], 1_000)).toBe(true);
+  });
+
+  it("waits while a tick is running, then reports drained once it settles", async () => {
+    let running = true;
+    const monitor = { health: () => ({ running }) };
+    let clock = 0;
+    const nowMs = () => clock;
+    const sleep = async (ms: number) => {
+      clock += ms;
+      if (clock >= 60) running = false; // the in-flight tick finishes after ~60ms
+    };
+    expect(await drainInFlightTicks([monitor], 1_000, nowMs, sleep, 20)).toBe(true);
+    expect(running).toBe(false);
+  });
+
+  it("returns drained=false when a tick stays wedged past the timeout", async () => {
+    const wedged = { health: () => ({ running: true }) }; // never settles
+    let clock = 0;
+    const drained = await drainInFlightTicks([wedged], 100, () => clock, async (ms) => { clock += ms; }, 20);
+    expect(drained).toBe(false);
   });
 });


### PR DESCRIPTION
Bundled M5 Stabilization — the worker-reliability cluster. A background loop that gets stuck is now **detected** (#809), **survived** on shutdown (#810), and **prevented** at the source (#812). All code-only, no infra. Version **2.2.5**.

## #809 — worker health returns 503 when a loop is stuck (liveness ≠ readiness)
The worker `/healthz` returned a hardcoded 200 regardless of monitor state, so a permanently stuck loop was invisible to Azure's probe and the container was never auto-replaced. New pure `evaluateWorkerHealth` with **per-monitor** thresholds derived from each monitor's own interval (the six span 4s..24h): **wedged** = in-flight tick running > interval×3; **stalled** = no success within interval×3; both floored at 60s so short-interval monitors and warm-up don't flap. Disabled monitors are always healthy. Each monitor exposes `health()` (adds `tickStartedAt`); `getStatus()` unchanged. Worker `healthCheckPath=/healthz` is already wired in bicep → Azure now auto-restarts a stuck worker.

## #810 — graceful shutdown drains in-flight work
`gracefulShutdown` stopped scheduling but didn't wait for a tick already running → shutdown could kill work mid-flight (e.g. an assessment job). Now async: drains (polling `health().running`, bounded 10s; Azure allows ~30s before SIGKILL) before exit. A wedged tick can't block the exit (force-exit + log on timeout).

## #812 — deadlines + bounded retries on ACS email & Microsoft Graph
Node's fetch has no default timeout and the ACS poller waits indefinitely → a hung dependency could wedge a tick (the root cause #809 detects). New `src/clients/externalCall.ts`:
- `withTimeout` bounds the ACS send (`ACS_EMAIL_SEND_TIMEOUT_MS`, 30s) and the Graph token — **no retry on ACS** (a re-send after a poll timeout could duplicate the email; monitors re-run next cycle and are audit-deduped).
- `fetchWithDeadlineAndRetry` gives the idempotent Graph GETs a per-attempt deadline (`ENTRA_GRAPH_TIMEOUT_MS`, 15s) + backoff retry on timeout/429/5xx.

## Tests
18 new: health evaluator (wedged/stalled/disabled/startup-grace/24h-not-stale/4s-floor/aggregate), in-flight `health()` snapshot, drain (idle/settle/wedged), external-call (timeout/retry/no-retry-4xx/abort). **tsc 0 · 829 unit · 393 integration** green (full local run).

New env vars (sensible defaults, no config change required): `ACS_EMAIL_SEND_TIMEOUT_MS=30000`, `ENTRA_GRAPH_TIMEOUT_MS=15000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
