### PR TITLE
M5 concurrency & atomicity cluster (#790-#794, #803) → 2.3.0

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,44 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.3.0 - 2026-07-25
+
+M5 concurrency & atomicity cluster (option 2) — eliminate lost-update races and audit/state divergence
+across the claim, assessment-job, MCQ, and mutation paths. Seven issues, each with a real-Postgres
+concurrency/atomicity proof test.
+
+- **#790 — appeal claim/resolve races.** Replaced `markAppealInReview`/`markAppealResolved` with guarded
+  `updateMany` transitions whose WHERE encodes the preconditions (status not terminal; owner match unless
+  admin takeover). Two racing claims/resolves can no longer both win — the loser gets `count 0` →
+  `ConflictError`, so duplicate resolution decisions are impossible. The guarded transition runs FIRST
+  inside the resolve transaction, before the decision is appended.
+- **#791 — manual-review claim/override races.** Same guarded-`updateMany` pattern for
+  `markManualReviewClaimedGuarded`/`resolveManualReviewGuarded`; the override finalization does the
+  guarded resolve first inside its transaction.
+- **#793 — one active assessment job per submission.** Partial unique index
+  (`WHERE status IN ('PENDING','RUNNING')`) as a DB invariant; enqueue catches the P2002 and returns the
+  concurrent winner instead of creating a duplicate (no extra LLM run/decision). Migration dedups any
+  pre-existing active duplicates before creating the index.
+- **#792 — assessment-job lease fencing + renewal.** Terminal writes (`markJobSucceeded`,
+  `markJobForRetryOrFailure`, `renewLease`) are fenced `updateMany`s keyed on `(id, status:RUNNING,
+  lockedBy, lockedAt)` returning `{count}`; a heartbeat renews the lease during processing. A worker that
+  lost its lease (`count 0`) skips the terminal write instead of clobbering the new owner's result.
+- **#794 — atomic, guarded MCQ finalization.** Response replacement + guard-complete (only while the
+  attempt is still open) + submission-status move happen in ONE transaction; a partial-unique
+  `@@unique([mcqAttemptId, questionId])` backs the response rewrite. Two concurrent submits can no longer
+  both finalize (`count 0` → `mcq_already_submitted`).
+- **#803 — audit writes atomic with the domain mutation.** `recordAuditEvent` now commits in the SAME
+  `runInTransaction` as the state change it records, threaded through ~53 call sites (course/section/
+  class/enrollment/content-owner/adminContent/assessment/appeal/manual-review/discussion/agent-token).
+  Under partial failure the audit log and actual state can no longer diverge. Non-DB I/O (email, enqueue,
+  blob reclaim, logging) stays outside the transaction; audit-only events (login/notification-sent/run-
+  summary) are intentionally left unwrapped. `test/m2-audit-transactional.ts` proves a forced audit
+  failure rolls the domain mutation back.
+
+Deferred to their own arcs: #796 (content-import atomicity — needs an idempotent ImportRun, blob
+staging, and the full graph built in one transaction); the import audit sites (moduleImported/
+courseImported) and the fire-and-forget completion-path tx forwarding go with it.
+
 ## 2.2.8 - 2026-07-24
 
 M5 stabilization — #809 cold-start grace + #789 token revocation + #802 discussion pagination

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.2.8",
+  "version": "2.3.0",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260724130000_assessment_job_active_unique/migration.sql
+++ b/prisma/migrations/20260724130000_assessment_job_active_unique/migration.sql
@@ -1,0 +1,21 @@
+-- #793: at most ONE active (PENDING/RUNNING) assessment job per submission, as a DB invariant. The app
+-- enqueue was findFirst-then-create, so two concurrent submits could both create a job → duplicate LLM
+-- spend / decisions / emails. A partial unique index makes the DB reject the second; the app catches the
+-- P2002 and returns the existing job.
+
+-- First resolve any pre-existing duplicate active jobs so the unique index can be built: keep the oldest
+-- active job per submission, fail the rest (they are indistinguishable duplicates of the same work).
+UPDATE "AssessmentJob"
+  SET "status" = 'FAILED', "errorMessage" = 'superseded_duplicate_active_job'
+  WHERE "id" IN (
+    SELECT "id" FROM (
+      SELECT "id", ROW_NUMBER() OVER (PARTITION BY "submissionId" ORDER BY "createdAt" ASC) AS rn
+      FROM "AssessmentJob"
+      WHERE "status" IN ('PENDING', 'RUNNING')
+    ) ranked
+    WHERE ranked.rn > 1
+  );
+
+CREATE UNIQUE INDEX "AssessmentJob_active_submission_uniq"
+  ON "AssessmentJob" ("submissionId")
+  WHERE "status" IN ('PENDING', 'RUNNING');

--- a/prisma/migrations/20260724140000_mcq_response_unique/migration.sql
+++ b/prisma/migrations/20260724140000_mcq_response_unique/migration.sql
@@ -1,0 +1,13 @@
+-- #794: one MCQ response per (attempt, question) as a DB invariant, so the delete+recreate finalization
+-- (or a concurrent/retried submit) can never leave duplicate answers. Dedupe any pre-existing duplicates
+-- (keep the oldest per pair) before adding the unique index.
+DELETE FROM "MCQResponse"
+  WHERE "id" IN (
+    SELECT "id" FROM (
+      SELECT "id", ROW_NUMBER() OVER (PARTITION BY "mcqAttemptId", "questionId" ORDER BY "createdAt" ASC) AS rn
+      FROM "MCQResponse"
+    ) ranked
+    WHERE ranked.rn > 1
+  );
+
+CREATE UNIQUE INDEX "MCQResponse_mcqAttemptId_questionId_key" ON "MCQResponse" ("mcqAttemptId", "questionId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -331,7 +331,9 @@ model MCQResponse {
   mcqAttempt     MCQAttempt  @relation(fields: [mcqAttemptId], references: [id], onDelete: Restrict)
   question       MCQQuestion @relation(fields: [questionId], references: [id], onDelete: Restrict)
 
-  @@index([mcqAttemptId])
+  // #794: one response per (attempt, question) as a DB invariant — the delete+recreate finalization
+  // can't leave duplicate answers even under a retry/race.
+  @@unique([mcqAttemptId, questionId])
 }
 
 model RubricVersion {

--- a/src/auth/agentAuthoringTokenService.ts
+++ b/src/auth/agentAuthoringTokenService.ts
@@ -9,6 +9,7 @@
 
 import { randomBytes } from "node:crypto";
 import { prisma } from "../db/prisma.js";
+import { runInTransaction } from "../db/transaction.js";
 import { sha256 } from "../utils/hash.js";
 import { recordAuditEvent } from "../services/auditService.js";
 import { auditActions, auditEntityTypes } from "../observability/auditEvents.js";
@@ -31,22 +32,29 @@ export async function issueAgentAuthoringToken(input: {
     Math.max(AGENT_TOKEN_MIN_TTL_MINUTES, input.ttlMinutes ?? AGENT_TOKEN_DEFAULT_TTL_MINUTES),
   );
   const secret = `${AGENT_TOKEN_PREFIX}${randomBytes(24).toString("hex")}`;
-  const record = await prisma.agentAuthoringToken.create({
-    data: {
-      tokenHash: sha256(secret),
-      label: input.label ?? null,
-      userId: input.userId,
-      rolesJson: JSON.stringify(input.roles ?? []),
-      expiresAt: new Date(Date.now() + ttl * 60_000),
-    },
-  });
+  const record = await runInTransaction(async (tx) => {
+    const created = await tx.agentAuthoringToken.create({
+      data: {
+        tokenHash: sha256(secret),
+        label: input.label ?? null,
+        userId: input.userId,
+        rolesJson: JSON.stringify(input.roles ?? []),
+        expiresAt: new Date(Date.now() + ttl * 60_000),
+      },
+    });
 
-  await recordAuditEvent({
-    entityType: auditEntityTypes.agentAuthoringToken,
-    entityId: record.id,
-    action: auditActions.agentAuthoring.tokenIssued,
-    actorId: input.userId,
-    metadata: { tokenId: record.id, expiresAt: record.expiresAt.toISOString() },
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.agentAuthoringToken,
+        entityId: created.id,
+        action: auditActions.agentAuthoring.tokenIssued,
+        actorId: input.userId,
+        metadata: { tokenId: created.id, expiresAt: created.expiresAt.toISOString() },
+      },
+      tx,
+    );
+
+    return created;
   });
 
   // The secret exists only in this return value — it is never persisted or logged.
@@ -96,16 +104,22 @@ export async function revokeAgentAuthoringToken(input: {
   if (token.userId !== input.actorUserId && !input.roles.includes("ADMINISTRATOR")) return null;
   if (token.revokedAt) return token;
 
-  const revoked = await prisma.agentAuthoringToken.update({
-    where: { id: token.id },
-    data: { revokedAt: new Date() },
-  });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.agentAuthoringToken,
-    entityId: token.id,
-    action: auditActions.agentAuthoring.tokenRevoked,
-    actorId: input.actorUserId,
-    metadata: { tokenId: token.id },
+  const revoked = await runInTransaction(async (tx) => {
+    const updated = await tx.agentAuthoringToken.update({
+      where: { id: token.id },
+      data: { revokedAt: new Date() },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.agentAuthoringToken,
+        entityId: token.id,
+        action: auditActions.agentAuthoring.tokenRevoked,
+        actorId: input.actorUserId,
+        metadata: { tokenId: token.id },
+      },
+      tx,
+    );
+    return updated;
   });
   return revoked;
 }
@@ -125,17 +139,22 @@ export async function revokeAllAgentTokensForUser(
   });
   if (active.length === 0) return 0;
 
-  await prisma.agentAuthoringToken.updateMany({
-    where: { userId, revokedAt: null },
-    data: { revokedAt: at },
-  });
-  for (const token of active) {
-    await recordAuditEvent({
-      entityType: auditEntityTypes.agentAuthoringToken,
-      entityId: token.id,
-      action: auditActions.agentAuthoring.tokenRevoked,
-      metadata: { tokenId: token.id, reason },
+  await runInTransaction(async (tx) => {
+    await tx.agentAuthoringToken.updateMany({
+      where: { userId, revokedAt: null },
+      data: { revokedAt: at },
     });
-  }
+    for (const token of active) {
+      await recordAuditEvent(
+        {
+          entityType: auditEntityTypes.agentAuthoringToken,
+          entityId: token.id,
+          action: auditActions.agentAuthoring.tokenRevoked,
+          metadata: { tokenId: token.id, reason },
+        },
+        tx,
+      );
+    }
+  });
   return active.length;
 }

--- a/src/modules/adminContent/adminContentCommands.ts
+++ b/src/modules/adminContent/adminContentCommands.ts
@@ -94,27 +94,35 @@ export async function createModule(input: CreateModuleInput) {
     throw new Error("validTo must be on or after validFrom.");
   }
 
-  const module = await adminContentRepository.createModule({
-    title: input.title,
-    description: input.description,
-    certificationLevel: input.certificationLevel,
-    validFrom: input.validFrom,
-    validTo: input.validTo,
-    createdById: input.actorId,
-  });
+  const module = await runInTransaction(async (tx) => {
+    const repo = createAdminContentRepository(tx);
+    const created = await repo.createModule({
+      title: input.title,
+      description: input.description,
+      certificationLevel: input.certificationLevel,
+      validFrom: input.validFrom,
+      validTo: input.validTo,
+      createdById: input.actorId,
+    });
 
-  await recordAuditEvent({
-    entityType: auditEntityTypes.module,
-    entityId: module.id,
-    action: auditActions.adminContent.moduleCreated,
-    actorId: input.actorId,
-    metadata: {
-      moduleId: module.id,
-      title: module.title,
-      certificationLevel: module.certificationLevel ?? null,
-      validFrom: module.validFrom?.toISOString() ?? null,
-      validTo: module.validTo?.toISOString() ?? null,
-    },
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.module,
+        entityId: created.id,
+        action: auditActions.adminContent.moduleCreated,
+        actorId: input.actorId,
+        metadata: {
+          moduleId: created.id,
+          title: created.title,
+          certificationLevel: created.certificationLevel ?? null,
+          validFrom: created.validFrom?.toISOString() ?? null,
+          validTo: created.validTo?.toISOString() ?? null,
+        },
+      },
+      tx,
+    );
+
+    return created;
   });
 
   // #787 slice 4a: creator becomes sole initial owner. Modules already set createdById and the backfill
@@ -174,13 +182,20 @@ export async function updateModuleTitle(moduleId: string, titlePatch: LocalizedT
     ...normalizeLocalizedTitleSeed(existingModule.title),
     ...normalizeLocalizedTitlePatch(titlePatch),
   });
-  const module = await adminContentRepository.updateModuleTitle(moduleId, title);
-  await recordAuditEvent({
-    entityType: auditEntityTypes.module,
-    entityId: moduleId,
-    action: auditActions.adminContent.moduleTitleUpdated,
-    actorId,
-    metadata: { moduleId, title },
+  const module = await runInTransaction(async (tx) => {
+    const repo = createAdminContentRepository(tx);
+    const updated = await repo.updateModuleTitle(moduleId, title);
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.module,
+        entityId: moduleId,
+        action: auditActions.adminContent.moduleTitleUpdated,
+        actorId,
+        metadata: { moduleId, title },
+      },
+      tx,
+    );
+    return updated;
   });
   return module;
 }
@@ -245,15 +260,18 @@ export async function purgeUnpublishedModules(actorId: string): Promise<PurgeRes
         await tx.rubricVersion.deleteMany({ where: { moduleId: candidate.id } });
         await tx.promptTemplateVersion.deleteMany({ where: { moduleId: candidate.id } });
         await tx.module.delete({ where: { id: candidate.id } });
+        await recordAuditEvent(
+          {
+            entityType: auditEntityTypes.module,
+            entityId: candidate.id,
+            action: auditActions.adminContent.moduleDeleted,
+            actorId,
+            metadata: { moduleId: candidate.id, title: candidate.title, purged: true, source: "bulk_purge_unpublished" },
+          },
+          tx,
+        );
       });
       result.deleted.push({ id: candidate.id, title: candidate.title });
-      await recordAuditEvent({
-        entityType: auditEntityTypes.module,
-        entityId: candidate.id,
-        action: auditActions.adminContent.moduleDeleted,
-        actorId,
-        metadata: { moduleId: candidate.id, title: candidate.title, purged: true, source: "bulk_purge_unpublished" },
-      });
     } catch (error) {
       const message = error instanceof Error ? error.message : "unknown_error";
       result.failed.push({ id: candidate.id, title: candidate.title, message });
@@ -289,17 +307,23 @@ export async function deleteModule(moduleId: string, actorId: string) {
     throw new Error(`Module cannot be deleted because it still has dependencies: ${dependencySummary}.`);
   }
 
-  const deletedModule = await adminContentRepository.deleteModule(moduleId);
-
-  await recordAuditEvent({
-    entityType: auditEntityTypes.module,
-    entityId: moduleId,
-    action: auditActions.adminContent.moduleDeleted,
-    actorId,
-    metadata: {
-      moduleId,
-      title: deletedModule.title,
-    },
+  const deletedModule = await runInTransaction(async (tx) => {
+    const repo = createAdminContentRepository(tx);
+    const deleted = await repo.deleteModule(moduleId);
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.module,
+        entityId: moduleId,
+        action: auditActions.adminContent.moduleDeleted,
+        actorId,
+        metadata: {
+          moduleId,
+          title: deleted.title,
+        },
+      },
+      tx,
+    );
+    return deleted;
   });
 
   return deletedModule;
@@ -669,28 +693,36 @@ export async function createBenchmarkExampleVersion(input: CreateBenchmarkExampl
     benchmarkVersionNo: versionNo,
   }));
 
