### PR TITLE
fix(#495): content producer (SMO) can take/test modules, like reading sections → 2.5.5

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,15 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.5.5 - 2026-07-25
+
+#495 consistency — a content producer (`SUBJECT_MATTER_OWNER`) can read course sections and open a module,
+but taking a module 403'd ("Krever en av rollene: PARTICIPANT, ADMINISTRATOR, REVIEWER") because the
+`submissions` + `assessments` capabilities excluded SMO, inconsistent with `courses`/`modules`/
+`content_assets` (which include SMO) and with `submissions.ts` (already exempts content roles from the
+course-required gate). Added `SUBJECT_MATTER_OWNER` to those two role sets so a content producer can test
+their own module end-to-end. tsc 0; unit 846/846; integration 424/424.
+
 ## 2.5.4 - 2026-07-25
 
 Participant-console UX fixes (frontend only, no migration).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/config/capabilities.ts
+++ b/src/config/capabilities.ts
@@ -60,14 +60,20 @@ export const API_ROUTE_CAPABILITIES = [
     ],
   },
   {
+    // #495 consistency: a content producer (SUBJECT_MATTER_OWNER) can read course sections and open a
+    // module, so they must also be able to TAKE/test a module (create a submission) — the same authoring/
+    // testing access. submissions.ts already exempts content roles from the course-required gate; without
+    // SMO here the route 403'd before that ("Krever en av rollene: PARTICIPANT, ADMINISTRATOR, REVIEWER").
     id: "submissions",
     prefix: "/api/submissions",
-    roles: [AppRole.PARTICIPANT, AppRole.ADMINISTRATOR, AppRole.REVIEWER],
+    roles: [AppRole.PARTICIPANT, AppRole.SUBJECT_MATTER_OWNER, AppRole.ADMINISTRATOR, AppRole.REVIEWER],
   },
   {
+    // #495 consistency: SMO tests their own module end-to-end, so the assessment endpoints must admit them
+    // too (matches `submissions` above and `modules`/`courses`, which already include SMO).
     id: "assessments",
     prefix: "/api/assessments",
-    roles: [AppRole.PARTICIPANT, AppRole.ADMINISTRATOR, AppRole.REVIEWER],
+    roles: [AppRole.PARTICIPANT, AppRole.SUBJECT_MATTER_OWNER, AppRole.ADMINISTRATOR, AppRole.REVIEWER],
   },
   {
     id: "audit",


### PR DESCRIPTION
A SUBJECT_MATTER_OWNER could read sections + open a module but got 403 on taking one, because submissions/assessments capabilities excluded SMO (inconsistent with courses/modules + submissions.ts which already exempts content roles). Added SUBJECT_MATTER_OWNER to those two role sets. tsc 0; unit 846/846; integration 424/424.

🤖 Generated with Claude Code