### PR TITLE
#475: declaration UX fixes (compact/understated UI, Norwegian reason, description to reviewer)

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,24 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.8.2 - 2026-07-26
+
+#475 — **Declaration UX fixes from stage testing.** Three fixes after live review on stage:
+
+- **Understated, compact declaration.** The options rendered as tall, right-aligned full-width rows (a
+  global `input{width:100%}` stretched the radio and pushed the text right). Rebuilt as quiet, compact,
+  left-aligned muted rows under a thin divider — no heavy blue box. Design principle: the answer field
+  and task content earn the space; the AI declaration is a quick end-step to click through.
+- **Trigger reason in Norwegian.** `AUTONOMOUS_REVIEW_REASON` was English; the reviewer audience is
+  Norwegian, so the ai-influence reason is now bokmål. (Other decisionReason strings remain English —
+  broader localisation is out of scope.)
+- **Participant's description reaches the reviewer.** The optional free-text ("how did you use AI?") is
+  now embedded in the trigger/decision reason (capped 600 chars), so it travels wherever the reason is
+  shown — not only the review-detail declaration line.
+
+Tests updated: unit `ai-influence` 15 (+description-in-reason), `TC-POL-AIINFLUENCE-001` asserts the
+Norwegian reason + carried description; e2e 3 green. Config-only + client + reason string. tsc 0.
+
 ## 2.8.1 - 2026-07-26
 
 #475 — **Enable AI-influence flagging (live).** Flips `config/assessment-rules.json` `aiInfluence` to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/participant.html
+++ b/public/participant.html
@@ -11,18 +11,20 @@
       .assessment-progress { margin-top: calc(var(--space-1) * 1.25); font-size: 16px; font-weight: 600; color: var(--color-progress-text); }
       .assessment-progress-seconds { margin-top: calc(var(--space-1) * 0.75); font-size: 28px; font-weight: 800; color: var(--color-blue); letter-spacing: 0.3px; }
       .inline { display: inline-block; width: auto; }
