### PR TITLE
perf(#799): batch participant course-listing reads → 2.5.3

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,18 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.5.3 - 2026-07-25
+
+#799 (parent #780) — kill the N+1 query fan-out on the participant course listing. `GET /api/courses` did
+~4 queries PER visible course (course items, passed-module count, read sections, latest submissions) —
+O(courses) round-trips that could exhaust the 10-connection pool. It now batch-fetches each of those across
+ALL visible courses (a fixed number of queries) and derives per-course progress in memory. New batch repo
+reads: `findCourseItemSectionIdsForCourses`, `findPassedModuleIds`, `findReadSectionIdsForCourses`;
+latest submissions fetched once for all modules. Behaviour-preserving — identical per-course counts
+(`m2-courses-participant-flow` asserts two distinct courses' progress from the batched listing and stays
+green). Scope: the participant listing (the worst, most user-facing fan-out); the admin-list + reporting
+fan-outs from the #799 evidence remain as follow-up. No migration. tsc 0; unit 848/848; integration 424/424.
+
 ## 2.5.2 - 2026-07-25
 
 #798 (parent #780) — bound the scheduled reminder scans to the reminder horizon instead of loading whole

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/modules/course/courseRepository.ts
+++ b/src/modules/course/courseRepository.ts
@@ -127,6 +127,43 @@ export function createCourseRepository(client: CourseRepositoryClient = prisma) 
         .then((rows) => rows.map((r) => r.sectionId));
     },
 
