### PR TITLE
M5 batch: #815 attachment parsing hardening + #820 cert-status enum (has DB migration)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,30 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.2.6 - 2026-07-23
+
+M5 stabilization — participant attachment hardening (#815) + certification-status enum (#820)
+
+- **#815 — bound participant PDF/DOCX attachment parsing.** Submission attachments were parsed inline
+  in the web request (pdf-parse/mammoth) with no size cap, decompressed-size limit, or timeout — a DOCX
+  zip-bomb or pathological file could exhaust web memory/CPU below the per-minute limit. Hardened in
+  process: a decoded-byte cap, file-signature (magic-byte) validation (PDF `%PDF`, DOCX ZIP `PK\x03\x04`),
+  a **DOCX decompressed-size + entry-count cap read from the ZIP central directory without inflating**
+  (the zip-bomb defense — mammoth is never invoked on a bomb), and a 10s wall-clock timeout. A rejected
+  file falls back to the submission's raw text if present. Full parser-worker isolation remains a
+  follow-up (parent #783).
+- **#820 — CertificationStatus.status is now a Postgres enum (DB-level CHECK).** It was free-text String
+  with "passed" inferred as `status != 'NOT_CERTIFIED'` — safe only because the sole writer is
+  union-typed; a raw-SQL/untyped writer could store a typo that reads as passed. New
+  `CertificationLifecycleStatus` enum + an in-place `USING`-cast migration (no data loss). Passing states
+  are now listed explicitly (`CERTIFICATION_PASSED_STATUSES`/`isCertificationPassed`) so the check stays
+  correct if a future non-passing state is added.
+
+Tests: attachment signature/zip-bomb/entry-cap rejection; the enum rejects an out-of-set value via raw
+SQL and accepts all five. tsc 0 · 836 unit · 395 integration.
+
+Note: this version includes a DB migration (applied on web startup via `prisma migrate deploy`).
+
 ## 2.2.5 - 2026-07-23
 
 M5 stabilization — worker reliability cluster (#809 + #810 + #812)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260723130000_cert_status_enum/migration.sql
+++ b/prisma/migrations/20260723130000_cert_status_enum/migration.sql
@@ -1,0 +1,12 @@
+-- #820: promote CertificationStatus.status from free-text String to a real Postgres enum, which is a
+-- DB-level CHECK that rejects any value outside the certification lifecycle set. Existing rows are all
+-- valid — the sole writer (upsertCertificationStatus) is TypeScript-union-typed to exactly these five
+-- values — so the in-place USING cast can never fail. No data is dropped.
+
+-- CreateEnum
+CREATE TYPE "CertificationLifecycleStatus" AS ENUM ('ACTIVE', 'DUE_SOON', 'DUE', 'EXPIRED', 'NOT_CERTIFIED');
+
+-- AlterTable: convert the column in place, casting existing text values to the enum.
+ALTER TABLE "CertificationStatus"
+  ALTER COLUMN "status" TYPE "CertificationLifecycleStatus"
+  USING "status"::"CertificationLifecycleStatus";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -455,12 +455,24 @@ model ManualReview {
   @@index([reviewStatus, createdAt])
 }
 
+// #820: certification lifecycle states. Previously CertificationStatus.status was free-text String and
+// "passed" was inferred as status != 'NOT_CERTIFIED' — safe only because the sole writer is union-typed;
+// a raw-SQL/untyped writer could store a typo that reads as "passed". A Postgres enum is a DB-level CHECK
+// that rejects any value outside this set. Passing states are all of these except NOT_CERTIFIED.
+enum CertificationLifecycleStatus {
+  ACTIVE
+  DUE_SOON
+  DUE
+  EXPIRED
+  NOT_CERTIFIED
+}
+
 model CertificationStatus {
   id                     String             @id @default(cuid())
   userId                 String
   moduleId               String
   latestDecisionId       String
-  status                 String
+  status                 CertificationLifecycleStatus
   passedAt               DateTime?
   expiryDate             DateTime?
   recertificationDueDate DateTime?

--- a/src/modules/assessment/documentParsingService.ts
+++ b/src/modules/assessment/documentParsingService.ts
@@ -1,5 +1,20 @@
 import path from "node:path";
 import { createRequire } from "node:module";
+import { withTimeout } from "../../clients/externalCall.js";
+
+// #815: participant submission attachments (PDF/DOCX, base64 within the upload cap) are parsed inline in
+// the web request. Without guards a DOCX zip-bomb or pathological file exhausts web memory/CPU below the
+// per-minute rate limit. These bounds neutralize that in-process:
+//   - a hard byte cap on the decoded attachment,
+//   - magic-byte (file-signature) validation so the bytes actually match the claimed PDF/DOCX,
+//   - a DOCX decompressed-size + entry-count cap read from the ZIP central directory WITHOUT inflating
+//     (the classic zip-bomb defense — a bomb declares a huge uncompressed size that we reject up front),
+//   - a wall-clock timeout around the parse.
+// Full out-of-process isolation (routing through the parser worker) is deliberately out of scope here.
+export const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024; // decoded payload cap (matches the ~5MB upload limit)
+export const MAX_DOCX_UNCOMPRESSED_BYTES = 50 * 1024 * 1024; // a real .docx is well under this; bombs aren't
+export const MAX_DOCX_ENTRIES = 512; // a real .docx has tens of parts; bombs pack far more
+export const DOCUMENT_PARSE_TIMEOUT_MS = 10_000;
 
 const require = createRequire(import.meta.url);
 const pdfParse = require("pdf-parse") as (buffer: Buffer) => Promise<{ text?: string }>;
@@ -87,8 +102,16 @@ export async function resolveSubmissionResponseJson(
   const payload = decodeAttachmentBase64(attachmentBase64);
 
   try {
-    const extracted =
-      format === "pdf" ? await adapters.parsePdf(payload) : await adapters.parseDocx(payload);
+    // #815: reject before handing anything to pdf-parse/mammoth.
+    assertAttachmentWithinByteCap(payload);
+    assertFileSignatureMatches(payload, format);
+    if (format === "docx") assertDocxWithinDecompressionLimits(payload);
+
+    const extracted = await withTimeout(
+      format === "pdf" ? adapters.parsePdf(payload) : adapters.parseDocx(payload),
+      DOCUMENT_PARSE_TIMEOUT_MS,
+      `parse_${format}`,
+    );
     const normalized = extracted.trim();
     if (!normalized) {
       if (hasResponseJson) {
@@ -154,6 +177,70 @@ function detectDocumentFormat(mimeType: string | undefined, fileName: string | u
     return "docx";
   }
   return "unknown";
+}
+
+// #815: hard cap on the decoded attachment — defense in depth behind the upload body limit.
+function assertAttachmentWithinByteCap(payload: Buffer) {
+  if (payload.length > MAX_ATTACHMENT_BYTES) {
+    throw new Error(`attachment_too_large_${payload.length}`);
+  }
+}
+
+// #815: verify the bytes actually start with the expected file signature, so a file can't be disguised
+// (e.g. a zip bomb sent with a .pdf name) to reach the wrong parser. PDF = "%PDF"; DOCX is a ZIP = "PK\x03\x04".
+function assertFileSignatureMatches(payload: Buffer, format: "pdf" | "docx") {
+  if (format === "pdf") {
+    if (!(payload.length >= 4 && payload[0] === 0x25 && payload[1] === 0x50 && payload[2] === 0x44 && payload[3] === 0x46)) {
+      throw new Error("pdf_signature_mismatch");
+    }
+    return;
+  }
+  // docx → local file header of a ZIP archive.
+  if (!(payload.length >= 4 && payload[0] === 0x50 && payload[1] === 0x4b && payload[2] === 0x03 && payload[3] === 0x04)) {
+    throw new Error("docx_signature_mismatch");
+  }
+}
+
+// #815: zip-bomb defense. A .docx is a ZIP; mammoth inflates it into memory. Read the declared uncompressed
+// size + entry count from the ZIP central directory WITHOUT inflating, and reject an archive that would
+// expand past the caps. Sizes hidden behind a ZIP64 marker (0xFFFFFFFF) are conservatively rejected.
+function assertDocxWithinDecompressionLimits(payload: Buffer) {
+  const EOCD_SIG = 0x06054b50; // End Of Central Directory record
+  const CDH_SIG = 0x02014b50; // Central Directory File Header
+
+  // EOCD sits at the end, before an optional comment (max 64KB). Scan backwards for its signature.
+  let eocd = -1;
+  const scanFloor = Math.max(0, payload.length - 22 - 0xffff);
+  for (let i = payload.length - 22; i >= scanFloor; i--) {
+    if (payload.readUInt32LE(i) === EOCD_SIG) {
+      eocd = i;
+      break;
+    }
+  }
+  if (eocd === -1) throw new Error("docx_zip_eocd_not_found");
+
+  const totalEntries = payload.readUInt16LE(eocd + 10);
+  if (totalEntries > MAX_DOCX_ENTRIES) throw new Error(`docx_too_many_entries_${totalEntries}`);
+  const cdOffset = payload.readUInt32LE(eocd + 16);
+  if (cdOffset === 0xffffffff) throw new Error("docx_zip64_unsupported");
+
+  let ptr = cdOffset;
+  let totalUncompressed = 0;
+  for (let n = 0; n < totalEntries; n++) {
+    if (ptr + 46 > payload.length || payload.readUInt32LE(ptr) !== CDH_SIG) {
+      throw new Error("docx_central_directory_malformed");
+    }
+    const uncompressedSize = payload.readUInt32LE(ptr + 24);
+    if (uncompressedSize === 0xffffffff) throw new Error("docx_zip64_unsupported");
+    totalUncompressed += uncompressedSize;
+    if (totalUncompressed > MAX_DOCX_UNCOMPRESSED_BYTES) {
+      throw new Error(`docx_decompressed_too_large_${totalUncompressed}`);
+    }
+    const nameLen = payload.readUInt16LE(ptr + 28);
+    const extraLen = payload.readUInt16LE(ptr + 30);
+    const commentLen = payload.readUInt16LE(ptr + 32);
+    ptr += 46 + nameLen + extraLen + commentLen;
+  }
 }
 
 function decodeAttachmentBase64(input: string) {

--- a/src/modules/certification/certificationRepository.ts
+++ b/src/modules/certification/certificationRepository.ts
@@ -1,6 +1,21 @@
+import type { CertificationLifecycleStatus } from "@prisma/client";
 import { prisma } from "../../db/prisma.js";
 
 type CertificationRepositoryClient = Pick<typeof prisma, "certificationStatus">;
+
+// #820: "passed a module" = any certification lifecycle state except NOT_CERTIFIED. Listing the passing
+// states explicitly (rather than the old `status != 'NOT_CERTIFIED'`) keeps the check correct if a future
+// non-passing state is ever added — the CertificationLifecycleStatus enum makes this set authoritative.
+export const CERTIFICATION_PASSED_STATUSES: CertificationLifecycleStatus[] = [
+  "ACTIVE",
+  "DUE_SOON",
+  "DUE",
+  "EXPIRED",
+];
+
+export function isCertificationPassed(status: CertificationLifecycleStatus | null | undefined): boolean {
+  return status != null && (CERTIFICATION_PASSED_STATUSES as string[]).includes(status);
+}
 
 export function createCertificationRepository(client: CertificationRepositoryClient = prisma) {
   return {

--- a/src/modules/course/courseRepository.ts
+++ b/src/modules/course/courseRepository.ts
@@ -1,5 +1,6 @@
 import { prisma } from "../../db/prisma.js";
 import type { ReportFilters } from "../reporting/types.js";
+import { CERTIFICATION_PASSED_STATUSES } from "../certification/certificationRepository.js";
 
 function buildSubmissionWhere(filters: Pick<ReportFilters, "dateFrom" | "dateTo" | "orgUnit"> = {}) {
   return {
@@ -76,7 +77,7 @@ export function createCourseRepository(client: CourseRepositoryClient = prisma) 
         where: {
           userId,
           moduleId: { in: moduleIds },
-          status: { not: "NOT_CERTIFIED" },
+          status: { in: CERTIFICATION_PASSED_STATUSES },
         },
       });
     },
@@ -268,7 +269,7 @@ export function createCourseRepository(client: CourseRepositoryClient = prisma) 
       return client.certificationStatus.count({
         where: {
           moduleId,
-          status: { not: "NOT_CERTIFIED" },
+          status: { in: CERTIFICATION_PASSED_STATUSES },
           ...buildCertificationWhere(filters),
         },
       });

--- a/src/routes/courses.ts
+++ b/src/routes/courses.ts
@@ -15,6 +15,7 @@ import {
 } from "../modules/course/index.js";
 import type { CourseListItem, CourseDetail, CourseSequenceItem } from "../modules/course/index.js";
 import { queryLatestSubmissionsForModules } from "../modules/submission/submissionRepository.js";
+import { isCertificationPassed } from "../modules/certification/certificationRepository.js";
 import { hasCertificateBackground } from "../modules/platformConfig/certificateBackgroundService.js";
 import { discussionsRouter } from "./discussions.js";
 
@@ -265,7 +266,7 @@ coursesRouter.get("/:courseId", async (request, response, next) => {
       }
       const moduleId = item.moduleId ?? item.module?.id ?? "";
       const certStatus = certStatusByModuleId.get(moduleId);
-      const passed = certStatus !== undefined && certStatus !== "NOT_CERTIFIED";
+      const passed = isCertificationPassed(certStatus);
       const hasStarted = latestSubmissionByModuleId.has(moduleId);
       // #502-followup: en modul er «tilgjengelig» for deltaker når den har en publisert aktiv
       // versjon og ikke er arkivert. Avpubliserte moduler markeres i UI (ikke en blindvei).
@@ -309,7 +310,7 @@ coursesRouter.get("/:courseId", async (request, response, next) => {
       },
       modules: course.modules.map((cm) => {
         const certStatus = certStatusByModuleId.get(cm.moduleId);
-        const passed = certStatus !== undefined && certStatus !== "NOT_CERTIFIED";
+        const passed = isCertificationPassed(certStatus);
         const hasStarted = latestSubmissionByModuleId.has(cm.moduleId);
         return {
           moduleId: cm.moduleId,

--- a/test/document-parsing.test.ts
+++ b/test/document-parsing.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { resolveSubmissionResponseJson, type DocumentParserAdapters } from "../src/modules/assessment/documentParsingService.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  resolveSubmissionResponseJson,
+  MAX_DOCX_UNCOMPRESSED_BYTES,
+  MAX_DOCX_ENTRIES,
+  type DocumentParserAdapters,
+} from "../src/modules/assessment/documentParsingService.js";
 
 const fakeAdapters: DocumentParserAdapters = {
   async parsePdf() {
@@ -10,23 +15,57 @@ const fakeAdapters: DocumentParserAdapters = {
   },
 };
 
+// #815: build a real PDF signature ("%PDF") in front of arbitrary bytes so the file-signature guard passes.
+const pdfBase64 = (text = "body"): string =>
+  Buffer.concat([Buffer.from("%PDF-1.4\n"), Buffer.from(text)]).toString("base64");
+
+// #815: build a minimal but structurally-valid ZIP (a .docx is a ZIP) whose central directory declares the
+// given uncompressed sizes — enough for the signature + zip-bomb guards to read it without any real deflate.
+function docxBase64(uncompressedSizes: number[]): string {
+  const local = Buffer.from([0x50, 0x4b, 0x03, 0x04]); // PK\x03\x04 local-file-header signature (for the magic check)
+  const cd = Buffer.concat(
+    uncompressedSizes.map((size) => {
+      const h = Buffer.alloc(46);
+      h.writeUInt32LE(0x02014b50, 0); // central directory file header signature
+      h.writeUInt32LE(size, 24); // uncompressed size
+      h.writeUInt16LE(0, 28); // file name length
+      h.writeUInt16LE(0, 30); // extra field length
+      h.writeUInt16LE(0, 32); // comment length
+      return h;
+    }),
+  );
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0); // end of central directory signature
+  eocd.writeUInt16LE(uncompressedSizes.length, 8); // entries on this disk
+  eocd.writeUInt16LE(uncompressedSizes.length, 10); // total entries
+  eocd.writeUInt32LE(cd.length, 12); // central directory size
+  eocd.writeUInt32LE(local.length, 16); // central directory offset
+  return Buffer.concat([local, cd, eocd]).toString("base64");
+}
+
 describe("Document parsing service", () => {
-  it("parses PDF attachment content", async () => {
+  it("parses a PDF attachment with a valid signature", async () => {
     const outcome = await resolveSubmissionResponseJson(
-      {
-        attachmentMimeType: "application/pdf",
-        attachmentBase64: Buffer.from("fake-pdf-content").toString("base64"),
-      },
+      { attachmentMimeType: "application/pdf", attachmentBase64: pdfBase64() },
       fakeAdapters,
     );
 
-    expect((outcome.resolvedResponseJson.response as string)).toContain("Parsed PDF text");
+    expect(outcome.resolvedResponseJson.response as string).toContain("Parsed PDF text");
     expect(outcome.parser.status).toBe("parsed");
     expect(outcome.parser.format).toBe("pdf");
     expect(outcome.parser.reason).toBeNull();
   });
 
-  it("falls back to responseJson when parser fails but fallback responseJson exists", async () => {
+  it("parses a DOCX attachment with a valid signature and modest size", async () => {
+    const outcome = await resolveSubmissionResponseJson(
+      { attachmentFilename: "submission.docx", attachmentBase64: docxBase64([4_000, 12_000]) },
+      fakeAdapters,
+    );
+    expect(outcome.parser.status).toBe("parsed");
+    expect(outcome.parser.format).toBe("docx");
+  });
+
+  it("falls back to responseJson when the parser throws but fallback text exists", async () => {
     const failingDocxAdapters: DocumentParserAdapters = {
       ...fakeAdapters,
       async parseDocx() {
@@ -37,7 +76,7 @@ describe("Document parsing service", () => {
     const outcome = await resolveSubmissionResponseJson(
       {
         attachmentFilename: "submission.docx",
-        attachmentBase64: Buffer.from("fake-docx-content").toString("base64"),
+        attachmentBase64: docxBase64([4_000]),
         responseJson: { response: "Manual fallback raw text" },
       },
       failingDocxAdapters,
@@ -45,7 +84,6 @@ describe("Document parsing service", () => {
 
     expect(outcome.resolvedResponseJson.response).toBe("Manual fallback raw text");
     expect(outcome.parser.status).toBe("fallback_raw_text");
-    expect(outcome.parser.format).toBe("docx");
     expect(outcome.parser.reason).toContain("DOCX parser failed");
   });
 
@@ -59,10 +97,7 @@ describe("Document parsing service", () => {
 
     await expect(
       resolveSubmissionResponseJson(
-        {
-          attachmentFilename: "submission.pdf",
-          attachmentBase64: Buffer.from("fake-pdf-content").toString("base64"),
-        },
+        { attachmentFilename: "submission.pdf", attachmentBase64: pdfBase64() },
         failingPdfAdapters,
       ),
     ).rejects.toThrow("Could not parse PDF attachment.");
@@ -71,12 +106,53 @@ describe("Document parsing service", () => {
   it("returns clear feedback for unsupported format without fallback responseJson", async () => {
     await expect(
       resolveSubmissionResponseJson(
-        {
-          attachmentFilename: "submission.txt",
-          attachmentBase64: Buffer.from("plain-text-content").toString("base64"),
-        },
+        { attachmentFilename: "submission.txt", attachmentBase64: Buffer.from("plain-text-content").toString("base64") },
         fakeAdapters,
       ),
     ).rejects.toThrow("Only PDF and DOCX are supported.");
+  });
+
+  // ── #815 hardening ─────────────────────────────────────────────────────────
+  it("rejects a file whose bytes don't match the claimed PDF signature (no parse)", async () => {
+    const parsePdf = vi.fn(fakeAdapters.parsePdf);
+    const outcome = await resolveSubmissionResponseJson(
+      {
+        attachmentMimeType: "application/pdf",
+        attachmentBase64: Buffer.from("this is not really a pdf").toString("base64"),
+        responseJson: { response: "fallback" },
+      },
+      { ...fakeAdapters, parsePdf },
+    );
+    expect(parsePdf).not.toHaveBeenCalled();
+    expect(outcome.parser.status).toBe("fallback_raw_text");
+    expect(outcome.parser.reason).toContain("pdf_signature_mismatch");
+  });
+
+  it("rejects a DOCX zip-bomb (declared uncompressed size over the cap) WITHOUT invoking mammoth", async () => {
+    const parseDocx = vi.fn(fakeAdapters.parseDocx);
+    const outcome = await resolveSubmissionResponseJson(
+      {
+        attachmentFilename: "bomb.docx",
+        attachmentBase64: docxBase64([MAX_DOCX_UNCOMPRESSED_BYTES + 1]),
+        responseJson: { response: "fallback" },
+      },
+      { ...fakeAdapters, parseDocx },
+    );
+    expect(parseDocx).not.toHaveBeenCalled();
+    expect(outcome.parser.reason).toContain("docx_decompressed_too_large");
+  });
+
+  it("rejects a DOCX with too many entries WITHOUT invoking mammoth", async () => {
+    const parseDocx = vi.fn(fakeAdapters.parseDocx);
+    const outcome = await resolveSubmissionResponseJson(
+      {
+        attachmentFilename: "many.docx",
+        attachmentBase64: docxBase64(new Array(MAX_DOCX_ENTRIES + 1).fill(10)),
+        responseJson: { response: "fallback" },
+      },
+      { ...fakeAdapters, parseDocx },
+    );
+    expect(parseDocx).not.toHaveBeenCalled();
+    expect(outcome.parser.reason).toContain("docx_too_many_entries");
   });
 });

--- a/test/m2-cert-status-enum.test.ts
+++ b/test/m2-cert-status-enum.test.ts
@@ -1,0 +1,26 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { prisma } from "../src/db/prisma.js";
+
+// #820: CertificationStatus.status is now a Postgres enum, which is a DB-level CHECK. The whole point is
+// that a raw-SQL / future untyped writer can no longer store a value outside the lifecycle set (which the
+// old free-text String column would have accepted, and `!= 'NOT_CERTIFIED'` would then read as "passed").
+describe("CertificationLifecycleStatus enum is a DB-level CHECK (#820)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("rejects a value outside the lifecycle set", async () => {
+    await expect(
+      prisma.$queryRawUnsafe(`SELECT 'CERTIFIED_TYPO'::"CertificationLifecycleStatus" AS s`),
+    ).rejects.toThrow();
+  });
+
+  it("accepts every declared lifecycle value", async () => {
+    for (const value of ["ACTIVE", "DUE_SOON", "DUE", "EXPIRED", "NOT_CERTIFIED"]) {
+      const rows = (await prisma.$queryRawUnsafe(
+        `SELECT '${value}'::"CertificationLifecycleStatus" AS s`,
+      )) as Array<{ s: string }>;
+      expect(rows[0]?.s).toBe(value);
+    }
+  });
+});

--- a/test/unit/certification-passed-status.test.ts
+++ b/test/unit/certification-passed-status.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  CERTIFICATION_PASSED_STATUSES,
+  isCertificationPassed,
+} from "../../src/modules/certification/certificationRepository.js";
+
+// #820: "passed a module" = any lifecycle state except NOT_CERTIFIED, listed explicitly.
+describe("isCertificationPassed (#820)", () => {
+  it("treats every non-NOT_CERTIFIED lifecycle state as passed", () => {
+    for (const status of CERTIFICATION_PASSED_STATUSES) {
+      expect(isCertificationPassed(status)).toBe(true);
+    }
+  });
+
+  it("treats NOT_CERTIFIED and absent status as not passed", () => {
+    expect(isCertificationPassed("NOT_CERTIFIED")).toBe(false);
+    expect(isCertificationPassed(null)).toBe(false);
+    expect(isCertificationPassed(undefined)).toBe(false);
+  });
+
+  it("does not include NOT_CERTIFIED in the passing set", () => {
+    expect((CERTIFICATION_PASSED_STATUSES as string[])).not.toContain("NOT_CERTIFIED");
+    expect(CERTIFICATION_PASSED_STATUSES).toEqual(["ACTIVE", "DUE_SOON", "DUE", "EXPIRED"]);
+  });
+});


### PR DESCRIPTION
Second M5 batch, accumulating on stage (prod promotion deferred to a larger release). Version **2.2.6**.

⚠️ **Includes a DB migration** (`20260723130000_cert_status_enum`) — applied on web startup via `prisma migrate deploy`. In-place `USING` cast, no data loss.

## #815 — bound participant PDF/DOCX attachment parsing (security, p2)
Submission attachments were parsed inline in the web request (pdf-parse/mammoth) with no size cap, decompressed-size limit, or timeout → a DOCX zip-bomb / pathological file could exhaust web memory/CPU below the per-minute rate limit. Hardened in-process:
- decoded-byte cap (5MB);
- file-signature/magic-byte validation (PDF `%PDF`, DOCX ZIP `PK\x03\x04`) — a file can't be disguised to reach the wrong parser;
- **DOCX decompressed-size + entry-count cap read from the ZIP central directory WITHOUT inflating** (the zip-bomb defense — reject >50MB declared uncompressed or >512 entries; ZIP64-hidden sizes rejected; mammoth never runs on a bomb);
- 10s wall-clock timeout around the parse.

A rejected file falls back to the submission's raw text if present, else a clear error. Full out-of-process parser-worker isolation is intentionally out of scope (tracked under parent #783).

## #820 — CertificationStatus.status → Postgres enum (data, p4)
Was free-text String with "passed" = `status != 'NOT_CERTIFIED'` — safe only because the sole writer is TS-union-typed; a raw-SQL/untyped writer could store a typo that reads as passed. Now a `CertificationLifecycleStatus` enum (a DB-level CHECK). Migration is an in-place `USING` cast (existing rows all valid → no data loss). Passing states are now listed explicitly (`CERTIFICATION_PASSED_STATUSES`/`isCertificationPassed`) so the check survives a future non-passing state.

## Tests
Attachment: valid PDF/DOCX still parse; signature-mismatch, zip-bomb, too-many-entries rejected without invoking the parser. Enum: rejects an out-of-set value via raw SQL (the untyped-writer scenario), accepts all five. **tsc 0 · 836 unit · 395 integration** (full local run, DB reset re-applies the migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