-      /* #475: AI-use declaration */
-      .ai-declaration { margin: var(--space-2) 0; border: 1.5px solid var(--color-blue); border-radius: var(--radius-card); padding: var(--space-2); background: var(--color-blue-light, #f2f7ff); }
-      .ai-declaration-head { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
-      .ai-declaration-head h3 { margin: 0; font-size: 15px; }
-      .ai-declaration-nograde { font-size: 12px; font-weight: 600; color: #1f7a4d; white-space: nowrap; }
-      .ai-declaration-intro { margin: 4px 0 8px; color: var(--color-meta, #555); }
-      .ai-declaration-options { display: flex; flex-direction: column; gap: 6px; }
-      .ai-declaration-opt { display: flex; gap: 9px; align-items: center; border: 1px solid var(--color-module-border, #d5dbe4); border-radius: 8px; padding: 8px 11px; background: var(--color-module-surface, #fff); cursor: pointer; font-size: 14px; }
-      .ai-declaration-opt:hover { border-color: var(--color-link-hover-border, #9db4d6); }
-      .ai-declaration-opt input { margin: 0; }
-      .ai-declaration-howto { margin-top: 10px; }
-      .ai-declaration-howto textarea { width: 100%; margin-top: 5px; border: 1px solid var(--color-module-border, #d5dbe4); border-radius: 8px; padding: 8px 10px; font: inherit; resize: vertical; }
+      /* #475: AI-use declaration — deliberately understated. The answer field + task content earn the
+         space; this is a quiet, quick step at the end. No heavy box; compact muted rows. */
+      .ai-declaration { margin: calc(var(--space-1) * 1.25) 0 0; padding-top: 10px; border-top: 1px solid var(--color-module-border, #e2e6ec); }
+      .ai-declaration-head { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+      .ai-declaration-head h3 { margin: 0; font-size: 13px; font-weight: 600; color: var(--color-text); }
+      .ai-declaration-nograde { font-size: 11px; font-weight: 500; color: var(--color-meta, #777); }
+      .ai-declaration-intro { margin: 2px 0 6px; font-size: 11.5px; color: var(--color-meta, #777); }
+      .ai-declaration-options { display: flex; flex-direction: column; gap: 2px; }
+      .ai-declaration-opt { display: flex; gap: 8px; align-items: center; text-align: left; padding: 4px 6px; border-radius: 6px; cursor: pointer; font-size: 12.5px; font-weight: 400; color: var(--color-text); }
+      .ai-declaration-opt:hover { background: var(--color-blue-light, #f2f7ff); }
+      .ai-declaration-opt input[type="radio"] { width: 14px; height: 14px; flex: 0 0 auto; margin: 0; }
+      .ai-declaration-opt span { flex: 1; text-align: left; }
+      .ai-declaration-howto { margin-top: 6px; }
+      .ai-declaration-howto textarea { width: 100%; margin-top: 3px; border: 1px solid var(--color-module-border, #d5dbe4); border-radius: 6px; padding: 6px 8px; font: inherit; font-size: 12.5px; resize: vertical; }
       /* reflective nudge overlay */
       .ai-nudge-overlay { position: fixed; inset: 0; background: rgba(16,21,28,.55); display: flex; align-items: center; justify-content: center; padding: 20px; z-index: 60; }
       .ai-nudge { background: #fff; border-radius: 14px; max-width: 460px; width: 100%; box-shadow: 0 10px 40px rgba(0,0,0,.3); overflow: hidden; }

--- a/src/modules/assessment/aiInfluence.ts
+++ b/src/modules/assessment/aiInfluence.ts
@@ -38,12 +38,14 @@ export type AiInfluenceDecision = {
   reason: string;
 };
 
-// English to match the other decisionReason strings in decisionService.ts; this becomes the
-// ManualReview.triggerReason verbatim.
+// Norwegian (bokmål): this becomes the ManualReview.triggerReason shown to the (Norwegian-speaking)
+// reviewer verbatim. The other decisionReason strings in decisionService.ts are still English — a
+// broader localisation of all reasons is out of scope; #475 surfaces this one to reviewers so it is
+// written in their language.
 export const AUTONOMOUS_REVIEW_REASON =
-  "Routed to manual review: the participant declared substantial autonomous AI use and chose to " +
-  "submit after being prompted to engage further with the material. Assumed too-autonomous AI use — " +
-  "a reviewer decides; this is not an automatic fail.";
+  "Rutet til manuell vurdering: deltakeren erklærte omfattende autonom KI-bruk og valgte å levere " +
+  "etter å ha blitt oppfordret til å bearbeide stoffet videre. Antatt for autonom KI-bruk — en " +
+  "sensor vurderer; dette er ikke en automatisk stryk.";
 
 function isAiDeclaration(value: unknown): value is AiDeclaration {
   return typeof value === "string" && (AI_DECLARATION_VALUES as readonly string[]).includes(value);
@@ -94,5 +96,12 @@ export function evaluateAiInfluence(args: {
   const forcesReview = signals.declaration === "autonomous" && signals.insistedAfterPrompt === true;
   if (!forcesReview) return null;
 
-  return { forcesReview: true, reason: AUTONOMOUS_REVIEW_REASON };
+  // Carry the participant's own free-text description INTO the reason so it reaches the reviewer
+  // wherever the trigger/decision reason is shown (not only the review-detail declaration line).
+  const description = signals.declarationText?.trim();
+  const reason = description
+    ? `${AUTONOMOUS_REVIEW_REASON} Deltakerens beskrivelse: «${description.slice(0, 600)}»`
+    : AUTONOMOUS_REVIEW_REASON;
+
+  return { forcesReview: true, reason };
 }

--- a/test/assessment-policy.integration.test.ts
+++ b/test/assessment-policy.integration.test.ts
@@ -451,10 +451,13 @@ describe("Local integration assessment policy suite", () => {
         decision: { decisionReason: string; passFailTotal: boolean };
       };
 
-      // Routed to review, NOT failed and NOT auto-passed.
+      // Routed to review, NOT failed and NOT auto-passed. The reason is Norwegian and carries the
+      // participant's own free-text description through to the reviewer.
       expect(result.status).toBe("UNDER_REVIEW");
       expect(result.decision.passFailTotal).toBe(false);
-      expect(result.decision.decisionReason).toContain("autonomous");
+      expect(result.decision.decisionReason).toContain("autonom");
+      expect(result.decision.decisionReason).toContain("Deltakerens beskrivelse");
+      expect(result.decision.decisionReason).toContain("write the whole answer");
     } finally {
       await prisma.moduleVersion.update({
         where: { id: versionId },

--- a/test/unit/ai-influence.test.ts
+++ b/test/unit/ai-influence.test.ts
@@ -78,6 +78,18 @@ describe("evaluateAiInfluence", () => {
     expect(result).toEqual({ forcesReview: true, reason: AUTONOMOUS_REVIEW_REASON });
   });
 
+  it("carries the participant's free-text description into the reason for the reviewer", () => {
+    const result = evaluateAiInfluence({
+      signals: { declaration: "autonomous", insistedAfterPrompt: true, declarationText: "ChatGPT wrote it all" },
+      policy: null,
+      rules: RULES_LIVE,
+    });
+    expect(result?.forcesReview).toBe(true);
+    expect(result?.reason).toContain(AUTONOMOUS_REVIEW_REASON);
+    expect(result?.reason).toContain("Deltakerens beskrivelse");
+    expect(result?.reason).toContain("ChatGPT wrote it all");
+  });
+
   it("lets a per-module policy enable flagging when the global default is off", () => {
     const policy: ModuleAssessmentPolicy = { aiInfluence: { enabled: true, shadowMode: false } };
     const result = evaluateAiInfluence({ signals: autonomousInsisted, policy, rules: RULES_OFF });


### PR DESCRIPTION
Three fixes from live stage testing of #475:

1. **Understated, compact declaration.** Options rendered as tall right-aligned full-width rows (a global `input{width:100%}` stretched the radio and shoved text right). Rebuilt as quiet compact left-aligned muted rows under a thin divider — no heavy blue box. Principle: the answer field + task content earn the space; the declaration is a quick end-step to click through. (Verified visually with a headless render.)
2. **Trigger reason in Norwegian** (`AUTONOMOUS_REVIEW_REASON`) — the reviewer audience is Norwegian.
3. **Participant's free-text description reaches the reviewer** — embedded in the trigger/decision reason (capped 600 chars) so it travels wherever the reason is shown.

Tests: unit `ai-influence` 15 (+description-in-reason), `TC-POL-AIINFLUENCE-001` asserts the Norwegian reason + carried description, e2e 3 green. tsc 0. Config/client/reason-string only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
