### PR TITLE
feat(#726,#795): idempotency-key + transactional outbox → 2.5.0

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,30 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.5.0 - 2026-07-25
+
+EPIC #779 durability batch, part 2 — retry-safe idempotency + a transactional outbox. Two additive
+migrations (IdempotencyKey, OutboxEvent); no change to existing behaviour unless the new header is sent.
+
+- **#726 — Idempotency-Key for create/import endpoints.** `POST /api/admin/content/{modules/import,
+  sections,courses}` accept an optional `Idempotency-Key` header. The first request for (userId, endpoint,
+  key) reserves a row, runs the handler, and stores the response; a replay with the same key + same body
+  returns the stored response without a second write; the same key + a different body is a 409
+  `idempotency_key_reuse`; an in-flight duplicate is a 409 `idempotency_in_progress`. Rows have a 24h TTL;
+  a failed request releases its reservation. No header → unchanged behaviour. (`src/middleware/idempotency.ts`.)
+- **#795 — transactional outbox for post-decision side effects.** Participant notification + course-
+  completion check were fire-and-forget after the assessment decision committed, so a crash after the job
+  was marked SUCCEEDED lost them with no retry. They are now enqueued as durable `OutboxEvent` rows
+  (awaited before SUCCEEDED), and a new `OutboxDeliveryWorker` leases pending rows and delivers them with
+  bounded exponential-backoff retries (fenced on lockedBy/lockedAt; the handlers are idempotent, so
+  re-delivery is safe). A failed enqueue now propagates so the job retries rather than silently dropping
+  the side effect. The worker is part of the worker role's health readiness (`#856` maxTickMs) and drains
+  on shutdown.
+
+Proof: `test/m2-idempotency` (replay / reuse-409 / no-key) + `test/m2-outbox` (enqueue persists;
+delivery marks delivered; failing delivery retries then fails after maxAttempts), both real Postgres.
+tsc 0; unit 847/847; full integration 424/424. Completes the #779 durability batch (#796 shipped in 2.4.0).
+
 ## 2.4.0 - 2026-07-25
 
 #796 — content import is now atomic (EPIC #779). A module/course import previously wrote its components

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260725000000_idempotency_key/migration.sql
+++ b/prisma/migrations/20260725000000_idempotency_key/migration.sql
@@ -1,0 +1,20 @@
+-- #726: retry-safe idempotency for create/import POST endpoints. One row per (userId, endpoint, key);
+-- stores the first response so a replay returns it without a second write. Rows expire after a TTL.
+CREATE TABLE "IdempotencyKey" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "payloadHash" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "statusCode" INTEGER,
+    "responseJson" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "IdempotencyKey_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "IdempotencyKey_expiresAt_idx" ON "IdempotencyKey"("expiresAt");
+
+CREATE UNIQUE INDEX "IdempotencyKey_userId_endpoint_key_key" ON "IdempotencyKey"("userId", "endpoint", "key");

