### PR TITLE
#809: web /healthz readiness probe (DB reachability) — v2.7.3

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,23 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.7.3 - 2026-07-25
+
+#809 — **web `/healthz` is now a readiness probe, not a static liveness stub.** It returned `200` as soon
+as Express bound the port — before/without DB connectivity — so Azure's health check
+(`healthCheckPath=/healthz`), the external availability pings, and the post-deploy smoke test couldn't
+tell a truly-ready web from a bound-but-broken one. Parent #782.
+
+- New `src/observability/webReadiness.ts` `isWebReady()`: probes the DB (`SELECT 1`), **cached 5s** (so
+  Azure's frequent pings don't hammer the DB) and **bounded by a 2s timeout** (so a hung DB can't hang
+  `/healthz` itself). `/healthz` returns `200 {status:"ok"}` when ready, `503 {status:"degraded"}` when
+  the DB is unreachable. A transient blip self-heals on the next check; a sustained outage now surfaces
+  honestly instead of being masked.
+- Complements #866 (worker self-heal) + #811 (worker migrate-on-startup) and is the readiness gate a
+  future #808 slot-swap would warm/gate on (instead of the old stub).
+
+Code-only, no migration. tsc 0; unit 862/862 (+ `web-readiness` 4). Bundled to stage with #818 (v2.7.2).
+
 ## 2.7.2 - 2026-07-25
 
 #818 (Phase 1) — de-duplicate the two authoring shells (`public/admin-content.js` advanced +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import { enforceAgentTokenScope } from "./auth/agentTokenScope.js";
 import { requireAnyRole } from "./auth/authorization.js";
 import { attachCorrelationId, requestLoggingMiddleware } from "./middleware/requestObservability.js";
 import { securityHeadersMiddleware } from "./middleware/securityHeaders.js";
+import { isWebReady } from "./observability/webReadiness.js";
 import { generalApiLimiter, preBodyApiLimiter } from "./middleware/rateLimiting.js";
 import { errorHandlingMiddleware } from "./middleware/errorHandling.js";
 import { requireConsent } from "./middleware/consentMiddleware.js";
@@ -85,8 +86,11 @@ app.get("/", (_request, response) => {
   response.status(200).send("a2-assessment-platform");
 });
 
