### PR TITLE
#475 Phase 2: AI-influence content-similarity signal (dormant)

### DIFF
--- a/config/assessment-rules.json
+++ b/config/assessment-rules.json
@@ -143,6 +143,11 @@
   },
   "aiInfluence": {
     "enabled": true,
-    "shadowMode": false
+    "shadowMode": false,
+    "contentSimilarity": {
+      "enabled": false,
+      "shadowMode": true,
+      "similarityThreshold": 0.82
+    }
   }
 }

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,32 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.9.0 - 2026-07-26
+
+#475 **Phase 2 — AI-influence content-similarity signal.** Post-submission, generate an independent
+"model answer" to the task and measure its similarity to the student's answer, as ONE additional review
+signal — never a verdict. Ships **feature-flagged OFF + shadow-mode** so it collects pilot data before
+it can route anyone. Same invariants as Phase 1 (review trigger only; never touches pass/fail).
+
+- **Local lexical cosine** (`src/modules/assessment/contentSimilarity.ts`) — deterministic, no embeddings
+  infra. Honest limitation (documented): two correct answers to the same task share vocabulary, so this
+  is a coarse signal on its own — hence shadow-first + a configurable threshold for the owner to
+  calibrate a false-positive rate.
+- **Model-answer generator** `generateModelAnswer` in `llmAssessmentService.ts` (stub + azure_openai,
+  mockable via the existing test seam). Only called when the signal is enabled — dormant = no extra LLM
+  call/cost.
+- **Persisted transparently:** new additive nullable `AssessmentDecision.aiInfluenceJson` stores the
+  computed signals (declaration outcome + `{similarity, threshold, exceeded, forcesReview}`) at decision
+  time — the pilot dataset. Combined with Phase 1 in `buildAiInfluenceOutcome`; either signal alone can
+  route (declaration reason wins when both fire).
+- **Config:** `aiInfluence.contentSimilarity {enabled, shadowMode, similarityThreshold:0.82}` global +
+  per-module override (`ModuleAssessmentPolicy.aiInfluence.contentSimilarity`). Both OFF by default.
+
+Tests: unit `content-similarity` (cosine/tokenize/extract) + `ai-influence` (evaluate/combine, shadow vs
+live); integration `TC-POL-AIINFLUENCE-002` (live → UNDER_REVIEW, never fail) + `-003` (shadow → persists
+the signal, routes no one, stays COMPLETED). tsc 0; unit 897; policy integration 11. Expand-only
+migration `20260726120000_decision_ai_influence`.
+
 ## 2.8.4 - 2026-07-26
 
 #475 — **Participant's AI-use description now surfaced prominently to the reviewer** + a stronger

--- a/doc/design/AI_INFLUENCE_FLAGGING_475.md
+++ b/doc/design/AI_INFLUENCE_FLAGGING_475.md
@@ -20,7 +20,16 @@ both simpler and lower-risk:
    choice to submit after the nudge**. This removes most of the DPIA burden (§9) — we store only the
    aggregate declaration the participant volunteers.
 
