### PR TITLE
M5 2.2.8: #809 cold-start grace + #789 agent-token revocation + #802 discussion pagination

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,25 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.2.8 - 2026-07-24
+
+fix(#809 follow-up): worker startup grace so cold-start doesn't report 503
+
+The 2.2.7 prod promotion's post-deploy smoke test failed: the worker `/healthz` returned 503 for ~4
+minutes during the B1 cold-start (then recovered to 200). Root cause was the #809 readiness check —
+a monitor that had not yet completed its FIRST cycle was flagged "stalled" once the process passed the
+monitor's normal stale window (60s floor for the 4s assessment poller), but a cold container + cold
+burstable Postgres + staggered worker starts can take minutes for that first tick. That not only fails
+the deploy smoke test but risks Azure's runtime health check restart-looping the worker before it warms.
+
+Fix: `evaluateWorkerHealth` now gives a monitor that has NEVER completed a cycle a generous startup
+grace (15 min from process start) before it can be "stalled"; once it has completed a cycle the normal
+tight stale window applies, and a HANGING first tick is still caught by the wedge check. So the worker
+reports 200 while warming up and only 503 once a loop is genuinely stuck.
+
+Tests: a never-completed 4s poller 5 min into cold-start is healthy; past the 15 min grace it is stalled.
+Code-only, no infra, no migration.
+
 ## 2.2.7 - 2026-07-23
 
 M5 stabilization — security/audit quick-wins (#788 + #797 + #805 + #807)

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -4,22 +4,26 @@ This document tracks release versions and what each version includes.
 
 ## 2.2.8 - 2026-07-24
 
-fix(#809 follow-up): worker startup grace so cold-start doesn't report 503
+M5 stabilization — #809 cold-start grace + #789 token revocation + #802 discussion pagination
 
-The 2.2.7 prod promotion's post-deploy smoke test failed: the worker `/healthz` returned 503 for ~4
-minutes during the B1 cold-start (then recovered to 200). Root cause was the #809 readiness check —
-a monitor that had not yet completed its FIRST cycle was flagged "stalled" once the process passed the
-monitor's normal stale window (60s floor for the 4s assessment poller), but a cold container + cold
-burstable Postgres + staggered worker starts can take minutes for that first tick. That not only fails
-the deploy smoke test but risks Azure's runtime health check restart-looping the worker before it warms.
+- **#809 follow-up — worker startup grace.** The 2.2.7 prod promotion's post-deploy smoke test failed:
+  the worker `/healthz` returned 503 for ~4 min during the B1 cold-start (then recovered). The #809
+  readiness check flagged a monitor that hadn't completed its FIRST cycle as "stalled" once the process
+  passed its normal stale window (60s floor for the 4s poller) — but a cold container + cold burstable
+  Postgres + staggered starts can take minutes for that first tick. Besides failing the smoke test, that
+  risks Azure restart-looping the worker before it warms. Fix: a monitor that has NEVER completed a cycle
+  gets a 15-min startup grace before it can be "stalled"; once it has ticked the tight window applies, and
+  a hanging first tick is still caught by the wedge check.
+- **#789 — agent-token revocation on role change.** An agent-authoring token freezes the issuer's roles
+  at issuance, so a removed SMO/ADMINISTRATOR role stayed authoring-capable until expiry (≤60 min). The
+  group→role reconciliation now revokes a user's outstanding tokens whenever it revokes a role.
+- **#802 — discussion read pagination.** Thread-list and thread-detail loaded every thread / every reply /
+  every subscriber into memory with no matching index. Now: composite indexes matching the sorts
+  (`[courseId, courseItemId, pinnedAt, updatedAt]`, `[threadId, createdAt]`), bounded reads (safety caps),
+  and `isSubscribed` via a per-viewer existence check instead of loading all subscribers.
 
-Fix: `evaluateWorkerHealth` now gives a monitor that has NEVER completed a cycle a generous startup
-grace (15 min from process start) before it can be "stalled"; once it has completed a cycle the normal
-tight stale window applies, and a HANGING first tick is still caught by the wedge check. So the worker
-reports 200 while warming up and only 503 once a loop is genuinely stuck.
-
-Tests: a never-completed 4s poller 5 min into cold-start is healthy; past the 15 min grace it is stalled.
-Code-only, no infra, no migration.
+Tests: cold-start grace (healthy while warming, stalled past grace); token revoke helper + group-sync
+path; per-viewer isSubscribed existence check. One migration (discussion index swap). tsc 0.
 
 ## 2.2.7 - 2026-07-23
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260724120000_discussion_pagination_indexes/migration.sql
+++ b/prisma/migrations/20260724120000_discussion_pagination_indexes/migration.sql
@@ -1,0 +1,10 @@
+-- #802: discussion reads had no index matching their sort. Replace the prefix-only indexes with composite
+-- indexes that cover the thread-list (WHERE courseId, courseItemId ORDER BY pinnedAt desc, updatedAt desc)
+-- and the reply load (WHERE threadId ORDER BY createdAt asc). The new indexes have the old ones as a
+-- prefix, so dropping the old ones loses no coverage.
+
+DROP INDEX "DiscussionThread_courseId_courseItemId_idx";
+CREATE INDEX "DiscussionThread_courseId_courseItemId_pinnedAt_updatedAt_idx" ON "DiscussionThread"("courseId", "courseItemId", "pinnedAt", "updatedAt");
+
+DROP INDEX "DiscussionReply_threadId_idx";
+CREATE INDEX "DiscussionReply_threadId_createdAt_idx" ON "DiscussionReply"("threadId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -800,7 +800,8 @@ model DiscussionThread {
   replies         DiscussionReply[]        @relation("ThreadReplies")
   subscriptions   DiscussionSubscription[]
 
-  @@index([courseId, courseItemId])
+  // #802: covers the thread-list query (WHERE courseId, courseItemId ORDER BY pinnedAt desc, updatedAt desc).
+  @@index([courseId, courseItemId, pinnedAt, updatedAt])
   @@index([authorId])
 }
 
@@ -818,7 +819,8 @@ model DiscussionReply {
   deletedBy         User?             @relation("DiscussionReplyDeletedBy", fields: [deletedById], references: [id], onDelete: SetNull)
   acceptedForThread DiscussionThread? @relation("AcceptedReply")
 
-  @@index([threadId])
+  // #802: covers the reply load (WHERE threadId ORDER BY createdAt asc).
+  @@index([threadId, createdAt])
   @@index([authorId])
 }
 

--- a/src/auth/agentAuthoringTokenService.ts
+++ b/src/auth/agentAuthoringTokenService.ts
@@ -109,3 +109,33 @@ export async function revokeAgentAuthoringToken(input: {
   });
   return revoked;
 }
+
+// #789: an agent-authoring token freezes the issuer's effective roles at issuance, so a role removed
+// afterwards would otherwise stay authoring-capable until the token expires (up to 60 min). Revoke all of
+// a user's outstanding tokens when their privileges change, so the next request must re-authenticate with
+// current roles. Returns the number of tokens revoked.
+export async function revokeAllAgentTokensForUser(
+  userId: string,
+  reason: string,
+  at = new Date(),
+): Promise<number> {
+  const active = await prisma.agentAuthoringToken.findMany({
+    where: { userId, revokedAt: null },
+    select: { id: true },
+  });
+  if (active.length === 0) return 0;
+
+  await prisma.agentAuthoringToken.updateMany({
+    where: { userId, revokedAt: null },
+    data: { revokedAt: at },
+  });
+  for (const token of active) {
+    await recordAuditEvent({
+      entityType: auditEntityTypes.agentAuthoringToken,
+      entityId: token.id,
+      action: auditActions.agentAuthoring.tokenRevoked,
+      metadata: { tokenId: token.id, reason },
+    });
+  }
+  return active.length;
+}

--- a/src/modules/discussion/discussionReadModels.ts
+++ b/src/modules/discussion/discussionReadModels.ts
@@ -140,12 +140,14 @@ export type ThreadDetailRow = ThreadSummaryRow & {
   authorId: string;
   bodyMarkdown: string;
   replies: ReplyRow[];
-  subscriptions: Array<{ userId: string }>;
 };
 
 export function toThreadDetailDto(
   row: ThreadDetailRow,
   viewer: ViewerContext,
+  // #802: computed from an existence check on the viewer's own subscription, not by loading every
+  // subscriber row into memory.
+  isSubscribed: boolean,
 ): DiscussionThreadDetailDto {
   const deleted = row.deletedAt !== null;
   const isOwn = row.authorId === viewer.userId;
@@ -163,7 +165,7 @@ export function toThreadDetailDto(
     author: toAuthorDto(row.author),
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
-    isSubscribed: row.subscriptions.some((s) => s.userId === viewer.userId),
+    isSubscribed,
     canEdit: !deleted && isOwn,
     canDelete: !deleted && (isOwn || viewer.canModerate),
     // Akseptert svar settes av spørrer (på QUESTION) eller moderator.

--- a/src/modules/discussion/discussionService.ts
+++ b/src/modules/discussion/discussionService.ts
@@ -63,12 +63,19 @@ const threadSummarySelect = {
   _count: { select: { replies: { where: { deletedAt: null } } } },
 } as const;
 
+// #802: bound reads so a thread with many replies / a board with many threads can't load an unbounded
+// set into memory. These are safety caps (well above any realistic thread); UX-visible cursor pagination
+// can layer on later if a board grows past them.
+export const DISCUSSION_MAX_THREADS = 500;
+export const DISCUSSION_MAX_REPLIES = 500;
+
 const threadDetailSelect = {
   ...threadSummarySelect,
   authorId: true,
   bodyMarkdown: true,
   replies: {
     orderBy: { createdAt: "asc" },
+    take: DISCUSSION_MAX_REPLIES,
     select: {
       id: true,
       authorId: true,
@@ -79,7 +86,7 @@ const threadDetailSelect = {
       author: authorSelect,
     },
   },
-  subscriptions: { select: { userId: true } },
+  // #802: no longer selects every subscriber — isSubscribed is an existence check on the viewer's own row.
 } as const;
 
 /**
@@ -150,6 +157,19 @@ async function assertScopeWritable(
   }
 }
 
+// #802: resolve the thread-detail DTO, computing isSubscribed via a targeted existence check on the
+// viewer's own subscription row rather than loading every subscriber. Used by every detail-returning path.
+async function detailDtoWithSubscription(
+  thread: Parameters<typeof toThreadDetailDto>[0],
+  viewer: Parameters<typeof toThreadDetailDto>[1],
+): Promise<DiscussionThreadDetailDto> {
+  const subscription = await prisma.discussionSubscription.findFirst({
+    where: { threadId: thread.id, userId: viewer.userId },
+    select: { id: true },
+  });
+  return toThreadDetailDto(thread, viewer, subscription !== null);
+}
+
 export async function listThreads(params: {
   courseId: string;
   courseItemId: string | null;
@@ -169,6 +189,7 @@ export async function listThreads(params: {
   const rows = await prisma.discussionThread.findMany({
     where: { courseId: course.id, courseItemId: params.courseItemId },
     orderBy: [{ pinnedAt: { sort: "desc", nulls: "last" } }, { updatedAt: "desc" }],
+    take: DISCUSSION_MAX_THREADS,
     select: threadSummarySelect,
   });
   const viewer = viewerOf(params.access);
@@ -223,7 +244,7 @@ export async function createThread(params: {
     }
   }
 
-  return toThreadDetailDto(thread, viewerOf(params.access));
+  return await detailDtoWithSubscription(thread, viewerOf(params.access));
 }
 
 async function loadThreadInCourse(courseId: string, threadId: string) {
@@ -244,7 +265,7 @@ export async function getThread(params: {
 }): Promise<DiscussionThreadDetailDto> {
   const course = await loadAccessibleCourse(params.courseId, params.access);
   const thread = await loadThreadInCourse(course.id, params.threadId);
-  return toThreadDetailDto(thread, viewerOf(params.access));
+  return await detailDtoWithSubscription(thread, viewerOf(params.access));
 }
 
 export type ThreadPatch = {
@@ -370,14 +391,14 @@ export async function updateThread(params: {
 
   if (Object.keys(data).length === 0) {
     // Ingen gyldige felter — returner uendret.
-    return toThreadDetailDto(thread, viewer);
+    return await detailDtoWithSubscription(thread, viewer);
   }
 
   await prisma.discussionThread.update({ where: { id: thread.id }, data });
   for (const call of auditCalls) await call();
 
   const updated = await loadThreadInCourse(course.id, thread.id);
-  return toThreadDetailDto(updated, viewer);
+  return await detailDtoWithSubscription(updated, viewer);
 }
 
 export async function deleteThread(params: {
@@ -455,7 +476,7 @@ export async function createReply(params: {
   }
 
   const updated = await loadThreadInCourse(course.id, thread.id);
-  return toThreadDetailDto(updated, viewerOf(params.access));
+  return await detailDtoWithSubscription(updated, viewerOf(params.access));
 }
 
 async function loadReplyInThread(courseId: string, threadId: string, replyId: string) {
@@ -496,7 +517,7 @@ export async function updateReply(params: {
     metadata: { courseId: course.id, threadId: params.threadId },
   });
   const updated = await loadThreadInCourse(course.id, params.threadId);
-  return toThreadDetailDto(updated, viewerOf(params.access));
+  return await detailDtoWithSubscription(updated, viewerOf(params.access));
 }
 
 export async function deleteReply(params: {

--- a/src/observability/workerHealth.ts
+++ b/src/observability/workerHealth.ts
@@ -58,6 +58,16 @@ export interface WorkerHealthThresholds {
   minStaleFloorMs: number;
   /** Lower bound on the wedge window, so a brief-but-legitimate slow tick isn't called wedged. */
   minWedgeFloorMs: number;
+  /**
+   * #809-followup: grace for a monitor that has NEVER completed a cycle yet. On a B1 cold-start (cold
+   * container + cold burstable Postgres + staggered worker starts) the first tick of a short-interval
+   * monitor can legitimately take minutes — longer than its normal stale window — so during warm-up we
+   * must NOT report the worker unhealthy (that fails the deploy smoke test and, worse, can make Azure's
+   * runtime health check restart-loop the worker before it ever warms up). A never-completed monitor is
+   * "starting" (healthy) until the process has been up longer than this; a HANGING first tick is still
+   * caught by the wedge check.
+   */
+  startupGraceMs: number;
 }
 
 // Factor 3 + 60 s floors: the 4 s assessment poller tolerates ~60 s of no progress before "stalled"
@@ -69,6 +79,9 @@ export const DEFAULT_WORKER_HEALTH_THRESHOLDS: WorkerHealthThresholds = {
   wedgeFactor: 3,
   minStaleFloorMs: 60_000,
   minWedgeFloorMs: 60_000,
+  // 15 min: comfortably longer than an observed B1 cold-start worker warm-up (~10 min). A worker that
+  // has not completed a SINGLE cycle of a monitor in 15 min is genuinely broken; until then it's warming.
+  startupGraceMs: 900_000,
 };
 
 function parseIso(value: string | null): number | null {
@@ -105,10 +118,14 @@ export function evaluateWorkerHealth(
       return { name: s.name, enabled: true, healthy: false, reason: "wedged", staleMs: null, runningMs };
     }
 
-    // No success yet → measure the grace window from process start.
-    const referenceMs = parseIso(s.lastCycleAt) ?? startMs;
+    // No success yet → measure from process start, and give it the (larger) startup grace: a monitor
+    // that has never completed a cycle is warming up, not stalled, until the process exceeds that grace.
+    // Once it HAS completed a cycle, the normal (tight) stale window applies.
+    const lastCycleMs = parseIso(s.lastCycleAt);
+    const referenceMs = lastCycleMs ?? startMs;
+    const effectiveStaleWindow = lastCycleMs === null ? Math.max(staleWindow, thresholds.startupGraceMs) : staleWindow;
     const staleMs = nowMs - referenceMs;
-    if (staleMs > staleWindow) {
+    if (staleMs > effectiveStaleWindow) {
       return { name: s.name, enabled: true, healthy: false, reason: "stalled", staleMs, runningMs };
     }
 

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -2,6 +2,7 @@ import type { AppRole as AppRoleType } from "@prisma/client";
 import { AppRole } from "../db/prismaRuntime.js";
 import type { AuthPrincipal } from "../auth/principal.js";
 import { parseEntraGroupRoleMapJson } from "../auth/entraRoleMap.js";
+import { revokeAllAgentTokensForUser } from "../auth/agentAuthoringTokenService.js";
 import { prisma } from "../db/prisma.js";
 import { env } from "../config/env.js";
 import fs from "node:fs";
@@ -296,13 +297,21 @@ export async function syncEntraGroupRoles(userId: string, principal: AuthPrincip
     }
   }
 
+  let revokedAnyRole = false;
   for (const assignment of activeAssignments) {
     if (!desiredRoles.has(assignment.appRole)) {
       await prisma.roleAssignment.update({
         where: { id: assignment.id },
         data: { validTo: at },
       });
+      revokedAnyRole = true;
     }
+  }
+
+  // #789: a role just went away — invalidate this user's outstanding agent-authoring tokens, which froze
+  // the old (broader) role set at issuance and would otherwise stay authoring-capable until they expire.
+  if (revokedAnyRole) {
+    await revokeAllAgentTokensForUser(userId, "entra_group_role_revoked", at);
   }
 
   // Marker som synket først etter vellykket reconcile (så et kast → retry neste request).

--- a/test/m2-agent-token-revocation.test.ts
+++ b/test/m2-agent-token-revocation.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { prisma } from "../src/db/prisma.js";
+import { env } from "../src/config/env.js";
+import {
+  issueAgentAuthoringToken,
+  revokeAllAgentTokensForUser,
+} from "../src/auth/agentAuthoringTokenService.js";
+import { syncEntraGroupRoles, resetGroupSyncThrottle } from "../src/repositories/userRepository.js";
+import type { AuthPrincipal } from "../src/auth/principal.js";
+
+// #789: an agent-authoring token freezes the issuer's roles at issuance, so a role removed afterwards
+// stays authoring-capable until expiry. Outstanding tokens must be revoked when the user's roles change.
+async function makeUser(tag: string) {
+  return prisma.user.create({
+    data: { externalId: `${tag}-${Date.now()}`, name: tag, email: `${tag}-${Date.now()}@x.test` },
+    select: { id: true },
+  });
+}
+
+describe("agent-token revocation on role change (#789)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("revokeAllAgentTokensForUser revokes only the user's active tokens and audits each", async () => {
+    const user = await makeUser("rev");
+    const other = await makeUser("other");
+    const a = await issueAgentAuthoringToken({ userId: user.id, roles: ["SUBJECT_MATTER_OWNER"] });
+    const b = await issueAgentAuthoringToken({ userId: user.id, roles: ["SUBJECT_MATTER_OWNER"] });
+    const untouched = await issueAgentAuthoringToken({ userId: other.id, roles: ["SUBJECT_MATTER_OWNER"] });
+
+    const count = await revokeAllAgentTokensForUser(user.id, "unit_test");
+    expect(count).toBe(2);
+
+    expect((await prisma.agentAuthoringToken.findUnique({ where: { id: a.record.id } }))?.revokedAt).not.toBeNull();
+    expect((await prisma.agentAuthoringToken.findUnique({ where: { id: b.record.id } }))?.revokedAt).not.toBeNull();
+    // a different user's token is untouched
+    expect((await prisma.agentAuthoringToken.findUnique({ where: { id: untouched.record.id } }))?.revokedAt).toBeNull();
+
+    const audits = await prisma.auditEvent.findMany({ where: { action: "agent_authoring_token_revoked", entityId: { in: [a.record.id, b.record.id] } } });
+    expect(audits.length).toBe(2);
+    expect(JSON.parse(audits[0].metadataJson).reason).toBe("unit_test");
+
+    // idempotent — a second call revokes nothing
+    expect(await revokeAllAgentTokensForUser(user.id, "unit_test")).toBe(0);
+  });
+
+  it("syncEntraGroupRoles revokes outstanding tokens when a group-synced role is removed", async () => {
+    const original = env.ENTRA_SYNC_GROUP_ROLES;
+    (env as { ENTRA_SYNC_GROUP_ROLES: boolean }).ENTRA_SYNC_GROUP_ROLES = true;
+    try {
+      const user = await makeUser("sync");
+      // A role the user currently holds via group sync.
+      await prisma.roleAssignment.create({
+        data: { userId: user.id, appRole: "SUBJECT_MATTER_OWNER", validFrom: new Date(Date.now() - 60_000), createdBy: "entra-group-sync" },
+      });
+      const token = await issueAgentAuthoringToken({ userId: user.id, roles: ["SUBJECT_MATTER_OWNER"] });
+
+      resetGroupSyncThrottle();
+      // Principal now carries NO groups → desired roles empty → the SMO assignment is revoked.
+      const principal = { userId: user.id, email: "x@x.test", name: "x", roles: [], groupIds: [] } as unknown as AuthPrincipal;
+      await syncEntraGroupRoles(user.id, principal, new Date());
+
+      expect((await prisma.agentAuthoringToken.findUnique({ where: { id: token.record.id } }))?.revokedAt).not.toBeNull();
+    } finally {
+      (env as { ENTRA_SYNC_GROUP_ROLES: boolean }).ENTRA_SYNC_GROUP_ROLES = original;
+    }
+  });
+});

--- a/test/m2-discussions-api.test.ts
+++ b/test/m2-discussions-api.test.ts
@@ -72,6 +72,23 @@ describe("Discussions API (#495/T-QA-2)", () => {
     expect(list.body.threads.some((t: { id: string }) => t.id === create.body.thread.id)).toBe(true);
   });
 
+  it("#802: isSubscribed is per-viewer (existence check), not 'any subscriber exists'", async () => {
+    const courseId = await makeOpenCourse();
+    const create = await request(app)
+      .post(`/api/courses/${courseId}/discussions`)
+      .set(asker)
+      .send({ kind: "DISCUSSION", title: "Sub", bodyMarkdown: "x" });
+    const threadId = create.body.thread.id;
+
+    // The author is auto-subscribed → true for them.
+    const askerView = await request(app).get(`/api/courses/${courseId}/discussions/${threadId}`).set(asker);
+    expect(askerView.body.thread.isSubscribed).toBe(true);
+
+    // The SMO has NOT subscribed → false, even though another subscriber (the author) exists.
+    const smoView = await request(app).get(`/api/courses/${courseId}/discussions/${threadId}`).set(smo);
+    expect(smoView.body.thread.isSubscribed).toBe(false);
+  });
+
   it("QUESTION-flyt: svar + aksepter svar (av spørrer) → RESOLVED", async () => {
     const courseId = await makeOpenCourse();
     const q = await request(app)

--- a/test/unit/worker-health.test.ts
+++ b/test/unit/worker-health.test.ts
@@ -116,6 +116,22 @@ describe("evaluateWorkerHealth (#809)", () => {
     expect(stalled.monitors[0].reason).toBe("stalled");
   });
 
+  it("a never-completed short-interval monitor is 'starting' (healthy) within the startup grace (#809 cold-start)", () => {
+    // The prod incident: the 4s assessment poller (60s stale window) had not completed its first cycle
+    // ~5 min into a B1 cold-start → it was wrongly flagged stalled → worker 503 → failed the smoke test.
+    const coldStart = new Date(nowMs - 5 * 60_000);
+    const report = evaluateWorkerHealth([snap({ intervalMs: 4_000, lastCycleAt: null })], NOW, coldStart);
+    expect(report.healthy).toBe(true);
+    expect(report.monitors[0].reason).toBe("ok");
+  });
+
+  it("a monitor that has never completed a cycle PAST the startup grace is stalled", () => {
+    const longDeadStart = new Date(nowMs - 20 * 60_000); // 20 min, beyond the 15 min startup grace
+    const report = evaluateWorkerHealth([snap({ intervalMs: 4_000, lastCycleAt: null })], NOW, longDeadStart);
+    expect(report.healthy).toBe(false);
+    expect(report.monitors[0].reason).toBe("stalled");
+  });
+
   it("one unhealthy monitor makes the whole worker unhealthy (all must be ready)", () => {
     const report = evaluateWorkerHealth(
       [snap({ lastCycleAt: iso(60_000) }), snap({ name: "stuck", lastCycleAt: iso(40 * 60_000) })],


### PR DESCRIPTION
Bundled follow-up + independent quick-wins. Version **2.2.8**. One migration (discussion index swap).

## #809 follow-up — worker startup grace (fixes the 2.2.7 prod smoke-test failure)
The 2.2.7 prod promotion's post-deploy smoke test failed: the worker `/healthz` returned **503 for ~4 min** during the B1 cold-start, then recovered. The readiness check flagged a monitor that hadn't completed its FIRST cycle as `stalled` once the process passed its normal stale window (60s floor for the 4s poller) — but cold container + cold Postgres + staggered starts take minutes for the first tick. Besides failing the smoke test, this **risks Azure restart-looping the worker** before it warms. Fix: a never-completed monitor gets a **15-min startup grace** before it can be `stalled`; a hanging first tick is still caught by the wedge check.

## #789 — agent-token revocation on role change (security, p2)
An agent-authoring token freezes the issuer's roles at issuance, so removing an SMO/ADMINISTRATOR role left an issued `aat_` token authoring-capable until expiry (≤60 min). The Entra group→role reconciliation now revokes a user's outstanding tokens whenever it revokes a role (`revokeAllAgentTokensForUser`, audited).

## #802 — discussion read pagination + indexes (p4)
Thread-list / thread-detail loaded every thread / reply / subscriber into memory with no matching index. Now: composite indexes matching the sorts (`[courseId, courseItemId, pinnedAt, updatedAt]`, `[threadId, createdAt]`), bounded reads (safety caps), and `isSubscribed` via a **per-viewer existence check** instead of loading all subscribers.

## Tests
tsc 0 · **842 unit** · integration green. New: cold-start grace (healthy while warming / stalled past grace); token-revoke helper + group-sync path; per-viewer isSubscribed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
