### PR TITLE
#818 (Phase 1): extract shared authoring-shell helpers — v2.7.2

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,25 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.7.2 - 2026-07-25
+
+#818 (Phase 1) — de-duplicate the two authoring shells (`public/admin-content.js` advanced +
+`public/static/admin-content-shell.js` conversation). **Behavior-preserving; no user-facing change.**
+
+- New `public/static/admin-content-shared.js` holds the genuinely-identical helpers: `makeSrBadge`
+  (was byte-identical in both) and `loadVersion(appVersionLabel, titlePrefix)` (was near-identical —
+  the two shells differed only in the document-title prefix + a null-guard, both preserved by
+  parameterizing). Both shells now import them; local copies removed.
+- **Scope correction:** the issue's "~5k duplicated lines" is a large overcount — the two files are
+  architecturally divergent (chat state-machine vs form/dialog CRUD); the genuinely-safe extractable
+  surface is ~a few hundred lines. A tempting further swap (advanced's `localizeContentValue` →
+  the shared `localizeValueForLocale`) was **rejected**: their locale-fallback order differs (advanced
+  lacks the `nb` middle step), so it would NOT be behavior-preserving. State-rail / console-bootstrap
+  sharing needs a view-model refactor (Phase 2) with real risk — deferred. #818 stays open for that.
+
+Frontend only, no migration. Verified: `admin-content-workspaces` e2e 39/39 (both shells) + DOM
+accessibility contracts 3/3; node syntax-check on all three files.
+
 ## 2.7.1 - 2026-07-25
 
 #811 — **worker no longer starts new code against an un-migrated schema.** The worker ran with

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/admin-content.js
+++ b/public/admin-content.js
@@ -26,6 +26,7 @@ import {
   resolveConversationModuleId,
 } from "/static/admin-content-handoff-routes.js";
 import { renderOwnerPanel } from "/static/owner-panel.js";