-**As built:** `Submission.processSignalsJson` (additive nullable) stores `{ declaration, declarationText?,
+**Phase 2 as built (v2.9.0):** content-similarity signal — `generateModelAnswer` (llmAssessmentService)
+produces an independent model answer to the task; `contentSimilarity.ts` computes a local lexical cosine
+between it and the student's answer; `evaluateContentSimilarity` + `buildAiInfluenceOutcome` (aiInfluence.ts)
+turn it into one more review signal (never a verdict) and persist `{similarity, threshold, exceeded,
+forcesReview}` alongside the declaration on the new additive `AssessmentDecision.aiInfluenceJson`. Gated by
+`aiInfluence.contentSimilarity {enabled, shadowMode, similarityThreshold}` (global + per-module), OFF +
+shadow by default. Coarse by design (lexical) — the §9 false-positive-budget gate still applies before it
+routes anyone. Phase 3 (student stylometric baseline) remains future.
+
+**Phase 1 as built:** `Submission.processSignalsJson` (additive nullable) stores `{ declaration, declarationText?,
 insistedAfterPrompt }`. `src/modules/assessment/aiInfluence.ts` evaluates it against the global
 `aiInfluence` rules (`config/assessment-rules.json`) + per-module `ModuleAssessmentPolicy.aiInfluence`
 override: it forces review only when **enabled && !shadowMode && declaration==="autonomous" &&

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.8.4",
+  "version": "2.9.0",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/prisma/migrations/20260726120000_decision_ai_influence/migration.sql
+++ b/prisma/migrations/20260726120000_decision_ai_influence/migration.sql
@@ -1,0 +1,5 @@
+-- #475 Phase 2: AI-influence flagging content-similarity signal. Additive, nullable column holding the
+-- computed AI-influence signals at decision time (declaration outcome + content-similarity score).
+-- Transparent, review-signal-only (never affects pass/fail). Expand-safe: nullable, no backfill, no
+-- drops/renames (CLAUDE.md invariant #13).
+ALTER TABLE "AssessmentDecision" ADD COLUMN "aiInfluenceJson" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -449,6 +449,10 @@ model AssessmentDecision {
   practicalScaledScore    Float
   totalScore              Float
   redFlagsJson            String
+  // #475 Phase 2: computed AI-influence signals at decision time (declaration outcome +
+  // content-similarity). Additive, nullable, transparent (not a black box). A REVIEW signal only —
+  // never contributes to pass/fail. Shape: aiInfluenceDecisionCodec.
+  aiInfluenceJson         String?
   passFailTotal           Boolean
   decisionType            DecisionType
   decisionReason          String

--- a/src/codecs/assessmentPolicyCodec.ts
+++ b/src/codecs/assessmentPolicyCodec.ts
@@ -19,6 +19,12 @@ export type ModuleAssessmentPolicy = {
   aiInfluence?: {
     enabled?: boolean;
     shadowMode?: boolean;
+    // #475 Phase 2: per-module override of the content-similarity signal.
+    contentSimilarity?: {
+      enabled?: boolean;
+      shadowMode?: boolean;
+      similarityThreshold?: number;
+    };
   };
 };
 

--- a/src/config/assessmentRules.ts
+++ b/src/config/assessmentRules.ts
@@ -143,10 +143,29 @@ export const rulesSchema = z.object({
     .object({
       enabled: z.boolean().default(false),
       shadowMode: z.boolean().default(true),
+      // #475 Phase 2: content-similarity signal — post-submission, generate a model answer to the task
+      // and measure similarity to the student's answer. ONE additional review signal, never a verdict.
+      // Coarse (lexical) by design; ships OFF + shadow so it collects pilot data before it can route.
+      contentSimilarity: z
+        .object({
+          enabled: z.boolean().default(false),
+          shadowMode: z.boolean().default(true),
+          similarityThreshold: z.number().min(0).max(1).default(0.82),
+        })
+        .default({
+          enabled: false,
+          shadowMode: true,
+          similarityThreshold: 0.82,
+        }),
     })
     .default({
       enabled: false,
       shadowMode: true,
+      contentSimilarity: {
+        enabled: false,
+        shadowMode: true,
+        similarityThreshold: 0.82,
+      },
     }),
 });
 

--- a/src/modules/assessment/AssessmentDecisionApplicationService.ts
+++ b/src/modules/assessment/AssessmentDecisionApplicationService.ts
@@ -25,6 +25,8 @@ type ApplyDecisionInput = {
   freetextOnly?: boolean;
   /** #475: AI-influence review trigger (undefined = no trigger). Routes to review, never fails. */
   aiInfluence?: { forcesReview: boolean; reason: string };
+  /** #475 Phase 2: computed AI-influence signals JSON persisted on the decision (null when none). */
+  aiInfluenceJson?: string | null;
   /** Localized module title text (may be a raw localization JSON string). */
   moduleTitle: string;
   submissionLocale: SupportedLocale;
@@ -58,6 +60,7 @@ export async function applyAssessmentDecision(input: ApplyDecisionInput): Promis
     rubricCriteriaIds: input.rubricCriteriaIds,
     freetextOnly: input.freetextOnly,
     aiInfluence: input.aiInfluence,
+    aiInfluenceJson: input.aiInfluenceJson,
   });
 
   if (!decisionResult.needsManualReview) {

--- a/src/modules/assessment/aiInfluence.ts
+++ b/src/modules/assessment/aiInfluence.ts
@@ -12,6 +12,8 @@
 // No keystroke/paste telemetry is captured or stored — only the aggregate declaration (DPIA-light).
 
 import type { ModuleAssessmentPolicy } from "../../codecs/assessmentPolicyCodec.js";
+import type { SupportedLocale } from "../../i18n/locale.js";
+import { lexicalCosineSimilarity } from "./contentSimilarity.js";
 
 export const AI_DECLARATION_VALUES = ["none", "ideas", "improve", "autonomous"] as const;
 export type AiDeclaration = (typeof AI_DECLARATION_VALUES)[number];
@@ -104,4 +106,152 @@ export function evaluateAiInfluence(args: {
     : AUTONOMOUS_REVIEW_REASON;
 
   return { forcesReview: true, reason };
+}
+
+// ── #475 Phase 2: content-similarity signal ─────────────────────────────────────────────────────
+
+/** Global defaults from config/assessmentRules.ts `aiInfluence.contentSimilarity`. */
+export type AiInfluenceContentRules = {
+  enabled: boolean;
+  shadowMode: boolean;
+  similarityThreshold: number;
+};
+
+/** The computed content-similarity signal, persisted for pilot analysis + (when live) routing. */
+export type ContentSimilaritySignal = {
+  /** Lexical cosine similarity between the student answer and an independent model answer, 0–1. */
+  similarity: number;
+  threshold: number;
+  /** similarity >= threshold. */
+  exceeded: boolean;
+  /** exceeded AND live (not shadow) — the only case where this contributes to review routing. */
+  forcesReview: boolean;
+};
+
+export const CONTENT_SIMILARITY_REVIEW_REASON_PREFIX =
+  "Rutet til manuell vurdering: besvarelsen ligner sterkt på et uavhengig generert modellsvar";
+
+/**
+ * Resolve the effective content-similarity rules: a per-module override (ModuleAssessmentPolicy) wins
+ * field-by-field over the global default, mirroring how the declaration signal merges policy over rules.
+ */
+export function resolveContentSimilarityRules(
+  policy: ModuleAssessmentPolicy | null | undefined,
+  globalRules: AiInfluenceContentRules,
+): AiInfluenceContentRules {
+  const override = policy?.aiInfluence?.contentSimilarity;
+  return {
+    enabled: override?.enabled ?? globalRules.enabled,
+    shadowMode: override?.shadowMode ?? globalRules.shadowMode,
+    similarityThreshold: override?.similarityThreshold ?? globalRules.similarityThreshold,
+  };
+}
+
+function roundSimilarity(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
+/**
+ * Generate a model answer to the task and measure its lexical similarity to the student's answer.
+ * Returns null when the feature is off or there is nothing to compare. In shadow mode it still returns
+ * the computed similarity (for the pilot dataset) but with `forcesReview: false`. A draft-generation
+ * failure NEVER breaks assessment — the signal is simply skipped.
+ */
+export async function evaluateContentSimilarity(args: {
+  taskText: string | undefined;
+  studentAnswer: string;
+  generateDraft: (ctx: {
+    moduleTaskText: string;
+    moduleGuidanceText?: string;
+    responseLocale?: SupportedLocale;
+  }) => Promise<string>;
+  moduleGuidanceText?: string;
+  responseLocale?: SupportedLocale;
+  rules: AiInfluenceContentRules;
+}): Promise<ContentSimilaritySignal | null> {
+  const { taskText, studentAnswer, generateDraft, rules } = args;
+  if (!rules.enabled) return null;
+  if (!taskText || studentAnswer.trim().length === 0) return null;
+
+  let draft: string;
+  try {
+    draft = await generateDraft({
+      moduleTaskText: taskText,
+      moduleGuidanceText: args.moduleGuidanceText,
+      responseLocale: args.responseLocale,
+    });
+  } catch (error) {
+    console.warn("[#475] content-similarity draft generation failed; skipping the signal.", error);
+    return null;
+  }
+  if (!draft || draft.trim().length === 0) return null;
+
+  const similarity = lexicalCosineSimilarity(studentAnswer, draft);
+  const exceeded = similarity >= rules.similarityThreshold;
+  return {
+    similarity: roundSimilarity(similarity),
+    threshold: rules.similarityThreshold,
+    exceeded,
+    forcesReview: exceeded && !rules.shadowMode,
+  };
+}
+
+// ── Combine the Phase-1 (declaration) + Phase-2 (content-similarity) signals ─────────────────────
+
+/** The persisted shape on AssessmentDecision.aiInfluenceJson. */
+export type AiInfluencePersisted = {
+  declaration: AiDeclaration | null;
+  declarationForcesReview: boolean;
+  contentSimilarity: ContentSimilaritySignal | null;
+  forcesReview: boolean;
+};
+
+export type AiInfluenceOutcome = {
+  /** Serialized AiInfluencePersisted for AssessmentDecision.aiInfluenceJson (null when no signals). */
+  signalsJson: string | null;
+  /** What the decision engine consumes — present only when something actually forces review. */
+  decision: AiInfluenceDecision | undefined;
+};
+
+function contentSimilarityReason(signal: ContentSimilaritySignal): string {
+  const pct = (n: number) => `${Math.round(n * 100)} %`;
+  return (
+    `${CONTENT_SIMILARITY_REVIEW_REASON_PREFIX} (${pct(signal.similarity)} ≥ terskel ${pct(signal.threshold)}). ` +
+    "Dette er ett signal, ikke bevis — en sensor vurderer; dette er ikke en automatisk stryk."
+  );
+}
+
+/**
+ * Combine the declaration (Phase 1) and content-similarity (Phase 2) signals into (a) the JSON persisted
+ * on the decision for transparency/pilot analysis, and (b) the review-trigger the decision engine reads.
+ * The declaration reason takes precedence when both fire; either alone is sufficient to route.
+ */
+export function buildAiInfluenceOutcome(args: {
+  declaration: AiDeclaration | undefined;
+  declarationResult: AiInfluenceDecision | null;
+  contentSignal: ContentSimilaritySignal | null;
+}): AiInfluenceOutcome {
+  const { declaration, declarationResult, contentSignal } = args;
+  if (!declaration && !contentSignal) {
+    return { signalsJson: null, decision: undefined };
+  }
+
+  const declarationForcesReview = Boolean(declarationResult?.forcesReview);
+  const forcesReview = declarationForcesReview || Boolean(contentSignal?.forcesReview);
+
+  const persisted: AiInfluencePersisted = {
+    declaration: declaration ?? null,
+    declarationForcesReview,
+    contentSimilarity: contentSignal,
+    forcesReview,
+  };
+
+  let decision: AiInfluenceDecision | undefined;
+  if (declarationForcesReview && declarationResult) {
+    decision = declarationResult;
+  } else if (contentSignal?.forcesReview) {
+    decision = { forcesReview: true, reason: contentSimilarityReason(contentSignal) };
+  }
+
+  return { signalsJson: JSON.stringify(persisted), decision };
 }

--- a/src/modules/assessment/assessmentJobService.ts
+++ b/src/modules/assessment/assessmentJobService.ts
@@ -8,7 +8,15 @@ import { runLlmEvaluationPipeline } from "./AssessmentEvaluator.js";
 import { applyAssessmentDecision, applyMcqOnlyDecision } from "./AssessmentDecisionApplicationService.js";
 import { assessmentPolicyCodec } from "../../codecs/assessmentPolicyCodec.js";
 import { getAssessmentRules } from "../../config/assessmentRules.js";
-import { evaluateAiInfluence, parseAiInfluenceSignals } from "./aiInfluence.js";
+import {
+  evaluateAiInfluence,
+  evaluateContentSimilarity,
+  buildAiInfluenceOutcome,
+  parseAiInfluenceSignals,
+  resolveContentSimilarityRules,
+} from "./aiInfluence.js";
+import { generateModelAnswer } from "./llmAssessmentService.js";
+import { extractAnswerText } from "./contentSimilarity.js";
 import {
   processAssessmentJobsNow as runnerProcessAssessmentJobsNow,
   processSubmissionJobNow as runnerProcessSubmissionJobNow,
@@ -81,15 +89,33 @@ async function runAssessment(jobId: string) {
 
   const inputContext = buildAssessmentInputContext(submission, submissionLocale);
 
-  // #475: evaluate the AI-use declaration into a review trigger (never a fail). Returns undefined
-  // unless the feature is enabled, live (not shadow), and the participant declared autonomous AI use
-  // and submitted after the nudge. The raw declaration is persisted regardless — it is the pilot data.
-  const aiInfluence =
-    evaluateAiInfluence({
-      signals: parseAiInfluenceSignals(submission.processSignalsJson),
-      policy: inputContext.assessmentPolicy,
-      rules: getAssessmentRules().aiInfluence,
-    }) ?? undefined;
+  // #475: evaluate the AI-influence signals into a review trigger (never a fail).
+  //  • Phase 1 — the participant's AI-use declaration (+ their choice to submit after the nudge).
+  //  • Phase 2 — content-similarity between the answer and an independently generated model answer.
+  // Each only routes when enabled + live; in shadow mode the signals are still computed and persisted
+  // (the pilot dataset). A content-similarity draft failure never breaks assessment (skipped).
+  const aiRules = getAssessmentRules().aiInfluence;
+  const declarationSignals = parseAiInfluenceSignals(submission.processSignalsJson);
+  const declarationResult = evaluateAiInfluence({
+    signals: declarationSignals,
+    policy: inputContext.assessmentPolicy,
+    rules: aiRules,
+  });
+  const contentSignal = await evaluateContentSimilarity({
+    taskText: inputContext.moduleTaskText,
+    studentAnswer: extractAnswerText(JSON.parse(submission.responseJson) as Record<string, unknown>),
+    generateDraft: generateModelAnswer,
+    moduleGuidanceText: inputContext.moduleGuidanceText,
+    responseLocale: submissionLocale,
+    rules: resolveContentSimilarityRules(inputContext.assessmentPolicy, aiRules.contentSimilarity),
+  });
+  const aiOutcome = buildAiInfluenceOutcome({
+    declaration: declarationSignals?.declaration,
+    declarationResult,
+    contentSignal,
+  });
+  const aiInfluence = aiOutcome.decision;
+  const aiInfluenceJson = aiOutcome.signalsJson;
 
   await recordAuditEvent({
     entityType: auditEntityTypes.submission,
@@ -130,6 +156,7 @@ async function runAssessment(jobId: string) {
     mcqPercentScore,
     freetextOnly: assessmentMode === "FREETEXT_ONLY",
     aiInfluence,
+    aiInfluenceJson,
     llmResult: finalLlmResult,
     forceManualReviewReason,
     assessmentPolicy: inputContext.assessmentPolicy,

--- a/src/modules/assessment/contentSimilarity.ts
+++ b/src/modules/assessment/contentSimilarity.ts
@@ -1,0 +1,69 @@
+// #475 Phase 2: lexical cosine similarity between two texts. Deterministic, self-contained (no
+// embeddings infra) — a coarse but transparent signal used ONLY to flag a submission for human review,
+// never as a verdict. See doc/design/AI_INFLUENCE_FLAGGING_475.md.
+//
+// Honest limitation: two correct answers to the same factual task naturally share domain vocabulary, so
+// high lexical similarity is a WEAK signal on its own. That is exactly why it ships OFF + shadow-mode:
+// it collects pilot data so a product owner can calibrate the threshold (and false-positive rate)
+// before it is ever allowed to route anyone. A future backend could swap in embeddings-cosine behind
+// this same function without changing callers.
+
+const TOKEN_RE = /[\p{L}\p{N}]+/gu;
+const MIN_TOKEN_LEN = 2;
+
+/** Lowercase word/number tokens of length >= 2. */
+export function tokenize(text: string): string[] {
+  if (typeof text !== "string" || text.length === 0) return [];
+  const matches = text.toLowerCase().match(TOKEN_RE);
+  if (!matches) return [];
+  return matches.filter((t) => t.length >= MIN_TOKEN_LEN);
+}
+
+function termFrequency(tokens: string[]): Map<string, number> {
+  const tf = new Map<string, number>();
+  for (const token of tokens) {
+    tf.set(token, (tf.get(token) ?? 0) + 1);
+  }
+  return tf;
+}
+
+/**
+ * Cosine similarity of the two texts' term-frequency vectors, in [0, 1]. Returns 0 when either side has
+ * no tokens (nothing to compare).
+ */
+export function lexicalCosineSimilarity(a: string, b: string): number {
+  const tfA = termFrequency(tokenize(a));
+  const tfB = termFrequency(tokenize(b));
+  if (tfA.size === 0 || tfB.size === 0) return 0;
+
+  // Dot product over the smaller map's keys.
+  const [small, large] = tfA.size <= tfB.size ? [tfA, tfB] : [tfB, tfA];
+  let dot = 0;
+  for (const [token, count] of small) {
+    const other = large.get(token);
+    if (other) dot += count * other;
+  }
+  if (dot === 0) return 0;
+
+  let sumSqA = 0;
+  for (const count of tfA.values()) sumSqA += count * count;
+  let sumSqB = 0;
+  for (const count of tfB.values()) sumSqB += count * count;
+
+  const magnitude = Math.sqrt(sumSqA) * Math.sqrt(sumSqB);
+  if (magnitude === 0) return 0;
+  // Clamp to [0,1] to guard against floating-point drift.
+  return Math.min(1, Math.max(0, dot / magnitude));
+}
+
+/**
+ * Concatenate the string field values of a submission responseJson into one comparable text blob.
+ * Non-string values are ignored (the student's answer is free text).
+ */
+export function extractAnswerText(responseJson: Record<string, unknown> | null | undefined): string {
+  if (!responseJson || typeof responseJson !== "object") return "";
+  return Object.values(responseJson)
+    .filter((v): v is string => typeof v === "string")
+    .join("\n")
+    .trim();
+}

--- a/src/modules/assessment/decisionService.ts
+++ b/src/modules/assessment/decisionService.ts
@@ -34,8 +34,11 @@ type BuildDecisionInput = {
   freetextOnly?: boolean;
   // #475: AI-influence review trigger. When present with forcesReview, routes to UNDER_REVIEW —
   // NEVER contributes to a FAIL (feeds `needsManualReview` only). Computed upstream from the
-  // participant's AI-use declaration; see aiInfluence.ts.
+  // participant's AI-use declaration + content-similarity; see aiInfluence.ts.
   aiInfluence?: { forcesReview: boolean; reason: string };
+  // #475 Phase 2: the computed AI-influence signals JSON, persisted on the decision for transparency
+  // and pilot analysis. Purely informational at the decision layer.
+  aiInfluenceJson?: string | null;
 };
 
 export type ResolvedAssessmentDecision = {
@@ -278,6 +281,7 @@ export async function createAssessmentDecision(input: BuildDecisionInput) {
       practicalScaledScore: practicalScoreScaled,
       totalScore: resolved.totalScore,
       redFlagsJson: redFlagsCodec.serialize(input.llmResult.red_flags),
+      aiInfluenceJson: input.aiInfluenceJson ?? null,
       passFailTotal: resolved.passFailTotal,
       decisionType: DecisionType.AUTOMATIC,
       decisionReason: resolved.decisionReason,

--- a/src/modules/assessment/llmAssessmentService.ts
+++ b/src/modules/assessment/llmAssessmentService.ts
@@ -141,6 +141,99 @@ export async function evaluatePracticalWithAzureOpenAi(
   }
 }
 
+// #475 Phase 2: generate a "model answer" to the task. Used ONLY to measure content-similarity against
+// the student's submission (a review signal, never a verdict). Mirrors evaluatePracticalWithLlm's dual
+// stub/azure_openai shape so tests mock it via the same module seam, and the stub path is hermetic.
+export type ModelAnswerContext = {
+  moduleTaskText: string;
+  moduleGuidanceText?: string;
+  responseLocale?: SupportedLocale;
+};
+
+export async function generateModelAnswer(input: ModelAnswerContext): Promise<string> {
+  if (env.LLM_MODE === "stub") {
+    return buildStubModelAnswer(input);
+  }
+  if (env.LLM_MODE === "azure_openai") {
+    return generateModelAnswerWithAzureOpenAi(input, {
+      endpoint: env.AZURE_OPENAI_ENDPOINT ?? "",
+      apiKey: env.AZURE_OPENAI_API_KEY ?? "",
+      deployment: env.AZURE_OPENAI_ASSESSMENT_DEPLOYMENT ?? env.AZURE_OPENAI_DEPLOYMENT ?? "",
+      apiVersion: env.AZURE_OPENAI_API_VERSION,
+      timeoutMs: env.AZURE_OPENAI_TIMEOUT_MS,
+      temperature: env.AZURE_OPENAI_ASSESSMENT_TEMPERATURE ?? env.AZURE_OPENAI_TEMPERATURE,
+      maxTokens: env.AZURE_OPENAI_MAX_TOKENS,
+      tokenLimitParameter: env.AZURE_OPENAI_TOKEN_LIMIT_PARAMETER,
+    });
+  }
+  throw new Error(`Unsupported LLM mode: ${env.LLM_MODE}`);
+}
+
+function buildStubModelAnswer(input: ModelAnswerContext): string {
+  const task = (input.moduleTaskText ?? "").trim();
+  // Deterministic pseudo-answer for local/dev runs; integration tests mock generateModelAnswer directly.
+  return task ? `Model answer addressing: ${task}` : "Model answer.";
+}
+
+async function generateModelAnswerWithAzureOpenAi(
+  input: ModelAnswerContext,
+  config: AzureOpenAiRuntimeConfig,
+): Promise<string> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), config.timeoutMs);
+  try {
+    const locale = input.responseLocale ?? "en-GB";
+    const messages = [
+      {
+        role: "system",
+        content:
+          "You are a strong student writing a concise model answer to an assignment. Return only the answer text, with no preamble or commentary.",
+      },
+      {
+        role: "user",
+        content:
+          `Write a model answer in ${locale} to the following assignment.\n\nAssignment:\n${input.moduleTaskText ?? ""}` +
+          (input.moduleGuidanceText ? `\n\nGuidance:\n${input.moduleGuidanceText}` : ""),
+      },
+    ];
+    const tokenParameter = config.tokenLimitParameter === "auto" ? "max_tokens" : config.tokenLimitParameter;
+    const body: Record<string, unknown> = { messages, [tokenParameter]: config.maxTokens };
+    if (Number.isFinite(config.temperature)) body.temperature = config.temperature;
+
+    const response = await fetchAzureOpenAiWithRetry(
+      buildAzureOpenAiCompletionsUrl(config),
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", "api-key": config.apiKey },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      },
+      {
+        onRetry: ({ status, waitMs, attempt, maxAttempts }) =>
+          console.warn(
+            `[#475] Azure OpenAI model-answer ${status} — retrying in ${waitMs}ms (attempt ${attempt}/${maxAttempts}).`,
+          ),
+      },
+    );
+    const rawBody = await response.text();
+    const responseBody = parseJsonBody(rawBody);
+    if (!response.ok) {
+      const providerMessage = extractProviderErrorMessage(responseBody);
+      throw new Error(
+        `Azure OpenAI model-answer request failed (${response.status}${providerMessage ? `: ${providerMessage}` : ""}).`,
+      );
+    }
+    return extractAssistantContent(responseBody) ?? "";
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`Azure OpenAI model-answer request timed out after ${config.timeoutMs}ms.`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 const DEFAULT_CRITERIA_IDS = [
   "task_comprehension",
   "quality_and_depth",

--- a/src/repositories/decisionRepository.ts
+++ b/src/repositories/decisionRepository.ts
@@ -15,6 +15,9 @@ export type CreateAssessmentDecisionInput = {
   practicalScaledScore: number;
   totalScore: number;
   redFlagsJson: string;
+  // #475 Phase 2: computed AI-influence signals JSON (declaration + content-similarity). Nullable;
+  // review-signal-only, never affects pass/fail.
+  aiInfluenceJson?: string | null;
   passFailTotal: boolean;
   decisionType: DecisionTypeType;
   decisionReason: string;

--- a/test/assessment-policy.integration.test.ts
+++ b/test/assessment-policy.integration.test.ts
@@ -12,6 +12,9 @@ import {
 } from "./support/participantFlow.js";
 
 const mockEvaluatePracticalWithLlm = vi.hoisted(() => vi.fn());
+// #475 Phase 2: the content-similarity "model answer" generator lives in the same module, so it is
+// mockable via this seam. Only called when content-similarity is enabled (off by default).
+const mockGenerateModelAnswer = vi.hoisted(() => vi.fn());
 
 vi.mock("../src/modules/assessment/llmAssessmentService.js", async () => {
   const actual = await vi.importActual<typeof import("../src/modules/assessment/llmAssessmentService.js")>(
@@ -21,6 +24,7 @@ vi.mock("../src/modules/assessment/llmAssessmentService.js", async () => {
   return {
     ...actual,
     evaluatePracticalWithLlm: mockEvaluatePracticalWithLlm,
+    generateModelAnswer: mockGenerateModelAnswer,
   };
 });
 
@@ -464,5 +468,112 @@ describe("Local integration assessment policy suite", () => {
         data: { assessmentPolicyJson: original.assessmentPolicyJson },
       });
     }
+  });
+
+  // #475 Phase 2: run a strong (would-pass) submission with content-similarity enabled per-module and a
+  // mocked model answer identical to the student's answer → high similarity. `shadowMode` toggles
+  // whether it routes. No declaration is sent, so ONLY the content-similarity signal is in play.
+  async function runContentSimilaritySubmission(app: Express, opts: { shadowMode: boolean }) {
+    const moduleId = await findModuleIdByTitle(app, participantHeaders, "Generative AI Foundations");
+    const moduleRow = await prisma.module.findUniqueOrThrow({
+      where: { id: moduleId },
+      select: { activeVersionId: true },
+    });
+    const versionId = moduleRow.activeVersionId!;
+    const original = await prisma.moduleVersion.findUniqueOrThrow({
+      where: { id: versionId },
+      select: { assessmentPolicyJson: true },
+    });
+    const basePolicy = original.assessmentPolicyJson ? JSON.parse(original.assessmentPolicyJson) : {};
+    await prisma.moduleVersion.update({
+      where: { id: versionId },
+      data: {
+        assessmentPolicyJson: JSON.stringify({
+          ...basePolicy,
+          aiInfluence: { contentSimilarity: { enabled: true, shadowMode: opts.shadowMode, similarityThreshold: 0.1 } },
+        }),
+      },
+    });
+
+    try {
+      mockEvaluatePracticalWithLlm.mockReset();
+      mockEvaluatePracticalWithLlm.mockResolvedValueOnce(buildAssessment());
+      const answerText =
+        "I used generative AI to improve a workshop agenda, refined the prompt twice, and validated the final output against the original notes before sending it.";
+      mockGenerateModelAnswer.mockReset();
+      mockGenerateModelAnswer.mockResolvedValue(answerText); // model answer == student answer → similar
+
+      const submissionResponse = await request(app)
+        .post("/api/submissions")
+        .set(participantHeaders)
+        .send({
+          moduleId,
+          deliveryType: "text",
+          responseJson: {
+            response: answerText,
+            reflection: "The second iteration was better because I constrained the output to actual decisions.",
+            promptExcerpt: "Rewrite this workshop brief with clear outcomes.",
+          },
+          // No processSignals — only content-similarity is in play.
+        });
+      expect(submissionResponse.status).toBe(201);
+      const submissionId = submissionResponse.body.submission.id as string;
+
+      const mcqStart = await startMcq(app, participantHeaders, moduleId, submissionId);
+      await submitMcqWithAnswerSelector(
+        app,
+        participantHeaders,
+        moduleId,
+        submissionId,
+        mcqStart.attemptId,
+        mcqStart.questions,
+        (question) =>
+          question.stem === "What is the recommended model ownership boundary?"
+            ? "Backend owns final decision"
+            : "Prompt versions and thresholds",
+      );
+      await runAssessmentSync(app, participantHeaders, submissionId);
+
+      const resultResponse = await request(app)
+        .get(`/api/submissions/${submissionId}/result`)
+        .set(participantHeaders);
+      expect(resultResponse.status).toBe(200);
+      const decision = await prisma.assessmentDecision.findFirstOrThrow({
+        where: { submissionId },
+        orderBy: { finalisedAt: "desc" },
+        select: { aiInfluenceJson: true },
+      });
+      return {
+        result: resultResponse.body as { status: string; decision: { decisionReason: string; passFailTotal: boolean } },
+        aiInfluence: decision.aiInfluenceJson ? JSON.parse(decision.aiInfluenceJson) : null,
+      };
+    } finally {
+      await prisma.moduleVersion.update({
+        where: { id: versionId },
+        data: { assessmentPolicyJson: original.assessmentPolicyJson },
+      });
+    }
+  }
+
+  it("TC-POL-AIINFLUENCE-002 live content-similarity routes a would-pass submission to review, never to fail", async () => {
+    const app = await loadFreshApp();
+    const { result, aiInfluence } = await runContentSimilaritySubmission(app, { shadowMode: false });
+    expect(result.status).toBe("UNDER_REVIEW");
+    expect(result.decision.passFailTotal).toBe(false);
+    expect(result.decision.decisionReason).toContain("modellsvar");
+    expect(aiInfluence.contentSimilarity.exceeded).toBe(true);
+    expect(aiInfluence.contentSimilarity.forcesReview).toBe(true);
+    expect(aiInfluence.declaration).toBeNull();
+    expect(mockGenerateModelAnswer).toHaveBeenCalledTimes(1);
+  });
+
+  it("TC-POL-AIINFLUENCE-003 shadow content-similarity persists the signal but routes no one", async () => {
+    const app = await loadFreshApp();
+    const { result, aiInfluence } = await runContentSimilaritySubmission(app, { shadowMode: true });
+    expect(result.status).toBe("COMPLETED");
+    expect(result.decision.passFailTotal).toBe(true);
+    expect(aiInfluence.contentSimilarity.exceeded).toBe(true);
+    expect(aiInfluence.contentSimilarity.forcesReview).toBe(false);
+    expect(aiInfluence.forcesReview).toBe(false);
   });
 });

