### PR TITLE
docs(#817,#818): record accepted technical debt in-code

### DIFF
--- a/public/static/admin-content-shared.js
+++ b/public/static/admin-content-shared.js
@@ -3,6 +3,12 @@
 // both. Behavior-preserving extractions only: callers pass their own DOM refs / strings so the functions
 // stay shell-agnostic (no reaching for page-specific globals). The two shells are otherwise genuinely
 // divergent and are NOT merged.
+//
+// ACCEPTED TECHNICAL DEBT (#818, closed 2026-07-25): Phase 1 (this module) extracted the truly-identical
+// helpers. A Phase 2 (share the state-rail + console-bootstrap via normalized view-models each shell
+// derives) was NOT done — modest payoff (~a few hundred lines; the issue's "~5k" was a big overcount) vs
+// real regression risk in two ~5k-line shells. Extend this module opportunistically when you're already
+// editing both shells for another reason; don't do a dedicated risky refactor for a p4 concern.
 import { escapeHtml } from "/static/html-escape.js";
 import { apiFetch } from "/static/api-client.js";
 

--- a/src/modules/course/index.ts
+++ b/src/modules/course/index.ts
@@ -1,3 +1,11 @@
+// ACCEPTED TECHNICAL DEBT (#817, closed as won't-fix-proactively 2026-07-25): this barrel is over-wide
+// and `course` ↔ `adminContent` import each other (cascade delete, assets, publish, import, agent
+// authoring); appeal/review also duplicate assessment's orchestration. No runtime ES cycle — it's a
+// maintainability/coupling smell (severity: low · plausible). The clean fix (extract a one-directional
+// shared kernel, shrink this barrel to a deliberate surface, lift duplicated orchestration into a shared
+// ApplicationService) is a large, risky refactor not worth a dedicated pass for a p4 concern. **Address
+// opportunistically:** when you next touch these modules, prefer a narrow import over the wide barrel and
+// nudge toward a shared kernel. See doc/design/ARCHITECTURE_REVIEW_2026-07-19.md.
 export { checkAndIssueCourseCompletions, checkCourseCompletionForCourse, reconcileCourseCompletionsForUser } from "./courseCompletionService.js";
 export { getCourseReport, getCourseLearnerReport } from "./courseReport.js";
 export { createCourse, updateCourse, publishCourse, unpublishCourse, archiveCourse, restoreCourse, setCourseModules, setCourseItems, deleteCourse } from "./courseCommands.js";


### PR DESCRIPTION
Closes #817 and #818 (and thus epic #784) as won't-fix-proactively — both are large/risky p4 refactors for low payoff (#817 is 'low · plausible', no runtime ES cycle; #818 Phase 2 is ~a few hundred lines, the issue's '~5k' overcounted). Records the debt **in-code** so it's discoverable and addressed opportunistically: a note atop the over-wide `course/index.ts` barrel (#817) and in `admin-content-shared.js` (#818 Phase 2). Comments only — no behavior change, no version bump, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)