### PR TITLE
perf(#798): bound reminder scans to the reminder horizon + date indexes → 2.5.2

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,19 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.5.2 - 2026-07-25
+
+#798 (parent #780) — bound the scheduled reminder scans to the reminder horizon instead of loading whole
+tables. The recert + course reminder schedules previously loaded every certification with an expiry / every
+non-revoked enrolment + class-assignment with a due date, then discarded >99% via an in-memory day-match.
+They now range-filter the scan to rows whose expiry/due date is `<= asOf + (largest offset + 1 day)`:
+recert reminders fire before expiry so far-future active certs (the bulk) are pruned at the DB; course
+reminders keep every overdue row (`dueAt < asOf < upperBound`) so no overdue reminder is missed. New
+indexes on `CertificationStatus.expiryDate`, `CourseEnrollment.dueAt`, `CourseGroupAssignment.dueAt` back
+the range filter (additive migration). Behaviour-preserving — no row that could match a reminder is
+excluded; reminder + recert integration flows stay green. (The retention batched-delete half of #798
+already shipped in #807.) tsc 0; unit 848/848; full integration 424/424.
+
 ## 2.5.1 - 2026-07-25
 
 #795 follow-up — bound each outbox delivery so a hung handler can't wedge the delivery worker. The 2.5.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260725020000_reminder_scan_indexes/migration.sql
+++ b/prisma/migrations/20260725020000_reminder_scan_indexes/migration.sql
@@ -1,0 +1,5 @@
+-- #798: the recert + course reminder scans now range-filter on the due/expiry date (<= horizon) instead
+-- of loading whole tables. Index those range columns so the filter is an index scan.
+CREATE INDEX "CertificationStatus_expiryDate_idx" ON "CertificationStatus"("expiryDate");
+CREATE INDEX "CourseEnrollment_dueAt_idx" ON "CourseEnrollment"("dueAt");
+CREATE INDEX "CourseGroupAssignment_dueAt_idx" ON "CourseGroupAssignment"("dueAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -529,6 +529,8 @@ model CertificationStatus {
 
   @@unique([userId, moduleId])
   @@index([moduleId, status])
+  // #798: recert reminder scan range-filters expiryDate (<= horizon); index the range column.
+  @@index([expiryDate])
 }
 
 model AuditEvent {
@@ -642,6 +644,8 @@ model CourseEnrollment {
   @@unique([userId, courseId])
   @@index([courseId])
   @@index([userId, revokedAt])
+  // #798: course reminder scan range-filters dueAt (<= horizon); index the range column.
+  @@index([dueAt])
 }
 
 // #645/CL-1: a "class" (klasse) — a platform-owned, many-to-many cohort used to assign courses to a
@@ -699,6 +703,8 @@ model CourseGroupAssignment {
 
   @@unique([courseId, classId])
   @@index([classId])
+  // #798: course reminder scan range-filters dueAt (<= horizon); index the range column.
+  @@index([dueAt])
 }
 
 // Læringsseksjon i et kurs (#476/#481). Speiler Module/ModuleVersion: innholdet

--- a/src/modules/certification/certificationRepository.ts
+++ b/src/modules/certification/certificationRepository.ts
@@ -54,10 +54,15 @@ export function createCertificationRepository(client: CertificationRepositoryCli
       });
     },
 
-    findCertificationsForReminderSchedule() {
+    // #798: only load certifications whose expiry is within the reminder horizon (`expiryDate <=
+    // upperBound`, where upperBound = asOf + the largest offset + a day). Recert reminders fire BEFORE
+    // expiry, so every candidate expiry is at or after asOf; far-future active certs (the bulk of the
+    // table) are pruned by the DB instead of loaded and discarded in memory. Backed by an index on
+    // expiryDate. Behaviour-preserving: no row that could match a reminder day is excluded.
+    findCertificationsForReminderSchedule(upperBound: Date) {
       return client.certificationStatus.findMany({
         where: {
-          expiryDate: { not: null },
+          expiryDate: { not: null, lte: upperBound },
         },
         include: {
           user: {

--- a/src/modules/certification/recertificationService.ts
+++ b/src/modules/certification/recertificationService.ts
@@ -141,7 +141,11 @@ export async function runRecertificationReminderSchedule(input?: { asOf?: Date }
     };
   }
 
-  const certifications = await certificationRepository.findCertificationsForReminderSchedule();
+  // #798: bound the scan to the reminder horizon. reminderDaysBefore is sorted descending, so [0] is the
+  // largest offset; +1 day of headroom covers the day-boundary match. Anything expiring beyond this can
+  // never match a "days before expiry" reminder on this run.
+  const upperBound = addDays(asOf, reminderDaysBefore[0] + 1);
+  const certifications = await certificationRepository.findCertificationsForReminderSchedule(upperBound);
 
   let processed = 0;
   let sent = 0;

--- a/src/modules/course/classRepository.ts
+++ b/src/modules/course/classRepository.ts
@@ -159,9 +159,10 @@ export function createClassRepository(client: ClassRepositoryClient = prisma) {
     // the service can expand membership (MANUAL rows are included; the system "Alle deltakere" class
     // has no rows and is resolved separately; ENTRA classes are not resolvable in a background job
     // and are skipped by the service).
-    findCourseGroupAssignmentsWithDueDate() {
+    // #798: bound to the reminder horizon (dueAt <= upperBound); includes overdue, prunes far-future.
+    findCourseGroupAssignmentsWithDueDate(upperBound: Date) {
       return client.courseGroupAssignment.findMany({
-        where: { dueAt: { not: null }, class: { archivedAt: null } },
+        where: { dueAt: { not: null, lte: upperBound }, class: { archivedAt: null } },
         include: {
           course: { select: { id: true, title: true } },
           class: {

--- a/src/modules/course/courseReminderService.ts
+++ b/src/modules/course/courseReminderService.ts
@@ -205,12 +205,12 @@ function localizeTitle(title: string): string {
 
 // Samler individuelle + klasse-tildelte frister til ÉN effektiv kandidat per (bruker, kurs).
 // Presedens: individuell frist vinner over klasse; ved flere klasse-frister vinner den tidligste.
-async function gatherCandidates(summary: CourseReminderScheduleSummary): Promise<ReminderCandidate[]> {
+async function gatherCandidates(summary: CourseReminderScheduleSummary, upperBound: Date): Promise<ReminderCandidate[]> {
   const map = new Map<string, ReminderCandidate>();
   const keyOf = (userId: string, courseId: string) => `${userId}::${courseId}`;
 
   // 1. Individuelle (eksplisitt tildelte) enrollments med frist.
-  const enrollments = await enrollmentRepository.findIndividualEnrollmentsWithDueDate();
+  const enrollments = await enrollmentRepository.findIndividualEnrollmentsWithDueDate(upperBound);
   for (const enrollment of enrollments) {
     if (!enrollment.dueAt) continue;
     map.set(keyOf(enrollment.userId, enrollment.courseId), {
@@ -228,7 +228,7 @@ async function gatherCandidates(summary: CourseReminderScheduleSummary): Promise
 
   // 2. Klasse-tildelte frister → ekspander til medlemmer. MANUAL = ClassMember-rader;
   //    system-klassen «Alle deltakere» = alle aktive deltakere (ingen rader). ENTRA hoppes over.
-  const assignments = await classRepository.findCourseGroupAssignmentsWithDueDate();
+  const assignments = await classRepository.findCourseGroupAssignmentsWithDueDate(upperBound);
   let allParticipants: Array<{ id: string; name: string; email: string }> | null = null;
 
   for (const assignment of assignments) {
@@ -304,7 +304,11 @@ export async function runCourseReminderSchedule(input?: {
     skippedEntraClass: 0,
   };
 
-  const candidates = await gatherCandidates(summary);
+  // #798: bound both due-date scans to the reminder horizon (largest due-soon offset + 1 day). This still
+  // includes every OVERDUE row (dueAt < asOf < upperBound), so overdue reminders are never missed; only
+  // far-future-dated enrolments/assignments are pruned at the DB.
+  const upperBound = addDays(asOf, (reminderDaysBefore[0] ?? 0) + 1);
+  const candidates = await gatherCandidates(summary, upperBound);
 
   for (const candidate of candidates) {
     if (!candidate.activeStatus || candidate.isAnonymized) {

--- a/src/modules/course/enrollmentRepository.ts
+++ b/src/modules/course/enrollmentRepository.ts
@@ -68,9 +68,11 @@ export function createEnrollmentRepository(client: EnrollmentRepositoryClient = 
     // schedule. Skips revoked enrollments and enrollments without a dueAt at the query level; the
     // service layer further filters completed courses and inactive/anonymized users. Includes the
     // participant + the (localized) course title so no extra per-row lookups are needed.
-    findIndividualEnrollmentsWithDueDate() {
+    // #798: bound to the reminder horizon (dueAt <= upperBound). Includes all overdue rows (dueAt < asOf),
+    // so no reminder is missed; prunes far-future-dated enrolments at the DB. Backed by an index on dueAt.
+    findIndividualEnrollmentsWithDueDate(upperBound: Date) {
       return client.courseEnrollment.findMany({
-        where: { revokedAt: null, dueAt: { not: null } },
+        where: { revokedAt: null, dueAt: { not: null, lte: upperBound } },
         include: {
           user: { select: { id: true, name: true, email: true, activeStatus: true, isAnonymized: true } },
           course: { select: { id: true, title: true } },

--- a/test/unit/certification-repository.test.ts
+++ b/test/unit/certification-repository.test.ts
@@ -49,12 +49,13 @@ describe("certification repository", () => {
       },
     } as never);
 
-    await repository.findCertificationsForReminderSchedule();
+    const upperBound = new Date("2026-08-01T00:00:00.000Z");
+    await repository.findCertificationsForReminderSchedule(upperBound);
 
     expect(findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: {
-          expiryDate: { not: null },
+          expiryDate: { not: null, lte: upperBound },
         },
         include: expect.objectContaining({
           user: expect.any(Object),


### PR DESCRIPTION
Recert + course reminder scans loaded whole tables + discarded >99% in memory. Now range-filter to rows with expiry/dueAt <= asOf + (largest offset + 1d) — recert prunes far-future active certs; course keeps all overdue (no reminder missed). New indexes on expiryDate/dueAt (additive migration). Behaviour-preserving; reminder+recert flows green. tsc 0; unit 848/848; integration 424/424. (Retention batched-delete half already in #807.) Parent #780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)