+    // #799: batch variants of the per-course reads above, so the participant course listing does a fixed
+    // number of queries instead of ~4 per visible course. Each returns rows the caller groups in memory.
+    findReadSectionIdsForCourses(userId: string, courseIds: string[]) {
+      if (courseIds.length === 0) return Promise.resolve([] as Array<{ courseId: string; sectionId: string }>);
+      return client.courseSectionRead.findMany({
+        where: { userId, courseId: { in: courseIds } },
+        select: { courseId: true, sectionId: true },
+      });
+    },
+
+    // The set of the user's PASSED module ids among the given modules (one query across every course's
+    // modules). The caller counts per course by intersecting with each course's module ids.
+    findPassedModuleIds(userId: string, moduleIds: string[]) {
+      if (moduleIds.length === 0) return Promise.resolve([] as string[]);
+      return client.certificationStatus
+        .findMany({
+          where: { userId, moduleId: { in: moduleIds }, status: { in: CERTIFICATION_PASSED_STATUSES } },
+          select: { moduleId: true },
+        })
+        .then((rows) => rows.map((r) => r.moduleId));
+    },
+
+    // SECTION course-item ids for many courses at once (one query), for the listing's section counts.
+    findCourseItemSectionIdsForCourses(courseIds: string[]) {
+      if (courseIds.length === 0) return Promise.resolve([] as Array<{ courseId: string; sectionId: string }>);
+      return client.courseItem
+        .findMany({
+          where: { courseId: { in: courseIds }, itemType: "SECTION", sectionId: { not: null } },
+          select: { courseId: true, sectionId: true },
+        })
+        .then((rows) =>
+          rows
+            .filter((r): r is { courseId: string; sectionId: string } => Boolean(r.sectionId))
+            .map((r) => ({ courseId: r.courseId, sectionId: r.sectionId })),
+        );
+    },
+
     findCourseItems(courseId: string) {
       return client.courseItem.findMany({
         where: { courseId },

--- a/src/routes/courses.ts
+++ b/src/routes/courses.ts
@@ -48,49 +48,60 @@ coursesRouter.get("/", async (request, response, next) => {
     const visibleIds = await filterVisibleCourseIds(userId, allCourses, new Set(classCourseDue.keys()));
     const courses = allCourses.filter((course) => visibleIds.has(course.id));
 
-    const items: CourseListItem[] = await Promise.all(
-      courses.map(async (course) => {
-        // Count all elements — modules + sections (#492). Modules are derived from
-        // CourseItem (itemType MODULE, via the repository); sections only exist in CourseItem.
-        const moduleIds = course.modules.map((m) => m.moduleId);
-        const courseItems = await courseRepository.findCourseItems(course.id);
-        const sectionIds = courseItems
-          .filter((i) => i.itemType === "SECTION")
-          .map((i) => i.sectionId)
-          .filter((id): id is string => Boolean(id));
-        const [passed, readIds, latestSubmissions] = await Promise.all([
-          moduleIds.length > 0
-            ? courseRepository.countPassedModulesForUser(userId, moduleIds)
-            : Promise.resolve(0),
-          sectionIds.length > 0
-            ? courseRepository.findReadSectionIds(userId, course.id)
-            : Promise.resolve([] as string[]),
-          moduleIds.length > 0
-            ? queryLatestSubmissionsForModules(userId, moduleIds)
-            : Promise.resolve([]),
-        ]);
-        const readCount = readIds.filter((id) => sectionIds.includes(id)).length;
-        const total = moduleIds.length + sectionIds.length;
-        const completed = passed + readCount;
-        const hasStarted = latestSubmissions.length > 0 || readCount > 0;
+    // #799: batch every per-course read across ALL visible courses (a fixed number of queries) instead of
+    // ~4 queries per course, then derive each course's progress in memory. Behaviour-preserving — the same
+    // counts as the previous per-course version, just fetched together.
+    const courseIds = courses.map((course) => course.id);
+    const allModuleIds = courses.flatMap((course) => course.modules.map((m) => m.moduleId));
 
-        return {
-          id: course.id,
-          title: localizeContentText(locale, course.title) ?? course.title,
-          description: localizeContentText(locale, course.description) ?? course.description,
-          moduleCount: moduleIds.length,
-          progress: {
-            completed,
-            total,
-            courseStatus: computeCourseStatus(completed, total, hasStarted),
-            moduleCompleted: passed,
-            moduleTotal: moduleIds.length,
-            sectionCompleted: readCount,
-            sectionTotal: sectionIds.length,
-          },
-        };
-      }),
-    );
+    const [sectionRows, passedModuleIds, readRows, latestSubmissions] = await Promise.all([
+      courseRepository.findCourseItemSectionIdsForCourses(courseIds),
+      courseRepository.findPassedModuleIds(userId, allModuleIds),
+      courseRepository.findReadSectionIdsForCourses(userId, courseIds),
+      allModuleIds.length > 0 ? queryLatestSubmissionsForModules(userId, allModuleIds) : Promise.resolve([]),
+    ]);
+
+    const sectionIdsByCourse = new Map<string, string[]>();
+    for (const row of sectionRows) {
+      const list = sectionIdsByCourse.get(row.courseId);
+      if (list) list.push(row.sectionId);
+      else sectionIdsByCourse.set(row.courseId, [row.sectionId]);
+    }
+    const passedModuleSet = new Set(passedModuleIds);
+    const readSectionsByCourse = new Map<string, Set<string>>();
+    for (const row of readRows) {
+      const set = readSectionsByCourse.get(row.courseId);
+      if (set) set.add(row.sectionId);
+      else readSectionsByCourse.set(row.courseId, new Set([row.sectionId]));
+    }
+    const startedModuleIds = new Set(latestSubmissions.map((s) => s.moduleId));
+
+    const items: CourseListItem[] = courses.map((course) => {
+      const moduleIds = course.modules.map((m) => m.moduleId);
+      const sectionIds = sectionIdsByCourse.get(course.id) ?? [];
+      const passed = moduleIds.filter((id) => passedModuleSet.has(id)).length;
+      const readSet = readSectionsByCourse.get(course.id);
+      const readCount = readSet ? sectionIds.filter((id) => readSet.has(id)).length : 0;
+      const total = moduleIds.length + sectionIds.length;
+      const completed = passed + readCount;
+      const hasStarted = moduleIds.some((id) => startedModuleIds.has(id)) || readCount > 0;
+
+      return {
+        id: course.id,
+        title: localizeContentText(locale, course.title) ?? course.title,
+        description: localizeContentText(locale, course.description) ?? course.description,
+        moduleCount: moduleIds.length,
+        progress: {
+          completed,
+          total,
+          courseStatus: computeCourseStatus(completed, total, hasStarted),
+          moduleCompleted: passed,
+          moduleTotal: moduleIds.length,
+          sectionCompleted: readCount,
+          sectionTotal: sectionIds.length,
+        },
+      };
+    });
 
     response.json({ courses: items });
   } catch (error) {


### PR DESCRIPTION
GET /api/courses did ~4 queries/course; now batch-fetches across all visible courses + derives in memory. Behaviour-preserving (m2-courses-participant-flow asserts two courses' progress, green). Scope: participant listing (worst fan-out); admin-list + reporting follow-up. No migration. tsc 0; unit 848/848; integration 424/424. Parent #780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)