-  const promptTemplateVersion = await adminContentRepository.createPromptTemplateVersion({
-    moduleId: input.moduleId,
-    versionNo,
-    systemPrompt: basePromptTemplate.systemPrompt,
-    userPromptTemplate: basePromptTemplate.userPromptTemplate,
-    examplesJson: JSON.stringify(enrichedExamples),
-    active: input.active,
-  });
-
-  await recordAuditEvent({
-    entityType: auditEntityTypes.promptTemplateVersion,
-    entityId: promptTemplateVersion.id,
-    action: auditActions.adminContent.benchmarkExampleVersionCreated,
-    actorId: input.actorId,
-    metadata: {
+  const promptTemplateVersion = await runInTransaction(async (tx) => {
+    const repo = createAdminContentRepository(tx);
+    const created = await repo.createPromptTemplateVersion({
       moduleId: input.moduleId,
-      promptTemplateVersionId: promptTemplateVersion.id,
-      sourcePromptTemplateVersionId: input.basePromptTemplateVersionId,
-      sourceModuleVersionId: input.linkedModuleVersionId ?? null,
-      benchmarkExampleCount: input.examples.length,
-      versionNo: promptTemplateVersion.versionNo,
-    },
+      versionNo,
+      systemPrompt: basePromptTemplate.systemPrompt,
+      userPromptTemplate: basePromptTemplate.userPromptTemplate,
+      examplesJson: JSON.stringify(enrichedExamples),
+      active: input.active,
+    });
+
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.promptTemplateVersion,
+        entityId: created.id,
+        action: auditActions.adminContent.benchmarkExampleVersionCreated,
+        actorId: input.actorId,
+        metadata: {
+          moduleId: input.moduleId,
+          promptTemplateVersionId: created.id,
+          sourcePromptTemplateVersionId: input.basePromptTemplateVersionId,
+          sourceModuleVersionId: input.linkedModuleVersionId ?? null,
+          benchmarkExampleCount: input.examples.length,
+          versionNo: created.versionNo,
+        },
+      },
+      tx,
+    );
+
+    return created;
   });
 
   return {
@@ -719,14 +751,20 @@ export async function archiveModule(moduleId: string, actorId: string) {
 
   // I3: arkivering auto-avpubliserer (rydder activeVersionId samtidig som archivedAt settes),
   // så tilstanden «arkivert men fortsatt publisert» aldri oppstår. Gjenopprett lander i Utkast.
-  const result = await adminContentRepository.archiveModule(moduleId, new Date());
-
-  await recordAuditEvent({
-    entityType: auditEntityTypes.module,
-    entityId: moduleId,
-    action: auditActions.adminContent.moduleArchived,
-    actorId,
-    metadata: { moduleId },
+  const result = await runInTransaction(async (tx) => {
+    const repo = createAdminContentRepository(tx);
+    const archived = await repo.archiveModule(moduleId, new Date());
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.module,
+        entityId: moduleId,
+        action: auditActions.adminContent.moduleArchived,
+        actorId,
+        metadata: { moduleId },
+      },
+      tx,
+    );
+    return archived;
   });
 
   return result;
@@ -743,14 +781,20 @@ export async function restoreModule(moduleId: string, actorId: string) {
     throw new Error("Module is not archived.");
   }
 
-  const result = await adminContentRepository.restoreModule(moduleId);
-
-  await recordAuditEvent({
-    entityType: auditEntityTypes.module,
-    entityId: moduleId,
-    action: auditActions.adminContent.moduleRestored,
-    actorId,
-    metadata: { moduleId },
+  const result = await runInTransaction(async (tx) => {
+    const repo = createAdminContentRepository(tx);
+    const restored = await repo.restoreModule(moduleId);
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.module,
+        entityId: moduleId,
+        action: auditActions.adminContent.moduleRestored,
+        actorId,
+        metadata: { moduleId },
+      },
+      tx,
+    );
+    return restored;
   });
 
   return result;
@@ -761,17 +805,23 @@ export async function unpublishModule(moduleId: string, actorId: string) {
   // G2 (bruk-lås): kan ikke avpublisere en modul som ligger i et kurs — det ville gi en
   // blindvei i kurset. Fjern den fra kursene først.
   await assertModuleNotInAnyCourse(moduleId, "avpubliseres");
-  const result = await adminContentRepository.unpublishModule(moduleId);
-
-  await recordAuditEvent({
-    entityType: auditEntityTypes.module,
-    entityId: moduleId,
-    action: auditActions.adminContent.moduleUnpublished,
-    actorId,
-    metadata: {
-      moduleId,
-      previousActiveVersionId: result.previousActiveVersionId,
-    },
+  const result = await runInTransaction(async (tx) => {
+    const repo = createAdminContentRepository(tx);
+    const unpublished = await repo.unpublishModule(moduleId);
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.module,
+        entityId: moduleId,
+        action: auditActions.adminContent.moduleUnpublished,
+        actorId,
+        metadata: {
+          moduleId,
+          previousActiveVersionId: unpublished.previousActiveVersionId,
+        },
+      },
+      tx,
+    );
+    return unpublished;
   });
 
   return result;
@@ -781,22 +831,32 @@ export async function publishModuleVersion(moduleId: string, moduleVersionId: st
   const module = await ensureModuleExists(moduleId);
   const now = new Date();
 
-  const published = await runInTransaction((tx) =>
-    createAdminContentRepository(tx).publishModuleVersion(moduleId, moduleVersionId, actorId, now),
-  );
-
-  await recordAuditEvent({
-    entityType: auditEntityTypes.moduleVersion,
-    entityId: moduleVersionId,
-    action: auditActions.adminContent.moduleVersionPublished,
-    actorId,
-    metadata: {
+  const published = await runInTransaction(async (tx) => {
+    const result = await createAdminContentRepository(tx).publishModuleVersion(
       moduleId,
       moduleVersionId,
-      versionNo: published.versionNo,
-      previousActiveVersionId: module.activeVersionId,
-      publishedAt: published.publishedAt?.toISOString() ?? null,
-    },
+      actorId,
+      now,
+    );
+
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.moduleVersion,
+        entityId: moduleVersionId,
+        action: auditActions.adminContent.moduleVersionPublished,
+        actorId,
+        metadata: {
+          moduleId,
+          moduleVersionId,
+          versionNo: result.versionNo,
+          previousActiveVersionId: module.activeVersionId,
+          publishedAt: result.publishedAt?.toISOString() ?? null,
+        },
+      },
+      tx,
+    );
+
+    return result;
   });
 
   return published;
@@ -844,7 +904,7 @@ export async function publishModuleVersionWithThresholds(input: PublishThreshold
   const versionNo = await getNextVersionNo("module", input.moduleId);
   const now = new Date();
 
-  const { newVersion, published } = await runInTransaction(async (tx) => {
+  const { published } = await runInTransaction(async (tx) => {
     const repo = createAdminContentRepository(tx);
     const newVersion = await repo.createModuleVersion({
       moduleId: input.moduleId,
@@ -860,24 +920,28 @@ export async function publishModuleVersionWithThresholds(input: PublishThreshold
       assessmentPolicyJson: assessmentPolicyCodec.serialize(newPolicy),
     });
     const published = await repo.publishModuleVersion(input.moduleId, newVersion.id, input.actorId, now);
-    return { newVersion, published };
-  });
 
-  await recordAuditEvent({
-    entityType: auditEntityTypes.moduleVersion,
-    entityId: newVersion.id,
-    action: auditActions.adminContent.calibrationThresholdsPublished,
-    actorId: input.actorId,
-    metadata: {
-      moduleId: input.moduleId,
-      moduleVersionId: newVersion.id,
-      versionNo: newVersion.versionNo,
-      sourceVersionId: sourceVersion.id,
-      totalMin: input.totalMin,
-      mcqMinPercent: input.mcqMinPercent ?? null,
-      practicalMinPercent: input.practicalMinPercent ?? null,
-      publishedAt: published.publishedAt?.toISOString() ?? null,
-    },
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.moduleVersion,
+        entityId: newVersion.id,
+        action: auditActions.adminContent.calibrationThresholdsPublished,
+        actorId: input.actorId,
+        metadata: {
+          moduleId: input.moduleId,
+          moduleVersionId: newVersion.id,
+          versionNo: newVersion.versionNo,
+          sourceVersionId: sourceVersion.id,
+          totalMin: input.totalMin,
+          mcqMinPercent: input.mcqMinPercent ?? null,
+          practicalMinPercent: input.practicalMinPercent ?? null,
+          publishedAt: published.publishedAt?.toISOString() ?? null,
+        },
+      },
+      tx,
+    );
+
+    return { newVersion, published };
   });
 
   return published;

--- a/src/modules/appeal/appealRepository.ts
+++ b/src/modules/appeal/appealRepository.ts
@@ -254,13 +254,20 @@ export function createAppealRepository(client: AppealRepositoryClient = prisma) 
       });
     },
 
-    markAppealInReview(appealId: string, handlerId: string, claimedAt?: Date | null) {
-      return client.appeal.update({
-        where: { id: appealId },
+    // #790: atomic guarded claim. The WHERE encodes the preconditions (not already terminal; and, unless an
+    // admin takeover, not already claimed by someone else), so two concurrent claims can't both succeed —
+    // exactly one updateMany affects a row; the loser gets count 0 and the caller raises ConflictError.
+    markAppealInReviewGuarded(appealId: string, handlerId: string, allowTakeover: boolean, alreadyClaimed: boolean) {
+      return client.appeal.updateMany({
+        where: {
+          id: appealId,
+          appealStatus: { notIn: ["RESOLVED", "REJECTED", "SUPERSEDED"] },
+          ...(allowTakeover ? {} : { OR: [{ resolvedById: null }, { resolvedById: handlerId }] }),
+        },
         data: {
           appealStatus: "IN_REVIEW",
           resolvedById: handlerId,
-          ...(claimedAt ? {} : { claimedAt: new Date() }),
+          ...(alreadyClaimed ? {} : { claimedAt: new Date() }),
         },
       });
     },
@@ -294,9 +301,27 @@ export function createAppealRepository(client: AppealRepositoryClient = prisma) 
       return client.assessmentDecision.create({ data });
     },
 
-    markAppealResolved(appealId: string, handlerId: string, resolvedAt: Date, resolutionNote: string) {
-      return client.appeal.update({
-        where: { id: appealId },
+    // #790: plain row re-read after a guarded transition (the guarded updateMany can't return the row).
+    findAppealById(appealId: string) {
+      return client.appeal.findUniqueOrThrow({ where: { id: appealId } });
+    },
+
+    // #790: atomic guarded resolve. Same guard as the claim: the appeal must not already be terminal, and
+    // (unless admin takeover) must be unassigned or ours. count 0 → another handler resolved first → the
+    // caller raises ConflictError, rolling back the transaction BEFORE any resolution decision is appended.
+    markAppealResolvedGuarded(
+      appealId: string,
+      handlerId: string,
+      resolvedAt: Date,
+      resolutionNote: string,
+      allowTakeover: boolean,
+    ) {
+      return client.appeal.updateMany({
+        where: {
+          id: appealId,
+          appealStatus: { notIn: ["RESOLVED", "REJECTED", "SUPERSEDED"] },
+          ...(allowTakeover ? {} : { OR: [{ resolvedById: null }, { resolvedById: handlerId }] }),
+        },
         data: {
           appealStatus: "RESOLVED",
           resolvedAt,

--- a/src/modules/appeal/appealService.ts
+++ b/src/modules/appeal/appealService.ts
@@ -164,33 +164,41 @@ export async function claimAppeal(appealId: string, handlerId: string, isAdmin =
   }
 
   // #790: atomic guarded claim. If a concurrent handler claimed first, count===0 → we lost the race.
-  const claimResult = await appealRepository.markAppealInReviewGuarded(
-    appealId,
-    handlerId,
-    isAdmin,
-    appeal.claimedAt != null,
-  );
-  if (claimResult.count === 0) {
-    throw new ConflictError(
-      "appeal_already_assigned",
-      "This appeal was just claimed by another handler. Refresh the queue and open another case.",
+  // #803: the guarded claim + its audit commit atomically.
+  const claimed = await runInTransaction(async (tx) => {
+    const repo = createAppealRepository(tx);
+    const claimResult = await repo.markAppealInReviewGuarded(
+      appealId,
+      handlerId,
+      isAdmin,
+      appeal.claimedAt != null,
     );
-  }
-  const claimed = await appealRepository.findAppealForClaim(appealId);
-  if (!claimed) {
-    throw new NotFoundError("Appeal");
-  }
+    if (claimResult.count === 0) {
+      throw new ConflictError(
+        "appeal_already_assigned",
+        "This appeal was just claimed by another handler. Refresh the queue and open another case.",
+      );
+    }
+    const claimedAppeal = await repo.findAppealForClaim(appealId);
+    if (!claimedAppeal) {
+      throw new NotFoundError("Appeal");
+    }
 
-  await recordAuditEvent({
-    entityType: auditEntityTypes.appeal,
-    entityId: claimed.id,
-    action: auditActions.appeal.claimed,
-    actorId: handlerId,
-    metadata: {
-      submissionId: appeal.submissionId,
-      appealStatus: claimed.appealStatus,
-      claimedAt: claimed.claimedAt?.toISOString() ?? null,
-    },
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.appeal,
+        entityId: claimedAppeal.id,
+        action: auditActions.appeal.claimed,
+        actorId: handlerId,
+        metadata: {
+          submissionId: appeal.submissionId,
+          appealStatus: claimedAppeal.appealStatus,
+          claimedAt: claimedAppeal.claimedAt?.toISOString() ?? null,
+        },
+      },
+      tx,
+    );
+    return claimedAppeal;
   });
 
   const claimLocale = normalizeLocale(appeal.submission.locale) ?? env.DEFAULT_LOCALE;

--- a/src/modules/appeal/appealService.ts
+++ b/src/modules/appeal/appealService.ts
@@ -163,7 +163,23 @@ export async function claimAppeal(appealId: string, handlerId: string, isAdmin =
     });
   }
 
-  const claimed = await appealRepository.markAppealInReview(appealId, handlerId, appeal.claimedAt);
+  // #790: atomic guarded claim. If a concurrent handler claimed first, count===0 → we lost the race.
+  const claimResult = await appealRepository.markAppealInReviewGuarded(
+    appealId,
+    handlerId,
+    isAdmin,
+    appeal.claimedAt != null,
+  );
+  if (claimResult.count === 0) {
+    throw new ConflictError(
+      "appeal_already_assigned",
+      "This appeal was just claimed by another handler. Refresh the queue and open another case.",
+    );
+  }
+  const claimed = await appealRepository.findAppealForClaim(appealId);
+  if (!claimed) {
+    throw new NotFoundError("Appeal");
+  }
 
   await recordAuditEvent({
     entityType: auditEntityTypes.appeal,
@@ -284,12 +300,29 @@ type ResolutionDecision = NonNullable<ResolutionAppeal["submission"]["decisions"
 
 async function resolveAppealCommand(
   appeal: ResolutionAppeal,
-  input: { handlerId: string; passFailTotal: boolean; decisionReason: string; resolutionNote: string },
+  input: { handlerId: string; passFailTotal: boolean; decisionReason: string; resolutionNote: string; isAdmin?: boolean },
   latestDecision: ResolutionDecision,
   finalisedAt: Date,
 ) {
   return runInTransaction(async (tx) => {
     const repo = createAppealRepository(tx);
+
+    // #790: perform the guarded state transition FIRST. If a concurrent resolve already moved the appeal
+    // to a terminal state, count===0 → ConflictError rolls the transaction back before we append a second
+    // APPEAL_RESOLUTION decision (which would corrupt the immutable lineage with duplicate resolutions).
+    const transition = await repo.markAppealResolvedGuarded(
+      appeal.id,
+      input.handlerId,
+      finalisedAt,
+      input.resolutionNote,
+      input.isAdmin ?? false,
+    );
+    if (transition.count === 0) {
+      throw new ConflictError(
+        "appeal_already_resolved",
+        "This appeal was just resolved by another handler. Refresh the queue to view the latest status.",
+      );
+    }
 
     const resolutionDecision = await appendDecisionWithLineage(
       {
@@ -311,12 +344,9 @@ async function resolveAppealCommand(
       tx,
     );
 
-    const resolvedAppeal = await repo.markAppealResolved(
-      appeal.id,
-      input.handlerId,
-      finalisedAt,
-      input.resolutionNote,
-    );
+    // Re-read the plain appeal row (same shape the old update-by-id returned) now that the guard has
+    // committed the transition, for the audit + the caller's response.
+    const resolvedAppeal = await repo.findAppealById(appeal.id);
 
     await recordAuditEvent({
       entityType: auditEntityTypes.appeal,

--- a/src/modules/assessment/AssessmentEvaluator.ts
+++ b/src/modules/assessment/AssessmentEvaluator.ts
@@ -1,5 +1,6 @@
 import { env } from "../../config/env.js";
-import { assessmentJobRepository } from "./assessmentJobRepository.js";
+import { createAssessmentJobRepository } from "./assessmentJobRepository.js";
+import { runInTransaction } from "../../db/transaction.js";
 import { evaluatePracticalWithLlm, type LlmStructuredAssessment } from "./llmAssessmentService.js";
 import { llmResponseCodec } from "../../codecs/llmResponseCodec.js";
 import { sha256 } from "../../utils/hash.js";
@@ -63,36 +64,45 @@ export async function runLlmEvaluationPipeline(ctx: EvaluatorContext): Promise<E
       },
     };
 
-    const llmEvaluation = await assessmentJobRepository.createLlmEvaluation({
-      submissionId,
-      moduleVersionId,
-      modelName:
-        env.LLM_MODE === "stub"
-          ? `${env.LLM_STUB_MODEL_NAME}:${assessmentPass}`
-          : `${env.AZURE_OPENAI_DEPLOYMENT ?? "azure_openai"}:${assessmentPass}`,
-      promptTemplateVersionId,
-      requestPayloadHash: sha256(JSON.stringify(requestPayload)),
-      responseJson: llmResponseCodec.serialize(llmResult),
-      rubricTotal: llmResult.rubric_total,
-      practicalScoreScaled: llmResult.practical_score_scaled,
-      passFailPractical: llmResult.pass_fail_practical,
-      manualReviewRecommended: llmResult.manual_review_recommended,
-      confidenceNote: llmResult.confidence_note,
-    });
-
-    await recordAuditEvent({
-      entityType: auditEntityTypes.llmEvaluation,
-      entityId: llmEvaluation.id,
-      action: auditActions.assessment.llmEvaluationCreated,
-      actorId: userId,
-      metadata: {
+    // #803: persisting the LLM evaluation record + its audit commit atomically. The LLM call itself
+    // (evaluatePracticalWithLlm) already ran before this and is not inside the transaction.
+    const llmEvaluation = await runInTransaction(async (tx) => {
+      const created = await createAssessmentJobRepository(tx).createLlmEvaluation({
         submissionId,
-        assessmentPass,
-        modelName: llmEvaluation.modelName,
-        practicalScoreScaled: llmEvaluation.practicalScoreScaled,
-        passFailPractical: llmEvaluation.passFailPractical,
-        manualReviewRecommended: llmEvaluation.manualReviewRecommended,
-      },
+        moduleVersionId,
+        modelName:
+          env.LLM_MODE === "stub"
+            ? `${env.LLM_STUB_MODEL_NAME}:${assessmentPass}`
+            : `${env.AZURE_OPENAI_DEPLOYMENT ?? "azure_openai"}:${assessmentPass}`,
+        promptTemplateVersionId,
+        requestPayloadHash: sha256(JSON.stringify(requestPayload)),
+        responseJson: llmResponseCodec.serialize(llmResult),
+        rubricTotal: llmResult.rubric_total,
+        practicalScoreScaled: llmResult.practical_score_scaled,
+        passFailPractical: llmResult.pass_fail_practical,
+        manualReviewRecommended: llmResult.manual_review_recommended,
+        confidenceNote: llmResult.confidence_note,
+      });
+
+      await recordAuditEvent(
+        {
+          entityType: auditEntityTypes.llmEvaluation,
+          entityId: created.id,
+          action: auditActions.assessment.llmEvaluationCreated,
+          actorId: userId,
+          metadata: {
+            submissionId,
+            assessmentPass,
+            modelName: created.modelName,
+            practicalScoreScaled: created.practicalScoreScaled,
+            passFailPractical: created.passFailPractical,
+            manualReviewRecommended: created.manualReviewRecommended,
+          },
+        },
+        tx,
+      );
+
+      return created;
     });
 
     return llmEvaluation;

--- a/src/modules/assessment/AssessmentJobRunner.ts
+++ b/src/modules/assessment/AssessmentJobRunner.ts
@@ -129,17 +129,39 @@ export async function processNextJob(runAssessment: AssessmentRunFn, submissionI
     return false;
   }
 
+  // #792: (WORKER_INSTANCE_ID, now) is the fence for THIS lock acquisition. A heartbeat renews the lease
+  // while the assessment runs (a long two-LLM-call run must not have its lease expire and get re-claimed),
+  // and every terminal write is conditioned on the fence, so if we DID lose the lease we no-op instead of
+  // overwriting the new owner's result.
+  const leaseDurationMs = env.ASSESSMENT_JOB_LEASE_DURATION_MS;
+  const heartbeat = setInterval(() => {
+    void assessmentJobRepository
+      .renewLease(candidate.id, WORKER_INSTANCE_ID, now, new Date(Date.now() + leaseDurationMs))
+      .catch(() => {
+        /* renewal is best-effort — the fenced terminal write is the real guard */
+      });
+  }, Math.max(1_000, Math.floor(leaseDurationMs / 3)));
+  heartbeat.unref?.();
+
   try {
     await runAssessment(candidate.id);
-    await assessmentJobRepository.markJobSucceeded(candidate.id);
+    const succeeded = await assessmentJobRepository.markJobSucceeded(candidate.id, WORKER_INSTANCE_ID, now);
+    if (succeeded.count === 0) {
+      logLeaseLost(candidate.id, candidate.submissionId, "success");
+      return true;
+    }
   } catch (error) {
     const job = await assessmentJobRepository.findAssessmentJobOrThrow(candidate.id);
     const willRetry = job.attempts < job.maxAttempts;
-    await assessmentJobRepository.markJobForRetryOrFailure(candidate.id, {
+    const finalised = await assessmentJobRepository.markJobForRetryOrFailure(candidate.id, WORKER_INSTANCE_ID, now, {
       status: willRetry ? AssessmentJobStatus.PENDING : AssessmentJobStatus.FAILED,
       availableAt: willRetry ? new Date(Date.now() + 30_000) : job.availableAt,
       errorMessage: error instanceof Error ? error.message : "Unknown assessment error",
     });
+    if (finalised.count === 0) {
+      logLeaseLost(candidate.id, candidate.submissionId, "failure");
+      return true;
+    }
 
     await recordAuditEvent({
       entityType: auditEntityTypes.assessmentJob,
@@ -155,9 +177,18 @@ export async function processNextJob(runAssessment: AssessmentRunFn, submissionI
       },
     });
   } finally {
+    clearInterval(heartbeat);
     await logQueueBacklog("worker_cycle", candidate.submissionId);
   }
   return true;
+}
+
+// #792: the lease was reset + re-claimed by another worker before we could finalize — do not overwrite it.
+function logLeaseLost(jobId: string, submissionId: string, phase: "success" | "failure") {
+  console.warn(
+    `[#792] assessment job ${jobId} (submission ${submissionId}) lost its lease before the ${phase} write; ` +
+      "another worker now owns it — skipping the terminal write to avoid clobbering its result.",
+  );
 }
 
 async function logQueueBacklog(trigger: string, submissionId: string) {

--- a/src/modules/assessment/AssessmentJobRunner.ts
+++ b/src/modules/assessment/AssessmentJobRunner.ts
@@ -8,7 +8,8 @@ import { env } from "../../config/env.js";
  * per container restart, which makes it safe in a multi-instance deployment.
  */
 const WORKER_INSTANCE_ID = randomUUID();
-import { assessmentJobRepository } from "./assessmentJobRepository.js";
+import { assessmentJobRepository, createAssessmentJobRepository } from "./assessmentJobRepository.js";
+import { runInTransaction } from "../../db/transaction.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { logOperationalEvent } from "../../observability/operationalLog.js";
 import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
@@ -31,10 +32,24 @@ export async function enqueueAssessmentJob(submissionId: string) {
 
   let job;
   try {
-    job = await assessmentJobRepository.createAssessmentJob({
-      submissionId,
-      status: AssessmentJobStatus.PENDING,
-      maxAttempts: env.ASSESSMENT_JOB_MAX_ATTEMPTS,
+    // #803: the enqueue create + its audit commit atomically. A P2002 from the partial unique index still
+    // surfaces from the transaction and is handled below.
+    job = await runInTransaction(async (tx) => {
+      const created = await createAssessmentJobRepository(tx).createAssessmentJob({
+        submissionId,
+        status: AssessmentJobStatus.PENDING,
+        maxAttempts: env.ASSESSMENT_JOB_MAX_ATTEMPTS,
+      });
+      await recordAuditEvent(
+        {
+          entityType: auditEntityTypes.assessmentJob,
+          entityId: created.id,
+          action: auditActions.assessment.assessmentJobEnqueued,
+          metadata: { submissionId },
+        },
+        tx,
+      );
+      return created;
     });
   } catch (error) {
     // #793: the partial unique index (one active job per submission) rejected this create — a concurrent
@@ -49,12 +64,6 @@ export async function enqueueAssessmentJob(submissionId: string) {
     throw error;
   }
 
-  await recordAuditEvent({
-    entityType: auditEntityTypes.assessmentJob,
-    entityId: job.id,
-    action: auditActions.assessment.assessmentJobEnqueued,
-    metadata: { submissionId },
-  });
   await logQueueBacklog("enqueue", submissionId);
 
   return job;
@@ -153,29 +162,44 @@ export async function processNextJob(runAssessment: AssessmentRunFn, submissionI
   } catch (error) {
     const job = await assessmentJobRepository.findAssessmentJobOrThrow(candidate.id);
     const willRetry = job.attempts < job.maxAttempts;
-    const finalised = await assessmentJobRepository.markJobForRetryOrFailure(candidate.id, WORKER_INSTANCE_ID, now, {
-      status: willRetry ? AssessmentJobStatus.PENDING : AssessmentJobStatus.FAILED,
-      availableAt: willRetry ? new Date(Date.now() + 30_000) : job.availableAt,
-      errorMessage: error instanceof Error ? error.message : "Unknown assessment error",
+    // #803: the fenced terminal write + its retry/failure audit commit atomically. The audit is written
+    // only when the fence still holds (count>0) — a lost lease (count===0) writes neither.
+    const finalised = await runInTransaction(async (tx) => {
+      const res = await createAssessmentJobRepository(tx).markJobForRetryOrFailure(
+        candidate.id,
+        WORKER_INSTANCE_ID,
+        now,
+        {
+          status: willRetry ? AssessmentJobStatus.PENDING : AssessmentJobStatus.FAILED,
+          availableAt: willRetry ? new Date(Date.now() + 30_000) : job.availableAt,
+          errorMessage: error instanceof Error ? error.message : "Unknown assessment error",
+        },
+      );
+      if (res.count === 0) {
+        return res;
+      }
+      await recordAuditEvent(
+        {
+          entityType: auditEntityTypes.assessmentJob,
+          entityId: candidate.id,
+          action: willRetry
+            ? auditActions.assessment.assessmentJobRetryScheduled
+            : auditActions.assessment.assessmentJobFailed,
+          metadata: {
+            submissionId: candidate.submissionId,
+            attempts: job.attempts,
+            maxAttempts: job.maxAttempts,
+            errorMessage: error instanceof Error ? error.message : "Unknown assessment error",
+          },
+        },
+        tx,
+      );
+      return res;
     });
     if (finalised.count === 0) {
       logLeaseLost(candidate.id, candidate.submissionId, "failure");
       return true;
     }
-
-    await recordAuditEvent({
-      entityType: auditEntityTypes.assessmentJob,
-      entityId: candidate.id,
-      action: willRetry
-        ? auditActions.assessment.assessmentJobRetryScheduled
-        : auditActions.assessment.assessmentJobFailed,
-      metadata: {
-        submissionId: candidate.submissionId,
-        attempts: job.attempts,
-        maxAttempts: job.maxAttempts,
-        errorMessage: error instanceof Error ? error.message : "Unknown assessment error",
-      },
-    });
   } finally {
     clearInterval(heartbeat);
     await logQueueBacklog("worker_cycle", candidate.submissionId);

--- a/src/modules/assessment/AssessmentJobRunner.ts
+++ b/src/modules/assessment/AssessmentJobRunner.ts
@@ -17,21 +17,37 @@ import { alertOnStuckJobs, scanAndResetStaleJobs } from "./staleLockScanner.js";
 
 export type AssessmentRunFn = (jobId: string) => Promise<void>;
 
+const ACTIVE_JOB_STATUSES = [AssessmentJobStatus.PENDING, AssessmentJobStatus.RUNNING];
+
 export async function enqueueAssessmentJob(submissionId: string) {
-  const existingPending = await assessmentJobRepository.findPendingOrRunningJobForSubmission(submissionId, [
-    AssessmentJobStatus.PENDING,
-    AssessmentJobStatus.RUNNING,
-  ]);
+  const existingPending = await assessmentJobRepository.findPendingOrRunningJobForSubmission(
+    submissionId,
+    ACTIVE_JOB_STATUSES,
+  );
 
   if (existingPending) {
     return existingPending;
   }
 
-  const job = await assessmentJobRepository.createAssessmentJob({
-    submissionId,
-    status: AssessmentJobStatus.PENDING,
-    maxAttempts: env.ASSESSMENT_JOB_MAX_ATTEMPTS,
-  });
+  let job;
+  try {
+    job = await assessmentJobRepository.createAssessmentJob({
+      submissionId,
+      status: AssessmentJobStatus.PENDING,
+      maxAttempts: env.ASSESSMENT_JOB_MAX_ATTEMPTS,
+    });
+  } catch (error) {
+    // #793: the partial unique index (one active job per submission) rejected this create — a concurrent
+    // enqueue won the race. Return the job it created instead of a duplicate (no extra LLM run/decision).
+    if (isActiveJobUniqueViolation(error)) {
+      const winner = await assessmentJobRepository.findPendingOrRunningJobForSubmission(
+        submissionId,
+        ACTIVE_JOB_STATUSES,
+      );
+      if (winner) return winner;
+    }
+    throw error;
+  }
 
   await recordAuditEvent({
     entityType: auditEntityTypes.assessmentJob,
@@ -42,6 +58,16 @@ export async function enqueueAssessmentJob(submissionId: string) {
   await logQueueBacklog("enqueue", submissionId);
 
   return job;
+}
+
+// A P2002 on the AssessmentJob active-submission unique index — the concurrent-enqueue loser.
+function isActiveJobUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "P2002"
+  );
 }
 
 export async function processAssessmentJobsNow(runAssessment: AssessmentRunFn, maxJobs = 1) {

--- a/src/modules/assessment/assessmentJobRepository.ts
+++ b/src/modules/assessment/assessmentJobRepository.ts
@@ -76,9 +76,12 @@ export function createAssessmentJobRepository(client: AssessmentJobRepositoryCli
       });
     },
 
-    markJobSucceeded(jobId: string) {
-      return client.assessmentJob.update({
-        where: { id: jobId },
+    // #792: fenced terminal write. Only succeeds if THIS worker still holds the lease it acquired (status
+    // RUNNING + same lockedBy + same lockedAt). If the lease was reset and re-claimed by another worker
+    // mid-run, count===0 and the caller must NOT overwrite the new owner's state.
+    markJobSucceeded(jobId: string, lockedBy: string, lockedAt: Date) {
+      return client.assessmentJob.updateMany({
+        where: { id: jobId, status: "RUNNING", lockedBy, lockedAt },
         data: { status: "SUCCEEDED", errorMessage: null, leaseExpiresAt: null },
       });
     },
@@ -87,14 +90,24 @@ export function createAssessmentJobRepository(client: AssessmentJobRepositoryCli
       return client.assessmentJob.findUniqueOrThrow({ where: { id: jobId } });
     },
 
-    markJobForRetryOrFailure(jobId: string, data: {
+    // #792: fenced terminal write (see markJobSucceeded). count===0 → lease lost, don't overwrite.
+    markJobForRetryOrFailure(jobId: string, lockedBy: string, lockedAt: Date, data: {
       status: AssessmentJobStatusType;
       availableAt: Date;
       errorMessage: string;
     }) {
-      return client.assessmentJob.update({
-        where: { id: jobId },
+      return client.assessmentJob.updateMany({
+        where: { id: jobId, status: "RUNNING", lockedBy, lockedAt },
         data: { ...data, leaseExpiresAt: null },
+      });
+    },
+
+    // #792: extend the lease while the assessment is still running, fenced on the current holder, so a long
+    // run (two sequential LLM calls) is not reset + re-claimed mid-flight. count===0 → we no longer hold it.
+    renewLease(jobId: string, lockedBy: string, lockedAt: Date, leaseExpiresAt: Date) {
+      return client.assessmentJob.updateMany({
+        where: { id: jobId, status: "RUNNING", lockedBy, lockedAt },
+        data: { leaseExpiresAt },
       });
     },
 

--- a/src/modules/assessment/mcqRepository.ts
+++ b/src/modules/assessment/mcqRepository.ts
@@ -54,7 +54,9 @@ export function createMcqRepository(client: McqRepositoryClient = prisma) {
       return client.mCQResponse.createMany({ data });
     },
 
-    completeAttempt(data: {
+    // #794: guarded finalization — only completes an attempt that is still open (completedAt IS NULL), so
+    // two concurrent submits can't both finalize it. count===0 → already submitted → the caller conflicts.
+    completeAttemptGuarded(data: {
       attemptId: string;
       completedAt: Date;
       rawScore: number;
@@ -62,8 +64,8 @@ export function createMcqRepository(client: McqRepositoryClient = prisma) {
       scaledScore: number;
       passFailMcq: boolean;
     }) {
-      return client.mCQAttempt.update({
-        where: { id: data.attemptId },
+      return client.mCQAttempt.updateMany({
+        where: { id: data.attemptId, completedAt: null },
         data: {
           completedAt: data.completedAt,
           rawScore: data.rawScore,
@@ -72,6 +74,11 @@ export function createMcqRepository(client: McqRepositoryClient = prisma) {
           passFailMcq: data.passFailMcq,
         },
       });
+    },
+
+    // #794: plain row re-read after the guarded finalization (updateMany can't return the row).
+    findAttemptById(attemptId: string) {
+      return client.mCQAttempt.findUniqueOrThrow({ where: { id: attemptId } });
     },
   };
 }

--- a/src/modules/assessment/mcqService.ts
+++ b/src/modules/assessment/mcqService.ts
@@ -1,8 +1,10 @@
 import { SubmissionStatus } from "../../db/prismaRuntime.js";
 import { getAssessmentRules } from "../../config/assessmentRules.js";
 import { assessmentJobRepository } from "./assessmentJobRepository.js";
-import { mcqRepository } from "./mcqRepository.js";
+import { mcqRepository, createMcqRepository } from "./mcqRepository.js";
 import { enqueueAssessmentJob, processSubmissionJobNow } from "./assessmentJobService.js";
+import { runInTransaction } from "../../db/transaction.js";
+import { ConflictError } from "../../errors/AppError.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
 import type { SupportedLocale } from "../../i18n/locale.js";
@@ -109,18 +111,6 @@ export async function submitMcqAttempt(input: {
     })
     .filter((item): item is NonNullable<typeof item> => item !== null);
 
-  await mcqRepository.deleteResponsesForAttempt(attempt.id);
-  if (evaluated.length > 0) {
-    await mcqRepository.createResponses(
-      evaluated.map((item) => ({
-        mcqAttemptId: attempt.id,
-        questionId: item.questionId,
-        selectedAnswer: item.selectedAnswer,
-        isCorrect: item.isCorrect,
-      })),
-    );
-  }
-
   const rawScore = evaluated.filter((response) => response.isCorrect).length;
   const totalQuestions = questions.length || 1;
   const percentScore = (rawScore / totalQuestions) * 100;
@@ -128,16 +118,40 @@ export async function submitMcqAttempt(input: {
   const scaledScore = (rawScore / totalQuestions) * rules.weights.mcqMaxScore;
   const passFailMcq = percentScore >= 50;
 
-  const completedAttempt = await mcqRepository.completeAttempt({
-    attemptId: attempt.id,
-    completedAt: new Date(),
-    rawScore,
-    percentScore,
-    scaledScore,
-    passFailMcq,
+  // #794: finalize atomically — replace the responses, guard-complete the attempt (only while still open),
+  // and move the submission to PROCESSING in ONE transaction. A failure can no longer leave a completed
+  // attempt with no responses / wrong status, and two concurrent submits can't both finalize (count 0 →
+  // ConflictError). The @@unique([mcqAttemptId, questionId]) backs the response replacement.
+  const completedAttempt = await runInTransaction(async (tx) => {
+    const repo = createMcqRepository(tx);
+    await repo.deleteResponsesForAttempt(attempt.id);
+    if (evaluated.length > 0) {
+      await repo.createResponses(
+        evaluated.map((item) => ({
+          mcqAttemptId: attempt.id,
+          questionId: item.questionId,
+          selectedAnswer: item.selectedAnswer,
+          isCorrect: item.isCorrect,
+        })),
+      );
+    }
+    const done = await repo.completeAttemptGuarded({
+      attemptId: attempt.id,
+      completedAt: new Date(),
+      rawScore,
+      percentScore,
+      scaledScore,
+      passFailMcq,
+    });
+    if (done.count === 0) {
+      throw new ConflictError("mcq_already_submitted", "This MCQ attempt was already submitted.");
+    }
+    await tx.submission.update({
+      where: { id: submission.id },
+      data: { submissionStatus: SubmissionStatus.PROCESSING },
+    });
+    return repo.findAttemptById(attempt.id);
   });
-
-  await assessmentJobRepository.updateSubmissionStatus(submission.id, SubmissionStatus.PROCESSING);
 
   await enqueueAssessmentJob(submission.id);
 

--- a/src/modules/assessment/mcqService.ts
+++ b/src/modules/assessment/mcqService.ts
@@ -150,6 +150,23 @@ export async function submitMcqAttempt(input: {
       where: { id: submission.id },
       data: { submissionStatus: SubmissionStatus.PROCESSING },
     });
+    // #803: the submission audit commits atomically with the finalization. Recorded here (inside the
+    // tx), before the post-commit enqueue/synchronous-assessment I/O below.
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.mcqAttempt,
+        entityId: attempt.id,
+        action: auditActions.assessment.mcqSubmitted,
+        actorId: input.userId,
+        metadata: {
+          submissionId: submission.id,
+          rawScore,
+          percentScore,
+          scaledScore,
+        },
+      },
+      tx,
+    );
     return repo.findAttemptById(attempt.id);
   });
 

--- a/src/modules/assessment/staleLockScanner.ts
+++ b/src/modules/assessment/staleLockScanner.ts
@@ -1,5 +1,6 @@
 import { env } from "../../config/env.js";
-import { assessmentJobRepository } from "./assessmentJobRepository.js";
+import { assessmentJobRepository, createAssessmentJobRepository } from "./assessmentJobRepository.js";
+import { runInTransaction } from "../../db/transaction.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { logOperationalEvent } from "../../observability/operationalLog.js";
 import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
@@ -22,24 +23,31 @@ export async function scanAndResetStaleJobs(): Promise<StaleLockScanResult> {
     const willFail = job.attempts >= job.maxAttempts;
     const status = willFail ? "FAILED" : "PENDING";
 
-    await assessmentJobRepository.resetExpiredJob(job.id, {
-      status,
-      availableAt: now,
-      errorMessage: "Stale lock: job exceeded lease duration without completing.",
-    });
+    // #803: each stale-job reset + its audit commit atomically (per job). The operational log below is
+    // non-DB I/O and stays outside the transaction.
+    await runInTransaction(async (tx) => {
+      await createAssessmentJobRepository(tx).resetExpiredJob(job.id, {
+        status,
+        availableAt: now,
+        errorMessage: "Stale lock: job exceeded lease duration without completing.",
+      });
 
-    await recordAuditEvent({
-      entityType: auditEntityTypes.assessmentJob,
-      entityId: job.id,
-      action: willFail
-        ? auditActions.assessment.assessmentJobStaleLockFailed
-        : auditActions.assessment.assessmentJobStaleLockReset,
-      metadata: {
-        submissionId: job.submissionId,
-        attempts: job.attempts,
-        maxAttempts: job.maxAttempts,
-        outcome: status,
-      },
+      await recordAuditEvent(
+        {
+          entityType: auditEntityTypes.assessmentJob,
+          entityId: job.id,
+          action: willFail
+            ? auditActions.assessment.assessmentJobStaleLockFailed
+            : auditActions.assessment.assessmentJobStaleLockReset,
+          metadata: {
+            submissionId: job.submissionId,
+            attempts: job.attempts,
+            maxAttempts: job.maxAttempts,
+            outcome: status,
+          },
+        },
+        tx,
+      );
     });
 
     logOperationalEvent(operationalEvents.assessment.jobStaleLockDetected, {

--- a/src/modules/content/contentOwnershipService.ts
+++ b/src/modules/content/contentOwnershipService.ts
@@ -5,6 +5,7 @@
 
 import type { AppRole as AppRoleType, ContentOwnerType } from "@prisma/client";
 import { prisma } from "../../db/prisma.js";
+import { runInTransaction } from "../../db/transaction.js";
 import { ForbiddenError, NotFoundError } from "../../errors/AppError.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
@@ -127,20 +128,25 @@ export async function addContentOwner(input: {
     select: { id: true },
   });
   if (existing) return; // already an owner
-  const owner = await prisma.contentOwner.create({
-    data: {
-      contentType: input.contentType,
-      contentId: input.contentId,
-      userId: input.ownerUserId,
-      addedById: input.actorUserId,
-    },
-  });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.contentOwner,
-    entityId: owner.id,
-    action: auditActions.contentOwner.added,
-    actorId: input.actorUserId,
-    metadata: { contentType: input.contentType, contentId: input.contentId, ownerUserId: input.ownerUserId },
+  await runInTransaction(async (tx) => {
+    const owner = await tx.contentOwner.create({
+      data: {
+        contentType: input.contentType,
+        contentId: input.contentId,
+        userId: input.ownerUserId,
+        addedById: input.actorUserId,
+      },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.contentOwner,
+        entityId: owner.id,
+        action: auditActions.contentOwner.added,
+        actorId: input.actorUserId,
+        metadata: { contentType: input.contentType, contentId: input.contentId, ownerUserId: input.ownerUserId },
+      },
+      tx,
+    );
   });
 }
 
@@ -163,14 +169,19 @@ export async function removeContentOwner(input: {
       "last_owner",
     );
   }
-  await prisma.contentOwner.deleteMany({
-    where: { contentType: input.contentType, contentId: input.contentId, userId: input.ownerUserId },
-  });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.contentOwner,
-    entityId: `${input.contentType}:${input.contentId}:${input.ownerUserId}`,
-    action: auditActions.contentOwner.removed,
-    actorId: input.actorUserId,
-    metadata: { contentType: input.contentType, contentId: input.contentId, ownerUserId: input.ownerUserId },
+  await runInTransaction(async (tx) => {
+    await tx.contentOwner.deleteMany({
+      where: { contentType: input.contentType, contentId: input.contentId, userId: input.ownerUserId },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.contentOwner,
+        entityId: `${input.contentType}:${input.contentId}:${input.ownerUserId}`,
+        action: auditActions.contentOwner.removed,
+        actorId: input.actorUserId,
+        metadata: { contentType: input.contentType, contentId: input.contentId, ownerUserId: input.ownerUserId },
+      },
+      tx,
+    );
   });
 }

--- a/src/modules/course/classService.ts
+++ b/src/modules/course/classService.ts
@@ -1,10 +1,11 @@
 import { prisma } from "../../db/prisma.js";
+import { runInTransaction } from "../../db/transaction.js";
 import { NotFoundError, ValidationError } from "../../errors/AppError.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
 import { localizeContentText } from "../../i18n/content.js";
 import { sendCourseAssignmentNotification } from "../certification/participantNotificationService.js";
-import { classRepository, SYSTEM_ALL_PARTICIPANTS_CLASS_ID } from "./classRepository.js";
+import { classRepository, createClassRepository, SYSTEM_ALL_PARTICIPANTS_CLASS_ID } from "./classRepository.js";
 import { isClassEntraLinkingEnabled } from "./classConfig.js";
 import { addContentOwner } from "../content/contentOwnershipService.js";
 
@@ -21,13 +22,20 @@ async function requireClass(classId: string) {
 export async function createClass(input: { name: string; description?: string | null }, actorId: string | null) {
   const name = input.name?.trim();
   if (!name) throw new ValidationError("Class name is required.");
-  const created = await classRepository.createClass({ name, description: input.description ?? null, createdById: actorId });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.class,
-    entityId: created.id,
-    action: auditActions.class.created,
-    actorId: actorId ?? undefined,
-    metadata: { classId: created.id, name },
+  const created = await runInTransaction(async (tx) => {
+    const repo = createClassRepository(tx);
+    const klass = await repo.createClass({ name, description: input.description ?? null, createdById: actorId });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.class,
+        entityId: klass.id,
+        action: auditActions.class.created,
+        actorId: actorId ?? undefined,
+        metadata: { classId: klass.id, name },
+      },
+      tx,
+    );
+    return klass;
   });
   // #787 slice 4a: creator becomes sole initial owner (inert until 4b enforcement).
   if (actorId) {
@@ -39,13 +47,19 @@ export async function createClass(input: { name: string; description?: string | 
 export async function archiveClass(classId: string, actorId: string | null) {
   const klass = await requireClass(classId);
   if (klass.isSystem) throw new ValidationError("System classes cannot be archived.");
-  await classRepository.archiveClass(classId);
-  await recordAuditEvent({
-    entityType: auditEntityTypes.class,
-    entityId: classId,
-    action: auditActions.class.archived,
-    actorId: actorId ?? undefined,
-    metadata: { classId },
+  await runInTransaction(async (tx) => {
+    const repo = createClassRepository(tx);
+    await repo.archiveClass(classId);
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.class,
+        entityId: classId,
+        action: auditActions.class.archived,
+        actorId: actorId ?? undefined,
+        metadata: { classId },
+      },
+      tx,
+    );
   });
 }
 
@@ -53,13 +67,19 @@ export async function restoreClass(classId: string, actorId: string | null) {
   const klass = await requireClass(classId);
   if (klass.isSystem) throw new ValidationError("System classes are never archived.");
   if (!klass.archivedAt) return; // already active — idempotent no-op
-  await classRepository.restoreClass(classId);
-  await recordAuditEvent({
-    entityType: auditEntityTypes.class,
-    entityId: classId,
-    action: auditActions.class.restored,
-    actorId: actorId ?? undefined,
-    metadata: { classId },
+  await runInTransaction(async (tx) => {
+    const repo = createClassRepository(tx);
+    await repo.restoreClass(classId);
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.class,
+        entityId: classId,
+        action: auditActions.class.restored,
+        actorId: actorId ?? undefined,
+        metadata: { classId },
+      },
+      tx,
+    );
   });
 }
 
@@ -70,28 +90,40 @@ export async function addMember(classId: string, userId: string, actorId: string
   }
   const user = await prisma.user.findUnique({ where: { id: userId }, select: { id: true } });
   if (!user) throw new ValidationError(`Unknown user id: ${userId}.`);
-  await classRepository.addMember(classId, userId, actorId);
-  await recordAuditEvent({
-    entityType: auditEntityTypes.class,
-    entityId: classId,
-    action: auditActions.class.memberAdded,
-    actorId: actorId ?? undefined,
-    metadata: { classId, userId },
+  await runInTransaction(async (tx) => {
+    const repo = createClassRepository(tx);
+    await repo.addMember(classId, userId, actorId);
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.class,
+        entityId: classId,
+        action: auditActions.class.memberAdded,
+        actorId: actorId ?? undefined,
+        metadata: { classId, userId },
+      },
+      tx,
+    );
   });
 }
 
 export async function removeMember(classId: string, userId: string, actorId: string | null) {
   await requireClass(classId);
-  const result = await classRepository.removeMember(classId, userId);
-  if (result.count > 0) {
-    await recordAuditEvent({
-      entityType: auditEntityTypes.class,
-      entityId: classId,
-      action: auditActions.class.memberRemoved,
-      actorId: actorId ?? undefined,
-      metadata: { classId, userId },
-    });
-  }
+  await runInTransaction(async (tx) => {
+    const repo = createClassRepository(tx);
+    const result = await repo.removeMember(classId, userId);
+    if (result.count > 0) {
+      await recordAuditEvent(
+        {
+          entityType: auditEntityTypes.class,
+          entityId: classId,
+          action: auditActions.class.memberRemoved,
+          actorId: actorId ?? undefined,
+          metadata: { classId, userId },
+        },
+        tx,
+      );
+    }
+  });
 }
 
 export async function listClasses() {
@@ -116,13 +148,19 @@ export async function assignCourseToClass(courseId: string, classId: string, due
   if (!course) throw new NotFoundError("Course", "course_not_found", "Course not found.");
   // #688: archived courses are retired and must not be assignable to a class.
   if (course.archivedAt) throw new ValidationError("Cannot assign an archived course.");
-  await classRepository.assignCourseToClass(courseId, classId, dueAt, actorId);
-  await recordAuditEvent({
-    entityType: auditEntityTypes.class,
-    entityId: classId,
-    action: auditActions.class.courseAssigned,
-    actorId: actorId ?? undefined,
-    metadata: { classId, courseId },
+  await runInTransaction(async (tx) => {
+    const repo = createClassRepository(tx);
+    await repo.assignCourseToClass(courseId, classId, dueAt, actorId);
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.class,
+        entityId: classId,
+        action: auditActions.class.courseAssigned,
+        actorId: actorId ?? undefined,
+        metadata: { classId, courseId },
+      },
+      tx,
+    );
   });
 
   // #684: email the members that their class was assigned a course. Skipped for the "Alle deltakere"
@@ -161,16 +199,22 @@ async function notifyClassMembersOfCourseAssignment(
 }
 
 export async function unassignCourseFromClass(courseId: string, classId: string, actorId: string | null) {
-  const result = await classRepository.unassignCourseFromClass(courseId, classId);
-  if (result.count > 0) {
-    await recordAuditEvent({
-      entityType: auditEntityTypes.class,
-      entityId: classId,
-      action: auditActions.class.courseUnassigned,
-      actorId: actorId ?? undefined,
-      metadata: { classId, courseId },
-    });
-  }
+  await runInTransaction(async (tx) => {
+    const repo = createClassRepository(tx);
+    const result = await repo.unassignCourseFromClass(courseId, classId);
+    if (result.count > 0) {
+      await recordAuditEvent(
+        {
+          entityType: auditEntityTypes.class,
+          entityId: classId,
+          action: auditActions.class.courseUnassigned,
+          actorId: actorId ?? undefined,
+          metadata: { classId, courseId },
+        },
+        tx,
+      );
+    }
+  });
 }
 
 export interface UserMembershipContext {

--- a/src/modules/course/courseCascadeDeleteService.ts
+++ b/src/modules/course/courseCascadeDeleteService.ts
@@ -229,30 +229,37 @@ export async function cascadeDeleteCourse(
     //    assignments, discussion threads) are removed by the DB; CourseCompletion is Restrict but
     //    guaranteed empty by the blocker check above.
     await tx.course.delete({ where: { id: courseId } });
+
+    // #803: the cascade-delete audit (one summary event for the course + a per-module deleted event,
+    // consistent with the bulk purge) commits atomically with the deletes. Audit rows have no FK to the
+    // deleted entities, so referencing removed ids is safe.
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.course,
+        entityId: courseId,
+        action: auditActions.course.cascadeDeleted,
+        actorId,
+        metadata: { courseId, deletedModuleIds, deletedSectionIds, sparedModuleIds, sparedSectionIds },
+      },
+      tx,
+    );
+    for (const moduleId of deletedModuleIds) {
+      await recordAuditEvent(
+        {
+          entityType: auditEntityTypes.module,
+          entityId: moduleId,
+          action: auditActions.adminContent.moduleDeleted,
+          actorId,
+          metadata: { moduleId, source: "course_cascade_delete" },
+        },
+        tx,
+      );
+    }
   });
 
   // #758: after commit, reclaim the deleted sections' asset blobs (best-effort — a failed blob
   // delete never fails the cascade; the section rows are already gone).
   await reclaimAssetBlobs(sectionBlobPaths);
-
-  // Audit: one summary event for the course, plus a per-module deleted event (consistent with the
-  // bulk purge). Audit rows have no FK to the deleted entities, so referencing removed ids is safe.
-  await recordAuditEvent({
-    entityType: auditEntityTypes.course,
-    entityId: courseId,
-    action: auditActions.course.cascadeDeleted,
-    actorId,
-    metadata: { courseId, deletedModuleIds, deletedSectionIds, sparedModuleIds, sparedSectionIds },
-  });
-  for (const moduleId of deletedModuleIds) {
-    await recordAuditEvent({
-      entityType: auditEntityTypes.module,
-      entityId: moduleId,
-      action: auditActions.adminContent.moduleDeleted,
-      actorId,
-      metadata: { moduleId, source: "course_cascade_delete" },
-    });
-  }
 
   return { deletedCourseId: courseId, deletedModuleIds, deletedSectionIds, sparedModuleIds, sparedSectionIds };
 }

--- a/src/modules/course/courseCommands.ts
+++ b/src/modules/course/courseCommands.ts
@@ -16,22 +16,28 @@ export async function createCourse(input: {
   // AA-5 (#653): agent-orchestrated creates carry a trace in the audit metadata.
   agent?: AgentAuthoringContext;
 }) {
-  const course = await prisma.course.create({
-    data: {
-      title: input.title,
-      description: input.description ?? null,
-      certificationLevel: input.certificationLevel ?? null,
-      ...(input.enrollmentPolicy ? { enrollmentPolicy: input.enrollmentPolicy } : {}),
-      ...(input.discussionsEnabled !== undefined ? { discussionsEnabled: input.discussionsEnabled } : {}),
-    },
-  });
-
-  await recordAuditEvent({
-    entityType: auditEntityTypes.course,
-    entityId: course.id,
-    action: auditActions.course.created,
-    actorId: input.actorId,
-    metadata: { courseId: course.id, ...agentAuthoringAuditMetadata(input.agent) },
+  // #803: create + its audit commit atomically.
+  const course = await runInTransaction(async (tx) => {
+    const created = await tx.course.create({
+      data: {
+        title: input.title,
+        description: input.description ?? null,
+        certificationLevel: input.certificationLevel ?? null,
+        ...(input.enrollmentPolicy ? { enrollmentPolicy: input.enrollmentPolicy } : {}),
+        ...(input.discussionsEnabled !== undefined ? { discussionsEnabled: input.discussionsEnabled } : {}),
+      },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.course,
+        entityId: created.id,
+        action: auditActions.course.created,
+        actorId: input.actorId,
+        metadata: { courseId: created.id, ...agentAuthoringAuditMetadata(input.agent) },
+      },
+      tx,
+    );
+    return created;
   });
 
   // #787 slice 4a: the creator becomes the sole initial owner (Q3 decision). Inert until enforcement
@@ -55,19 +61,25 @@ export async function updateCourse(
   },
   actorId?: string,
 ) {
-  const course = await prisma.course.update({ where: { id: courseId }, data: input });
   // #805: a course-metadata edit is a state change and must leave a trail. Record which fields changed.
-  await recordAuditEvent({
-    entityType: auditEntityTypes.course,
-    entityId: courseId,
-    action: auditActions.course.updated,
-    actorId,
-    metadata: {
-      courseId,
-      changedFields: Object.keys(input).filter((key) => input[key as keyof typeof input] !== undefined),
-    },
+  // #803: update + audit commit atomically.
+  return runInTransaction(async (tx) => {
+    const course = await tx.course.update({ where: { id: courseId }, data: input });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.course,
+        entityId: courseId,
+        action: auditActions.course.updated,
+        actorId,
+        metadata: {
+          courseId,
+          changedFields: Object.keys(input).filter((key) => input[key as keyof typeof input] !== undefined),
+        },
+      },
+      tx,
+    );
+    return course;
   });
-  return course;
 }
 
 export async function publishCourse(courseId: string, actorId?: string) {
@@ -80,20 +92,24 @@ export async function publishCourse(courseId: string, actorId?: string) {
     throw new ValidationError("Cannot publish a course with no modules.");
   }
 
-  const updated = await prisma.course.update({
-    where: { id: courseId },
-    data: { publishedAt: new Date() },
+  // #803: publish + audit commit atomically.
+  return runInTransaction(async (tx) => {
+    const updated = await tx.course.update({
+      where: { id: courseId },
+      data: { publishedAt: new Date() },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.course,
+        entityId: courseId,
+        action: auditActions.course.published,
+        actorId,
+        metadata: { courseId },
+      },
+      tx,
+    );
+    return updated;
   });
-
-  await recordAuditEvent({
-    entityType: auditEntityTypes.course,
-    entityId: courseId,
-    action: auditActions.course.published,
-    actorId,
-    metadata: { courseId },
-  });
-
-  return updated;
 }
 
 // #705: avpubliser et kurs (motstykke til publishCourse). Symmetri med modul/seksjon.
@@ -104,20 +120,24 @@ export async function unpublishCourse(courseId: string, actorId?: string) {
   const course = await prisma.course.findUnique({ where: { id: courseId }, select: { id: true } });
   if (!course) throw new NotFoundError("Course", "course_not_found", "Course not found.");
 
-  const updated = await prisma.course.update({
-    where: { id: courseId },
-    data: { publishedAt: null },
+  // #803: unpublish + audit commit atomically.
+  return runInTransaction(async (tx) => {
+    const updated = await tx.course.update({
+      where: { id: courseId },
+      data: { publishedAt: null },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.course,
+        entityId: courseId,
+        action: auditActions.course.unpublished,
+        actorId,
+        metadata: { courseId },
+      },
+      tx,
+    );
+    return updated;
   });
-
-  await recordAuditEvent({
-    entityType: auditEntityTypes.course,
-    entityId: courseId,
-    action: auditActions.course.unpublished,
-    actorId,
-    metadata: { courseId },
-  });
-
-  return updated;
 }
 
 export async function archiveCourse(courseId: string, actorId?: string) {
@@ -129,36 +149,46 @@ export async function archiveCourse(courseId: string, actorId?: string) {
 
   // I3: arkivering auto-avpubliserer (publishedAt nullstilles) så «arkivert men publisert» aldri
   // oppstår. Gjenopprett (restoreCourse) lander dermed i Utkast.
-  const updated = await prisma.course.update({
-    where: { id: courseId },
-    data: { archivedAt: new Date(), publishedAt: null },
+  // #803: archive + audit commit atomically.
+  return runInTransaction(async (tx) => {
+    const updated = await tx.course.update({
+      where: { id: courseId },
+      data: { archivedAt: new Date(), publishedAt: null },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.course,
+        entityId: courseId,
+        action: auditActions.course.archived,
+        actorId,
+        metadata: { courseId },
+      },
+      tx,
+    );
+    return updated;
   });
-
-  await recordAuditEvent({
-    entityType: auditEntityTypes.course,
-    entityId: courseId,
-    action: auditActions.course.archived,
-    actorId,
-    metadata: { courseId },
-  });
-
-  return updated;
 }
 
 // #673: gjenopprett et arkivert kurs (nullstill archivedAt). Motstykke til archiveCourse.
 export async function restoreCourse(courseId: string, actorId?: string) {
-  const updated = await prisma.course.update({
-    where: { id: courseId },
-    data: { archivedAt: null },
+  // #803: restore + audit commit atomically.
+  return runInTransaction(async (tx) => {
+    const updated = await tx.course.update({
+      where: { id: courseId },
+      data: { archivedAt: null },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.course,
+        entityId: courseId,
+        action: auditActions.course.restored,
+        actorId,
+        metadata: { courseId },
+      },
+      tx,
+    );
+    return updated;
   });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.course,
-    entityId: courseId,
-    action: auditActions.course.restored,
-    actorId,
-    metadata: { courseId },
-  });
-  return updated;
 }
 
 export async function deleteCourse(courseId: string, actorId?: string) {
@@ -177,17 +207,20 @@ export async function deleteCourse(courseId: string, actorId?: string) {
     );
   }
 
+  // #803: delete + audit commit atomically.
   await runInTransaction(async (tx) => {
     await tx.course.delete({ where: { id: courseId } });
-  });
-
-  await recordAuditEvent({
-    entityType: auditEntityTypes.course,
-    entityId: courseId,
-    // #705: a delete is a delete — was previously mislogged as `archived`.
-    action: auditActions.course.deleted,
-    actorId,
-    metadata: { courseId },
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.course,
+        entityId: courseId,
+        // #705: a delete is a delete — was previously mislogged as `archived`.
+        action: auditActions.course.deleted,
+        actorId,
+        metadata: { courseId },
+      },
+      tx,
+    );
   });
 }
 
@@ -243,13 +276,17 @@ export async function setCourseItems(
       });
     }
     await tx.course.update({ where: { id: courseId }, data: { updatedAt: new Date() } });
-  });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.course,
-    entityId: courseId,
-    action: auditActions.course.itemsUpdated,
-    actorId: options?.actorId,
-    metadata: { courseId, itemCount: items.length, ...agentAuthoringAuditMetadata(options?.agent) },
+    // #803: itemsUpdated audit commits atomically with the item rewrite.
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.course,
+        entityId: courseId,
+        action: auditActions.course.itemsUpdated,
+        actorId: options?.actorId,
+        metadata: { courseId, itemCount: items.length, ...agentAuthoringAuditMetadata(options?.agent) },
+      },
+      tx,
+    );
   });
   return result;
 }

--- a/src/modules/course/enrollmentService.ts
+++ b/src/modules/course/enrollmentService.ts
@@ -3,7 +3,8 @@ import { prisma } from "../../db/prisma.js";
 import { NotFoundError, ValidationError } from "../../errors/AppError.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
-import { enrollmentRepository } from "./enrollmentRepository.js";
+import { enrollmentRepository, createEnrollmentRepository } from "./enrollmentRepository.js";
+import { runInTransaction } from "../../db/transaction.js";
 import { deriveEnrollmentStatus, type EnrollmentStatus } from "./enrollmentStatus.js";
 import { getUserClassIds, getClassAssignedCourseDueDates } from "./classService.js";
 
@@ -74,19 +75,27 @@ export async function assignEnrollments(
   const assignedUserIds: string[] = [];
   try {
     for (const userId of userIds) {
-      await enrollmentRepository.assignEnrollment({
-        userId,
-        courseId,
-        assignedById: actorId,
-        source,
-        dueAt: input.dueAt ?? null,
-      });
-      await recordAuditEvent({
-        entityType: auditEntityTypes.course,
-        entityId: courseId,
-        action: auditActions.enrollment.assigned,
-        actorId: actorId ?? undefined,
-        metadata: { userId, courseId, source },
+      // #803: per-iteration tx — each user's enrollment upsert + its audit row commit atomically,
+      // but NEVER one giant tx over the whole loop (a later failure must not roll back earlier users).
+      await runInTransaction(async (tx) => {
+        const repo = createEnrollmentRepository(tx);
+        await repo.assignEnrollment({
+          userId,
+          courseId,
+          assignedById: actorId,
+          source,
+          dueAt: input.dueAt ?? null,
+        });
+        await recordAuditEvent(
+          {
+            entityType: auditEntityTypes.course,
+            entityId: courseId,
+            action: auditActions.enrollment.assigned,
+            actorId: actorId ?? undefined,
+            metadata: { userId, courseId, source },
+          },
+          tx,
+        );
       });
       assignedUserIds.push(userId);
     }
@@ -113,16 +122,22 @@ export async function assignEnrollments(
 /** Soft-revoke a participant's enrollment. No-op (still 200) if there was no active enrollment. */
 export async function revokeEnrollment(courseId: string, userId: string, actorId: string | null): Promise<void> {
   await requireCourse(courseId);
-  const result = await enrollmentRepository.revokeEnrollment(userId, courseId);
-  if (result.count > 0) {
-    await recordAuditEvent({
-      entityType: auditEntityTypes.course,
-      entityId: courseId,
-      action: auditActions.enrollment.revoked,
-      actorId: actorId ?? undefined,
-      metadata: { userId, courseId },
-    });
-  }
+  await runInTransaction(async (tx) => {
+    const repo = createEnrollmentRepository(tx);
+    const result = await repo.revokeEnrollment(userId, courseId);
+    if (result.count > 0) {
+      await recordAuditEvent(
+        {
+          entityType: auditEntityTypes.course,
+          entityId: courseId,
+          action: auditActions.enrollment.revoked,
+          actorId: actorId ?? undefined,
+          metadata: { userId, courseId },
+        },
+        tx,
+      );
+    }
+  });
 }
 
 /**
@@ -134,19 +149,25 @@ export async function selfEnroll(courseId: string, userId: string): Promise<void
   if (course.enrollmentPolicy !== "OPEN") {
     throw new ValidationError("This course is restricted — self-enrolment is not allowed.");
   }
-  await enrollmentRepository.assignEnrollment({
-    userId,
-    courseId,
-    assignedById: null,
-    source: "SELF",
-    dueAt: null,
-  });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.course,
-    entityId: courseId,
-    action: auditActions.enrollment.selfEnrolled,
-    actorId: userId,
-    metadata: { userId, courseId },
+  await runInTransaction(async (tx) => {
+    const repo = createEnrollmentRepository(tx);
+    await repo.assignEnrollment({
+      userId,
+      courseId,
+      assignedById: null,
+      source: "SELF",
+      dueAt: null,
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.course,
+        entityId: courseId,
+        action: auditActions.enrollment.selfEnrolled,
+        actorId: userId,
+        metadata: { userId, courseId },
+      },
+      tx,
+    );
   });
 }
 

--- a/src/modules/course/sectionCommands.ts
+++ b/src/modules/course/sectionCommands.ts
@@ -65,28 +65,31 @@ export async function createSection(input: {
         publishedAt: input.draft ? null : new Date(),
       },
     });
-    if (input.draft) {
-      return tx.courseSection.findUniqueOrThrow({
-        where: { id: section.id },
-        include: { activeVersion: true },
-      });
-    }
-    return tx.courseSection.update({
-      where: { id: section.id },
-      data: { activeVersionId: version.id },
-      include: { activeVersion: true },
-    });
-  });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.courseSection,
-    entityId: created.id,
-    action: auditActions.section.created,
-    actorId: input.actorId,
-    metadata: {
-      sectionId: created.id,
-      draft: Boolean(input.draft),
-      ...agentAuthoringAuditMetadata(input.agent),
-    },
+    const result = input.draft
+      ? await tx.courseSection.findUniqueOrThrow({
+          where: { id: section.id },
+          include: { activeVersion: true },
+        })
+      : await tx.courseSection.update({
+          where: { id: section.id },
+          data: { activeVersionId: version.id },
+          include: { activeVersion: true },
+        });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.courseSection,
+        entityId: result.id,
+        action: auditActions.section.created,
+        actorId: input.actorId,
+        metadata: {
+          sectionId: result.id,
+          draft: Boolean(input.draft),
+          ...agentAuthoringAuditMetadata(input.agent),
+        },
+      },
+      tx,
+    );
+    return result;
   });
   // #787 slice 4a: creator becomes sole initial owner (inert until 4b enforcement).
   if (input.actorId) {
@@ -213,17 +216,23 @@ export async function publishSection(sectionId: string, actorId?: string) {
   if (!latest) {
     throw new ValidationError("Seksjonen har ikke noe innhold å publisere.");
   }
-  const updated = await prisma.courseSection.update({
-    where: { id: sectionId },
-    data: { activeVersionId: latest.id },
-    include: { activeVersion: true },
-  });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.courseSection,
-    entityId: sectionId,
-    action: auditActions.section.published,
-    actorId,
-    metadata: { sectionId },
+  const updated = await runInTransaction(async (tx) => {
+    const section = await tx.courseSection.update({
+      where: { id: sectionId },
+      data: { activeVersionId: latest.id },
+      include: { activeVersion: true },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.courseSection,
+        entityId: sectionId,
+        action: auditActions.section.published,
+        actorId,
+        metadata: { sectionId },
+      },
+      tx,
+    );
+    return section;
   });
   return updated;
 }
@@ -232,17 +241,23 @@ export async function publishSection(sectionId: string, actorId?: string) {
 export async function unpublishSection(sectionId: string, actorId?: string) {
   await assertSectionExists(sectionId);
   await assertSectionNotInAnyCourse(sectionId, "avpubliseres");
-  const updated = await prisma.courseSection.update({
-    where: { id: sectionId },
-    data: { activeVersionId: null },
-    include: { activeVersion: true },
-  });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.courseSection,
-    entityId: sectionId,
-    action: auditActions.section.unpublished,
-    actorId,
-    metadata: { sectionId },
+  const updated = await runInTransaction(async (tx) => {
+    const section = await tx.courseSection.update({
+      where: { id: sectionId },
+      data: { activeVersionId: null },
+      include: { activeVersion: true },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.courseSection,
+        entityId: sectionId,
+        action: auditActions.section.unpublished,
+        actorId,
+        metadata: { sectionId },
+      },
+      tx,
+    );
+    return section;
   });
   return updated;
 }
@@ -260,17 +275,23 @@ export async function archiveSection(sectionId: string, actorId?: string) {
     throw new ValidationError("Seksjonen er allerede arkivert.");
   }
   await assertSectionNotInAnyCourse(sectionId, "arkiveres");
-  const updated = await prisma.courseSection.update({
-    where: { id: sectionId },
-    data: { archivedAt: new Date(), activeVersionId: null },
-    include: { activeVersion: true },
-  });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.courseSection,
-    entityId: sectionId,
-    action: auditActions.section.archived,
-    actorId,
-    metadata: { sectionId },
+  const updated = await runInTransaction(async (tx) => {
+    const section = await tx.courseSection.update({
+      where: { id: sectionId },
+      data: { archivedAt: new Date(), activeVersionId: null },
+      include: { activeVersion: true },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.courseSection,
+        entityId: sectionId,
+        action: auditActions.section.archived,
+        actorId,
+        metadata: { sectionId },
+      },
+      tx,
+    );
+    return section;
   });
   return updated;
 }
@@ -287,17 +308,23 @@ export async function restoreSection(sectionId: string, actorId?: string) {
   if (!section.archivedAt) {
     throw new ValidationError("Seksjonen er ikke arkivert.");
   }
-  const updated = await prisma.courseSection.update({
-    where: { id: sectionId },
-    data: { archivedAt: null },
-    include: { activeVersion: true },
-  });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.courseSection,
-    entityId: sectionId,
-    action: auditActions.section.restored,
-    actorId,
-    metadata: { sectionId },
+  const updated = await runInTransaction(async (tx) => {
+    const section = await tx.courseSection.update({
+      where: { id: sectionId },
+      data: { archivedAt: null },
+      include: { activeVersion: true },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.courseSection,
+        entityId: sectionId,
+        action: auditActions.section.restored,
+        actorId,
+        metadata: { sectionId },
+      },
+      tx,
+    );
+    return section;
   });
   return updated;
 }

--- a/src/modules/discussion/discussionService.ts
+++ b/src/modules/discussion/discussionService.ts
@@ -1,6 +1,7 @@
 import type { AppRole as AppRoleType } from "@prisma/client";
 import { AppRole } from "../../db/prismaRuntime.js";
 import { prisma } from "../../db/prisma.js";
+import { runInTransaction, type DbTransactionClient } from "../../db/transaction.js";
 import { ForbiddenError, NotFoundError } from "../../errors/AppError.js";
 import { recordAuditEvent } from "../../services/auditService.js";
 import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
@@ -207,26 +208,33 @@ export async function createThread(params: {
   const course = await loadAccessibleCourse(params.courseId, params.access);
   await assertScopeWritable(course, params.courseItemId);
 
-  const thread = await prisma.discussionThread.create({
-    data: {
-      courseId: course.id,
-      courseItemId: params.courseItemId,
-      authorId: params.access.userId,
-      kind: params.kind,
-      title: params.title,
-      bodyMarkdown: params.bodyMarkdown,
-      // Forfatter abonnerer automatisk på egen tråd (#495 §4).
-      subscriptions: { create: { userId: params.access.userId } },
-    },
-    select: threadDetailSelect,
-  });
+  const thread = await runInTransaction(async (tx) => {
+    const created = await tx.discussionThread.create({
+      data: {
+        courseId: course.id,
+        courseItemId: params.courseItemId,
+        authorId: params.access.userId,
+        kind: params.kind,
+        title: params.title,
+        bodyMarkdown: params.bodyMarkdown,
+        // Forfatter abonnerer automatisk på egen tråd (#495 §4).
+        subscriptions: { create: { userId: params.access.userId } },
+      },
+      select: threadDetailSelect,
+    });
 
-  await recordAuditEvent({
-    entityType: auditEntityTypes.discussionThread,
-    entityId: thread.id,
-    action: auditActions.discussion.threadCreated,
-    actorId: params.access.userId,
-    metadata: { courseId: course.id, courseItemId: params.courseItemId, kind: params.kind },
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.discussionThread,
+        entityId: created.id,
+        action: auditActions.discussion.threadCreated,
+        actorId: params.access.userId,
+        metadata: { courseId: course.id, courseItemId: params.courseItemId, kind: params.kind },
+      },
+      tx,
+    );
+
+    return created;
   });
 
   // #495/T-QA-5: nytt spørsmål varsler kursets SMO-er. Svelg feil — varsling skal aldri velte
@@ -292,7 +300,7 @@ export async function updateThread(params: {
   }
 
   const data: Record<string, unknown> = {};
-  const auditCalls: Array<() => Promise<void>> = [];
+  const auditCalls: Array<(tx: DbTransactionClient) => Promise<void>> = [];
 
   // 1) Innholdsredigering — kun forfatter.
   if (params.patch.title !== undefined || params.patch.bodyMarkdown !== undefined) {
@@ -301,14 +309,17 @@ export async function updateThread(params: {
     }
     if (params.patch.title !== undefined) data.title = params.patch.title;
     if (params.patch.bodyMarkdown !== undefined) data.bodyMarkdown = params.patch.bodyMarkdown;
-    auditCalls.push(() =>
-      recordAuditEvent({
-        entityType: auditEntityTypes.discussionThread,
-        entityId: thread.id,
-        action: auditActions.discussion.threadEdited,
-        actorId: params.access.userId,
-        metadata: { courseId: course.id, threadId: thread.id },
-      }),
+    auditCalls.push((tx) =>
+      recordAuditEvent(
+        {
+          entityType: auditEntityTypes.discussionThread,
+          entityId: thread.id,
+          action: auditActions.discussion.threadEdited,
+          actorId: params.access.userId,
+          metadata: { courseId: course.id, threadId: thread.id },
+        },
+        tx,
+      ),
     );
   }
 
@@ -318,14 +329,17 @@ export async function updateThread(params: {
       throw new ForbiddenError("Only a moderator can pin threads.", "forbidden");
     }
     data.pinnedAt = params.patch.pinned ? new Date() : null;
-    auditCalls.push(() =>
-      recordAuditEvent({
-        entityType: auditEntityTypes.discussionThread,
-        entityId: thread.id,
-        action: auditActions.discussion.threadModerated,
-        actorId: params.access.userId,
-        metadata: { courseId: course.id, threadId: thread.id, change: params.patch.pinned ? "pinned" : "unpinned" },
-      }),
+    auditCalls.push((tx) =>
+      recordAuditEvent(
+        {
+          entityType: auditEntityTypes.discussionThread,
+          entityId: thread.id,
+          action: auditActions.discussion.threadModerated,
+          actorId: params.access.userId,
+          metadata: { courseId: course.id, threadId: thread.id, change: params.patch.pinned ? "pinned" : "unpinned" },
+        },
+        tx,
+      ),
     );
   }
 
@@ -335,14 +349,17 @@ export async function updateThread(params: {
       throw new ForbiddenError("Only a moderator can lock threads.", "forbidden");
     }
     data.status = params.patch.lock ? "LOCKED" : "OPEN";
-    auditCalls.push(() =>
-      recordAuditEvent({
-        entityType: auditEntityTypes.discussionThread,
-        entityId: thread.id,
-        action: auditActions.discussion.threadModerated,
-        actorId: params.access.userId,
-        metadata: { courseId: course.id, threadId: thread.id, change: params.patch.lock ? "locked" : "unlocked" },
-      }),
+    auditCalls.push((tx) =>
+      recordAuditEvent(
+        {
+          entityType: auditEntityTypes.discussionThread,
+          entityId: thread.id,
+          action: auditActions.discussion.threadModerated,
+          actorId: params.access.userId,
+          metadata: { courseId: course.id, threadId: thread.id, change: params.patch.lock ? "locked" : "unlocked" },
+        },
+        tx,
+      ),
     );
   }
 
@@ -357,14 +374,17 @@ export async function updateThread(params: {
     if (params.patch.acceptedReplyId === null) {
       data.acceptedReplyId = null;
       data.status = "OPEN";
-      auditCalls.push(() =>
-        recordAuditEvent({
-          entityType: auditEntityTypes.discussionThread,
-          entityId: thread.id,
-          action: auditActions.discussion.threadModerated,
-          actorId: params.access.userId,
-          metadata: { courseId: course.id, threadId: thread.id, change: "answer_unaccepted" },
-        }),
+      auditCalls.push((tx) =>
+        recordAuditEvent(
+          {
+            entityType: auditEntityTypes.discussionThread,
+            entityId: thread.id,
+            action: auditActions.discussion.threadModerated,
+            actorId: params.access.userId,
+            metadata: { courseId: course.id, threadId: thread.id, change: "answer_unaccepted" },
+          },
+          tx,
+        ),
       );
     } else {
       const reply = await prisma.discussionReply.findFirst({
@@ -377,14 +397,17 @@ export async function updateThread(params: {
       data.acceptedReplyId = reply.id;
       data.status = "RESOLVED";
       const replyId = reply.id;
-      auditCalls.push(() =>
-        recordAuditEvent({
-          entityType: auditEntityTypes.discussionThread,
-          entityId: thread.id,
-          action: auditActions.discussion.answerAccepted,
-          actorId: params.access.userId,
-          metadata: { courseId: course.id, threadId: thread.id, replyId },
-        }),
+      auditCalls.push((tx) =>
+        recordAuditEvent(
+          {
+            entityType: auditEntityTypes.discussionThread,
+            entityId: thread.id,
+            action: auditActions.discussion.answerAccepted,
+            actorId: params.access.userId,
+            metadata: { courseId: course.id, threadId: thread.id, replyId },
+          },
+          tx,
+        ),
       );
     }
   }
@@ -394,8 +417,10 @@ export async function updateThread(params: {
     return await detailDtoWithSubscription(thread, viewer);
   }
 
-  await prisma.discussionThread.update({ where: { id: thread.id }, data });
-  for (const call of auditCalls) await call();
+  await runInTransaction(async (tx) => {
+    await tx.discussionThread.update({ where: { id: thread.id }, data });
+    for (const call of auditCalls) await call(tx);
+  });
 
   const updated = await loadThreadInCourse(course.id, thread.id);
   return await detailDtoWithSubscription(updated, viewer);
@@ -413,16 +438,21 @@ export async function deleteThread(params: {
     throw new ForbiddenError("You cannot delete this thread.", "forbidden");
   }
   if (thread.deletedAt) return; // idempotent
-  await prisma.discussionThread.update({
-    where: { id: thread.id },
-    data: { deletedAt: new Date(), deletedById: params.access.userId },
-  });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.discussionThread,
-    entityId: thread.id,
-    action: auditActions.discussion.threadDeleted,
-    actorId: params.access.userId,
-    metadata: { courseId: course.id, threadId: thread.id },
+  await runInTransaction(async (tx) => {
+    await tx.discussionThread.update({
+      where: { id: thread.id },
+      data: { deletedAt: new Date(), deletedById: params.access.userId },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.discussionThread,
+        entityId: thread.id,
+        action: auditActions.discussion.threadDeleted,
+        actorId: params.access.userId,
+        metadata: { courseId: course.id, threadId: thread.id },
+      },
+      tx,
+    );
   });
 }
 
@@ -454,14 +484,16 @@ export async function createReply(params: {
       create: { threadId: thread.id, userId: params.access.userId },
       update: {},
     });
-  });
-
-  await recordAuditEvent({
-    entityType: auditEntityTypes.discussionReply,
-    entityId: thread.id,
-    action: auditActions.discussion.replyCreated,
-    actorId: params.access.userId,
-    metadata: { courseId: course.id, threadId: thread.id },
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.discussionReply,
+        entityId: thread.id,
+        action: auditActions.discussion.replyCreated,
+        actorId: params.access.userId,
+        metadata: { courseId: course.id, threadId: thread.id },
+      },
+      tx,
+    );
   });
 
   // #495/T-QA-5: nytt svar varsler trådens abonnenter (ekskl. svarets forfatter). Best-effort.
@@ -505,16 +537,21 @@ export async function updateReply(params: {
   if (reply.authorId !== params.access.userId) {
     throw new ForbiddenError("Only the author can edit this reply.", "forbidden");
   }
-  await prisma.discussionReply.update({
-    where: { id: reply.id },
-    data: { bodyMarkdown: params.bodyMarkdown },
-  });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.discussionReply,
-    entityId: reply.id,
-    action: auditActions.discussion.replyEdited,
-    actorId: params.access.userId,
-    metadata: { courseId: course.id, threadId: params.threadId },
+  await runInTransaction(async (tx) => {
+    await tx.discussionReply.update({
+      where: { id: reply.id },
+      data: { bodyMarkdown: params.bodyMarkdown },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.discussionReply,
+        entityId: reply.id,
+        action: auditActions.discussion.replyEdited,
+        actorId: params.access.userId,
+        metadata: { courseId: course.id, threadId: params.threadId },
+      },
+      tx,
+    );
   });
   const updated = await loadThreadInCourse(course.id, params.threadId);
   return await detailDtoWithSubscription(updated, viewerOf(params.access));
@@ -533,16 +570,21 @@ export async function deleteReply(params: {
     throw new ForbiddenError("You cannot delete this reply.", "forbidden");
   }
   if (reply.deletedAt) return; // idempotent
-  await prisma.discussionReply.update({
-    where: { id: reply.id },
-    data: { deletedAt: new Date(), deletedById: params.access.userId },
-  });
-  await recordAuditEvent({
-    entityType: auditEntityTypes.discussionReply,
-    entityId: reply.id,
-    action: auditActions.discussion.replyDeleted,
-    actorId: params.access.userId,
-    metadata: { courseId: course.id, threadId: params.threadId },
+  await runInTransaction(async (tx) => {
+    await tx.discussionReply.update({
+      where: { id: reply.id },
+      data: { deletedAt: new Date(), deletedById: params.access.userId },
+    });
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.discussionReply,
+        entityId: reply.id,
+        action: auditActions.discussion.replyDeleted,
+        actorId: params.access.userId,
+        metadata: { courseId: course.id, threadId: params.threadId },
+      },
+      tx,
+    );
   });
 }
 

--- a/src/modules/review/manualReviewRepository.ts
+++ b/src/modules/review/manualReviewRepository.ts
@@ -155,14 +155,23 @@ export function createManualReviewRepository(client: ManualReviewRepositoryClien
       });
     },
 
-    markManualReviewClaimed(reviewId: string, reviewerId: string, reviewStatus: ReviewStatusType) {
-      return client.manualReview.update({
-        where: { id: reviewId },
-        data: {
-          reviewerId,
-          reviewStatus,
+    // #791: atomic guarded claim (same shape as the appeal fix, #790). WHERE encodes the preconditions —
+    // not already terminal, and (unless admin takeover) unassigned or ours — so two concurrent claims can't
+    // both succeed; the loser gets count 0 and the service raises ConflictError.
+    markManualReviewClaimedGuarded(reviewId: string, reviewerId: string, reviewStatus: ReviewStatusType, allowTakeover: boolean) {
+      return client.manualReview.updateMany({
+        where: {
+          id: reviewId,
+          reviewStatus: { notIn: ["RESOLVED", "SUPERSEDED"] },
+          ...(allowTakeover ? {} : { OR: [{ reviewerId: null }, { reviewerId } ] }),
         },
+        data: { reviewerId, reviewStatus },
       });
+    },
+
+    // #791: plain row re-read after a guarded transition (updateMany can't return the row).
+    findManualReviewById(reviewId: string) {
+      return client.manualReview.findUniqueOrThrow({ where: { id: reviewId } });
     },
 
     findManualReviewForOverride(reviewId: string) {
@@ -196,16 +205,23 @@ export function createManualReviewRepository(client: ManualReviewRepositoryClien
       return client.assessmentDecision.create({ data });
     },
 
-    resolveManualReview(data: {
+    // #791: atomic guarded resolve. Same guard as the claim; count 0 → another reviewer finalized first →
+    // ConflictError rolls the transaction back BEFORE a second MANUAL_OVERRIDE decision is appended.
+    resolveManualReviewGuarded(data: {
       reviewId: string;
       reviewerId: string;
       reviewStatus: ReviewStatusType;
       reviewedAt: Date;
       overrideDecision: string;
       overrideReason: string;
+      allowTakeover: boolean;
     }) {
-      return client.manualReview.update({
-        where: { id: data.reviewId },
+      return client.manualReview.updateMany({
+        where: {
+          id: data.reviewId,
+          reviewStatus: { notIn: ["RESOLVED", "SUPERSEDED"] },
+          ...(data.allowTakeover ? {} : { OR: [{ reviewerId: null }, { reviewerId: data.reviewerId }] }),
+        },
         data: {
           reviewerId: data.reviewerId,
           reviewStatus: data.reviewStatus,

--- a/src/modules/review/manualReviewService.ts
+++ b/src/modules/review/manualReviewService.ts
@@ -75,7 +75,17 @@ export async function claimManualReview(reviewId: string, reviewerId: string, is
     });
   }
 
-  const claimed = await manualReviewRepository.markManualReviewClaimed(reviewId, reviewerId, ReviewStatus.IN_REVIEW);
+  // #791: atomic guarded claim. count===0 → a concurrent reviewer claimed first → we lost the race.
+  const claimResult = await manualReviewRepository.markManualReviewClaimedGuarded(
+    reviewId,
+    reviewerId,
+    ReviewStatus.IN_REVIEW,
+    isAdmin,
+  );
+  if (claimResult.count === 0) {
+    throw new ConflictError("review_already_assigned", "This manual review was just claimed by another reviewer.");
+  }
+  const claimed = await manualReviewRepository.findManualReviewById(reviewId);
 
   await recordAuditEvent({
     entityType: auditEntityTypes.manualReview,
@@ -178,12 +188,30 @@ type LatestDecision = NonNullable<OverrideReview["submission"]["decisions"][numb
 
 async function finalizeManualReviewOverrideCommand(
   review: OverrideReview,
-  input: { reviewerId: string; passFailTotal: boolean; decisionReason: string; overrideReason: string },
+  input: { reviewerId: string; passFailTotal: boolean; decisionReason: string; overrideReason: string; isAdmin?: boolean },
   latestDecision: LatestDecision,
   finalisedAt: Date,
 ) {
   return runInTransaction(async (tx) => {
     const repo = createManualReviewRepository(tx);
+
+    // #791: guarded transition FIRST. If a concurrent override already resolved this review, count===0 →
+    // ConflictError rolls back before we append a second MANUAL_OVERRIDE decision (duplicate lineage).
+    const transition = await repo.resolveManualReviewGuarded({
+      reviewId: review.id,
+      reviewerId: input.reviewerId,
+      reviewStatus: ReviewStatus.RESOLVED,
+      reviewedAt: finalisedAt,
+      overrideDecision: input.passFailTotal ? "PASS" : "FAIL",
+      overrideReason: input.overrideReason,
+      allowTakeover: input.isAdmin ?? false,
+    });
+    if (transition.count === 0) {
+      throw new ConflictError(
+        "review_already_resolved",
+        "This manual review was just resolved by another reviewer. Refresh the queue to view the latest status.",
+      );
+    }
 
     const overrideDecision = await appendDecisionWithLineage(
       {
@@ -205,14 +233,7 @@ async function finalizeManualReviewOverrideCommand(
       tx,
     );
 
-    const resolvedReview = await repo.resolveManualReview({
-      reviewId: review.id,
-      reviewerId: input.reviewerId,
-      reviewStatus: ReviewStatus.RESOLVED,
-      reviewedAt: finalisedAt,
-      overrideDecision: input.passFailTotal ? "PASS" : "FAIL",
-      overrideReason: input.overrideReason,
-    });
+    const resolvedReview = await repo.findManualReviewById(review.id);
 
     await recordAuditEvent({
       entityType: auditEntityTypes.manualReview,

--- a/src/modules/review/manualReviewService.ts
+++ b/src/modules/review/manualReviewService.ts
@@ -76,29 +76,36 @@ export async function claimManualReview(reviewId: string, reviewerId: string, is
   }
 
   // #791: atomic guarded claim. count===0 → a concurrent reviewer claimed first → we lost the race.
-  const claimResult = await manualReviewRepository.markManualReviewClaimedGuarded(
-    reviewId,
-    reviewerId,
-    ReviewStatus.IN_REVIEW,
-    isAdmin,
-  );
-  if (claimResult.count === 0) {
-    throw new ConflictError("review_already_assigned", "This manual review was just claimed by another reviewer.");
-  }
-  const claimed = await manualReviewRepository.findManualReviewById(reviewId);
+  // #803: the guarded claim + its audit commit atomically.
+  return runInTransaction(async (tx) => {
+    const repo = createManualReviewRepository(tx);
+    const claimResult = await repo.markManualReviewClaimedGuarded(
+      reviewId,
+      reviewerId,
+      ReviewStatus.IN_REVIEW,
+      isAdmin,
+    );
+    if (claimResult.count === 0) {
+      throw new ConflictError("review_already_assigned", "This manual review was just claimed by another reviewer.");
+    }
+    const claimed = await repo.findManualReviewById(reviewId);
 
-  await recordAuditEvent({
-    entityType: auditEntityTypes.manualReview,
-    entityId: claimed.id,
-    action: auditActions.manualReview.claimed,
-    actorId: reviewerId,
-    metadata: {
-      submissionId: review.submissionId,
-      reviewStatus: claimed.reviewStatus,
-    },
+    await recordAuditEvent(
+      {
+        entityType: auditEntityTypes.manualReview,
+        entityId: claimed.id,
+        action: auditActions.manualReview.claimed,
+        actorId: reviewerId,
+        metadata: {
+          submissionId: review.submissionId,
+          reviewStatus: claimed.reviewStatus,
+        },
+      },
+      tx,
+    );
+
+    return claimed;
   });
-
-  return claimed;
 }
 
 export async function finalizeManualReviewOverride(input: {

--- a/test/m2-appeal-concurrency.test.ts
+++ b/test/m2-appeal-concurrency.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { prisma } from "../src/db/prisma.js";
+import { appealRepository } from "../src/modules/appeal/appealRepository.js";
+
+// #790: the appeal claim + resolve transitions are guarded updateMany calls whose WHERE encodes the
+// preconditions, so under real concurrency exactly ONE of two racing operations affects a row (count 1)
+// and the loser gets count 0 → ConflictError. This exercises that against a real Postgres — two claims /
+// two resolves fired together must not both "win" (which is what produced duplicate resolution decisions).
+async function seedClaimableAppeal(resolvedById: string | null) {
+  const mv = await prisma.moduleVersion.findFirstOrThrow({ select: { id: true, moduleId: true } });
+  const user = await prisma.user.create({
+    data: { externalId: `appeal-conc-${Date.now()}-${Math.random()}`, name: "Appellant", email: `ac-${Date.now()}-${Math.random()}@x.test` },
+    select: { id: true },
+  });
+  const submission = await prisma.submission.create({
+    data: { userId: user.id, moduleId: mv.moduleId, moduleVersionId: mv.id, deliveryType: "text" },
+    select: { id: true },
+  });
+  const appeal = await prisma.appeal.create({
+    data: {
+      submissionId: submission.id,
+      appealedById: user.id,
+      appealReason: "concurrency test",
+      appealStatus: "IN_REVIEW",
+      resolvedById,
+    },
+    select: { id: true },
+  });
+  return appeal.id;
+}
+
+async function makeHandler(tag: string) {
+  const u = await prisma.user.create({
+    data: { externalId: `appeal-h-${tag}-${Date.now()}-${Math.random()}`, name: tag, email: `h-${tag}-${Date.now()}-${Math.random()}@x.test` },
+    select: { id: true },
+  });
+  return u.id;
+}
+
+describe("appeal transition concurrency (#790)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("two concurrent claims: exactly one wins (count 1), the other loses (count 0)", async () => {
+    const appealId = await seedClaimableAppeal(null);
+    const handlerA = await makeHandler("A");
+    const handlerB = await makeHandler("B");
+
+    const results = await Promise.all([
+      appealRepository.markAppealInReviewGuarded(appealId, handlerA, false, false),
+      appealRepository.markAppealInReviewGuarded(appealId, handlerB, false, false),
+    ]);
+
+    expect(results.filter((r) => r.count === 1)).toHaveLength(1);
+    expect(results.filter((r) => r.count === 0)).toHaveLength(1);
+
+    const appeal = await prisma.appeal.findUniqueOrThrow({ where: { id: appealId }, select: { appealStatus: true, resolvedById: true } });
+    expect(appeal.appealStatus).toBe("IN_REVIEW");
+    expect([handlerA, handlerB]).toContain(appeal.resolvedById);
+  });
+
+  it("two concurrent resolves: exactly one wins, the appeal ends terminal once", async () => {
+    const handlerA = await makeHandler("R");
+    // Claimed by handlerA; two resolves race (e.g. a double-submit).
+    const appealId = await seedClaimableAppeal(handlerA);
+    const finalisedAt = new Date();
+
+    const results = await Promise.all([
+      appealRepository.markAppealResolvedGuarded(appealId, handlerA, finalisedAt, "note-1", false),
+      appealRepository.markAppealResolvedGuarded(appealId, handlerA, finalisedAt, "note-2", false),
+    ]);
+
+    expect(results.filter((r) => r.count === 1)).toHaveLength(1);
+    expect(results.filter((r) => r.count === 0)).toHaveLength(1);
+
+    const appeal = await prisma.appeal.findUniqueOrThrow({ where: { id: appealId }, select: { appealStatus: true } });
+    expect(appeal.appealStatus).toBe("RESOLVED");
+  });
+});

--- a/test/m2-assessment-enqueue-concurrency.test.ts
+++ b/test/m2-assessment-enqueue-concurrency.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { prisma } from "../src/db/prisma.js";
+import { enqueueAssessmentJob } from "../src/modules/assessment/AssessmentJobRunner.js";
+
+// #793: at most one ACTIVE (PENDING/RUNNING) assessment job per submission is a DB invariant (partial
+// unique index). Two concurrent enqueues must not both create a job — the loser returns the winner's
+// job, so there is never duplicate LLM spend / decisions / emails for one submission.
+async function seedSubmission() {
+  const mv = await prisma.moduleVersion.findFirstOrThrow({ select: { id: true, moduleId: true } });
+  const user = await prisma.user.create({
+    data: { externalId: `enq-${Date.now()}-${Math.random()}`, name: "S", email: `enq-${Date.now()}-${Math.random()}@x.test` },
+    select: { id: true },
+  });
+  const submission = await prisma.submission.create({
+    data: { userId: user.id, moduleId: mv.moduleId, moduleVersionId: mv.id, deliveryType: "text" },
+    select: { id: true },
+  });
+  return submission.id;
+}
+
+describe("assessment enqueue concurrency (#793)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("two concurrent enqueues yield one active job; both callers get the same job", async () => {
+    const submissionId = await seedSubmission();
+
+    const [a, b] = await Promise.all([enqueueAssessmentJob(submissionId), enqueueAssessmentJob(submissionId)]);
+
+    // Both resolve to a job, and to the SAME job (one created it, the other returned it).
+    expect(a.id).toBe(b.id);
+
+    const activeCount = await prisma.assessmentJob.count({
+      where: { submissionId, status: { in: ["PENDING", "RUNNING"] } },
+    });
+    expect(activeCount).toBe(1);
+  });
+
+  it("the DB rejects a second active job for the same submission (invariant, not just app logic)", async () => {
+    const submissionId = await seedSubmission();
+    await prisma.assessmentJob.create({ data: { submissionId, status: "PENDING" } });
+
+    await expect(
+      prisma.assessmentJob.create({ data: { submissionId, status: "RUNNING" } }),
+    ).rejects.toMatchObject({ code: "P2002" });
+  });
+});

--- a/test/m2-assessment-lease-fencing.test.ts
+++ b/test/m2-assessment-lease-fencing.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { prisma } from "../src/db/prisma.js";
+import { assessmentJobRepository } from "../src/modules/assessment/assessmentJobRepository.js";
+
+// #792: a job's terminal writes and lease renewals are fenced on (status RUNNING, lockedBy, lockedAt).
+// If a slow worker A's lease expires, gets reset, and worker B re-locks the job, A's late terminal write
+// must NO-OP (count 0) instead of overwriting B's result — otherwise both would finalize the same job.
+async function seedRunningJob(lockedBy: string, lockedAt: Date) {
+  const mv = await prisma.moduleVersion.findFirstOrThrow({ select: { id: true, moduleId: true } });
+  const user = await prisma.user.create({
+    data: { externalId: `lease-${Date.now()}-${Math.random()}`, name: "S", email: `lease-${Date.now()}-${Math.random()}@x.test` },
+    select: { id: true },
+  });
+  const submission = await prisma.submission.create({
+    data: { userId: user.id, moduleId: mv.moduleId, moduleVersionId: mv.id, deliveryType: "text" },
+    select: { id: true },
+  });
+  const job = await prisma.assessmentJob.create({
+    data: { submissionId: submission.id, status: "RUNNING", lockedBy, lockedAt, leaseExpiresAt: new Date(Date.now() + 300_000) },
+    select: { id: true },
+  });
+  return job.id;
+}
+
+describe("assessment job lease fencing (#792)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("a stale-fence terminal write no-ops; only the current lease holder finalizes", async () => {
+    const t1 = new Date("2026-01-01T00:00:00.000Z");
+    const jobId = await seedRunningJob("worker-A", t1);
+
+    // A's lease expired → the scanner reset it and worker B re-locked it (fresh lockedAt).
+    const t2 = new Date("2026-01-01T00:10:00.000Z");
+    await prisma.assessmentJob.update({ where: { id: jobId }, data: { lockedBy: "worker-B", lockedAt: t2 } });
+
+    // A finishes late and tries to finalize with its STALE fence → must not touch the row.
+    const stale = await assessmentJobRepository.markJobSucceeded(jobId, "worker-A", t1);
+    expect(stale.count).toBe(0);
+    expect((await prisma.assessmentJob.findUniqueOrThrow({ where: { id: jobId } })).status).toBe("RUNNING");
+
+    // B (the current holder) finalizes with its fence → wins.
+    const current = await assessmentJobRepository.markJobSucceeded(jobId, "worker-B", t2);
+    expect(current.count).toBe(1);
+    expect((await prisma.assessmentJob.findUniqueOrThrow({ where: { id: jobId } })).status).toBe("SUCCEEDED");
+  });
+
+  it("lease renewal is fenced too — a stale holder cannot extend the lease", async () => {
+    const t1 = new Date("2026-02-01T00:00:00.000Z");
+    const jobId = await seedRunningJob("worker-A", t1);
+    const t2 = new Date("2026-02-01T00:10:00.000Z");
+    await prisma.assessmentJob.update({ where: { id: jobId }, data: { lockedBy: "worker-B", lockedAt: t2 } });
+
+    const stale = await assessmentJobRepository.renewLease(jobId, "worker-A", t1, new Date(Date.now() + 300_000));
+    expect(stale.count).toBe(0);
+
+    const current = await assessmentJobRepository.renewLease(jobId, "worker-B", t2, new Date(Date.now() + 300_000));
+    expect(current.count).toBe(1);
+  });
+});

--- a/test/m2-audit-transactional.test.ts
+++ b/test/m2-audit-transactional.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { prisma } from "../src/db/prisma.js";
+
+// #803: audit writes now commit in the SAME transaction as the domain mutation they record. This proves
+// the guarantee against a real Postgres: when the audit write fails, the domain mutation is rolled back
+// (no divergence), and when it succeeds, both the domain change and the audit row are present. We force
+// the failure by mocking recordAuditEvent to reject — it runs inside the command's runInTransaction, so a
+// rejection must abort the whole transaction.
+const recordAuditEvent = vi.fn();
+vi.mock("../src/services/auditService.js", () => ({ recordAuditEvent }));
+
+async function seedCourse(title: string) {
+  const course = await prisma.course.create({ data: { title }, select: { id: true, title: true } });
+  return course;
+}
+
+describe("audit writes are transactional with the domain mutation (#803)", () => {
+  beforeEach(() => {
+    recordAuditEvent.mockReset();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("rolls back the domain mutation when the in-transaction audit write fails", async () => {
+    const course = await seedCourse(`before-${Date.now()}-${Math.random()}`);
+    // The audit write (inside updateCourse's runInTransaction) throws → the whole transaction aborts.
+    recordAuditEvent.mockRejectedValueOnce(new Error("audit write failed"));
+
+    const { updateCourse } = await import("../src/modules/course/courseCommands.js");
+    await expect(updateCourse(course.id, { title: "after-should-not-persist" }, "actor-1")).rejects.toThrow(
+      "audit write failed",
+    );
+
+    // Atomicity: the title change was rolled back with the failed audit — no divergence.
+    const persisted = await prisma.course.findUniqueOrThrow({ where: { id: course.id }, select: { title: true } });
+    expect(persisted.title).toBe(course.title);
+    expect(recordAuditEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("commits the domain mutation together with the audit write on success", async () => {
+    const course = await seedCourse(`before-${Date.now()}-${Math.random()}`);
+    recordAuditEvent.mockResolvedValueOnce(undefined);
+
+    const { updateCourse } = await import("../src/modules/course/courseCommands.js");
+    const newTitle = `after-${Date.now()}-${Math.random()}`;
+    await updateCourse(course.id, { title: newTitle }, "actor-1");
+
+    const persisted = await prisma.course.findUniqueOrThrow({ where: { id: course.id }, select: { title: true } });
+    expect(persisted.title).toBe(newTitle);
+    // The audit was recorded on the transaction client (2nd arg present).
+    expect(recordAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "course_updated", entityId: course.id }),
+      expect.anything(),
+    );
+  });
+});

--- a/test/m2-manual-review-concurrency.test.ts
+++ b/test/m2-manual-review-concurrency.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { prisma } from "../src/db/prisma.js";
+import { manualReviewRepository } from "../src/modules/review/manualReviewRepository.js";
+
+// #791: manual-review claim + override transitions are guarded updateMany calls, so under real concurrency
+// exactly one of two racing operations affects a row (the loser gets count 0 → ConflictError). This
+// prevents the duplicate owner / duplicate MANUAL_OVERRIDE decisions the check-then-act version allowed.
+async function seedReview(reviewerId: string | null) {
+  const mv = await prisma.moduleVersion.findFirstOrThrow({ select: { id: true, moduleId: true } });
+  const user = await prisma.user.create({
+    data: { externalId: `mr-conc-${Date.now()}-${Math.random()}`, name: "S", email: `mr-${Date.now()}-${Math.random()}@x.test` },
+    select: { id: true },
+  });
+  const submission = await prisma.submission.create({
+    data: { userId: user.id, moduleId: mv.moduleId, moduleVersionId: mv.id, deliveryType: "text" },
+    select: { id: true },
+  });
+  const review = await prisma.manualReview.create({
+    data: { submissionId: submission.id, triggerReason: "concurrency test", reviewStatus: "IN_REVIEW", reviewerId },
+    select: { id: true },
+  });
+  return review.id;
+}
+
+async function makeReviewer(tag: string) {
+  const u = await prisma.user.create({
+    data: { externalId: `mr-r-${tag}-${Date.now()}-${Math.random()}`, name: tag, email: `r-${tag}-${Date.now()}-${Math.random()}@x.test` },
+    select: { id: true },
+  });
+  return u.id;
+}
+
+describe("manual review transition concurrency (#791)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("two concurrent claims: exactly one wins", async () => {
+    const reviewId = await seedReview(null);
+    const a = await makeReviewer("A");
+    const b = await makeReviewer("B");
+
+    const results = await Promise.all([
+      manualReviewRepository.markManualReviewClaimedGuarded(reviewId, a, "IN_REVIEW", false),
+      manualReviewRepository.markManualReviewClaimedGuarded(reviewId, b, "IN_REVIEW", false),
+    ]);
+
+    expect(results.filter((r) => r.count === 1)).toHaveLength(1);
+    expect(results.filter((r) => r.count === 0)).toHaveLength(1);
+    const review = await prisma.manualReview.findUniqueOrThrow({ where: { id: reviewId }, select: { reviewerId: true } });
+    expect([a, b]).toContain(review.reviewerId);
+  });
+
+  it("two concurrent overrides: exactly one wins, resolved once", async () => {
+    const reviewer = await makeReviewer("R");
+    const reviewId = await seedReview(reviewer);
+    const now = new Date();
+
+    const results = await Promise.all([
+      manualReviewRepository.resolveManualReviewGuarded({ reviewId, reviewerId: reviewer, reviewStatus: "RESOLVED", reviewedAt: now, overrideDecision: "PASS", overrideReason: "a", allowTakeover: false }),
+      manualReviewRepository.resolveManualReviewGuarded({ reviewId, reviewerId: reviewer, reviewStatus: "RESOLVED", reviewedAt: now, overrideDecision: "FAIL", overrideReason: "b", allowTakeover: false }),
+    ]);
+
+    expect(results.filter((r) => r.count === 1)).toHaveLength(1);
+    expect(results.filter((r) => r.count === 0)).toHaveLength(1);
+    const review = await prisma.manualReview.findUniqueOrThrow({ where: { id: reviewId }, select: { reviewStatus: true } });
+    expect(review.reviewStatus).toBe("RESOLVED");
+  });
+});

--- a/test/m2-mcq-concurrency.test.ts
+++ b/test/m2-mcq-concurrency.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { prisma } from "../src/db/prisma.js";
+import { mcqRepository } from "../src/modules/assessment/mcqRepository.js";
+
+// #794: MCQ finalization is guarded (completeAttemptGuarded only completes an OPEN attempt) and responses
+// are unique per (attempt, question). This proves the DB invariants under real concurrency.
+async function seedOpenAttempt() {
+  const mv = await prisma.moduleVersion.findFirstOrThrow({ select: { id: true, moduleId: true } });
+  const setVersion = await prisma.mCQSetVersion.findFirstOrThrow({ select: { id: true } });
+  const user = await prisma.user.create({
+    data: { externalId: `mcq-${Date.now()}-${Math.random()}`, name: "S", email: `mcq-${Date.now()}-${Math.random()}@x.test` },
+    select: { id: true },
+  });
+  const submission = await prisma.submission.create({
+    data: { userId: user.id, moduleId: mv.moduleId, moduleVersionId: mv.id, deliveryType: "text" },
+    select: { id: true },
+  });
+  const attempt = await prisma.mCQAttempt.create({
+    data: { submissionId: submission.id, mcqSetVersionId: setVersion.id, startedAt: new Date() },
+    select: { id: true },
+  });
+  return attempt.id;
+}
+
+const scores = { completedAt: new Date(), rawScore: 1, percentScore: 50, scaledScore: 5, passFailMcq: true };
+
+describe("MCQ finalization concurrency (#794)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("two concurrent finalizations: exactly one completes the attempt", async () => {
+    const attemptId = await seedOpenAttempt();
+
+    const results = await Promise.all([
+      mcqRepository.completeAttemptGuarded({ attemptId, ...scores }),
+      mcqRepository.completeAttemptGuarded({ attemptId, ...scores }),
+    ]);
+
+    expect(results.filter((r) => r.count === 1)).toHaveLength(1);
+    expect(results.filter((r) => r.count === 0)).toHaveLength(1);
+    expect((await prisma.mCQAttempt.findUniqueOrThrow({ where: { id: attemptId } })).completedAt).not.toBeNull();
+  });
+
+  it("the DB rejects a duplicate response for the same (attempt, question)", async () => {
+    const attemptId = await seedOpenAttempt();
+    const question = await prisma.mCQQuestion.findFirstOrThrow({ select: { id: true } });
+    await prisma.mCQResponse.create({ data: { mcqAttemptId: attemptId, questionId: question.id, selectedAnswer: "a", isCorrect: true } });
+
+    await expect(
+      prisma.mCQResponse.create({ data: { mcqAttemptId: attemptId, questionId: question.id, selectedAnswer: "b", isCorrect: false } }),
+    ).rejects.toMatchObject({ code: "P2002" });
+  });
+});

--- a/test/unit/admin-content-service.test.ts
+++ b/test/unit/admin-content-service.test.ts
@@ -136,7 +136,7 @@ describe("admin content service", () => {
         validFrom: "2026-03-01T00:00:00.000Z",
         validTo: "2027-03-01T00:00:00.000Z",
       },
-    });
+    }, expect.anything());
     expect(result).toEqual({
       id: "module-1",
       title: "Module One",
@@ -346,7 +346,7 @@ describe("admin content service", () => {
         moduleId: "module-1",
         title: "Module One",
       },
-    });
+    }, expect.anything());
     expect(result).toEqual({
       id: "module-1",
       title: "Module One",
@@ -471,7 +471,7 @@ describe("admin content service", () => {
         benchmarkExampleCount: 1,
         versionNo: 5,
       },
-    });
+    }, expect.anything());
     expect(result).toEqual({
       id: "prompt-5",
       moduleId: "module-1",
@@ -519,7 +519,7 @@ describe("admin content service", () => {
         previousActiveVersionId: "module-version-2",
         publishedAt: "2026-03-11T12:30:00.000Z",
       },
-    });
+    }, expect.anything());
     expect(result).toEqual({
       id: "module-version-3",
       moduleId: "module-1",

--- a/test/unit/appeal-repository.test.ts
+++ b/test/unit/appeal-repository.test.ts
@@ -29,19 +29,21 @@ describe("appeal repository", () => {
     });
   });
 
-  it("updates an appeal to resolved state with the expected payload", async () => {
-    const update = vi.fn().mockResolvedValue({ id: "appeal-1" });
+  it("#790: resolves via a guarded updateMany that encodes the preconditions (non-admin)", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
     const repository = createAppealRepository({
-      appeal: {
-        update,
-      },
+      appeal: { updateMany },
     } as never);
     const resolvedAt = new Date("2026-03-11T07:00:00.000Z");
 
-    await repository.markAppealResolved("appeal-1", "handler-1", resolvedAt, "Resolved after review.");
+    await repository.markAppealResolvedGuarded("appeal-1", "handler-1", resolvedAt, "Resolved after review.", false);
 
-    expect(update).toHaveBeenCalledWith({
-      where: { id: "appeal-1" },
+    expect(updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "appeal-1",
+        appealStatus: { notIn: ["RESOLVED", "REJECTED", "SUPERSEDED"] },
+        OR: [{ resolvedById: null }, { resolvedById: "handler-1" }],
+      },
       data: {
         appealStatus: "RESOLVED",
         resolvedAt,
@@ -49,5 +51,18 @@ describe("appeal repository", () => {
         resolutionNote: "Resolved after review.",
       },
     });
+  });
+
+  it("#790: admin takeover drops the ownership precondition from the guard", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const repository = createAppealRepository({ appeal: { updateMany } } as never);
+
+    await repository.markAppealResolvedGuarded("appeal-1", "admin-1", new Date(), "note", true);
+
+    expect(updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "appeal-1", appealStatus: { notIn: ["RESOLVED", "REJECTED", "SUPERSEDED"] } },
+      }),
+    );
   });
 });

--- a/test/unit/appeal-service.test.ts
+++ b/test/unit/appeal-service.test.ts
@@ -11,9 +11,10 @@ const createAppeal = vi.fn();
 const updateSubmissionStatus = vi.fn();
 const findUserNotificationRecipient = vi.fn();
 const findAppealForClaim = vi.fn();
-const markAppealInReview = vi.fn();
+const markAppealInReviewGuarded = vi.fn();
 const findAppealForResolution = vi.fn();
-const markAppealResolved = vi.fn();
+const markAppealResolvedGuarded = vi.fn();
+const findAppealById = vi.fn();
 const recordAuditEvent = vi.fn();
 const notifyAppealStatusTransition = vi.fn();
 const logOperationalEvent = vi.fn();
@@ -31,13 +32,14 @@ vi.mock("../../src/modules/appeal/appealRepository.js", () => ({
     supersedeMany,
     findUserNotificationRecipient,
     findAppealForClaim,
-    markAppealInReview,
+    markAppealInReviewGuarded,
     findAppealForResolution,
   },
   createAppealRepository: () => ({
     createAppeal,
     updateSubmissionStatus,
-    markAppealResolved,
+    markAppealResolvedGuarded,
+    findAppealById,
     findOpenByUserAndModule,
     supersedeMany,
   }),
@@ -69,9 +71,10 @@ describe("appeal service", () => {
     updateSubmissionStatus.mockReset();
     findUserNotificationRecipient.mockReset();
     findAppealForClaim.mockReset();
-    markAppealInReview.mockReset();
+    markAppealInReviewGuarded.mockReset();
     findAppealForResolution.mockReset();
-    markAppealResolved.mockReset();
+    markAppealResolvedGuarded.mockReset();
+    findAppealById.mockReset();
     recordAuditEvent.mockReset();
     notifyAppealStatusTransition.mockReset();
     logOperationalEvent.mockReset();
@@ -201,7 +204,7 @@ describe("appeal service", () => {
       code: "appeal_already_assigned",
     });
 
-    expect(markAppealInReview).not.toHaveBeenCalled();
+    expect(markAppealInReviewGuarded).not.toHaveBeenCalled();
   });
 
   it("resolves an appeal by creating a new immutable decision and completing the submission", async () => {
@@ -236,7 +239,8 @@ describe("appeal service", () => {
       passFailTotal: true,
       decisionType: DecisionType.APPEAL_RESOLUTION,
     });
-    markAppealResolved.mockResolvedValue({
+    markAppealResolvedGuarded.mockResolvedValue({ count: 1 });
+    findAppealById.mockResolvedValue({
       id: "appeal-1",
       appealStatus: AppealStatus.RESOLVED,
     });
@@ -264,11 +268,12 @@ describe("appeal service", () => {
       }),
       expect.anything(),
     );
-    expect(markAppealResolved).toHaveBeenCalledWith(
+    expect(markAppealResolvedGuarded).toHaveBeenCalledWith(
       "appeal-1",
       "handler-1",
       expect.any(Date),
       "Resolved after human review.",
+      false,
     );
     expect(recordAuditEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -316,7 +321,7 @@ describe("appeal service", () => {
     await expect(claimAppeal("appeal-1", "handler-1")).rejects.toMatchObject({
       code: "appeal_already_resolved",
     });
-    expect(markAppealInReview).not.toHaveBeenCalled();
+    expect(markAppealInReviewGuarded).not.toHaveBeenCalled();
   });
 
   it("supersedes open appeals for a user+module", async () => {

--- a/test/unit/assessment-evaluator.test.ts
+++ b/test/unit/assessment-evaluator.test.ts
@@ -28,8 +28,15 @@ const recordAuditEvent = vi.fn();
 const logOperationalEvent = vi.fn();
 const sha256 = vi.fn(() => "hash");
 
-vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => ({
-  assessmentJobRepository: { createLlmEvaluation },
+vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => {
+  const repo = { createLlmEvaluation };
+  // #803: createLlmEvaluation + its audit now run inside runInTransaction via createAssessmentJobRepository(tx).
+  return { assessmentJobRepository: repo, createAssessmentJobRepository: () => repo };
+});
+
+// #803: run the transaction callback inline with a throwaway tx client.
+vi.mock("../../src/db/transaction.js", () => ({
+  runInTransaction: (cb: (tx: unknown) => unknown) => cb({}),
 }));
 
 vi.mock("../../src/modules/assessment/llmAssessmentService.js", () => ({

--- a/test/unit/assessment-job-runner.test.ts
+++ b/test/unit/assessment-job-runner.test.ts
@@ -4,6 +4,7 @@ const findNextRunnableJob = vi.fn();
 const tryLockPendingJob = vi.fn();
 const markJobSucceeded = vi.fn();
 const markJobForRetryOrFailure = vi.fn();
+const renewLease = vi.fn();
 const findAssessmentJobOrThrow = vi.fn();
 const findPendingOrRunningJobForSubmission = vi.fn();
 const findPendingOrRunningJobIdForSubmission = vi.fn();
@@ -21,6 +22,7 @@ vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => ({
     tryLockPendingJob,
     markJobSucceeded,
     markJobForRetryOrFailure,
+    renewLease,
     findAssessmentJobOrThrow,
     findPendingOrRunningJobForSubmission,
     findPendingOrRunningJobIdForSubmission,
@@ -46,7 +48,13 @@ describe("AssessmentJobRunner", () => {
     findNextRunnableJob.mockReset();
     tryLockPendingJob.mockReset();
     markJobSucceeded.mockReset();
+    // #792: terminal writes are now fenced updateMany calls returning { count }. Default to the winning
+    // case so the existing behavioural tests exercise the normal (lease-held) path.
+    markJobSucceeded.mockResolvedValue({ count: 1 });
     markJobForRetryOrFailure.mockReset();
+    markJobForRetryOrFailure.mockResolvedValue({ count: 1 });
+    renewLease.mockReset();
+    renewLease.mockResolvedValue({ count: 1 });
     findAssessmentJobOrThrow.mockReset();
     findPendingOrRunningJobForSubmission.mockReset();
     findPendingOrRunningJobIdForSubmission.mockReset();
@@ -90,7 +98,7 @@ describe("AssessmentJobRunner", () => {
     it("returns true and marks job succeeded when runAssessment succeeds", async () => {
       findNextRunnableJob.mockResolvedValue({ id: "job-1", submissionId: "sub-1" });
       tryLockPendingJob.mockResolvedValue({ count: 1 });
-      markJobSucceeded.mockResolvedValue(undefined);
+      markJobSucceeded.mockResolvedValue({ count: 1 });
       const { processNextJob } = await import("../../src/modules/assessment/AssessmentJobRunner.js");
       const runAssessment = vi.fn().mockResolvedValue(undefined);
 
@@ -98,7 +106,8 @@ describe("AssessmentJobRunner", () => {
 
       expect(result).toBe(true);
       expect(runAssessment).toHaveBeenCalledWith("job-1");
-      expect(markJobSucceeded).toHaveBeenCalledWith("job-1");
+      // #792: fenced terminal write — job id + the lock owner + the lock timestamp.
+      expect(markJobSucceeded).toHaveBeenCalledWith("job-1", expect.any(String), expect.any(Date));
     });
 
     it("schedules retry when runAssessment fails and attempts < maxAttempts", async () => {
@@ -110,7 +119,7 @@ describe("AssessmentJobRunner", () => {
         maxAttempts: 3,
         availableAt: new Date(),
       });
-      markJobForRetryOrFailure.mockResolvedValue(undefined);
+      markJobForRetryOrFailure.mockResolvedValue({ count: 1 });
       const { processNextJob } = await import("../../src/modules/assessment/AssessmentJobRunner.js");
       const runAssessment = vi.fn().mockRejectedValue(new Error("LLM timeout"));
 
@@ -119,6 +128,8 @@ describe("AssessmentJobRunner", () => {
       expect(result).toBe(true);
       expect(markJobForRetryOrFailure).toHaveBeenCalledWith(
         "job-1",
+        expect.any(String),
+        expect.any(Date),
         expect.objectContaining({ status: "PENDING" }),
       );
       expect(recordAuditEvent).toHaveBeenCalledWith(
@@ -135,7 +146,7 @@ describe("AssessmentJobRunner", () => {
         maxAttempts: 3,
         availableAt: new Date(),
       });
-      markJobForRetryOrFailure.mockResolvedValue(undefined);
+      markJobForRetryOrFailure.mockResolvedValue({ count: 1 });
       const { processNextJob } = await import("../../src/modules/assessment/AssessmentJobRunner.js");
       const runAssessment = vi.fn().mockRejectedValue(new Error("Persistent error"));
 
@@ -143,6 +154,8 @@ describe("AssessmentJobRunner", () => {
 
       expect(markJobForRetryOrFailure).toHaveBeenCalledWith(
         "job-1",
+        expect.any(String),
+        expect.any(Date),
         expect.objectContaining({ status: "FAILED" }),
       );
       expect(recordAuditEvent).toHaveBeenCalledWith(

--- a/test/unit/assessment-job-runner.test.ts
+++ b/test/unit/assessment-job-runner.test.ts
@@ -16,8 +16,8 @@ const findLongRunningJobs = vi.fn();
 const recordAuditEvent = vi.fn();
 const logOperationalEvent = vi.fn();
 
-vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => ({
-  assessmentJobRepository: {
+vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => {
+  const repo = {
     findNextRunnableJob,
     tryLockPendingJob,
     markJobSucceeded,
@@ -31,7 +31,15 @@ vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => ({
     findExpiredRunningJobs,
     resetExpiredJob,
     findLongRunningJobs,
-  },
+  };
+  // #803: audit writes now run inside runInTransaction via createAssessmentJobRepository(tx). The
+  // factory returns the same mock methods so tx-scoped calls hit the same spies.
+  return { assessmentJobRepository: repo, createAssessmentJobRepository: () => repo };
+});
+
+// #803: run the transaction callback inline with a throwaway tx client.
+vi.mock("../../src/db/transaction.js", () => ({
+  runInTransaction: (cb: (tx: unknown) => unknown) => cb({}),
 }));
 
 vi.mock("../../src/services/auditService.js", () => ({
@@ -134,6 +142,7 @@ describe("AssessmentJobRunner", () => {
       );
       expect(recordAuditEvent).toHaveBeenCalledWith(
         expect.objectContaining({ action: "assessment_job_retry_scheduled" }),
+        expect.anything(),
       );
     });
 
@@ -160,6 +169,7 @@ describe("AssessmentJobRunner", () => {
       );
       expect(recordAuditEvent).toHaveBeenCalledWith(
         expect.objectContaining({ action: "assessment_job_failed" }),
+        expect.anything(),
       );
     });
   });
@@ -190,6 +200,7 @@ describe("AssessmentJobRunner", () => {
       );
       expect(recordAuditEvent).toHaveBeenCalledWith(
         expect.objectContaining({ action: "assessment_job_enqueued" }),
+        expect.anything(),
       );
     });
   });

--- a/test/unit/assessment-job-service.test.ts
+++ b/test/unit/assessment-job-service.test.ts
@@ -178,7 +178,7 @@ describe("assessment job service traffic-light policy", () => {
       submission: buildSubmissionFixture(),
     });
     createLlmEvaluation.mockResolvedValue({ id: "llm-eval-1" });
-    markJobSucceeded.mockResolvedValue(undefined);
+    markJobSucceeded.mockResolvedValue({ count: 1 });
     countJobsByStatus.mockResolvedValue(0);
     createAssessmentDecision.mockResolvedValue({
       decision: { id: "decision-1" },

--- a/test/unit/assessment-job-service.test.ts
+++ b/test/unit/assessment-job-service.test.ts
@@ -14,8 +14,8 @@ const evaluatePracticalWithLlm = vi.fn();
 const recordAuditEvent = vi.fn();
 const logOperationalEvent = vi.fn();
 
-vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => ({
-  assessmentJobRepository: {
+vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => {
+  const repo = {
     findNextRunnableJob,
     tryLockPendingJob,
     findAssessmentJobWithSubmissionOrThrow,
@@ -28,7 +28,14 @@ vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => ({
     findExpiredRunningJobs: vi.fn().mockResolvedValue([]),
     resetExpiredJob: vi.fn().mockResolvedValue(undefined),
     findLongRunningJobs: vi.fn().mockResolvedValue([]),
-  },
+  };
+  // #803: createLlmEvaluation now runs inside runInTransaction via createAssessmentJobRepository(tx).
+  return { assessmentJobRepository: repo, createAssessmentJobRepository: () => repo };
+});
+
+// #803: run the transaction callback inline with a throwaway tx client.
+vi.mock("../../src/db/transaction.js", () => ({
+  runInTransaction: (cb: (tx: unknown) => unknown) => cb({}),
 }));
 
 vi.mock("../../src/modules/assessment/decisionService.js", () => ({

--- a/test/unit/manual-review-repository.test.ts
+++ b/test/unit/manual-review-repository.test.ts
@@ -27,22 +27,28 @@ describe("manual review repository", () => {
     const update = vi.fn().mockResolvedValue({ id: "review-1" });
     const repository = createManualReviewRepository({
       manualReview: {
-        update,
+        updateMany: update,
       },
     } as never);
     const reviewedAt = new Date("2026-03-11T09:00:00.000Z");
 
-    await repository.resolveManualReview({
+    await repository.resolveManualReviewGuarded({
       reviewId: "review-1",
       reviewerId: "reviewer-1",
       reviewStatus: "RESOLVED",
       reviewedAt,
       overrideDecision: "PASS",
       overrideReason: "Validated against rubric.",
+      allowTakeover: false,
     });
 
+    // #791: guarded updateMany with the precondition WHERE.
     expect(update).toHaveBeenCalledWith({
-      where: { id: "review-1" },
+      where: {
+        id: "review-1",
+        reviewStatus: { notIn: ["RESOLVED", "SUPERSEDED"] },
+        OR: [{ reviewerId: null }, { reviewerId: "reviewer-1" }],
+      },
       data: {
         reviewerId: "reviewer-1",
         reviewStatus: "RESOLVED",

--- a/test/unit/manual-review-service.test.ts
+++ b/test/unit/manual-review-service.test.ts
@@ -3,9 +3,10 @@ import { DecisionType, ReviewStatus } from "../../src/db/prismaRuntime.js";
 import { ConflictError, NotFoundError } from "../../src/errors/AppError.js";
 
 const findManualReviewForClaim = vi.fn();
-const markManualReviewClaimed = vi.fn();
+const markManualReviewClaimedGuarded = vi.fn();
 const findManualReviewForOverride = vi.fn();
-const resolveManualReview = vi.fn();
+const resolveManualReviewGuarded = vi.fn();
+const findManualReviewById = vi.fn();
 const findOpenByUserAndModule = vi.fn();
 const supersedeMany = vi.fn();
 const updateSubmissionStatus = vi.fn();
@@ -21,15 +22,17 @@ vi.mock("../../src/db/prisma.js", () => ({
 vi.mock("../../src/modules/review/manualReviewRepository.js", () => ({
   manualReviewRepository: {
     findManualReviewForClaim,
-    markManualReviewClaimed,
+    markManualReviewClaimedGuarded,
+    findManualReviewById,
     findManualReviewForOverride,
-    resolveManualReview,
+    resolveManualReviewGuarded,
     findOpenByUserAndModule,
     supersedeMany,
     updateSubmissionStatus,
   },
   createManualReviewRepository: () => ({
-    resolveManualReview,
+    resolveManualReviewGuarded,
+    findManualReviewById,
     findOpenByUserAndModule,
     supersedeMany,
     updateSubmissionStatus,
@@ -55,9 +58,12 @@ vi.mock("../../src/observability/operationalLog.js", () => ({
 describe("manual review service", () => {
   beforeEach(() => {
     findManualReviewForClaim.mockReset();
-    markManualReviewClaimed.mockReset();
+    markManualReviewClaimedGuarded.mockReset();
+    markManualReviewClaimedGuarded.mockResolvedValue({ count: 1 });
+    findManualReviewById.mockReset();
     findManualReviewForOverride.mockReset();
-    resolveManualReview.mockReset();
+    resolveManualReviewGuarded.mockReset();
+    resolveManualReviewGuarded.mockResolvedValue({ count: 1 });
     findOpenByUserAndModule.mockReset();
     supersedeMany.mockReset();
     updateSubmissionStatus.mockReset();
@@ -73,7 +79,7 @@ describe("manual review service", () => {
     const { claimManualReview } = await import("../../src/modules/review/manualReviewService.js");
 
     await expect(claimManualReview("review-1", "reviewer-1")).rejects.toBeInstanceOf(NotFoundError);
-    expect(markManualReviewClaimed).not.toHaveBeenCalled();
+    expect(markManualReviewClaimedGuarded).not.toHaveBeenCalled();
   });
 
   it("rejects claim when the manual review is already assigned to another reviewer", async () => {
@@ -89,7 +95,7 @@ describe("manual review service", () => {
     await expect(claimManualReview("review-1", "reviewer-1")).rejects.toMatchObject({
       code: "review_already_assigned",
     });
-    expect(markManualReviewClaimed).not.toHaveBeenCalled();
+    expect(markManualReviewClaimedGuarded).not.toHaveBeenCalled();
   });
 
   it("rejects override when the submission has no decision yet", async () => {
@@ -132,7 +138,7 @@ describe("manual review service", () => {
     await expect(claimManualReview("review-1", "reviewer-1")).rejects.toMatchObject({
       code: "review_already_resolved",
     });
-    expect(markManualReviewClaimed).not.toHaveBeenCalled();
+    expect(markManualReviewClaimedGuarded).not.toHaveBeenCalled();
   });
 
   it("creates an override decision and resolves the review", async () => {
@@ -167,7 +173,8 @@ describe("manual review service", () => {
       passFailTotal: false,
       decisionType: DecisionType.MANUAL_OVERRIDE,
     });
-    resolveManualReview.mockResolvedValue({
+    resolveManualReviewGuarded.mockResolvedValue({ count: 1 });
+    findManualReviewById.mockResolvedValue({
       id: "review-1",
       reviewStatus: ReviewStatus.RESOLVED,
       overrideDecision: "FAIL",
@@ -195,13 +202,14 @@ describe("manual review service", () => {
       }),
       expect.anything(),
     );
-    expect(resolveManualReview).toHaveBeenCalledWith({
+    expect(resolveManualReviewGuarded).toHaveBeenCalledWith({
       reviewId: "review-1",
       reviewerId: "reviewer-1",
       reviewStatus: ReviewStatus.RESOLVED,
       reviewedAt: expect.any(Date),
       overrideDecision: "FAIL",
       overrideReason: "Human reviewer found the response insufficient.",
+      allowTakeover: false,
     });
     expect(recordAuditEvent).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/test/unit/mcq-service.test.ts
+++ b/test/unit/mcq-service.test.ts
@@ -11,28 +11,37 @@ const findActiveQuestionsForSet = vi.fn();
 const findAttemptForSubmission = vi.fn();
 const deleteResponsesForAttempt = vi.fn();
 const createResponses = vi.fn();
-const completeAttempt = vi.fn();
-const updateSubmissionStatus = vi.fn();
+const completeAttemptGuarded = vi.fn();
+const findAttemptById = vi.fn();
+const submissionUpdate = vi.fn();
 const enqueueAssessmentJobMock = vi.fn();
 const recordAuditEvent = vi.fn();
 
+const mcqRepoWrites = {
+  findSubmissionForModuleMcq,
+  findOpenAttemptForSubmission,
+  createAttempt,
+  findActiveQuestionsForSet,
+  findAttemptForSubmission,
+  deleteResponsesForAttempt,
+  createResponses,
+  completeAttemptGuarded,
+  findAttemptById,
+};
+
 vi.mock("../../src/modules/assessment/mcqRepository.js", () => ({
-  mcqRepository: {
-    findSubmissionForModuleMcq,
-    findOpenAttemptForSubmission,
-    createAttempt,
-    findActiveQuestionsForSet,
-    findAttemptForSubmission,
-    deleteResponsesForAttempt,
-    createResponses,
-    completeAttempt,
-  },
+  mcqRepository: mcqRepoWrites,
+  // #794: the finalization now runs through createMcqRepository(tx); return the same mocked writes.
+  createMcqRepository: () => mcqRepoWrites,
+}));
+
+// #794: the transaction wrapper — run the callback with a tx exposing submission.update.
+vi.mock("../../src/db/transaction.js", () => ({
+  runInTransaction: (cb: (tx: unknown) => unknown) => cb({ submission: { update: submissionUpdate } }),
 }));
 
 vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => ({
-  assessmentJobRepository: {
-    updateSubmissionStatus,
-  },
+  assessmentJobRepository: {},
 }));
 
 vi.mock("../../src/modules/assessment/assessmentJobService.js", () => ({
@@ -77,8 +86,9 @@ describe("mcq service — submitMcqAttempt", () => {
     findActiveQuestionsForSet.mockReset();
     deleteResponsesForAttempt.mockReset();
     createResponses.mockReset();
-    completeAttempt.mockReset();
-    updateSubmissionStatus.mockReset();
+    completeAttemptGuarded.mockReset();
+    findAttemptById.mockReset();
+    submissionUpdate.mockReset();
     enqueueAssessmentJobMock.mockReset();
     recordAuditEvent.mockReset();
 
@@ -87,10 +97,9 @@ describe("mcq service — submitMcqAttempt", () => {
     findActiveQuestionsForSet.mockResolvedValue(baseQuestions);
     deleteResponsesForAttempt.mockResolvedValue(undefined);
     createResponses.mockResolvedValue(undefined);
-    completeAttempt.mockImplementation(({ attemptId }) =>
-      Promise.resolve({ id: attemptId }),
-    );
-    updateSubmissionStatus.mockResolvedValue(undefined);
+    completeAttemptGuarded.mockResolvedValue({ count: 1 });
+    findAttemptById.mockImplementation((attemptId: string) => Promise.resolve({ id: attemptId }));
+    submissionUpdate.mockResolvedValue(undefined);
     enqueueAssessmentJobMock.mockResolvedValue(undefined);
     recordAuditEvent.mockResolvedValue(undefined);
   });

--- a/test/unit/stale-lock-recovery.test.ts
+++ b/test/unit/stale-lock-recovery.test.ts
@@ -20,8 +20,8 @@ const findLongRunningJobs = vi.fn();
 const recordAuditEvent = vi.fn();
 const logOperationalEvent = vi.fn();
 
-vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => ({
-  assessmentJobRepository: {
+vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => {
+  const repo = {
     findNextRunnableJob,
     tryLockPendingJob,
     markJobSucceeded,
@@ -34,7 +34,15 @@ vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => ({
     findPendingOrRunningJobForSubmission: vi.fn(),
     findPendingOrRunningJobIdForSubmission: vi.fn(),
     createAssessmentJob: vi.fn(),
-  },
+  };
+  // #803: stale-lock reset + retry/failure terminal writes now run inside runInTransaction via
+  // createAssessmentJobRepository(tx); the factory returns the same mock spies.
+  return { assessmentJobRepository: repo, createAssessmentJobRepository: () => repo };
+});
+
+// #803: run the transaction callback inline with a throwaway tx client.
+vi.mock("../../src/db/transaction.js", () => ({
+  runInTransaction: (cb: (tx: unknown) => unknown) => cb({}),
 }));
 
 vi.mock("../../src/services/auditService.js", () => ({ recordAuditEvent }));
@@ -93,6 +101,7 @@ describe("stale-lock recovery path", () => {
         entityId: "job-1",
         action: "assessment_job_stale_lock_reset",
       }),
+      expect.anything(),
     );
 
     // Runner then picked up and completed the (now-PENDING) job
@@ -120,6 +129,7 @@ describe("stale-lock recovery path", () => {
     );
     expect(recordAuditEvent).toHaveBeenCalledWith(
       expect.objectContaining({ action: "assessment_job_stale_lock_failed" }),
+      expect.anything(),
     );
     expect(runAssessment).not.toHaveBeenCalled();
   });

--- a/test/unit/stale-lock-recovery.test.ts
+++ b/test/unit/stale-lock-recovery.test.ts
@@ -51,8 +51,8 @@ describe("stale-lock recovery path", () => {
     vi.resetModules();
     findNextRunnableJob.mockReset();
     tryLockPendingJob.mockReset();
-    markJobSucceeded.mockReset().mockResolvedValue(undefined);
-    markJobForRetryOrFailure.mockReset().mockResolvedValue(undefined);
+    markJobSucceeded.mockReset().mockResolvedValue({ count: 1 });
+    markJobForRetryOrFailure.mockReset().mockResolvedValue({ count: 1 });
     findAssessmentJobOrThrow.mockReset();
     countJobsByStatus.mockResolvedValue(0);
     findExpiredRunningJobs.mockReset();
@@ -97,7 +97,7 @@ describe("stale-lock recovery path", () => {
 
     // Runner then picked up and completed the (now-PENDING) job
     expect(runAssessment).toHaveBeenCalledWith("job-1");
-    expect(markJobSucceeded).toHaveBeenCalledWith("job-1");
+    expect(markJobSucceeded).toHaveBeenCalledWith("job-1", expect.any(String), expect.any(Date));
   });
 
   it("fails a stale job permanently when at max attempts and does not process it", async () => {
@@ -139,7 +139,7 @@ describe("stale-lock recovery path", () => {
 
     expect(resetExpiredJob).toHaveBeenCalledTimes(2);
     expect(runAssessment).toHaveBeenCalledWith("job-1");
-    expect(markJobSucceeded).toHaveBeenCalledWith("job-1");
+    expect(markJobSucceeded).toHaveBeenCalledWith("job-1", expect.any(String), expect.any(Date));
   });
 
   it("still processes a normal job when there are no stale jobs", async () => {
@@ -155,7 +155,7 @@ describe("stale-lock recovery path", () => {
     expect(result).toBe(true);
     expect(resetExpiredJob).not.toHaveBeenCalled();
     expect(runAssessment).toHaveBeenCalledWith("job-3");
-    expect(markJobSucceeded).toHaveBeenCalledWith("job-3");
+    expect(markJobSucceeded).toHaveBeenCalledWith("job-3", expect.any(String), expect.any(Date));
   });
 
   it("proceeds to run normal jobs even if the stale scanner itself throws", async () => {

--- a/test/unit/stale-lock-scanner.test.ts
+++ b/test/unit/stale-lock-scanner.test.ts
@@ -7,12 +7,15 @@ const logOperationalEvent = vi.fn();
 
 const findLongRunningJobs = vi.fn();
 
-vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => ({
-  assessmentJobRepository: {
-    findExpiredRunningJobs,
-    resetExpiredJob,
-    findLongRunningJobs,
-  },
+vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => {
+  const repo = { findExpiredRunningJobs, resetExpiredJob, findLongRunningJobs };
+  // #803: resetExpiredJob + its audit now run inside runInTransaction via createAssessmentJobRepository(tx).
+  return { assessmentJobRepository: repo, createAssessmentJobRepository: () => repo };
+});
+
+// #803: run the transaction callback inline with a throwaway tx client.
+vi.mock("../../src/db/transaction.js", () => ({
+  runInTransaction: (cb: (tx: unknown) => unknown) => cb({}),
 }));
 
 vi.mock("../../src/config/env.js", () => ({
@@ -73,6 +76,7 @@ describe("stale-lock scanner", () => {
         action: "assessment_job_stale_lock_reset",
         metadata: expect.objectContaining({ outcome: "PENDING" }),
       }),
+      expect.anything(),
     );
     expect(logOperationalEvent).toHaveBeenCalledWith(
       "assessment_job_stale_lock_detected",
@@ -100,6 +104,7 @@ describe("stale-lock scanner", () => {
         action: "assessment_job_stale_lock_failed",
         metadata: expect.objectContaining({ outcome: "FAILED" }),
       }),
+      expect.anything(),
     );
   });
 

--- a/test/unit/transactional-failure-injection.test.ts
+++ b/test/unit/transactional-failure-injection.test.ts
@@ -34,7 +34,8 @@ const notifyAssessmentResult = vi.fn();
 
 const findAppealForResolution = vi.fn();
 const createResolutionDecision = vi.fn();
-const markAppealResolved = vi.fn();
+const markAppealResolvedGuarded = vi.fn();
+const findAppealById = vi.fn();
 const appealSubmissionUpdate = vi.fn();
 const notifyAppealStatusTransition = vi.fn();
 
@@ -84,12 +85,14 @@ vi.mock("../../src/modules/appeal/appealRepository.js", () => ({
   appealRepository: {
     findAppealForResolution,
     createResolutionDecision,
-    markAppealResolved,
+    markAppealResolvedGuarded,
+    findAppealById,
     updateSubmissionStatus: appealSubmissionUpdate,
   },
   createAppealRepository: () => ({
     createResolutionDecision,
-    markAppealResolved,
+    markAppealResolvedGuarded,
+    findAppealById,
     updateSubmissionStatus: appealSubmissionUpdate,
   }),
 }));
@@ -243,7 +246,10 @@ describe("transactional failure injection", () => {
     notifyAssessmentResult.mockReset().mockResolvedValue(undefined);
     findAppealForResolution.mockReset();
     createResolutionDecision.mockReset();
-    markAppealResolved.mockReset();
+    markAppealResolvedGuarded.mockReset();
+    markAppealResolvedGuarded.mockResolvedValue({ count: 1 });
+    findAppealById.mockReset();
+    findAppealById.mockResolvedValue({ id: "appeal-1", appealStatus: AppealStatus.RESOLVED });
     appealSubmissionUpdate.mockReset();
     notifyAppealStatusTransition.mockReset().mockResolvedValue(undefined);
   });
@@ -436,7 +442,9 @@ describe("transactional failure injection", () => {
         }),
       ).rejects.toThrow("DB write failed");
 
-      expect(markAppealResolved).not.toHaveBeenCalled();
+      // #790: the guarded transition runs FIRST now; the later failure rolls the whole transaction back
+      // (nothing persists), but the guard call itself was made before the failure.
+      expect(markAppealResolvedGuarded).toHaveBeenCalled();
       expect(decisionSubmissionUpdate).not.toHaveBeenCalled();
       expect(upsertRecertificationStatusFromDecision).not.toHaveBeenCalled();
       expect(recordAuditEvent).not.toHaveBeenCalled();
@@ -451,7 +459,7 @@ describe("transactional failure injection", () => {
         decisionType: DecisionType.APPEAL_RESOLUTION,
       });
       decisionSubmissionUpdate.mockResolvedValue({ id: "submission-1" });
-      markAppealResolved.mockRejectedValue(new Error("Optimistic lock conflict"));
+      markAppealResolvedGuarded.mockRejectedValue(new Error("Optimistic lock conflict"));
 
       const { resolveAppeal } = await import("../../src/modules/appeal/appealService.js");
 
@@ -489,7 +497,9 @@ describe("transactional failure injection", () => {
         }),
       ).rejects.toThrow("Deadlock detected");
 
-      expect(markAppealResolved).not.toHaveBeenCalled();
+      // #790: the guarded transition runs FIRST now; the later failure rolls the whole transaction back
+      // (nothing persists), but the guard call itself was made before the failure.
+      expect(markAppealResolvedGuarded).toHaveBeenCalled();
       expect(upsertRecertificationStatusFromDecision).not.toHaveBeenCalled();
       expect(recordAuditEvent).not.toHaveBeenCalled();
       expect(notifyAppealStatusTransition).not.toHaveBeenCalled();
@@ -503,10 +513,6 @@ describe("transactional failure injection", () => {
         decisionType: DecisionType.APPEAL_RESOLUTION,
       });
       decisionSubmissionUpdate.mockResolvedValue({ id: "submission-1" });
-      markAppealResolved.mockResolvedValue({
-        id: "appeal-1",
-        appealStatus: AppealStatus.RESOLVED,
-      });
       notifyAppealStatusTransition.mockRejectedValue(new Error("webhook timeout"));
 
       const { resolveAppeal } = await import("../../src/modules/appeal/appealService.js");

--- a/test/unit/transactional-failure-injection.test.ts
+++ b/test/unit/transactional-failure-injection.test.ts
@@ -26,7 +26,8 @@ const decisionSubmissionUpdate = vi.fn();
 
 const findManualReviewForOverride = vi.fn();
 const createOverrideDecision = vi.fn();
-const resolveManualReview = vi.fn();
+const resolveManualReviewGuarded = vi.fn();
+const findManualReviewById = vi.fn();
 const manualReviewSubmissionUpdate = vi.fn();
 const notifyAssessmentResult = vi.fn();
 
@@ -71,12 +72,14 @@ vi.mock("../../src/modules/review/manualReviewRepository.js", () => ({
   manualReviewRepository: {
     findManualReviewForOverride,
     createOverrideDecision,
-    resolveManualReview,
+    resolveManualReviewGuarded,
+    findManualReviewById,
     updateSubmissionStatus: manualReviewSubmissionUpdate,
   },
   createManualReviewRepository: () => ({
     createOverrideDecision,
-    resolveManualReview,
+    resolveManualReviewGuarded,
+    findManualReviewById,
     updateSubmissionStatus: manualReviewSubmissionUpdate,
   }),
 }));
@@ -241,7 +244,10 @@ describe("transactional failure injection", () => {
     decisionSubmissionUpdate.mockReset();
     findManualReviewForOverride.mockReset();
     createOverrideDecision.mockReset();
-    resolveManualReview.mockReset();
+    resolveManualReviewGuarded.mockReset();
+    resolveManualReviewGuarded.mockResolvedValue({ count: 1 });
+    findManualReviewById.mockReset();
+    findManualReviewById.mockResolvedValue({ id: "review-1", reviewStatus: ReviewStatus.RESOLVED, overrideDecision: "PASS" });
     manualReviewSubmissionUpdate.mockReset();
     notifyAssessmentResult.mockReset().mockResolvedValue(undefined);
     findAppealForResolution.mockReset();
@@ -327,7 +333,8 @@ describe("transactional failure injection", () => {
         }),
       ).rejects.toThrow("DB write failed");
 
-      expect(resolveManualReview).not.toHaveBeenCalled();
+      // #791: the guarded transition runs FIRST; the later failure rolls the whole transaction back.
+      expect(resolveManualReviewGuarded).toHaveBeenCalled();
       expect(decisionSubmissionUpdate).not.toHaveBeenCalled();
       expect(upsertRecertificationStatusFromDecision).not.toHaveBeenCalled();
       expect(recordAuditEvent).not.toHaveBeenCalled();
@@ -342,7 +349,7 @@ describe("transactional failure injection", () => {
         decisionType: DecisionType.MANUAL_OVERRIDE,
       });
       decisionSubmissionUpdate.mockResolvedValue({ id: "submission-1" });
-      resolveManualReview.mockRejectedValue(new Error("Row locked by concurrent request"));
+      resolveManualReviewGuarded.mockRejectedValue(new Error("Row locked by concurrent request"));
 
       const { finalizeManualReviewOverride } = await import("../../src/modules/review/manualReviewService.js");
 
@@ -380,7 +387,8 @@ describe("transactional failure injection", () => {
         }),
       ).rejects.toThrow("FK constraint violation");
 
-      expect(resolveManualReview).not.toHaveBeenCalled();
+      // #791: the guarded transition runs FIRST; the later failure rolls the whole transaction back.
+      expect(resolveManualReviewGuarded).toHaveBeenCalled();
       expect(upsertRecertificationStatusFromDecision).not.toHaveBeenCalled();
       expect(recordAuditEvent).not.toHaveBeenCalled();
       expect(notifyAssessmentResult).not.toHaveBeenCalled();
@@ -394,11 +402,6 @@ describe("transactional failure injection", () => {
         decisionType: DecisionType.MANUAL_OVERRIDE,
       });
       decisionSubmissionUpdate.mockResolvedValue({ id: "submission-1" });
-      resolveManualReview.mockResolvedValue({
-        id: "review-1",
-        reviewStatus: ReviewStatus.RESOLVED,
-        overrideDecision: "PASS",
-      });
       notifyAssessmentResult.mockRejectedValue(new Error("webhook unreachable"));
 
       const { finalizeManualReviewOverride } = await import("../../src/modules/review/manualReviewService.js");


### PR DESCRIPTION
## M5 concurrency & atomicity cluster (option 2) → 2.3.0

Eliminates lost-update races and audit/state divergence across the claim, assessment-job, MCQ, and mutation paths. **Seven issues, each with a real-Postgres concurrency/atomicity proof test.**

| Issue | Fix |
|---|---|
| **#790** | Appeal claim/resolve → guarded `updateMany` (loser gets `count 0` → `ConflictError`); no duplicate resolutions |
| **#791** | Manual-review claim/override → same guarded pattern |
| **#793** | One active assessment job per submission (partial unique index); enqueue catches P2002 → returns winner |
| **#792** | Assessment-job lease fencing on `(id, status:RUNNING, lockedBy, lockedAt)` + heartbeat renewal; lost lease skips terminal write |
| **#794** | Atomic guarded MCQ finalization + `@@unique([mcqAttemptId, questionId])` |
| **#803** | `recordAuditEvent` commits in the SAME transaction as the domain mutation (~53 call sites) |

### Verification
- `tsc --noEmit` → 0
- Unit: **843/843**
- Integration (reset+seed, incl. the two new migrations): **414/414**
- New proofs: `test/m2-appeal-concurrency`, `m2-manual-review-concurrency`, `m2-assessment-enqueue-concurrency`, `m2-assessment-lease-fencing`, `m2-mcq-concurrency`, `m2-audit-transactional`

### Migrations (additive)
- `20260724130000_assessment_job_active_unique` — dedup active jobs + partial unique index
- `20260724140000_mcq_response_unique` — dedup responses + `MCQResponse(mcqAttemptId, questionId)` unique

### Scope notes
- **#803** wraps DB mutation + audit only; non-DB I/O (email, enqueue, blob reclaim, logging) stays outside; audit-only events (login/notification-sent/run-summary) intentionally unwrapped.
- **Deferred to its own arc: #796** (content-import atomicity — needs idempotent ImportRun, blob staging, full graph in one transaction). The import audit sites + fire-and-forget completion-path tx forwarding go with it.

No infra/Bicep/workflow changes → code-only deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
