### PR TITLE
fix(#856): bound assessment-job runtime so a stuck job can't wedge the worker → 2.3.1

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,29 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.3.1 - 2026-07-25
+
+#856 — assessment-job heartbeat wedge hardening (follow-up to #792). The 2.3.0 stage deploy's smoke test
+failed on a wedged worker: a single leftover assessment job sat RUNNING for ~14 min with the #792 lease
+heartbeat renewing its lease forever, so the stale-lock scanner could never reclaim it (before #792 the
+lease would have expired → reset → retry). The `assessmentWorker` monitor tick ran past its 60 s wedge
+window → `/healthz` 503. A manual worker restart cleared it (not systemic — a leftover job, most likely a
+DB lock-wait against a zombie connection from the killed prior container, NOT the LLM, which self-aborts
+at `AZURE_OPENAI_TIMEOUT_MS`). Hardening so this self-recovers instead of failing deploys:
+
+- **Per-job runtime deadline** (`ASSESSMENT_JOB_MAX_RUNTIME_MS`, default 300 s). The runner races
+  `runAssessment` against the deadline; on timeout it abandons the run and takes the fenced failure path
+  (retry/fail), so the poll tick returns instead of wedging. Set above the worst-case legit assessment
+  (primary + secondary LLM ≈ 2 × `AZURE_OPENAI_TIMEOUT_MS`). Residual: the abandoned run cannot be
+  cancelled, so if it later completes it may write a duplicate decision — narrow (job must exceed 300 s
+  AND then succeed); tracked in #856.
+- **Wedge window decoupled from poll interval.** `MonitorHealthSnapshot.maxTickMs` lets the assessment
+  worker declare its true max tick (job-runtime cap + grace) instead of deriving a 60 s window from its
+  4 s poll interval — so a legitimately slow assessment (up to ~240 s) is no longer falsely wedged.
+- **A running tick is never "stalled".** `evaluateWorkerHealth` now treats an in-flight tick within its
+  budget as healthy (was falling through to the stale check and mis-flagging a minutes-long job as
+  stalled once its last completed cycle aged past the stale window).
+
 ## 2.3.0 - 2026-07-25
 
 M5 concurrency & atomicity cluster (option 2) — eliminate lost-update races and audit/state divergence

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -128,6 +128,12 @@ const envSchema = z.object({
   ASSESSMENT_JOB_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(4000),
   ASSESSMENT_JOB_MAX_ATTEMPTS: z.coerce.number().int().positive().default(3),
   ASSESSMENT_JOB_LEASE_DURATION_MS: z.coerce.number().int().positive().default(300000),
+  // #856: hard wall-clock cap on a single job's in-process execution. The #792 lease heartbeat renews a
+  // running job's lease forever, so without this an in-process-stuck job (a DB lock-wait, not the LLM —
+  // that self-aborts at AZURE_OPENAI_TIMEOUT_MS) never returns and wedges the worker. Must exceed the
+  // worst-case legit assessment (primary + secondary LLM ≈ 2 × AZURE_OPENAI_TIMEOUT_MS + overhead). At
+  // the deadline the runner fails/retries the job (fenced) so the tick returns instead of wedging.
+  ASSESSMENT_JOB_MAX_RUNTIME_MS: z.coerce.number().int().positive().default(300000),
   ASSESSMENT_JOB_STUCK_THRESHOLD_MS: z.coerce.number().int().positive().default(600000),
   PARSER_WORKER_URL: z.preprocess(
     (value) => (typeof value === "string" && value.trim().length === 0 ? undefined : value),

--- a/src/modules/assessment/AssessmentJobRunner.ts
+++ b/src/modules/assessment/AssessmentJobRunner.ts
@@ -153,7 +153,17 @@ export async function processNextJob(runAssessment: AssessmentRunFn, submissionI
   heartbeat.unref?.();
 
   try {
-    await runAssessment(candidate.id);
+    // #856: bound the in-process runtime. #792's lease heartbeat renews the lease forever, so without a
+    // hard cap a stuck job (observed: a DB lock-wait against a zombie connection — NOT the LLM, which
+    // self-aborts at AZURE_OPENAI_TIMEOUT_MS) runs forever and wedges the worker's poll loop. On the
+    // deadline we abandon the run and fall into the failure path below (fenced retry), so the tick
+    // returns and the scanner/retry re-runs the job instead of it wedging. The deadline is set above the
+    // worst-case legit assessment (primary + secondary LLM ≈ 2 × AZURE_OPENAI_TIMEOUT_MS + overhead).
+    await runWithDeadline(
+      runAssessment(candidate.id),
+      env.ASSESSMENT_JOB_MAX_RUNTIME_MS,
+      `Assessment job ${candidate.id} exceeded the ${env.ASSESSMENT_JOB_MAX_RUNTIME_MS}ms runtime deadline (#856).`,
+    );
     const succeeded = await assessmentJobRepository.markJobSucceeded(candidate.id, WORKER_INSTANCE_ID, now);
     if (succeeded.count === 0) {
       logLeaseLost(candidate.id, candidate.submissionId, "success");
@@ -205,6 +215,21 @@ export async function processNextJob(runAssessment: AssessmentRunFn, submissionI
     await logQueueBacklog("worker_cycle", candidate.submissionId);
   }
   return true;
+}
+
+// #856: race a unit of work against a wall-clock deadline. If the deadline wins, reject (the caller
+// treats it as a job failure). The abandoned work keeps running to completion in the background — we
+// cannot cancel it — but its terminal job write is a no-op once the fence has moved on. The timer is
+// cleared as soon as the work settles so a fast job doesn't keep a pending timer alive.
+function runWithDeadline<T>(work: Promise<T>, deadlineMs: number, timeoutMessage: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(timeoutMessage)), deadlineMs);
+    timer.unref?.();
+  });
+  return Promise.race([work, deadline]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
 }
 
 // #792: the lease was reset + re-claimed by another worker before we could finalize — do not overwrite it.

--- a/src/modules/assessment/AssessmentWorker.ts
+++ b/src/modules/assessment/AssessmentWorker.ts
@@ -66,6 +66,11 @@ export class AssessmentWorker {
       tickStartedAt: this.tickStartedAt?.toISOString() ?? null,
       lastCycleAt: this.lastCycleAt?.toISOString() ?? null,
       lastError: null,
+      // #856: a tick spans a full job execution (up to a couple of LLM calls), so its wedge window is
+      // governed by the per-job runtime cap — NOT the 4 s poll interval. Sized above the cap so the
+      // runner's own deadline (which fails the job and returns the tick) fires first; wedge is the
+      // backstop for if that deadline mechanism itself breaks.
+      maxTickMs: env.ASSESSMENT_JOB_MAX_RUNTIME_MS + 60_000,
     };
   }
 

--- a/src/observability/workerHealth.ts
+++ b/src/observability/workerHealth.ts
@@ -28,6 +28,14 @@ export interface MonitorHealthSnapshot {
   lastCycleAt: string | null;
   /** Last error message, if the most recent tick failed. Informational — does not by itself mark unhealthy. */
   lastError: string | null;
+  /**
+   * #856: explicit upper bound on how long a SINGLE legitimate tick may run, overriding the
+   * interval-derived wedge window. The assessment worker's tick includes a full job execution (up to a
+   * couple of LLM calls), so its tolerable tick time is governed by the job runtime cap, NOT its 4 s
+   * poll interval. Omit for monitors whose tick is short relative to their interval (the default
+   * `intervalMs × wedgeFactor` window applies).
+   */
+  maxTickMs?: number;
 }
 
 export type MonitorHealthReason = "ok" | "disabled" | "wedged" | "stalled";
@@ -109,27 +117,37 @@ export function evaluateWorkerHealth(
       return { name: s.name, enabled: false, healthy: true, reason: "disabled", staleMs: null, runningMs: null };
     }
 
-    const wedgeWindow = Math.max(s.intervalMs * thresholds.wedgeFactor, thresholds.minWedgeFloorMs);
+    // #856: the wedge window is the monitor's explicit max-tick bound when given (the assessment worker's
+    // tick spans a full job execution, not its 4 s poll interval), else the interval-derived window.
+    const wedgeWindow = s.maxTickMs ?? Math.max(s.intervalMs * thresholds.wedgeFactor, thresholds.minWedgeFloorMs);
     const staleWindow = Math.max(s.intervalMs * thresholds.staleFactor, thresholds.minStaleFloorMs);
 
     const tickStartedMs = parseIso(s.tickStartedAt);
     const runningMs = s.running && tickStartedMs !== null ? nowMs - tickStartedMs : null;
-    if (runningMs !== null && runningMs > wedgeWindow) {
-      return { name: s.name, enabled: true, healthy: false, reason: "wedged", staleMs: null, runningMs };
+
+    // #856: a tick that is actively in flight is either wedged (running past its budget) or healthy
+    // (still working) — it is NOT "stalled". Only fall through to the stale check when idle; otherwise a
+    // long-but-legitimate job (running for minutes, so its lastCycleAt is old) would be mis-flagged
+    // stalled the moment it passes the stale window, even though the loop is plainly alive.
+    if (runningMs !== null) {
+      if (runningMs > wedgeWindow) {
+        return { name: s.name, enabled: true, healthy: false, reason: "wedged", staleMs: null, runningMs };
+      }
+      return { name: s.name, enabled: true, healthy: true, reason: "ok", staleMs: null, runningMs };
     }
 
-    // No success yet → measure from process start, and give it the (larger) startup grace: a monitor
-    // that has never completed a cycle is warming up, not stalled, until the process exceeds that grace.
-    // Once it HAS completed a cycle, the normal (tight) stale window applies.
+    // Idle (no tick in flight). No success yet → measure from process start, and give it the (larger)
+    // startup grace: a monitor that has never completed a cycle is warming up, not stalled, until the
+    // process exceeds that grace. Once it HAS completed a cycle, the normal (tight) stale window applies.
     const lastCycleMs = parseIso(s.lastCycleAt);
     const referenceMs = lastCycleMs ?? startMs;
     const effectiveStaleWindow = lastCycleMs === null ? Math.max(staleWindow, thresholds.startupGraceMs) : staleWindow;
     const staleMs = nowMs - referenceMs;
     if (staleMs > effectiveStaleWindow) {
-      return { name: s.name, enabled: true, healthy: false, reason: "stalled", staleMs, runningMs };
+      return { name: s.name, enabled: true, healthy: false, reason: "stalled", staleMs, runningMs: null };
     }
 
-    return { name: s.name, enabled: true, healthy: true, reason: "ok", staleMs, runningMs };
+    return { name: s.name, enabled: true, healthy: true, reason: "ok", staleMs, runningMs: null };
   });
 
   return {

--- a/test/unit/assessment-job-runner.test.ts
+++ b/test/unit/assessment-job-runner.test.ts
@@ -172,6 +172,39 @@ describe("AssessmentJobRunner", () => {
         expect.anything(),
       );
     });
+
+    // #856: a job whose runAssessment never returns within the runtime cap must NOT wedge the worker —
+    // the deadline fires, the tick takes the (fenced) failure path, and processNextJob returns.
+    it("fails a job that exceeds the runtime deadline instead of running forever", async () => {
+      const prev = process.env.ASSESSMENT_JOB_MAX_RUNTIME_MS;
+      process.env.ASSESSMENT_JOB_MAX_RUNTIME_MS = "30"; // 30ms deadline for the test
+      try {
+        vi.resetModules(); // re-read env so the tiny deadline takes effect
+        findNextRunnableJob.mockResolvedValue({ id: "job-slow", submissionId: "sub-slow" });
+        tryLockPendingJob.mockResolvedValue({ count: 1 });
+        findAssessmentJobOrThrow.mockResolvedValue({ id: "job-slow", attempts: 0, maxAttempts: 3, availableAt: new Date() });
+        markJobForRetryOrFailure.mockResolvedValue({ count: 1 });
+
+        const { processNextJob } = await import("../../src/modules/assessment/AssessmentJobRunner.js");
+        // runAssessment that never settles — only the deadline can end the tick.
+        const runAssessment = vi.fn(() => new Promise<void>(() => {}));
+
+        const result = await processNextJob(runAssessment);
+
+        expect(result).toBe(true);
+        // Deadline → failure path: retry scheduled (attempts 0 < max 3), never marked succeeded.
+        expect(markJobForRetryOrFailure).toHaveBeenCalledWith(
+          "job-slow",
+          expect.any(String),
+          expect.any(Date),
+          expect.objectContaining({ status: "PENDING" }),
+        );
+        expect(markJobSucceeded).not.toHaveBeenCalled();
+      } finally {
+        if (prev === undefined) delete process.env.ASSESSMENT_JOB_MAX_RUNTIME_MS;
+        else process.env.ASSESSMENT_JOB_MAX_RUNTIME_MS = prev;
+      }
+    });
   });
 
   describe("enqueueAssessmentJob", () => {

--- a/test/unit/worker-health.test.ts
+++ b/test/unit/worker-health.test.ts
@@ -141,6 +141,41 @@ describe("evaluateWorkerHealth (#809)", () => {
     expect(report.healthy).toBe(false);
     expect(report.monitors.find((m) => m.name === "stuck")?.healthy).toBe(false);
   });
+
+  // #856: the assessment worker's tick spans a full job execution, so `maxTickMs` overrides the tiny
+  // interval-derived wedge window (a 4 s poller would otherwise be "wedged" at 60 s).
+  it("maxTickMs: a long-but-legitimate tick within the job runtime cap is OK, not wedged", () => {
+    const report = evaluateWorkerHealth(
+      [snap({ intervalMs: 4_000, running: true, tickStartedAt: iso(200_000), maxTickMs: 360_000 })],
+      NOW,
+      START,
+    );
+    expect(report.healthy).toBe(true);
+    expect(report.monitors[0].reason).toBe("ok");
+    expect(report.monitors[0].runningMs).toBe(200_000);
+  });
+
+  it("maxTickMs: a tick running past the cap is wedged (backstop for a broken runtime deadline)", () => {
+    const report = evaluateWorkerHealth(
+      [snap({ intervalMs: 4_000, running: true, tickStartedAt: iso(400_000), maxTickMs: 360_000 })],
+      NOW,
+      START,
+    );
+    expect(report.healthy).toBe(false);
+    expect(report.monitors[0].reason).toBe("wedged");
+  });
+
+  // #856: an actively-running tick is never "stalled" — the loop is plainly alive. Before this, a job
+  // running for minutes (so lastCycleAt is old) fell through to the stale check and was mis-flagged.
+  it("an in-flight tick within budget is OK even when its last completed cycle is old (not stalled)", () => {
+    const report = evaluateWorkerHealth(
+      [snap({ intervalMs: 4_000, running: true, tickStartedAt: iso(120_000), lastCycleAt: iso(120_000), maxTickMs: 360_000 })],
+      NOW,
+      START,
+    );
+    expect(report.healthy).toBe(true);
+    expect(report.monitors[0].reason).toBe("ok");
+  });
 });
 
 // #809: the monitor's health() snapshot must expose the in-flight tick so a wedge is detectable.