--- a/prisma/migrations/20260725010000_outbox_event/migration.sql
+++ b/prisma/migrations/20260725010000_outbox_event/migration.sql
@@ -1,0 +1,21 @@
+-- #795: transactional outbox for post-decision side effects (participant notification + course-completion
+-- check). The decision path enqueues a durable row; a delivery worker leases pending rows and delivers
+-- them with bounded retries, so a crash after SUCCEEDED no longer loses the email/completion.
+CREATE TABLE "OutboxEvent" (
+    "id" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "payloadJson" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "maxAttempts" INTEGER NOT NULL DEFAULT 5,
+    "availableAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lockedBy" TEXT,
+    "lockedAt" TIMESTAMP(3),
+    "lastError" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deliveredAt" TIMESTAMP(3),
+
+    CONSTRAINT "OutboxEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "OutboxEvent_status_availableAt_idx" ON "OutboxEvent"("status", "availableAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -161,6 +161,28 @@ model IdempotencyKey {
   @@index([expiresAt])
 }
 
+// #795: transactional outbox for the post-decision side effects (participant notification + course-
+// completion check) that were previously fire-and-forget — a SIGTERM/crash after the job was marked
+// SUCCEEDED but before those promises settled lost the email/completion with no retry. Now the decision
+// path enqueues a durable OutboxEvent, and a delivery worker leases pending rows and delivers them with
+// bounded retries (the handlers are idempotent, so re-delivery is safe).
+model OutboxEvent {
+  id          String    @id @default(cuid())
+  type        String // "assessment_notification" | "course_completion_check"
+  payloadJson String
+  status      String    @default("pending") // "pending" | "delivered" | "failed"
+  attempts    Int       @default(0)
+  maxAttempts Int       @default(5)
+  availableAt DateTime  @default(now())
+  lockedBy    String?
+  lockedAt    DateTime?
+  lastError   String?
+  createdAt   DateTime  @default(now())
+  deliveredAt DateTime?
+
+  @@index([status, availableAt])
+}
+
 model DeletionRequest {
   id           String                @id @default(cuid())
   userId       String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,6 +140,27 @@ model UserConsent {
   @@index([userId])
 }
 
+// #726: retry-safe idempotency for create/import POST endpoints. A request may carry an `Idempotency-Key`
+// header; the first request for (userId, endpoint, key) reserves a row (status "pending"), runs the
+// handler, and stores its response. A replay with the SAME key + SAME payloadHash returns the stored
+// response (no second write); a SAME key + DIFFERENT payloadHash is rejected (409). Rows expire after a
+// TTL (no relation to User on purpose — the record is ephemeral and must survive user changes for its TTL).
+model IdempotencyKey {
+  id           String   @id @default(cuid())
+  userId       String
+  endpoint     String
+  key          String
+  payloadHash  String
+  status       String   @default("pending") // "pending" while the handler runs, "completed" once stored
+  statusCode   Int?
+  responseJson String?
+  createdAt    DateTime @default(now())
+  expiresAt    DateTime
+
+  @@unique([userId, endpoint, key])
+  @@index([expiresAt])
+}
+
 model DeletionRequest {
   id           String                @id @default(cuid())
   userId       String

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -135,6 +135,9 @@ const envSchema = z.object({
   // the deadline the runner fails/retries the job (fenced) so the tick returns instead of wedging.
   ASSESSMENT_JOB_MAX_RUNTIME_MS: z.coerce.number().int().positive().default(300000),
   ASSESSMENT_JOB_STUCK_THRESHOLD_MS: z.coerce.number().int().positive().default(600000),
+  // #795: outbox delivery worker cadence + lease.
+  OUTBOX_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(5000),
+  OUTBOX_LEASE_DURATION_MS: z.coerce.number().int().positive().default(60000),
   PARSER_WORKER_URL: z.preprocess(
     (value) => (typeof value === "string" && value.trim().length === 0 ? undefined : value),
     z.string().url().optional(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { PseudonymizationMonitor } from "./modules/user/PseudonymizationMonitor.
 import { AuditRetentionMonitor } from "./modules/retention/AuditRetentionMonitor.js";
 import { EntraUserSyncMonitor } from "./modules/orgSync/EntraUserSyncMonitor.js";
 import { CourseReminderMonitor } from "./modules/course/CourseReminderMonitor.js";
+import { OutboxDeliveryWorker } from "./modules/outbox/OutboxDeliveryWorker.js";
 import { evaluateWorkerHealth, drainInFlightTicks, type MonitorHealthSnapshot } from "./observability/workerHealth.js";
 
 export function resolveProcessRoleFlags(role: string) {
@@ -28,6 +29,7 @@ const pseudonymizationMonitor = startWorkers ? new PseudonymizationMonitor() : n
 const auditRetentionMonitor = startWorkers ? new AuditRetentionMonitor() : null;
 const entraUserSyncMonitor = startWorkers ? new EntraUserSyncMonitor() : null;
 const courseReminderMonitor = startWorkers ? new CourseReminderMonitor() : null;
+const outboxDeliveryWorker = startWorkers ? new OutboxDeliveryWorker() : null;
 
 const backgroundMonitors = [
   assessmentWorker,
@@ -36,6 +38,7 @@ const backgroundMonitors = [
   auditRetentionMonitor,
   entraUserSyncMonitor,
   courseReminderMonitor,
+  outboxDeliveryWorker,
 ];
 
 // #810: on shutdown, stop scheduling AND drain any in-flight tick before exiting, so we don't kill work
@@ -118,6 +121,7 @@ async function startServer() {
       auditRetentionMonitor,
       entraUserSyncMonitor,
       courseReminderMonitor,
+      outboxDeliveryWorker,
     ];
     staggeredWorkers.forEach((worker, index) => {
       setTimeout(() => {

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,0 +1,117 @@
+import type { NextFunction, Request, Response } from "express";
+import { prisma } from "../db/prisma.js";
+import { sha256 } from "../utils/hash.js";
+
+// #726: retry-safe idempotency for create/import POST endpoints. A request may carry an `Idempotency-Key`
+// header. The first request for (userId, endpoint, key) RESERVES a row (status "pending"), runs the
+// handler, and stores the response; a replay with the SAME key + SAME payload returns the stored response
+// without re-running the handler; a SAME key + DIFFERENT payload is a 409. Rows expire after the TTL.
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+function isUniqueViolation(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "P2002";
+}
+
+async function storeOrRelease(
+  where: { userId: string; endpoint: string; key: string },
+  statusCode: number,
+  body: unknown,
+): Promise<void> {
+  // Only a success is worth replaying; a failed attempt releases its reservation so the client can retry.
+  if (statusCode >= 200 && statusCode < 300) {
+    await prisma.idempotencyKey.updateMany({
+      where: { ...where, status: "pending" },
+      data: { status: "completed", statusCode, responseJson: JSON.stringify(body ?? null) },
+    });
+  } else {
+    await prisma.idempotencyKey.deleteMany({ where: { ...where, status: "pending" } });
+  }
+}
+
+export function idempotency(endpoint: string) {
+  return async function idempotencyMiddleware(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const key = req.header("Idempotency-Key");
+    const userId = req.context?.userId;
+    // No key, or no authenticated user yet → normal flow (the route enforces auth).
+    if (!key || !userId) {
+      next();
+      return;
+    }
+
+    const payloadHash = sha256(JSON.stringify(req.body ?? {}));
+    const where = { userId, endpoint, key };
+
+    // Reserve the key. Winning the insert means we own execution; a conflict means someone got there first.
+    let owned = false;
+    for (let attempt = 0; attempt < 2 && !owned; attempt += 1) {
+      const now = new Date();
+      try {
+        await prisma.idempotencyKey.create({
+          data: { userId, endpoint, key, payloadHash, status: "pending", expiresAt: new Date(now.getTime() + IDEMPOTENCY_TTL_MS) },
+        });
+        owned = true;
+      } catch (error) {
+        if (!isUniqueViolation(error)) {
+          next(error as Error);
+          return;
+        }
+        const existing = await prisma.idempotencyKey.findUnique({
+          where: { userId_endpoint_key: { userId, endpoint, key } },
+        });
+        if (!existing) {
+          continue; // raced away (e.g. expiry cleanup) — retry the reserve
+        }
+        if (existing.expiresAt <= now) {
+          // Expired → reclaim and retry the reserve as a fresh request.
+          await prisma.idempotencyKey.deleteMany({ where: { id: existing.id, expiresAt: { lte: now } } });
+          continue;
+        }
+        if (existing.payloadHash !== payloadHash) {
+          res.status(409).json({
+            error: "idempotency_key_reuse",
+            message: "This Idempotency-Key was already used with a different request body.",
+          });
+          return;
+        }
+        if (existing.status === "completed" && existing.statusCode != null && existing.responseJson != null) {
+          res.status(existing.statusCode).json(JSON.parse(existing.responseJson));
+          return;
+        }
+        // Still pending — an identical request is in flight. Ask the client to retry.
+        res.status(409).json({
+          error: "idempotency_in_progress",
+          message: "A request with this Idempotency-Key is still being processed.",
+        });
+        return;
+      }
+    }
+    if (!owned) {
+      // Could not reserve after retrying (persistent contention) — proceed without idempotency protection
+      // rather than fail the request outright.
+      next();
+      return;
+    }
+
+    // We own the reservation: capture the response to store it (on 2xx) or release it (on failure).
+    const originalJson = res.json.bind(res);
+    let settled = false;
+    res.json = (body: unknown) => {
+      if (!settled) {
+        settled = true;
+        void storeOrRelease(where, res.statusCode, body).catch(() => {
+          /* best-effort: a failed store just means the next replay re-runs the handler */
+        });
+      }
+      return originalJson(body);
+    };
+    // Safety net: if the response finishes without res.json (e.g. res.end/send), release the reservation.
+    res.on("finish", () => {
+      if (!settled) {
+        settled = true;
+        void prisma.idempotencyKey.deleteMany({ where: { ...where, status: "pending" } }).catch(() => {});
+      }
+    });
+
+    next();
+  };
+}

--- a/src/modules/assessment/AssessmentDecisionApplicationService.ts
+++ b/src/modules/assessment/AssessmentDecisionApplicationService.ts
@@ -1,10 +1,7 @@
 import { createAssessmentDecision, createMcqOnlyDecision, type ModuleAssessmentPolicy } from "./decisionService.js";
 import { recordAuditEvent } from "../../services/auditService.js";
-import { logOperationalEvent } from "../../observability/operationalLog.js";
 import { auditActions, auditEntityTypes } from "../../observability/auditEvents.js";
-import { operationalEvents } from "../../observability/operationalEvents.js";
-import { notifyAssessmentResult } from "../certification/index.js";
-import { checkAndIssueCourseCompletions } from "../course/index.js";
+import { enqueueOutboxEvents, OUTBOX_EVENT_TYPES } from "../outbox/outboxService.js";
 import { localizeContentText } from "../../i18n/content.js";
 import type { LlmStructuredAssessment } from "./llmAssessmentService.js";
 import type { SupportedLocale } from "../../i18n/locale.js";
@@ -61,7 +58,7 @@ export async function applyAssessmentDecision(input: ApplyDecisionInput): Promis
   });
 
   if (!decisionResult.needsManualReview) {
-    notifyAndCheckCompletion(input, decisionResult.decision.passFailTotal);
+    await enqueuePostDecisionSideEffects(input, decisionResult.decision.passFailTotal);
   }
 
   await recordJobCompletedAudit(input.jobId, input.submissionId, input.userId);
@@ -98,7 +95,7 @@ export async function applyMcqOnlyDecision(input: ApplyMcqOnlyDecisionInput): Pr
     assessmentPolicy: input.assessmentPolicy,
   });
 
-  notifyAndCheckCompletion(input, decisionResult.decision.passFailTotal);
+  await enqueuePostDecisionSideEffects(input, decisionResult.decision.passFailTotal);
 
   await recordJobCompletedAudit(input.jobId, input.submissionId, input.userId);
 }
@@ -114,44 +111,31 @@ type NotifyInput = {
   recipientName: string;
 };
 
-/** Fire-and-forget participant notification + course-completion check (shared by both paths). */
-function notifyAndCheckCompletion(input: NotifyInput, passFailTotal: boolean): void {
-  const moduleTitle =
-    localizeContentText(input.submissionLocale, input.moduleTitle) ?? input.moduleId;
+// #795: durably enqueue the participant notification + course-completion check instead of firing them
+// and forgetting. Awaited before the job is marked SUCCEEDED, so a crash after SUCCEEDED can no longer
+// lose them — the outbox delivery worker delivers them (with retries) from the persisted rows.
+async function enqueuePostDecisionSideEffects(input: NotifyInput, passFailTotal: boolean): Promise<void> {
+  const moduleTitle = localizeContentText(input.submissionLocale, input.moduleTitle) ?? input.moduleId;
 
-  notifyAssessmentResult({
-    submissionId: input.submissionId,
-    submittedAt: input.submittedAt,
-    recipientEmail: input.recipientEmail,
-    recipientName: input.recipientName,
-    moduleTitle,
-    moduleId: input.moduleId,
-    passFailTotal,
-    locale: input.submissionLocale,
-  }).catch((error: unknown) => {
-    logOperationalEvent(
-      operationalEvents.certification.participantNotificationPipelineFailed,
-      {
+  await enqueueOutboxEvents([
+    {
+      type: OUTBOX_EVENT_TYPES.assessmentNotification,
+      payload: {
         submissionId: input.submissionId,
-        errorMessage: error instanceof Error ? error.message : "Unknown error",
+        submittedAt: input.submittedAt.toISOString(),
+        recipientEmail: input.recipientEmail,
+        recipientName: input.recipientName,
+        moduleTitle,
+        moduleId: input.moduleId,
+        passFailTotal,
+        locale: input.submissionLocale,
       },
-      "error",
-    );
-  });
-
-  checkAndIssueCourseCompletions({ userId: input.userId, moduleId: input.moduleId }).catch(
-    (error: unknown) => {
-      logOperationalEvent(
-        operationalEvents.course.completionCheckFailed,
-        {
-          userId: input.userId,
-          moduleId: input.moduleId,
-          errorMessage: error instanceof Error ? error.message : "Unknown error",
-        },
-        "error",
-      );
     },
-  );
+    {
+      type: OUTBOX_EVENT_TYPES.courseCompletionCheck,
+      payload: { userId: input.userId, moduleId: input.moduleId },
+    },
+  ]);
 }
 
 async function recordJobCompletedAudit(jobId: string, submissionId: string, userId: string): Promise<void> {

--- a/src/modules/outbox/OutboxDeliveryWorker.ts
+++ b/src/modules/outbox/OutboxDeliveryWorker.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from "node:crypto";
+import { env } from "../../config/env.js";
+import type { MonitorHealthSnapshot } from "../../observability/workerHealth.js";
+import { processNextOutboxEvent } from "./outboxService.js";
+
+type OutboxProcessFn = (workerId: string, leaseMs: number) => Promise<boolean>;
+
+// #795: background delivery worker for the transactional outbox. Each tick drains up to MAX_PER_TICK due
+// events (claim → deliver → mark), so a backlog is worked down without one tick running unbounded. Modeled
+// on AssessmentWorker (re-entrancy guard, health snapshot). Idempotent handlers make re-delivery safe.
+const MAX_PER_TICK = 10;
+
+export type OutboxDeliveryWorkerStatus = {
+  instanceId: string;
+  lastCycleAt: string | null;
+};
+
+export class OutboxDeliveryWorker {
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private tickStartedAt: Date | null = null;
+  private lastCycleAt: Date | null = null;
+  readonly instanceId: string;
+
+  constructor(
+    private readonly pollIntervalMs = env.OUTBOX_POLL_INTERVAL_MS,
+    private readonly leaseMs = env.OUTBOX_LEASE_DURATION_MS,
+    private readonly processFn: OutboxProcessFn = processNextOutboxEvent,
+    instanceId?: string,
+  ) {
+    this.instanceId = instanceId ?? randomUUID();
+  }
+
+  start() {
+    if (this.timer) return;
+    void this.tick();
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.pollIntervalMs);
+  }
+
+  stop() {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  // Drain one event (test/manual hook).
+  runOnce() {
+    return this.processFn(this.instanceId, this.leaseMs);
+  }
+
+  getStatus(): OutboxDeliveryWorkerStatus {
+    return { instanceId: this.instanceId, lastCycleAt: this.lastCycleAt?.toISOString() ?? null };
+  }
+
+  health(): MonitorHealthSnapshot {
+    return {
+      name: "outboxDeliveryWorker",
+      enabled: true,
+      intervalMs: this.pollIntervalMs,
+      running: this.running,
+      tickStartedAt: this.tickStartedAt?.toISOString() ?? null,
+      lastCycleAt: this.lastCycleAt?.toISOString() ?? null,
+      lastError: null,
+      // #856: a tick can deliver up to MAX_PER_TICK events, each an email/ACS or DB call, so its wedge
+      // window is governed by the drain budget + lease — not the poll interval.
+      maxTickMs: this.leaseMs + 120_000,
+    };
+  }
+
+  private async tick() {
+    if (this.running) return;
+    this.running = true;
+    this.tickStartedAt = new Date();
+    try {
+      let processed = 0;
+      while (processed < MAX_PER_TICK && (await this.processFn(this.instanceId, this.leaseMs))) {
+        processed += 1;
+      }
+      this.lastCycleAt = new Date();
+    } catch {
+      // processNextOutboxEvent handles per-event errors + retry internally; swallow here so the
+      // void-fired tick never becomes an unhandled rejection.
+    } finally {
+      this.running = false;
+      this.tickStartedAt = null;
+    }
+  }
+}

--- a/src/modules/outbox/outboxService.ts
+++ b/src/modules/outbox/outboxService.ts
@@ -1,0 +1,177 @@
+import { prisma } from "../../db/prisma.js";
+import type { DbTransactionClient } from "../../db/transaction.js";
+import { notifyAssessmentResult } from "../certification/index.js";
+import { checkAndIssueCourseCompletions } from "../course/index.js";
+import type { SupportedLocale } from "../../i18n/locale.js";
+
+// #795: a durable outbox for the post-decision side effects that used to be fire-and-forget. The decision
+// path enqueues these rows (ideally in the same transaction as the decision), and the delivery worker
+// leases pending rows and delivers them with bounded retries. The handlers are idempotent, so a
+// re-delivery after a crash or lost lease is safe.
+
+export const OUTBOX_EVENT_TYPES = {
+  assessmentNotification: "assessment_notification",
+  courseCompletionCheck: "course_completion_check",
+} as const;
+
+type AssessmentNotificationPayload = {
+  submissionId: string;
+  submittedAt: string; // ISO
+  recipientEmail: string;
+  recipientName: string;
+  moduleTitle: string;
+  moduleId: string;
+  passFailTotal: boolean;
+  locale: SupportedLocale;
+};
+
+type CourseCompletionCheckPayload = {
+  userId: string;
+  moduleId: string;
+};
+
+export type OutboxEnqueueInput =
+  | { type: typeof OUTBOX_EVENT_TYPES.assessmentNotification; payload: AssessmentNotificationPayload }
+  | { type: typeof OUTBOX_EVENT_TYPES.courseCompletionCheck; payload: CourseCompletionCheckPayload };
+
+// Retry backoff: 30s, 60s, 120s, … capped at 15 min. Small enough that a transient failure recovers
+// quickly, large enough that a persistently-failing handler doesn't hot-loop.
+const RETRY_BASE_MS = 30_000;
+const RETRY_CAP_MS = 900_000;
+function backoffMs(attempts: number): number {
+  return Math.min(RETRY_BASE_MS * 2 ** Math.max(0, attempts - 1), RETRY_CAP_MS);
+}
+
+// #795: enqueue durable outbox rows. Accepts an optional tx client so the enqueue commits atomically with
+// the domain write (e.g. the assessment decision) — a crash then either has both or neither.
+export function enqueueOutboxEvents(events: OutboxEnqueueInput[], tx?: DbTransactionClient) {
+  if (events.length === 0) return Promise.resolve({ count: 0 });
+  const client = tx ?? prisma;
+  return client.outboxEvent.createMany({
+    data: events.map((e) => ({ type: e.type, payloadJson: JSON.stringify(e.payload) })),
+  });
+}
+
+export type ClaimedOutboxEvent = {
+  id: string;
+  type: string;
+  payloadJson: string;
+  attempts: number;
+  maxAttempts: number;
+  lockedBy: string;
+  lockedAt: Date;
+};
+
+// Lease the next due pending row. Fenced on `availableAt` (compare-and-set): two workers that select the
+// same candidate can't both win. On claim we push `availableAt` out by the lease so the row isn't
+// re-selected until the lease expires (a dead worker's row becomes claimable again then).
+export async function claimNextOutboxEvent(
+  workerId: string,
+  now: Date,
+  leaseMs: number,
+): Promise<ClaimedOutboxEvent | null> {
+  const candidate = await prisma.outboxEvent.findFirst({
+    where: { status: "pending", availableAt: { lte: now } },
+    orderBy: { availableAt: "asc" },
+    select: { id: true, type: true, payloadJson: true, attempts: true, maxAttempts: true, availableAt: true },
+  });
+  if (!candidate) return null;
+
+  const leaseUntil = new Date(now.getTime() + leaseMs);
+  const res = await prisma.outboxEvent.updateMany({
+    where: { id: candidate.id, status: "pending", availableAt: candidate.availableAt },
+    data: { lockedBy: workerId, lockedAt: now, availableAt: leaseUntil },
+  });
+  if (res.count === 0) return null; // another worker claimed it first
+
+  return {
+    id: candidate.id,
+    type: candidate.type,
+    payloadJson: candidate.payloadJson,
+    attempts: candidate.attempts,
+    maxAttempts: candidate.maxAttempts,
+    lockedBy: workerId,
+    lockedAt: now,
+  };
+}
+
+// Deliver one event by dispatching on its type. Both handlers are idempotent (completion checks whether
+// the certificate already exists; the notification pipeline dedupes on its own audit trail).
+export async function deliverOutboxEvent(event: { type: string; payloadJson: string }): Promise<void> {
+  if (event.type === OUTBOX_EVENT_TYPES.assessmentNotification) {
+    const p = JSON.parse(event.payloadJson) as AssessmentNotificationPayload;
+    await notifyAssessmentResult({
+      submissionId: p.submissionId,
+      submittedAt: new Date(p.submittedAt),
+      recipientEmail: p.recipientEmail,
+      recipientName: p.recipientName,
+      moduleTitle: p.moduleTitle,
+      moduleId: p.moduleId,
+      passFailTotal: p.passFailTotal,
+      locale: p.locale,
+    });
+    return;
+  }
+  if (event.type === OUTBOX_EVENT_TYPES.courseCompletionCheck) {
+    const p = JSON.parse(event.payloadJson) as CourseCompletionCheckPayload;
+    await checkAndIssueCourseCompletions({ userId: p.userId, moduleId: p.moduleId });
+    return;
+  }
+  throw new Error(`Unknown outbox event type: ${event.type}`);
+}
+
+// Fenced terminal writes: only the lease holder (lockedBy + lockedAt) may settle the row, so a row
+// re-leased by another worker after a lost lease is never clobbered.
+export function markOutboxDelivered(id: string, lockedBy: string, lockedAt: Date, deliveredAt: Date) {
+  return prisma.outboxEvent.updateMany({
+    where: { id, lockedBy, lockedAt },
+    data: { status: "delivered", deliveredAt, lockedBy: null, lockedAt: null, lastError: null },
+  });
+}
+
+export function markOutboxRetryOrFailed(
+  id: string,
+  lockedBy: string,
+  lockedAt: Date,
+  now: Date,
+  attempts: number,
+  maxAttempts: number,
+  errorMessage: string,
+) {
+  const willRetry = attempts < maxAttempts;
+  return prisma.outboxEvent.updateMany({
+    where: { id, lockedBy, lockedAt },
+    data: {
+      attempts,
+      status: willRetry ? "pending" : "failed",
+      availableAt: willRetry ? new Date(now.getTime() + backoffMs(attempts)) : now,
+      lockedBy: null,
+      lockedAt: null,
+      lastError: errorMessage.slice(0, 1000),
+    },
+  });
+}
+
+// Process at most one due event. Returns true if an event was handled (so a caller can loop until empty).
+export async function processNextOutboxEvent(workerId: string, leaseMs: number): Promise<boolean> {
+  const now = new Date();
+  const claimed = await claimNextOutboxEvent(workerId, now, leaseMs);
+  if (!claimed) return false;
+
+  try {
+    await deliverOutboxEvent(claimed);
+    await markOutboxDelivered(claimed.id, claimed.lockedBy, claimed.lockedAt, new Date());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown outbox delivery error";
+    await markOutboxRetryOrFailed(
+      claimed.id,
+      claimed.lockedBy,
+      claimed.lockedAt,
+      new Date(),
+      claimed.attempts + 1,
+      claimed.maxAttempts,
+      message,
+    );
+  }
+  return true;
+}

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -82,6 +82,7 @@ import {
   toCreateModuleVersionInput,
 } from "../modules/adminContent/adminContentMapper.js";
 import { adminCoursesRouter } from "./adminCourses.js";
+import { idempotency } from "../middleware/idempotency.js";
 import { adminClassesRouter } from "./adminClasses.js";
 import { adminUsersRouter } from "./adminUsers.js";
 import { adminSectionsRouter } from "./adminSections.js";
@@ -423,7 +424,7 @@ adminContentRouter.get("/modules/:moduleId/export", async (request, response) =>
 // /modules/:id/export-package. mode=createNew creates a fresh module; mode=
 // replaceExisting appends a new active version to the existing targetId
 // (history preserved; never silently overwrites).
-adminContentRouter.post("/modules/import", async (request, response) => {
+adminContentRouter.post("/modules/import", idempotency("modules.import"), async (request, response) => {
   const actorId = request.context?.userId;
   if (!actorId) {
     response.status(401).json({ error: "unauthorized" });

--- a/src/routes/adminCourses.ts
+++ b/src/routes/adminCourses.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { requireContentOwnership } from "./requireContentOwnership.js";
+import { idempotency } from "../middleware/idempotency.js";
 import { listManageableContentIds } from "../modules/content/contentOwnershipService.js";
 import { z } from "zod";
 import {
@@ -81,7 +82,7 @@ const courseCreateBodySchema = courseBodySchema.extend({
   agentRunId: agentRunIdSchema.optional(),
 });
 
-adminCoursesRouter.post("/", async (request, response, next) => {
+adminCoursesRouter.post("/", idempotency("courses.create"), async (request, response, next) => {
   const parsed = courseCreateBodySchema.safeParse(request.body);
   if (!parsed.success) {
     response.status(400).json({ error: "validation_error", issues: parsed.error.issues });

--- a/src/routes/adminSections.ts
+++ b/src/routes/adminSections.ts
@@ -29,6 +29,7 @@ import { NotFoundError } from "../errors/AppError.js";
 import { renderSectionMarkdown } from "../modules/course/sectionContent.js";
 import { localizeSectionContent } from "../modules/adminContent/llmContentGenerationService.js";
 import { generateLimiter } from "../middleware/rateLimiting.js";
+import { idempotency } from "../middleware/idempotency.js";
 
 const adminSectionsRouter = Router();
 
@@ -91,7 +92,7 @@ function toDetail(section: SectionWithActiveVersion) {
   };
 }
 
-adminSectionsRouter.post("/", async (request, response, next) => {
+adminSectionsRouter.post("/", idempotency("sections.create"), async (request, response, next) => {
   const parsed = createSectionSchema.safeParse(request.body);
   if (!parsed.success) {
     response.status(400).json({ error: "validation_error", issues: parsed.error.issues });

--- a/test/m2-idempotency.test.ts
+++ b/test/m2-idempotency.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, describe, expect, it } from "vitest";
+import request from "supertest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+
+// #726: create/import POST endpoints accept an optional `Idempotency-Key` header. A replay with the same
+// key + same body returns the stored response WITHOUT a second write; a same key + different body is a
+// 409; no key behaves normally. Proven end-to-end against a real Postgres via the course-create endpoint.
+
+const adminHeaders = {
+  "x-user-id": "admin-1",
+  "x-user-email": "admin@company.com",
+  "x-user-name": "Platform Admin",
+};
+
+const uniq = () => `${Date.now()}-${Math.random()}`;
+const titleBody = (title: string) => ({ title: { "en-GB": title, nb: title, nn: title } });
+
+describe("Idempotency-Key on create endpoints (#726)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("replays the stored response for the same key + same body (no second write)", async () => {
+    const key = `idem-${uniq()}`;
+    const title = `idem-course-${uniq()}`;
+
+    const first = await request(app)
+      .post("/api/admin/content/courses")
+      .set({ ...adminHeaders, "Idempotency-Key": key })
+      .send(titleBody(title));
+    expect(first.status).toBe(201);
+    const courseId = first.body.course.id as string;
+
+    const replay = await request(app)
+      .post("/api/admin/content/courses")
+      .set({ ...adminHeaders, "Idempotency-Key": key })
+      .send(titleBody(title));
+    expect(replay.status).toBe(201);
+    // Same response replayed…
+    expect(replay.body.course.id).toBe(courseId);
+    // …and NO second course was created.
+    expect(await prisma.course.count({ where: { title: { contains: title } } })).toBe(1);
+  });
+
+  it("rejects the same key with a different body (409 idempotency_key_reuse)", async () => {
+    const key = `idem-${uniq()}`;
+
+    const first = await request(app)
+      .post("/api/admin/content/courses")
+      .set({ ...adminHeaders, "Idempotency-Key": key })
+      .send(titleBody(`idem-a-${uniq()}`));
+    expect(first.status).toBe(201);
+
+    const reuse = await request(app)
+      .post("/api/admin/content/courses")
+      .set({ ...adminHeaders, "Idempotency-Key": key })
+      .send(titleBody(`idem-b-${uniq()}`));
+    expect(reuse.status).toBe(409);
+    expect(reuse.body.error).toBe("idempotency_key_reuse");
+  });
+
+  it("without a key, each request runs normally (two distinct courses)", async () => {
+    const title = `idem-nokey-${uniq()}`;
+    const a = await request(app).post("/api/admin/content/courses").set(adminHeaders).send(titleBody(title));
+    const b = await request(app).post("/api/admin/content/courses").set(adminHeaders).send(titleBody(title));
+    expect(a.status).toBe(201);
+    expect(b.status).toBe(201);
+    expect(a.body.course.id).not.toBe(b.body.course.id);
+    expect(await prisma.course.count({ where: { title: { contains: title } } })).toBe(2);
+  });
+});

--- a/test/m2-outbox.test.ts
+++ b/test/m2-outbox.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { prisma } from "../src/db/prisma.js";
+import { enqueueOutboxEvents, processNextOutboxEvent, OUTBOX_EVENT_TYPES } from "../src/modules/outbox/outboxService.js";
+
+// #795: the decision path enqueues post-decision side effects to a durable outbox; a delivery worker
+// leases pending rows and delivers them with bounded retries. This proves that against a real Postgres:
+// enqueue persists pending rows, a successful delivery marks the row delivered, and a failing delivery
+// retries (attempts++/backoff) until maxAttempts flips it to failed.
+
+const WORKER = "test-outbox-worker";
+const LEASE_MS = 60_000;
+
+describe("transactional outbox delivery (#795)", () => {
+  beforeEach(async () => {
+    // Isolate from any rows other suites may have enqueued, so processNextOutboxEvent claims ours.
+    await prisma.outboxEvent.deleteMany({ where: { status: "pending" } });
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("enqueue persists durable pending rows", async () => {
+    await enqueueOutboxEvents([
+      { type: OUTBOX_EVENT_TYPES.courseCompletionCheck, payload: { userId: "u1", moduleId: "m1" } },
+    ]);
+    const pending = await prisma.outboxEvent.count({ where: { status: "pending", type: OUTBOX_EVENT_TYPES.courseCompletionCheck } });
+    expect(pending).toBeGreaterThanOrEqual(1);
+  });
+
+  it("delivers a course-completion-check event and marks it delivered", async () => {
+    // A completion check for a user with no completable enrollment is a safe no-op (delivery succeeds).
+    const user = await prisma.user.create({
+      data: { externalId: `ob-${Date.now()}-${Math.random()}`, name: "OB", email: `ob-${Date.now()}-${Math.random()}@x.test` },
+      select: { id: true },
+    });
+    const mv = await prisma.moduleVersion.findFirstOrThrow({ select: { moduleId: true } });
+    const row = await prisma.outboxEvent.create({
+      data: {
+        type: OUTBOX_EVENT_TYPES.courseCompletionCheck,
+        payloadJson: JSON.stringify({ userId: user.id, moduleId: mv.moduleId }),
+        availableAt: new Date(Date.now() - 1000),
+      },
+      select: { id: true },
+    });
+
+    const processed = await processNextOutboxEvent(WORKER, LEASE_MS);
+    expect(processed).toBe(true);
+
+    const after = await prisma.outboxEvent.findUniqueOrThrow({ where: { id: row.id } });
+    expect(after.status).toBe("delivered");
+    expect(after.deliveredAt).not.toBeNull();
+    expect(after.lockedBy).toBeNull();
+  });
+
+  it("retries a failing delivery, then fails it after maxAttempts", async () => {
+    // An unknown type makes deliverOutboxEvent throw — a clean, deterministic delivery failure.
+    const row = await prisma.outboxEvent.create({
+      data: { type: "bogus_unknown_type", payloadJson: "{}", maxAttempts: 2, availableAt: new Date(Date.now() - 1000) },
+      select: { id: true },
+    });
+
+    // Attempt 1 → failure → retry (still pending, attempts 1, availableAt pushed into the future).
+    expect(await processNextOutboxEvent(WORKER, LEASE_MS)).toBe(true);
+    let after = await prisma.outboxEvent.findUniqueOrThrow({ where: { id: row.id } });
+    expect(after.status).toBe("pending");
+    expect(after.attempts).toBe(1);
+    expect(after.availableAt.getTime()).toBeGreaterThan(Date.now());
+    expect(after.lastError).toContain("Unknown outbox event type");
+
+    // Make it due again and process → attempt 2 reaches maxAttempts → failed.
+    await prisma.outboxEvent.update({ where: { id: row.id }, data: { availableAt: new Date(Date.now() - 1000) } });
+    expect(await processNextOutboxEvent(WORKER, LEASE_MS)).toBe(true);
+    after = await prisma.outboxEvent.findUniqueOrThrow({ where: { id: row.id } });
+    expect(after.status).toBe("failed");
+    expect(after.attempts).toBe(2);
+  });
+});

--- a/test/unit/assessment-decision-application-service.test.ts
+++ b/test/unit/assessment-decision-application-service.test.ts
@@ -5,6 +5,17 @@ const recordAuditEvent = vi.fn();
 const logOperationalEvent = vi.fn();
 const notifyAssessmentResult = vi.fn();
 const localizeContentText = vi.fn((_, text) => text ?? null);
+// #795: the decision path now enqueues the post-decision side effects to the durable outbox instead of
+// firing them and forgetting.
+const enqueueOutboxEvents = vi.fn();
+
+vi.mock("../../src/modules/outbox/outboxService.js", () => ({
+  enqueueOutboxEvents,
+  OUTBOX_EVENT_TYPES: {
+    assessmentNotification: "assessment_notification",
+    courseCompletionCheck: "course_completion_check",
+  },
+}));
 
 vi.mock("../../src/modules/assessment/decisionService.js", () => ({
   createAssessmentDecision,
@@ -74,6 +85,7 @@ describe("AssessmentDecisionApplicationService — applyAssessmentDecision", () 
     logOperationalEvent.mockReset();
     notifyAssessmentResult.mockReset();
     localizeContentText.mockReset();
+    enqueueOutboxEvents.mockReset().mockResolvedValue({ count: 2 });
 
     recordAuditEvent.mockResolvedValue(undefined);
     localizeContentText.mockImplementation((_locale, text) => text ?? null);
@@ -83,12 +95,11 @@ describe("AssessmentDecisionApplicationService — applyAssessmentDecision", () 
     vi.clearAllMocks();
   });
 
-  it("creates a decision and sends notification when manual review is not needed", async () => {
+  it("creates a decision and enqueues the notification + completion outbox events when no manual review", async () => {
     createAssessmentDecision.mockResolvedValue({
       decision: { id: "decision-1", passFailTotal: true },
       needsManualReview: false,
     });
-    notifyAssessmentResult.mockResolvedValue(undefined);
 
     const { applyAssessmentDecision } = await import("../../src/modules/assessment/AssessmentDecisionApplicationService.js");
     await applyAssessmentDecision({ ...BASE_INPUT, llmResult: buildLlmResult() });
@@ -101,14 +112,16 @@ describe("AssessmentDecisionApplicationService — applyAssessmentDecision", () 
         mcqPercentScore: 100,
       }),
     );
-    expect(notifyAssessmentResult).toHaveBeenCalledWith(
-      expect.objectContaining({
-        submissionId: "sub-1",
-        recipientEmail: "participant@example.com",
-        passFailTotal: true,
-        locale: "en-GB",
-      }),
+    // #795: side effects go to the durable outbox (awaited), not fire-and-forget notification calls.
+    expect(notifyAssessmentResult).not.toHaveBeenCalled();
+    expect(enqueueOutboxEvents).toHaveBeenCalledTimes(1);
+    const enqueued = enqueueOutboxEvents.mock.calls[0][0] as Array<{ type: string; payload: Record<string, unknown> }>;
+    const notification = enqueued.find((e) => e.type === "assessment_notification");
+    const completion = enqueued.find((e) => e.type === "course_completion_check");
+    expect(notification?.payload).toEqual(
+      expect.objectContaining({ submissionId: "sub-1", recipientEmail: "participant@example.com", passFailTotal: true, locale: "en-GB" }),
     );
+    expect(completion?.payload).toEqual(expect.objectContaining({ userId: "user-1", moduleId: "module-1" }));
     expect(recordAuditEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         entityType: "assessment_job",
@@ -131,34 +144,28 @@ describe("AssessmentDecisionApplicationService — applyAssessmentDecision", () 
       forceManualReviewReason: "Escalated for review.",
     });
 
-    expect(notifyAssessmentResult).not.toHaveBeenCalled();
+    expect(enqueueOutboxEvents).not.toHaveBeenCalled();
     expect(recordAuditEvent).toHaveBeenCalledWith(
       expect.objectContaining({ action: "assessment_job_completed" }),
     );
   });
 
-  it("logs and swallows notification errors rather than propagating them", async () => {
+  it("propagates when the outbox enqueue fails, so the job retries instead of losing the side effects", async () => {
     createAssessmentDecision.mockResolvedValue({
       decision: { id: "decision-3", passFailTotal: true },
       needsManualReview: false,
     });
-    notifyAssessmentResult.mockRejectedValue(new Error("Email service unavailable"));
+    // #795: the enqueue is awaited (not fire-and-forget). A failure must propagate so the runner fails/
+    // retries the job — the side effects are then re-enqueued rather than silently lost.
+    enqueueOutboxEvents.mockRejectedValue(new Error("DB unavailable"));
 
     const { applyAssessmentDecision } = await import("../../src/modules/assessment/AssessmentDecisionApplicationService.js");
 
-    // Should not throw even though notification failed
     await expect(
       applyAssessmentDecision({ ...BASE_INPUT, llmResult: buildLlmResult() }),
-    ).resolves.toBeUndefined();
-
-    // Wait a tick for the catch in the fire-and-forget notifyAssessmentResult to run
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    expect(logOperationalEvent).toHaveBeenCalledWith(
-      "participant_notification_pipeline_failed",
-      expect.objectContaining({ submissionId: "sub-1" }),
-      "error",
-    );
+    ).rejects.toThrow("DB unavailable");
+    // The job-completed audit must NOT be written when the side effects weren't durably enqueued.
+    expect(recordAuditEvent).not.toHaveBeenCalled();
   });
 
   it("passes forceManualReviewReason through to createAssessmentDecision", async () => {

--- a/test/unit/assessment-job-service.test.ts
+++ b/test/unit/assessment-job-service.test.ts
@@ -13,6 +13,7 @@ const createAssessmentDecision = vi.fn();
 const evaluatePracticalWithLlm = vi.fn();
 const recordAuditEvent = vi.fn();
 const logOperationalEvent = vi.fn();
+const enqueueOutboxEvents = vi.fn();
 
 vi.mock("../../src/modules/assessment/assessmentJobRepository.js", () => {
   const repo = {
@@ -40,6 +41,15 @@ vi.mock("../../src/db/transaction.js", () => ({
 
 vi.mock("../../src/modules/assessment/decisionService.js", () => ({
   createAssessmentDecision,
+}));
+
+// #795: the decision path enqueues its side effects to the outbox — mock it so the unit test needs no DB.
+vi.mock("../../src/modules/outbox/outboxService.js", () => ({
+  enqueueOutboxEvents,
+  OUTBOX_EVENT_TYPES: {
+    assessmentNotification: "assessment_notification",
+    courseCompletionCheck: "course_completion_check",
+  },
 }));
 
 vi.mock("../../src/modules/assessment/llmAssessmentService.js", () => ({
@@ -82,6 +92,7 @@ function buildSubmissionFixture() {
     moduleId: "module-1",
     moduleVersionId: "module-version-1",
     locale: "nb",
+    submittedAt: new Date("2026-03-13T22:00:00.000Z"),
     responseJson: JSON.stringify({ response: "raw text", reflection: "reflection text", promptExcerpt: "prompt excerpt" }),
     user: {
       email: "participant@company.com",
@@ -174,6 +185,7 @@ describe("assessment job service traffic-light policy", () => {
     evaluatePracticalWithLlm.mockReset();
     recordAuditEvent.mockReset();
     logOperationalEvent.mockReset();
+    enqueueOutboxEvents.mockReset().mockResolvedValue({ count: 2 });
 
     findNextRunnableJob.mockResolvedValue({
       id: "job-1",


### PR DESCRIPTION
## EPIC #779 durability batch, part 2 → 2.5.0

Retry-safe idempotency + a transactional outbox. Two **additive** migrations (`IdempotencyKey`, `OutboxEvent`); no change to existing behaviour unless the new header is sent.

### #726 — Idempotency-Key for create/import endpoints
`POST /api/admin/content/{modules/import,sections,courses}` accept an optional `Idempotency-Key` header. First request for (userId, endpoint, key) reserves a row → runs → stores the response; **replay** (same key + same body) returns the stored response with no second write; same key + **different body** → 409 `idempotency_key_reuse`; in-flight duplicate → 409 `idempotency_in_progress`. 24h TTL; a failed request releases its reservation. No header → unchanged.

### #795 — transactional outbox for post-decision side effects
Participant notification + course-completion check were fire-and-forget after the decision committed — a crash after SUCCEEDED lost them. Now enqueued as durable `OutboxEvent` rows (**awaited before SUCCEEDED**); a new `OutboxDeliveryWorker` leases pending rows and delivers with bounded exponential-backoff retries (fenced on lockedBy/lockedAt; idempotent handlers → safe re-delivery). A failed enqueue propagates so the job retries. Worker is in the worker-role health readiness (#856 maxTickMs) + drains on shutdown.

### Verification
- `tsc` 0 · unit **847/847** · full integration **424/424** (reset+seed, both new migrations applied)
- New: `test/m2-idempotency` (replay/reuse-409/no-key) · `test/m2-outbox` (enqueue→pending, deliver→delivered, fail→retry→failed)

### Deploy
Code + two additive migrations (new tables) → `deploy-app.yml`. No infra/Bicep. Completes the #779 durability batch (#796 shipped in 2.4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
