### PR TITLE
#475: parallelize content-similarity + per-env enable; defer Phase 3 (#886)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,10 @@ AZURE_OPENAI_MAX_TOKENS=1200
 AZURE_OPENAI_TOKEN_LIMIT_PARAMETER=auto
 PARTICIPANT_CONSOLE_CONFIG_FILE=config/participant-console.json
 ASSESSMENT_RULES_FILE=config/assessment-rules.json
+# #475 Phase 2: per-environment override of the content-similarity signal (unset = use the rules file).
+# Set on staging only to pilot it without affecting prod or the test suite. Both "true"/"false".
+# AI_CONTENT_SIMILARITY_ENABLED=true
+# AI_CONTENT_SIMILARITY_SHADOW=false
 ASSESSMENT_JOB_POLL_INTERVAL_MS=4000
 ASSESSMENT_JOB_MAX_ATTEMPTS=3
 ASSESSMENT_JOB_LEASE_DURATION_MS=300000

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,23 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.9.1 - 2026-07-26
+
+#475 — **Content-similarity: parallelized + per-environment enable; Phase 3 split out (#886).**
+
+- **Parallelized (latency):** the model-answer LLM call now runs concurrently with the main assessment
+  (`Promise.all`) instead of serially before it — when the signal is enabled, the added wall-clock is the
+  slower of the two calls, not their sum, instead of ~doubling assessment time.
+- **Per-environment enable:** new tri-state env override `AI_CONTENT_SIMILARITY_ENABLED` /
+  `AI_CONTENT_SIMILARITY_SHADOW` (unset = use the shared rules file). Lets us pilot content-similarity on
+  **staging only** without touching the committed rules file — so prod stays dormant and the test suite is
+  unaffected. Applied in `getAssessmentRules()`.
+- **Phase 3 deferred:** student stylometric baseline split to #886 (weakest value/risk: cold-start, high
+  false positives, heavier GDPR profiling). #475 now covers Phase 1 (live) + Phase 2 (shippable).
+
+Config file stays content-similarity OFF. tsc 0; unit 897; policy integration 11 (incl. content-similarity
+live/shadow). Client-invisible; no migration.
+
 ## 2.9.0 - 2026-07-26
 
 #475 **Phase 2 — AI-influence content-similarity signal.** Post-submission, generate an independent

--- a/doc/design/AI_INFLUENCE_FLAGGING_475.md
+++ b/doc/design/AI_INFLUENCE_FLAGGING_475.md
@@ -27,7 +27,8 @@ turn it into one more review signal (never a verdict) and persist `{similarity, 
 forcesReview}` alongside the declaration on the new additive `AssessmentDecision.aiInfluenceJson`. Gated by
 `aiInfluence.contentSimilarity {enabled, shadowMode, similarityThreshold}` (global + per-module), OFF +
 shadow by default. Coarse by design (lexical) — the §9 false-positive-budget gate still applies before it