### PR DESCRIPTION
## #856 — assessment-job heartbeat wedge hardening (→ 2.3.1)

Follow-up to #792. The 2.3.0 stage deploy's smoke test failed on a **wedged worker**: a single leftover assessment job sat `RUNNING` for ~14 min with the #792 lease heartbeat renewing its lease forever, so the stale-lock scanner could never reclaim it. The `assessmentWorker` monitor tick ran past its **60 s wedge window** → `/healthz` 503. A manual worker restart cleared it — **not systemic** (a leftover job, most likely a DB lock-wait against a zombie connection from the killed prior container; NOT the LLM, which self-aborts at `AZURE_OPENAI_TIMEOUT_MS`). 2.3.0 stage is healthy.

### Fix
1. **Per-job runtime deadline** (`ASSESSMENT_JOB_MAX_RUNTIME_MS`, default 300 s). The runner races `runAssessment` against the deadline; on timeout it abandons the run and takes the **fenced** failure path (retry/fail), so the poll tick returns instead of wedging. Sized above the worst-case legit assessment (primary + secondary LLM ≈ 2 × `AZURE_OPENAI_TIMEOUT_MS`).
2. **`MonitorHealthSnapshot.maxTickMs`** decouples the wedge window from the poll interval — the assessment worker's tick spans a full job execution, so a legit slow assessment (~240 s) is no longer falsely wedged by the 60 s (4 s poll × 3, floored) window.
3. **A running tick is never "stalled".** `evaluateWorkerHealth` treats an in-flight tick within budget as healthy (was falling through to the stale check and mis-flagging a minutes-long job once its last completed cycle aged out).

### Verification
- `tsc` 0; unit **847/847** (new: runtime-deadline failure path; `maxTickMs` override; running-within-budget-not-stalled). #809 worker-health tests still green.

### Residual (tracked in #856)
The abandoned run can't be cancelled, so if it later completes it may write a duplicate decision — narrow (job must exceed 300 s AND then succeed). Optional DB `statement_timeout`/`lock_timeout` (root-cause defense) left as a follow-up.

No infra/Bicep/workflow changes → code-only deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