+import { makeSrBadge, loadVersion } from "/static/admin-content-shared.js";
 
 const translations = Object.fromEntries(
   supportedLocales.map((locale) => [
@@ -1115,10 +1116,6 @@ function deriveModuleStatusView(moduleExport) {
 // State rail
 // ---------------------------------------------------------------------------
 
-function makeSrBadge(modifier, text) {
-  return `<span class="sr-badge sr-badge--${modifier}">${escapeHtml(text)}</span>`;
-}
-
 function updateStateRail() {
   if (!stateRail) return;
   const hasModule = !!selectedModuleId && !!selectedModuleStatus;
@@ -1779,17 +1776,6 @@ function resolveModuleIdOrThrow() {
   renderModuleDropdown();
   renderModuleMeta();
   return moduleId;
-}
-
-async function loadVersion() {
-  try {
-    const body = await apiFetch("/version", { headers: {} });
-    const version = body.version ?? "unknown";
-    document.title = `A2 Content Setup Workspace v${version}`;
-    appVersionLabel.textContent = `v${version}`;
-  } catch {
-    appVersionLabel.textContent = "unknown";
-  }
 }
 
 async function loadParticipantConsoleConfig() {
@@ -4248,7 +4234,7 @@ document.getElementById("previewCardsBtn")?.addEventListener("click", async () =
 populateLocaleSelect();
 setLocale(currentLocale);
 setDefaultFormValues();
-loadVersion();
+loadVersion(appVersionLabel, "A2 Content Setup Workspace");
 loadParticipantConsoleConfig().then(async () => {
   const pathModuleId = window.location.pathname.match(/\/admin-content\/module\/([^/]+)\//)?.[1] ?? null;
   const autoModuleId = pathModuleId ?? new URLSearchParams(location.search).get("moduleId");

--- a/public/static/admin-content-shared.js
+++ b/public/static/admin-content-shared.js
@@ -1,0 +1,28 @@
+// #818: helpers shared by the two authoring shells — `public/admin-content.js` (advanced, form/dialog)
+// and `public/static/admin-content-shell.js` (conversation, chat). These were byte- or near-identical in
+// both. Behavior-preserving extractions only: callers pass their own DOM refs / strings so the functions
+// stay shell-agnostic (no reaching for page-specific globals). The two shells are otherwise genuinely
+// divergent and are NOT merged.
+import { escapeHtml } from "/static/html-escape.js";
+import { apiFetch } from "/static/api-client.js";
+
+/** Screen-reader status badge markup (was byte-identical in both shells). */
+export function makeSrBadge(modifier, text) {
+  return `<span class="sr-badge sr-badge--${modifier}">${escapeHtml(text)}</span>`;
+}
+
+/**
+ * Load the app version and stamp it into the document title + the version label. The two shells differed
+ * only in the title prefix ("A2 Content Setup Workspace" vs "A2 Content Workspace") and a null-guard on
+ * the label element — both preserved by parameterizing.
+ */
+export async function loadVersion(appVersionLabel, documentTitlePrefix) {
+  try {
+    const body = await apiFetch("/version", { headers: {} });
+    const version = body.version ?? "unknown";
+    document.title = `${documentTitlePrefix} v${version}`;
+    if (appVersionLabel) appVersionLabel.textContent = `v${version}`;
+  } catch {
+    if (appVersionLabel) appVersionLabel.textContent = "unknown";
+  }
+}

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -30,6 +30,7 @@ import {
 import { buildAdminContentAdvancedUrl } from "/static/admin-content-handoff-routes.js";
 import { deriveModuleStatusChains } from "/static/module-status-logic.js";
 import { renderOwnerPanel } from "/static/owner-panel.js";
+import { makeSrBadge, loadVersion } from "/static/admin-content-shared.js";
 import {
   buildExternalLlmAuthoringPrompt,
   parseExternalLlmJson,
@@ -1130,10 +1131,6 @@ function scrollPreviewToBottom() {
 // ---------------------------------------------------------------------------
 // State rail
 // ---------------------------------------------------------------------------
-
-function makeSrBadge(modifier, text) {
-  return `<span class="sr-badge sr-badge--${modifier}">${escapeHtml(text)}</span>`;
-}
 
 function updateStateRail() {
   if (!stateRail) return;
@@ -4656,17 +4653,6 @@ function askForCustomMcqOptionCount(sourceMaterial, certLevel, locale, generatio
 // Nav / version / locale
 // ---------------------------------------------------------------------------
 
-async function loadVersion() {
-  try {
-    const body = await apiFetch("/version", { headers: {} });
-    const version = body.version ?? "unknown";
-    document.title = `A2 Content Workspace v${version}`;
-    if (appVersionLabel) appVersionLabel.textContent = `v${version}`;
-  } catch {
-    if (appVersionLabel) appVersionLabel.textContent = "unknown";
-  }
-}
-
 function renderWorkspaceNavigation() {
   if (!workspaceNav) return;
   const roles = activeUserRoles.join(",") || participantRuntimeConfig.identityDefaults?.roles?.join(",") || "SUBJECT_MATTER_OWNER";
@@ -4767,7 +4753,7 @@ async function initShell() {
   bindModeSwitchButtons();
   renderPreviewLocaleBar();
   renderPreview();
-  loadVersion();
+  loadVersion(appVersionLabel, "A2 Content Workspace");
   await loadConsoleConfig();
 
   // Path-based moduleId: /admin-content/module/:moduleId/conversation


### PR DESCRIPTION
Behavior-preserving de-dup of the two authoring shells (advanced `admin-content.js` + conversation `admin-content-shell.js`).

New `public/static/admin-content-shared.js`: **makeSrBadge** (was byte-identical) + **loadVersion(appVersionLabel, titlePrefix)** (near-identical — differed only in the document-title prefix + a null-guard, both preserved by parameterizing). Local copies removed from both shells.

**Scope correction:** the issue's "~5k duplicated lines" is a large overcount — the two files are architecturally divergent (chat state-machine vs form/dialog CRUD); the genuinely-safe extractable surface is a few hundred lines. A tempting `localizeContentValue`→shared `localizeValueForLocale` swap was **rejected** (their locale-fallback order differs — not behavior-preserving). State-rail/console-bootstrap sharing needs a view-model refactor (Phase 2) — deferred; #818 stays open.

Frontend only, no migration. Verified: `admin-content-workspaces` e2e **39/39** (both shells) + DOM accessibility contracts 3/3; node syntax-check on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)