### PR TITLE
fix(participant): keep expanded course after mark-read + module-section FOUC fix → 2.5.4

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,21 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.5.4 - 2026-07-25
+
+Participant-console UX fixes (frontend only, no migration).
+
+- **Mine Kurs accordion keeps the expanded course after "mark as read".** Marking a section read
+  re-rendered the course list and collapsed the course the user was in. `renderParticipantCourseAccordion`
+  now captures the expanded courses and re-opens them after the re-render; the `?courseId` deep-link only
+  fires on the first render so it no longer fights the preservation.
+- **#495 FOUC fix.** The legacy standalone module section (`#moduleListSection`) flashed for a couple
+  seconds then hid, because it rendered visible and was only hidden client-side once the runtime config
+  loaded. It is now hidden by DEFAULT (inline style) and revealed only when course-only mode is OFF, so in
+  production it stays hidden from first paint — no flash. The standalone flow itself is retained (it is
+  still the test suite's module selector); fully removing it + migrating the ~2 e2e / ~25 integration
+  tests that submit on standalone modules is a separate follow-up.
+
 ## 2.5.3 - 2026-07-25
 
 #799 (parent #780) — kill the N+1 query fan-out on the participant course listing. `GET /api/courses` did

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/participant.html
+++ b/public/participant.html
@@ -162,7 +162,7 @@
     <!-- v1.2.22 (#465): seksjon kan kollapses når en modul er aktivert, så innholdet får
          mer plass. Kollapser kun selve modullisten (header + Load-knapp er fortsatt synlig
          så bruker kan klikke for å ekspandere igjen). -->
-    <section class="card" id="moduleListSection">
+    <section class="card" id="moduleListSection" style="display:none">
       <h2 data-i18n="modules.title">Modules</h2>
       <button id="loadModules" class="btn-secondary" data-i18n="modules.load">Load modules</button>
       <div class="small" data-i18n="modules.summaryHint">Select one module card before creating submission.</div>

--- a/public/participant.js
+++ b/public/participant.js
@@ -1572,8 +1572,12 @@ async function loadParticipantConsoleConfig() {
 // frittstående modul-seksjonen. Modul åpnet via course player bruker submission-/MCQ-seksjonene
 // (ikke denne lista), så den flyten er upåvirket.
 function applyCourseOnlyMode() {
-  if (participantRuntimeConfig?.courseOnly) {
-    setHidden(document.getElementById("moduleListSection"), true);
+  // #495: the standalone module section is hidden by DEFAULT (inline style in participant.html) so it no
+  // longer flashes-then-hides (FOUC) while the runtime config loads. Reveal it only when course-only mode
+  // is OFF — i.e. the legacy standalone flow is explicitly enabled (dev/test). In prod (courseOnly) it
+  // simply stays hidden from first paint.
+  if (!participantRuntimeConfig?.courseOnly) {
+    setHidden(document.getElementById("moduleListSection"), false);
   }
 }
 
@@ -2822,9 +2826,26 @@ function renderParticipantCourseAccordion() {
     container.innerHTML = `<p class="small" style="color:var(--color-meta);margin-top:4px">${escapeHtmlP(t("courses.empty"))}</p>`;
     return;
   }
+  // Preserve which courses the user had expanded across this re-render (e.g. after marking a section read),
+  // so returning to the list doesn't collapse the course they're working in.
+  const previouslyOpen = new Set(
+    Array.from(container.querySelectorAll(".course-accordion-item.open")).map((el) => el.dataset.courseId),
+  );
+  const isFirstRender = !courseAccordionInitialized;
+
   container.innerHTML = "";
   for (const course of participantCourses) {
     container.appendChild(buildCourseAccordionItem(course));
+  }
+
+  // Re-expand the previously-open courses (their detail is re-fetched since the cache was invalidated).
+  for (const courseId of previouslyOpen) {
+    if (!courseId) continue;
+    const item = container.querySelector(`.course-accordion-item[data-course-id="${courseId}"]`);
+    if (!item) continue;
+    item.classList.add("open");
+    item.querySelector(".course-accordion-header")?.setAttribute("aria-expanded", "true");
+    loadCourseDetail(courseId);
   }
 
   // #550: confetti when a course becomes completed during this session.
@@ -2843,9 +2864,10 @@ function renderParticipantCourseAccordion() {
   }
   courseAccordionInitialized = true;
 
-  // Deep link: ?courseId=xxx opens that course
+  // Deep link: ?courseId=xxx opens that course — only on the FIRST render, so a later re-render (e.g. after
+  // marking a section read) doesn't re-toggle it and fight the open-state preservation above.
   const linkedCourseId = new URLSearchParams(window.location.search).get("courseId");
-  if (linkedCourseId) {
+  if (isFirstRender && linkedCourseId) {
     const header = container.querySelector(`[data-course-id="${linkedCourseId}"] .course-accordion-header`);
     if (header) {
       header.click();


### PR DESCRIPTION
Two frontend fixes (no migration): (1) Mine Kurs accordion preserves the expanded course across the mark-read re-render; (2) #495 FOUC — the standalone module section is now hidden by default (was visible-then-hidden after config load = the flash you saw), revealed only when course-only mode is off. The standalone flow is RETAINED (it's the test suite's module selector); full removal + test migration is a follow-up. Frontend-only; participant e2e still green. 🤖 Generated with Claude Code