--- a/test/unit/ai-influence.test.ts
+++ b/test/unit/ai-influence.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect } from "vitest";
 import {
   parseAiInfluenceSignals,
   evaluateAiInfluence,
+  evaluateContentSimilarity,
+  buildAiInfluenceOutcome,
   AUTONOMOUS_REVIEW_REASON,
+  CONTENT_SIMILARITY_REVIEW_REASON_PREFIX,
   type AiInfluenceRules,
+  type AiInfluenceContentRules,
 } from "../../src/modules/assessment/aiInfluence.js";
 import { resolveAssessmentDecision } from "../../src/modules/assessment/decisionService.js";
 import type { LlmStructuredAssessment } from "../../src/modules/assessment/llmAssessmentService.js";
@@ -176,5 +180,92 @@ describe("resolveAssessmentDecision + aiInfluence (review trigger, never fail)",
     });
     expect(resolved.needsManualReview).toBe(true);
     expect(resolved.decisionReason).toContain("red flag");
+  });
+});
+
+// ── #475 Phase 2: content-similarity signal ─────────────────────────────────────────────────────
+
+const CONTENT_LIVE: AiInfluenceContentRules = { enabled: true, shadowMode: false, similarityThreshold: 0.8 };
+const CONTENT_SHADOW: AiInfluenceContentRules = { enabled: true, shadowMode: true, similarityThreshold: 0.8 };
+const CONTENT_OFF: AiInfluenceContentRules = { enabled: false, shadowMode: true, similarityThreshold: 0.8 };
+
+const draftEqualTo = (text: string) => async () => text;
+const draftDisjoint = async () => "completely unrelated vocabulary here";
+
+describe("evaluateContentSimilarity", () => {
+  const answer = "kvalitetssikring av konsept og styringsunderlag i statens prosjektmodell";
+
+  it("returns null when disabled", async () => {
+    const r = await evaluateContentSimilarity({ taskText: "task", studentAnswer: answer, generateDraft: draftEqualTo(answer), rules: CONTENT_OFF });
+    expect(r).toBeNull();
+  });
+
+  it("returns null when there is no task text or an empty answer", async () => {
+    expect(await evaluateContentSimilarity({ taskText: undefined, studentAnswer: answer, generateDraft: draftEqualTo(answer), rules: CONTENT_LIVE })).toBeNull();
+    expect(await evaluateContentSimilarity({ taskText: "task", studentAnswer: "   ", generateDraft: draftEqualTo(answer), rules: CONTENT_LIVE })).toBeNull();
+  });
+
+  it("skips the signal (null) when draft generation throws — never breaks assessment", async () => {
+    const r = await evaluateContentSimilarity({ taskText: "task", studentAnswer: answer, generateDraft: async () => { throw new Error("llm down"); }, rules: CONTENT_LIVE });
+    expect(r).toBeNull();
+  });
+
+  it("in shadow mode computes similarity but never forces review", async () => {
+    const r = await evaluateContentSimilarity({ taskText: "task", studentAnswer: answer, generateDraft: draftEqualTo(answer), rules: CONTENT_SHADOW });
+    expect(r).not.toBeNull();
+    expect(r!.similarity).toBe(1);
+    expect(r!.exceeded).toBe(true);
+    expect(r!.forcesReview).toBe(false);
+  });
+
+  it("live + high similarity → forcesReview true", async () => {
+    const r = await evaluateContentSimilarity({ taskText: "task", studentAnswer: answer, generateDraft: draftEqualTo(answer), rules: CONTENT_LIVE });
+    expect(r!.exceeded).toBe(true);
+    expect(r!.forcesReview).toBe(true);
+  });
+
+  it("live + low similarity → not exceeded, does not force review", async () => {
+    const r = await evaluateContentSimilarity({ taskText: "task", studentAnswer: answer, generateDraft: draftDisjoint, rules: CONTENT_LIVE });
+    expect(r!.similarity).toBe(0);
+    expect(r!.exceeded).toBe(false);
+    expect(r!.forcesReview).toBe(false);
+  });
+});
+
+describe("buildAiInfluenceOutcome", () => {
+  const contentForcing = { similarity: 0.95, threshold: 0.8, exceeded: true, forcesReview: true };
+  const contentShadow = { similarity: 0.95, threshold: 0.8, exceeded: true, forcesReview: false };
+
+  it("no signals → nothing to persist, no decision", () => {
+    expect(buildAiInfluenceOutcome({ declaration: undefined, declarationResult: null, contentSignal: null })).toEqual({
+      signalsJson: null,
+      decision: undefined,
+    });
+  });
+
+  it("declaration forces review → decision is the declaration result; persisted forcesReview true", () => {
+    const declarationResult = { forcesReview: true as const, reason: AUTONOMOUS_REVIEW_REASON };
+    const out = buildAiInfluenceOutcome({ declaration: "autonomous", declarationResult, contentSignal: contentShadow });
+    expect(out.decision).toBe(declarationResult);
+    const persisted = JSON.parse(out.signalsJson!);
+    expect(persisted.declaration).toBe("autonomous");
+    expect(persisted.declarationForcesReview).toBe(true);
+    expect(persisted.forcesReview).toBe(true);
+    expect(persisted.contentSimilarity.similarity).toBe(0.95);
+  });
+
+  it("only content forces review → decision uses the content-similarity reason", () => {
+    const out = buildAiInfluenceOutcome({ declaration: undefined, declarationResult: null, contentSignal: contentForcing });
+    expect(out.decision?.forcesReview).toBe(true);
+    expect(out.decision?.reason).toContain(CONTENT_SIMILARITY_REVIEW_REASON_PREFIX);
+    expect(JSON.parse(out.signalsJson!).forcesReview).toBe(true);
+  });
+
+  it("shadow content signal alone → persisted but no decision (routes no one)", () => {
+    const out = buildAiInfluenceOutcome({ declaration: undefined, declarationResult: null, contentSignal: contentShadow });
+    expect(out.decision).toBeUndefined();
+    const persisted = JSON.parse(out.signalsJson!);
+    expect(persisted.forcesReview).toBe(false);
+    expect(persisted.contentSimilarity.exceeded).toBe(true);
   });
 });

