### PR TITLE
fix(#795): bound outbox delivery so a hung handler can't wedge the worker → 2.5.1

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,18 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.5.1 - 2026-07-25
+
+#795 follow-up — bound each outbox delivery so a hung handler can't wedge the delivery worker. The 2.5.0
+stage deploy surfaced the new `outboxDeliveryWorker` as `wedged`: a pending event's delivery (a handler
+with no internal timeout — same class as #856 for the assessment worker) never returned, so the tick ran
+unbounded. Fix: `processNextOutboxEvent` now races each delivery against `OUTBOX_DELIVERY_TIMEOUT_MS`
+(default 20s); on timeout the delivery is abandoned and the row is retried (idempotent handlers make a
+later completion of the abandoned call safe). `MAX_PER_TICK` lowered to 5 and the worker's wedge window
+(`maxTickMs`) is now derived from `MAX_PER_TICK × OUTBOX_DELIVERY_TIMEOUT_MS + buffer`, so the per-delivery
+deadline guarantees the tick returns before wedge — making wedge a pure backstop. Code-only; no migration.
+Proof: `test/unit/outbox-service` — a hung delivery times out and retries instead of hanging.
+
 ## 2.5.0 - 2026-07-25
 
 EPIC #779 durability batch, part 2 — retry-safe idempotency + a transactional outbox. Two additive

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -138,6 +138,10 @@ const envSchema = z.object({
   // #795: outbox delivery worker cadence + lease.
   OUTBOX_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(5000),
   OUTBOX_LEASE_DURATION_MS: z.coerce.number().int().positive().default(60000),
+  // #795-followup: per-delivery wall-clock cap. A hung handler (e.g. an ACS email call with no timeout)
+  // would otherwise wedge the worker's tick forever (no return). On timeout the delivery is abandoned and
+  // the row is retried; idempotent handlers make a later completion of the abandoned call safe.
+  OUTBOX_DELIVERY_TIMEOUT_MS: z.coerce.number().int().positive().default(20000),
   PARSER_WORKER_URL: z.preprocess(
     (value) => (typeof value === "string" && value.trim().length === 0 ? undefined : value),
     z.string().url().optional(),

--- a/src/modules/outbox/OutboxDeliveryWorker.ts
+++ b/src/modules/outbox/OutboxDeliveryWorker.ts
@@ -8,7 +8,9 @@ type OutboxProcessFn = (workerId: string, leaseMs: number) => Promise<boolean>;
 // #795: background delivery worker for the transactional outbox. Each tick drains up to MAX_PER_TICK due
 // events (claim → deliver → mark), so a backlog is worked down without one tick running unbounded. Modeled
 // on AssessmentWorker (re-entrancy guard, health snapshot). Idempotent handlers make re-delivery safe.
-const MAX_PER_TICK = 10;
+// Each delivery is itself bounded (OUTBOX_DELIVERY_TIMEOUT_MS), so a tick's worst case is MAX_PER_TICK ×
+// that timeout — which the wedge window (maxTickMs below) is sized to exceed.
+const MAX_PER_TICK = 5;
 
 export type OutboxDeliveryWorkerStatus = {
   instanceId: string;
@@ -63,9 +65,10 @@ export class OutboxDeliveryWorker {
       tickStartedAt: this.tickStartedAt?.toISOString() ?? null,
       lastCycleAt: this.lastCycleAt?.toISOString() ?? null,
       lastError: null,
-      // #856: a tick can deliver up to MAX_PER_TICK events, each an email/ACS or DB call, so its wedge
-      // window is governed by the drain budget + lease — not the poll interval.
-      maxTickMs: this.leaseMs + 120_000,
+      // #856: a tick delivers up to MAX_PER_TICK events, each bounded by OUTBOX_DELIVERY_TIMEOUT_MS, so its
+      // wedge window is the worst-case drain time + buffer — NOT the poll interval. The per-delivery
+      // deadline guarantees the tick returns within this, making wedge a pure backstop.
+      maxTickMs: MAX_PER_TICK * env.OUTBOX_DELIVERY_TIMEOUT_MS + 60_000,
     };
   }
 

--- a/src/modules/outbox/outboxService.ts
+++ b/src/modules/outbox/outboxService.ts
@@ -1,8 +1,23 @@
 import { prisma } from "../../db/prisma.js";
+import { env } from "../../config/env.js";
 import type { DbTransactionClient } from "../../db/transaction.js";
 import { notifyAssessmentResult } from "../certification/index.js";
 import { checkAndIssueCourseCompletions } from "../course/index.js";
 import type { SupportedLocale } from "../../i18n/locale.js";
+
+// #795-followup: race a delivery against a wall-clock deadline so a hung handler (e.g. an ACS email call
+// with no timeout) can't wedge the worker's tick. On timeout we reject; the caller retries the row. The
+// abandoned handler keeps running but its effect is idempotent, so a later completion is harmless.
+function withDeadline<T>(work: Promise<T>, deadlineMs: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), deadlineMs);
+    timer.unref?.();
+  });
+  return Promise.race([work, deadline]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
 
 // #795: a durable outbox for the post-decision side effects that used to be fire-and-forget. The decision
 // path enqueues these rows (ideally in the same transaction as the decision), and the delivery worker
@@ -159,7 +174,12 @@ export async function processNextOutboxEvent(workerId: string, leaseMs: number):
   if (!claimed) return false;
 
   try {
-    await deliverOutboxEvent(claimed);
+    // #795-followup: bound each delivery so a hung handler can't wedge the worker tick.
+    await withDeadline(
+      deliverOutboxEvent(claimed),
+      env.OUTBOX_DELIVERY_TIMEOUT_MS,
+      `Outbox delivery for ${claimed.id} (${claimed.type}) exceeded ${env.OUTBOX_DELIVERY_TIMEOUT_MS}ms.`,
+    );
     await markOutboxDelivered(claimed.id, claimed.lockedBy, claimed.lockedAt, new Date());
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown outbox delivery error";

--- a/test/unit/outbox-service.test.ts
+++ b/test/unit/outbox-service.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #795-followup: a hung delivery must not wedge the worker — processNextOutboxEvent bounds each delivery
+// with OUTBOX_DELIVERY_TIMEOUT_MS, and on timeout retries the row instead of hanging forever.
+
+const findFirst = vi.fn();
+const updateMany = vi.fn();
+const notifyAssessmentResult = vi.fn();
+const checkAndIssueCourseCompletions = vi.fn();
+
+vi.mock("../../src/db/prisma.js", () => ({
+  prisma: { outboxEvent: { findFirst, updateMany } },
+}));
+vi.mock("../../src/modules/certification/index.js", () => ({ notifyAssessmentResult }));
+vi.mock("../../src/modules/course/index.js", () => ({ checkAndIssueCourseCompletions }));
+
+describe("outbox delivery timeout (#795-followup)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    findFirst.mockReset();
+    updateMany.mockReset().mockResolvedValue({ count: 1 });
+    notifyAssessmentResult.mockReset();
+    checkAndIssueCourseCompletions.mockReset();
+    process.env.OUTBOX_DELIVERY_TIMEOUT_MS = "30"; // 30ms deadline for the test
+  });
+
+  it("retries (does not hang) when a delivery exceeds the deadline", async () => {
+    findFirst.mockResolvedValue({
+      id: "evt-1",
+      type: "assessment_notification",
+      payloadJson: JSON.stringify({
+        submissionId: "s1",
+        submittedAt: new Date().toISOString(),
+        recipientEmail: "a@b.test",
+        recipientName: "A",
+        moduleTitle: "M",
+        moduleId: "m1",
+        passFailTotal: true,
+        locale: "en-GB",
+      }),
+      attempts: 0,
+      maxAttempts: 5,
+      availableAt: new Date(Date.now() - 1000),
+    });
+    // The delivery hangs forever — only the deadline can end it.
+    notifyAssessmentResult.mockReturnValue(new Promise(() => {}));
+
+    const { processNextOutboxEvent } = await import("../../src/modules/outbox/outboxService.js");
+    const processed = await processNextOutboxEvent("worker-1", 60_000);
+
+    expect(processed).toBe(true);
+    // The last updateMany is the retry terminal write: still pending (attempts 1 < max), error recorded.
+    const retryCall = updateMany.mock.calls.at(-1)?.[0];
+    expect(retryCall.data.status).toBe("pending");
+    expect(retryCall.data.attempts).toBe(1);
+    expect(retryCall.data.lastError).toMatch(/exceeded/);
+  });
+});


### PR DESCRIPTION
The 2.5.0 stage deploy surfaced outboxDeliveryWorker as 'wedged' — a pending delivery with no internal timeout never returned (same class as #856). processNextOutboxEvent now races each delivery against OUTBOX_DELIVERY_TIMEOUT_MS (20s) → abandon+retry (idempotent). maxTickMs derived from MAX_PER_TICK×timeout so the deadline guarantees the tick returns before wedge. Code-only. tsc 0; unit 848/848 (new timeout test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)