-app.get("/healthz", (_request, response) => {
-  response.json({ status: "ok" });
+app.get("/healthz", async (_request, response) => {
+  // #809: readiness, not just liveness — 200 only when the DB is reachable, so Azure's health check +
+  // the deploy smoke test reflect a truly-ready web (was a static 200 stub).
+  const ready = await isWebReady();
+  response.status(ready ? 200 : 503).json({ status: ready ? "ok" : "degraded" });
 });
 
 app.get("/version", generalApiLimiter, (_request, response) => {

--- a/src/observability/webReadiness.ts
+++ b/src/observability/webReadiness.ts
@@ -1,0 +1,43 @@
+import { prisma } from "../db/prisma.js";
+
+// #809: the web `/healthz` used to be a static stub returning 200 as soon as Express bound the port —
+// before/without DB connectivity. So Azure's health check (healthCheckPath=/healthz), the external
+// availability pings, and the post-deploy smoke test couldn't tell a truly-ready web from a bound-but-
+// broken one (e.g. DB unreachable). A readiness probe fixes that: /healthz reflects real DB reachability.
+//
+// Cached so Azure's frequent pings don't hammer the DB, and bounded so a hung DB can never hang the probe
+// (which would itself make /healthz time out). A transient blip self-heals on the next check after the
+// cache expires; a sustained outage is a real incident the honest 503 should surface, not mask.
+
+const READY_CACHE_MS = 5_000;
+const PROBE_TIMEOUT_MS = 2_000;
+
+let lastCheckedAt = 0;
+let lastResult = false;
+
+/**
+ * True when the DB answered a trivial query within the timeout. Result is cached for READY_CACHE_MS.
+ * `now` is injectable for tests.
+ */
+export async function isWebReady(now: number = Date.now()): Promise<boolean> {
+  if (lastCheckedAt !== 0 && now - lastCheckedAt < READY_CACHE_MS) {
+    return lastResult;
+  }
+  lastCheckedAt = now;
+  try {
+    await Promise.race([
+      prisma.$queryRaw`SELECT 1`,
+      new Promise((_resolve, reject) => setTimeout(() => reject(new Error("db_probe_timeout")), PROBE_TIMEOUT_MS)),
+    ]);
+    lastResult = true;
+  } catch {
+    lastResult = false;
+  }
+  return lastResult;
+}
+
+// Test seam: reset the cache between cases.
+export function __resetWebReadinessCache() {
+  lastCheckedAt = 0;
+  lastResult = false;
+}

--- a/test/unit/web-readiness.test.ts
+++ b/test/unit/web-readiness.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// #809: web /healthz readiness probe — 200 only when the DB answers, cached + bounded.
+const queryRaw = vi.fn();
+vi.mock("../../src/db/prisma.js", () => ({
+  prisma: { $queryRaw: (...args: unknown[]) => queryRaw(...args) },
+}));
+
+import { isWebReady, __resetWebReadinessCache } from "../../src/observability/webReadiness.js";
+
+describe("isWebReady (#809)", () => {
+  beforeEach(() => {
+    queryRaw.mockReset();
+    __resetWebReadinessCache();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("is ready when the DB answers", async () => {
+    queryRaw.mockResolvedValue([{ ok: 1 }]);
+    expect(await isWebReady(1_000)).toBe(true);
+  });
+
+  it("is not ready when the DB query rejects", async () => {
+    queryRaw.mockRejectedValue(new Error("connection refused"));
+    expect(await isWebReady(1_000)).toBe(false);
+  });
+
+  it("caches within the window, then re-checks after it", async () => {
+    queryRaw.mockResolvedValue([{ ok: 1 }]);
+    expect(await isWebReady(1_000)).toBe(true);
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+
+    // within 5s cache window → served from cache, no new probe
+    expect(await isWebReady(3_000)).toBe(true);
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+
+    // after the window → re-probes, and reflects the new (failing) state
+    queryRaw.mockRejectedValue(new Error("down"));
+    expect(await isWebReady(7_000)).toBe(false);
+    expect(queryRaw).toHaveBeenCalledTimes(2);
+  });
+
+  it("is not ready when the DB probe exceeds the timeout (never hangs /healthz)", async () => {
+    vi.useFakeTimers();
+    queryRaw.mockReturnValue(new Promise(() => {})); // never resolves
+    const pending = isWebReady(1_000);
+    await vi.advanceTimersByTimeAsync(2_001); // fire the 2s probe timeout
+    expect(await pending).toBe(false);
+  });
+});


### PR DESCRIPTION
The web `/healthz` returned `200` as soon as Express bound the port — **before/without DB connectivity** — so Azure's health check (`healthCheckPath=/healthz`), the external availability pings, and the post-deploy smoke test couldn't tell a truly-ready web from a bound-but-broken one. Parent #782.

New `src/observability/webReadiness.ts` `isWebReady()`: probes the DB (`SELECT 1`), **cached 5s** (Azure's frequent pings don't hammer the DB) + **bounded by a 2s timeout** (a hung DB can't hang `/healthz` itself). `/healthz` → `200 {status:ok}` when ready, `503 {status:degraded}` when the DB is unreachable. A transient blip self-heals on the next check; a sustained outage surfaces honestly instead of being masked.

Complements #866 (worker self-heal) + #811 (worker migrate-on-startup); it's the readiness gate a future #808 slot-swap would warm/gate on (instead of the old stub).

Code-only, no migration. `tsc` 0; unit **862/862** (+ `web-readiness` 4). Bundling to stage with #818 (v2.7.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)