--- a/test/unit/assessment-job-service.test.ts
+++ b/test/unit/assessment-job-service.test.ts
@@ -11,6 +11,7 @@ const markJobForRetryOrFailure = vi.fn();
 const findAssessmentJobOrThrow = vi.fn();
 const createAssessmentDecision = vi.fn();
 const evaluatePracticalWithLlm = vi.fn();
+const generateModelAnswer = vi.fn();
 const recordAuditEvent = vi.fn();
 const logOperationalEvent = vi.fn();
 const enqueueOutboxEvents = vi.fn();
@@ -54,6 +55,7 @@ vi.mock("../../src/modules/outbox/outboxService.js", () => ({
 
 vi.mock("../../src/modules/assessment/llmAssessmentService.js", () => ({
   evaluatePracticalWithLlm,
+  generateModelAnswer,
 }));
 
 vi.mock("../../src/services/auditService.js", () => ({

--- a/test/unit/content-similarity.test.ts
+++ b/test/unit/content-similarity.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import {
+  tokenize,
+  lexicalCosineSimilarity,
+  extractAnswerText,
+} from "../../src/modules/assessment/contentSimilarity.js";
+
+describe("tokenize", () => {
+  it("lowercases and keeps word/number tokens of length >= 2", () => {
+    expect(tokenize("Hei, KS1 og KS2!")).toEqual(["hei", "ks1", "og", "ks2"]);
+  });
+  it("drops single-character tokens and splits on punctuation", () => {
+    // "I/O" splits on the slash into "i" and "o" (both length 1, dropped); "io24" survives.
+    expect(tokenize("a I/O, x — io24")).toEqual(["io24"]);
+  });
+  it("returns [] for empty / non-string", () => {
+    expect(tokenize("")).toEqual([]);
+    expect(tokenize(undefined as unknown as string)).toEqual([]);
+  });
+});
+
+describe("lexicalCosineSimilarity", () => {
+  it("is 1 for identical text", () => {
+    expect(lexicalCosineSimilarity("the quick brown fox", "the quick brown fox")).toBe(1);
+  });
+  it("is 0 for disjoint vocabularies", () => {
+    expect(lexicalCosineSimilarity("alpha beta gamma", "delta epsilon zeta")).toBe(0);
+  });
+  it("is 0 when either side is empty", () => {
+    expect(lexicalCosineSimilarity("", "anything here")).toBe(0);
+    expect(lexicalCosineSimilarity("anything here", "")).toBe(0);
+  });
+  it("is between 0 and 1 for partial overlap, and symmetric", () => {
+    const a = "kvalitetssikring av konsept og styringsunderlag";
+    const b = "kvalitetssikring av kostnadsoverslag og styringsunderlag";
+    const s = lexicalCosineSimilarity(a, b);
+    expect(s).toBeGreaterThan(0);
+    expect(s).toBeLessThan(1);
+    expect(lexicalCosineSimilarity(b, a)).toBeCloseTo(s, 10);
+  });
+  it("ignores word order (bag-of-words)", () => {
+    expect(lexicalCosineSimilarity("fox brown quick the", "the quick brown fox")).toBe(1);
+  });
+});
+
+describe("extractAnswerText", () => {
+  it("joins string field values, ignoring non-strings", () => {
+    expect(extractAnswerText({ response: "Line one", reflection: "Line two", count: 3 })).toBe(
+      "Line one\nLine two",
+    );
+  });
+  it("returns '' for empty / non-object", () => {
+    expect(extractAnswerText({})).toBe("");
+    expect(extractAnswerText(null)).toBe("");
+  });
+});


### PR DESCRIPTION
Begins **Phase 2** of #475: a content-similarity signal — post-submission, generate an independent "model answer" to the task and measure its similarity to the student's answer, as **ONE additional review signal, never a verdict**. Ships **feature-flagged OFF + shadow-mode** so it collects pilot data before it can route anyone. Same invariants as Phase 1 (review trigger only; never touches pass/fail).

## Approach
- **Local lexical cosine** (`contentSimilarity.ts`) — deterministic, no embeddings infra to provision across the two Azure tenants, no per-call cost when off. Honest limitation documented: two correct answers to the same task share vocabulary, so it's coarse on its own → shadow-first + a configurable threshold for the owner to calibrate a false-positive rate. Swappable for embeddings-cosine later behind the same function.
- **`generateModelAnswer`** in `llmAssessmentService.ts` (stub + azure_openai), mockable via the existing test seam; only called when enabled (dormant = no extra LLM call).
- **Persisted transparently:** additive nullable `AssessmentDecision.aiInfluenceJson` stores the computed signals (declaration + `{similarity,threshold,exceeded,forcesReview}`). `buildAiInfluenceOutcome` combines Phase 1 + 2; either alone can route (declaration reason wins when both fire).
- **Config:** `aiInfluence.contentSimilarity {enabled, shadowMode, similarityThreshold:0.82}` global + per-module override, both OFF by default.

## Safety / rollout
- Ships dormant; enabling in prod is still gated on the §9 owner gates (esp. the false-positive budget) — a product-owner decision, not this PR.
- Expand-only migration `20260726120000_decision_ai_influence` (additive nullable).
- Rollback: revert; the nullable column can stay unused.

## Tests
- Unit: `content-similarity` (cosine/tokenize/extract) + `ai-influence` (evaluate/combine, shadow vs live).
- Integration: `TC-POL-AIINFLUENCE-002` (live → UNDER_REVIEW, never fail; signal persisted) + `-003` (shadow → persists the signal, routes no one, stays COMPLETED).
- tsc 0; unit 897; policy integration 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