-routes anyone. Phase 3 (student stylometric baseline) remains future.
+routes anyone. **Phase 3 (student stylometric baseline) is split out and deferred → #886** (weakest
+value/risk of the three: cold-start, high false positives, heavier GDPR profiling).
 
 **Phase 1 as built:** `Submission.processSignalsJson` (additive nullable) stores `{ declaration, declarationText?,
 insistedAfterPrompt }`. `src/modules/assessment/aiInfluence.ts` evaluates it against the global

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/config/assessmentRules.ts
+++ b/src/config/assessmentRules.ts
@@ -181,6 +181,17 @@ export function getAssessmentRules(): AssessmentRules {
   const rulesPath = path.resolve(process.cwd(), env.ASSESSMENT_RULES_FILE);
   const raw = fs.readFileSync(rulesPath, "utf8");
   const parsedJson = JSON.parse(raw);
-  cached = rulesSchema.parse(parsedJson);
+  const rules = rulesSchema.parse(parsedJson);
+
+  // #475 Phase 2: per-environment override of the content-similarity signal (enable on staging only
+  // without touching the shared file). Unset env vars leave the file value untouched.
+  if (env.AI_CONTENT_SIMILARITY_ENABLED !== undefined) {
+    rules.aiInfluence.contentSimilarity.enabled = env.AI_CONTENT_SIMILARITY_ENABLED === "true";
+  }
+  if (env.AI_CONTENT_SIMILARITY_SHADOW !== undefined) {
+    rules.aiInfluence.contentSimilarity.shadowMode = env.AI_CONTENT_SIMILARITY_SHADOW === "true";
+  }
+
+  cached = rules;
   return cached;
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -125,6 +125,11 @@ const envSchema = z.object({
   PARTICIPANT_CONSOLE_CONFIG_FILE: z.string().default("config/participant-console.json"),
   PARTICIPANT_CONSOLE_DEBUG_MODE: z.enum(["auto", "true", "false"]).default("auto"),
   ASSESSMENT_RULES_FILE: z.string().default("config/assessment-rules.json"),
+  // #475 Phase 2: per-environment override of the content-similarity signal, so it can be enabled on a
+  // single environment (e.g. staging) without touching the shared rules file (which would also affect
+  // prod + the test suite). Tri-state: unset = use the rules file; "true"/"false" = override.
+  AI_CONTENT_SIMILARITY_ENABLED: z.enum(["true", "false"]).optional(),
+  AI_CONTENT_SIMILARITY_SHADOW: z.enum(["true", "false"]).optional(),
   ASSESSMENT_JOB_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(4000),
   ASSESSMENT_JOB_MAX_ATTEMPTS: z.coerce.number().int().positive().default(3),
   ASSESSMENT_JOB_LEASE_DURATION_MS: z.coerce.number().int().positive().default(300000),

--- a/src/modules/assessment/assessmentJobService.ts
+++ b/src/modules/assessment/assessmentJobService.ts
@@ -101,7 +101,10 @@ async function runAssessment(jobId: string) {
     policy: inputContext.assessmentPolicy,
     rules: aiRules,
   });
-  const contentSignal = await evaluateContentSimilarity({
+  // Content-similarity needs its own LLM call (the model answer) but does NOT depend on the assessment
+  // pipeline, so kick it off here and await it alongside the pipeline below — the extra call overlaps
+  // the assessment instead of adding to it. Returns null (no extra call) when the feature is disabled.
+  const contentSignalPromise = evaluateContentSimilarity({
     taskText: inputContext.moduleTaskText,
     studentAnswer: extractAnswerText(JSON.parse(submission.responseJson) as Record<string, unknown>),
     generateDraft: generateModelAnswer,
@@ -109,13 +112,6 @@ async function runAssessment(jobId: string) {
     responseLocale: submissionLocale,
     rules: resolveContentSimilarityRules(inputContext.assessmentPolicy, aiRules.contentSimilarity),
   });
-  const aiOutcome = buildAiInfluenceOutcome({
-    declaration: declarationSignals?.declaration,
-    declarationResult,
-    contentSignal,
-  });
-  const aiInfluence = aiOutcome.decision;
-  const aiInfluenceJson = aiOutcome.signalsJson;
 
   await recordAuditEvent({
     entityType: auditEntityTypes.submission,
@@ -132,15 +128,28 @@ async function runAssessment(jobId: string) {
     },
   });
 
-  const { finalLlmResult, forceManualReviewReason } = await runLlmEvaluationPipeline({
-    jobId,
-    submissionId: submission.id,
-    userId: submission.userId,
-    moduleId: submission.moduleId,
-    moduleVersionId: submission.moduleVersionId,
-    promptTemplateVersionId,
-    inputContext,
+  // Run the (independent) content-similarity and the main assessment concurrently; total added latency
+  // is the slower of the two, not the sum.
+  const [{ finalLlmResult, forceManualReviewReason }, contentSignal] = await Promise.all([
+    runLlmEvaluationPipeline({
+      jobId,
+      submissionId: submission.id,
+      userId: submission.userId,
+      moduleId: submission.moduleId,
+      moduleVersionId: submission.moduleVersionId,
+      promptTemplateVersionId,
+      inputContext,
+    }),
+    contentSignalPromise,
+  ]);
+
+  const aiOutcome = buildAiInfluenceOutcome({
+    declaration: declarationSignals?.declaration,
+    declarationResult,
+    contentSignal,
   });
+  const aiInfluence = aiOutcome.decision;
+  const aiInfluenceJson = aiOutcome.signalsJson;
 
   await applyAssessmentDecision({
     jobId,


### PR DESCRIPTION
Prepares to pilot the Phase 2 content-similarity signal on **staging only**, safely.

- **Parallelized (latency):** the model-answer LLM call now runs concurrently with the main assessment (`Promise.all`) rather than serially before it — when enabled, added wall-clock is the slower of the two calls, not their sum (was ~doubling assessment time).
- **Per-environment enable:** tri-state env override `AI_CONTENT_SIMILARITY_ENABLED` / `AI_CONTENT_SIMILARITY_SHADOW` (unset = use the shared rules file), applied in `getAssessmentRules()`. Lets us enable content-similarity on **staging via an app setting** while the committed rules file — and thus **prod + the test suite** — stays dormant. Avoids the "shared-file flag leaks to prod on next promotion" problem for a coarse auto-firing signal.
- **Phase 3 deferred → #886** (student stylometric baseline: cold-start, high false positives, heavier GDPR profiling).

The committed `config/assessment-rules.json` keeps content-similarity OFF. Enabling on stage is a follow-up app-setting step (documented; not in Bicep yet, so `deploy-azure.yml` would reset it — fine for a pilot).

tsc 0; unit 897; policy integration 11 (incl. content-similarity live/shadow); m2-manual-review isolated pass. Client-invisible; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
