### PR TITLE
docs: consolidate deploy/ops knowledge from the 2.7.x batch (#811/#809/#804)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ These rules exist because their violation caused or worsened the May 2026 produc
 10. **Always** confirm staging `/healthz` is healthy before a production deploy.
 11. **Always** propose `az deployment group what-if` output for staging (and prod) before implementing non-trivial Bicep changes. ARM what-if is the only check that catches schema drift before deploy.
 12. **Always** apply credential changes atomically: a KV secret and the underlying resource (PostgreSQL server, Storage account, etc.) must be updated in the same deploy, or one must explicitly re-read the existing value. Drift between KV and the underlying resource is silent until the next app restart.
+13. **Always** keep DB migrations expand/contract-safe (#811). Both web and worker run `prisma migrate deploy` on startup (`SKIP_MIGRATE=false`), so during a rollout old containers run against the new schema and new code runs briefly against the old schema. **Expand within a deploy** (additive only); **contract in a follow-up deploy** (drop/rename only after all code using the object is gone). Never combine an additive and a destructive change to the same object in one deploy. See `doc/OPERATIONS_RUNBOOK.md` → "Migrations and Schema Changes".
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,7 @@ These rules exist because their violation caused or worsened the May 2026 produc
 10. **Always** verify staging `/healthz` is healthy before triggering a production deploy.
 11. **Always** propose `az deployment group what-if` output for staging (and prod) before implementing non-trivial Bicep changes. ARM what-if is the only check that catches schema drift before deploy.
 12. **Always** apply credential changes atomically: a KV secret and the underlying resource (PostgreSQL server, Storage account, etc.) must be updated in the same deploy, or one must explicitly re-read the existing value. Drift between KV and the underlying resource is silent until the next app restart.
+13. **Always** keep DB migrations expand/contract-safe (#811) — see Deploy discipline → Process rule 5. Both web and worker run `prisma migrate deploy` on startup, so old containers run against the new schema and new code runs briefly against the old schema during a rollout. Additive within a deploy; drop/rename in a follow-up; never both on the same object in one deploy.
 
 ---
 
@@ -302,6 +303,7 @@ See `doc/DEPLOY_OPTIMIZATION.md` for the full incident narrative and wave-based 
 2. **CI-only fixes before prod fixes.** If a fix can be validated in CI (e.g. `actionlint`, type check, unit tests), ship it BEFORE any deploy that depends on the workflow being correct. Saves whole 45-min deploy cycles.
 3. **One released version per confirmed fix, not per attempt.** Don't bump `package.json` version for every failed-attempt commit. Wait for the fix to be confirmed correct, then bump. Failed attempts can be additional commits on the same in-progress version.
 4. **Never push Bicep or workflow changes that another commit could be bundled with.** Push-to-main does not auto-deploy, but the next manual deploy will include all pending main commits. Coordinate timing or stage the change in a branch until ready.
+5. **Migrations MUST be expand/contract-safe (#811).** Both web AND worker now run `prisma migrate deploy` on startup (`SKIP_MIGRATE=false` on both; Prisma advisory-locks concurrent deploys). But during a rollout, OLD containers still run against the NEW schema, and new code runs briefly against the OLD schema before its own migrate finishes. So: **expand within a deploy** (additive only — add columns/tables/indexes), and **contract in a follow-up deploy** (drop/rename only after all code using the object is gone). Never combine an additive and a destructive change to the same object in one deploy — a destructive migration bundled with code that still reads the dropped object breaks old containers mid-rollout (the 2026-05-21 incident class). See `doc/OPERATIONS_RUNBOOK.md` → "Migrations and Schema Changes".
 
 ### Diagnostic rules
 

--- a/doc/OPERATIONS_RUNBOOK.md
+++ b/doc/OPERATIONS_RUNBOOK.md
@@ -202,11 +202,14 @@ Use:
 - `GET /healthz`
 - `GET /version`
 
-`/healthz` confirms the HTTP app is up.
-It does not prove:
-- database connectivity
-- worker health
+`/healthz` is a **readiness probe (#809, 2026-07-25):** it returns `200 {status:"ok"}` only when the DB is
+reachable (a `SELECT 1` probe, cached 5s, bounded by a 2s timeout), and `503 {status:"degraded"}` when the
+DB is unreachable. It was previously a static `200` stub that returned as soon as Express bound the port —
+which masked a bound-but-broken web and made the health check / deploy smoke test meaningless. It still
+does NOT prove:
+- worker health (use the worker `/healthz`)
 - queue drain behavior
+- that migrations finished (they run before the app starts, so a ready `/healthz` implies they did)
 
 ### Worker app
 
@@ -240,15 +243,27 @@ Use logs and queue signals for deeper worker health assessment.
 
 ### Production and staging
 
-Current expectation:
-- the web role owns runtime schema application
-- worker role skips migrations
+Current expectation (updated by #811, 2026-07-25):
+- **both the web AND worker roles run `prisma migrate deploy` on startup** (`SKIP_MIGRATE=false` on
+  both). Prisma serializes concurrent migrate deploys with an advisory lock, so web + worker migrating on
+  the same deploy is safe (one applies, the other sees "up to date").
+- **Why the worker migrates too (#811):** previously the worker had `SKIP_MIGRATE=true` and relied on web
+  to migrate first. On a deploy the new worker container could start and process a job *before* web
+  applied the migration → a missing column failed/partial-processed the job. Now each role's runtime only
+  starts after its own migrate completes, so new code never runs against an un-migrated schema.
 
-Normal deploy path:
-- deploy artifact
-- web role starts
-- `prisma migrate deploy` runs
-- app starts
+Normal deploy path (per role):
+- deploy artifact → container starts → `scripts/runtime/startup.mjs` runs `prisma migrate deploy` → app starts.
+
+**Migrations MUST be expand/contract-safe (deploy invariant):**
+- **Expand within a deploy** — additive only (add columns/tables/indexes). Old (still-running) containers
+  must keep working against the NEW schema during the rollout overlap, and the new code must tolerate the
+  OLD schema for the brief window before its own migrate completes.
+- **Contract in a FOLLOW-UP deploy** — drop/rename a column or table only after every container running
+  code that used it is gone. Never combine an additive change and a destructive change to the same object
+  in one deploy.
+- A destructive migration bundled with code that still reads the dropped object will error on the old
+  containers mid-rollout (this class caused the 2026-05-21 incident).
 
 Compatibility fallback:
 - `PRISMA_RUNTIME_ALLOW_DB_PUSH_FALLBACK=true` allows a non-production fallback to `prisma db push`
@@ -275,6 +290,38 @@ npm run prisma:generate
 ```
 
 Never edit an already-applied migration in place.
+
+## Audit Hash Chain Maintenance (#804)
+
+The audit log is a tamper-evident hash chain (`AuditEvent.payloadHash` covers `prevHash | actor |
+timestamp | content`; `chainSeq` gives the order). Appends are serialized by a Postgres advisory lock in
+`recordAuditEvent`, so the chain stays linear under concurrency.
+
+**One-time backfill after deploying #804 to an environment.** The additive migration adds `chainSeq` +
+`prevHash` but leaves pre-#804 rows unsealed; `verifyAuditChain` fails on them until they're re-sealed. New
+rows chain forward regardless, but run the backfill once per env so the whole table verifies:
+
+```bash
+# against whatever DATABASE_URL is set — target the env explicitly
+dotenv -e .env.<env> -- npm run maint:backfill-audit-chain   # re-seals existing rows
+dotenv -e .env.<env> -- npm run maint:verify-audit-chain     # exits non-zero if the chain is broken
+```
+
+**Historical PII scrub (#806)** — one-time, removes email/name left in old audit metadata (idempotent;
+0 = nothing to clean). It re-seals the chain internally:
+
+```bash
+dotenv -e .env.<env> -- npm run maint:scrub-audit-pii
+```
+
+**Running these against PRODUCTION** needs a temporary Postgres firewall rule for your IP, and the prod RG
+has a `CanNotDelete` lock that blocks *deleting* the temp rule. See the operator memory
+`prod-db-firewall-lock-gotcha` for the exact create → run → remove-lock → delete-rule → **re-create-lock**
+→ verify recipe (and switch subscription: prod sub `5b3f760b-…`, KV `a2-prd-kv-hea5kl`). Always re-verify
+the RG lock is restored afterward. As of 2026-07-25 the prod backfill re-sealed 90 rows; scrub = 0.
+
+**Verification is also a maintenance script** — schedule or run `maint:verify-audit-chain` ad hoc to detect
+tampering (a non-zero exit means a row was edited/removed/reordered).
 
 ## Seed Behavior
 


### PR DESCRIPTION
Captures the operational knowledge from this batch so it isn't lost:

- **OPERATIONS_RUNBOOK → Migrations:** the worker now runs `migrate deploy` on startup too (#811); adds the **expand/contract-safe** migration invariant (additive within a deploy; drop/rename in a follow-up) + corrects the deploy path.
- **OPERATIONS_RUNBOOK → Health Checks/Web:** `/healthz` is now a DB-**readiness** probe (#809) — 200 when the DB is reachable, 503 when not — not the old static liveness stub.
- **OPERATIONS_RUNBOOK → new 'Audit Hash Chain Maintenance (#804)':** backfill/verify/scrub script usage + the prod firewall/RG-lock cleanup dance (references the `prod-db-firewall-lock-gotcha` operator memory).
- **CLAUDE.md + AGENTS.md:** mirror the expand/contract migration invariant (Deploy-discipline Process rule 5 + Infra invariant 13) so both agents respect it.

Docs only — no code, no version bump, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)