### PR TITLE
Kursspor-typografi, ærlig lokalisering av modultitler og språkbytte i kurslista — v2.11.2–2.11.4

### DIFF
--- a/doc/OPERATIONS_RUNBOOK.md
+++ b/doc/OPERATIONS_RUNBOOK.md
@@ -323,6 +323,46 @@ the RG lock is restored afterward. As of 2026-07-25 the prod backfill re-sealed 
 **Verification is also a maintenance script** — schedule or run `maint:verify-audit-chain` ad hoc to detect
 tampering (a non-zero exit means a row was edited/removed/reordered).
 
+### Collapse duplicated localized titles (#892)
+
+Renaming a module used to copy the author's one title into `en-GB`, `nb` **and** `nn`. The rename path is
+fixed (v2.11.3), but rows written before it still look translated — which is exactly the signal a
+translation-status view needs. This collapses such values back to a plain string.
+
+**Dry run by default.** `--apply` is required to write, and the dry run prints the ids it would touch:
+
+```bash
+dotenv -e .env.<env> -- npm run maint:collapse-duplicated-titles             # dry run — read the ids
+dotenv -e .env.<env> -- npm run maint:collapse-duplicated-titles -- --apply  # write
+```
+
+Safe because the change is **display-neutral**: `localizeContentText` resolves
+`map[locale] ?? map["en-GB"] ?? first value`, and a plain string is returned verbatim for every locale — so
+when every entry holds the same string, both encodings render identically everywhere. Only the false claim
+"this has a per-locale translation" goes away. Idempotent; a second run reports 0.
+
+Deliberately does **not** touch genuine translations, partial translations (two equal + one different),
+single-locale maps (`{"nb":"…"}` records *which* language the text is in), or values that are already plain
+strings. Covers `Module.title`, `CourseSection.title`, `Course.title`, `Course.description`.
+
+**Against staging** the resource group has no lock, so the firewall step is straightforward:
+
+```powershell
+az account set --subscription df46af7a-1806-4bda-a24b-0b3c112bd261
+az postgres flexible-server firewall-rule create -g rg-a2-assessment-stg `
+  --server-name a2-assessment-platform-stg-pg-x6eyx4 --name tmp-<you> `
+  --start-ip-address <your-ip> --end-ip-address <your-ip>
+$env:DATABASE_URL = az keyvault secret show --vault-name a2-stg-kv-x6eyx4 --name DATABASE-URL --query value -o tsv
+npx tsx scripts/maintenance/collapse-duplicated-titles.ts            # dry run
+npx tsx scripts/maintenance/collapse-duplicated-titles.ts --apply    # write
+az postgres flexible-server firewall-rule delete -g rg-a2-assessment-stg `
+  --server-name a2-assessment-platform-stg-pg-x6eyx4 --name tmp-<you> --yes
+```
+
+**Against production** the RG carries a `CanNotDelete` lock that blocks *deleting* the temp rule — follow the
+create → run → remove-lock → delete-rule → **re-create-lock** → verify recipe in the operator memory
+`prod-db-firewall-lock-gotcha`, in small separate steps, and re-verify the lock is restored afterwards.
+
 ## Seed Behavior
 
 ### Bootstrap seed

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,27 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.11.2 - 2026-08-11
+
+**Kursporet leses roligere.** To observasjoner fra deltakertesting med et ekte 18-stegs kurs.
+
+- **Titlene sto ikke på linje.** Typeetiketten hadde variabel bredde («Lesestoff» mot «Test»), så
+  hver rad startet tittelen på ulik x. Den flisete venstrekanten fikk lista til å se rotete ut selv
+  når innholdet var ryddig. Etiketten har nå fast bredde, og titlene danner én kolonne.
+- **Versalene er droppet.** `LESESTOFF`/`TEST` i store bokstaver gjentatt over 18 rader roper, og
+  etiketten er metadata — ikke en overskrift. Nå gemen tekst i småtekst-fargen, 12px. Samme for
+  tegnforklaringen og posisjonsteksten på det aktuelle steget.
+
+Merk at **teksten** i etiketten var uendret hele veien (`Lesestoff`/`Test`) — versalene var ren CSS,
+så e2e-assertions og skjermlesere er upåvirket.
+
+Denne endringen fjerner én av to årsaker til at lista så uryddig ut. Den andre er at modultitler
+lagres identisk på tvers av språk i stedet for å oversettes, slik at en nynorsk kursliste viser
+bokmål på annenhver rad — sporet i #892.
+
+Tests: uendret; `participant-course-sequence` og `participant-discussions` grønne. CSS only; ingen
+i18n-, API- eller modellendring.
+
 ## 2.11.1 - 2026-08-11
 
 **To funn fra deltakertesting av 2.11.0 på stage.**

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,41 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.11.3 - 2026-08-11
+
+**#892 — modultitler skrives ikke lenger identisk til alle språk.** En omdøping skrev forfatterens
+ene tittel inn i `en-GB`, `nb` **og** `nn`. Tre ting gikk galt: hver tittel så oversatt ut,
+deltakeren fikk forfatterens språk under alle locales uten noe signal, og «denne mangler
+oversettelse» ble umulig å oppdage — et utfylt `nn` kunne ikke skilles fra et bevisst.
+
+- En **ren streng** lagres nå som ren streng, akkurat som `updateSectionTitle` allerede gjorde.
+  Visningen er uendret (`localizeContentText` faller tilbake til den for alle språk), men dataene
+  er ærlige — og det er nettopp det som gjør en oversettelsesstatus mulig (#894).
+- Et **lokalisert objekt** merges fortsatt mot eksisterende verdier, så å oversette ett språk lar
+  de andre stå.
+- Dupliseringen lå **fire steder**: `normalizeLocalizedTitlePatch` i backend, pluss tre i klienten
+  (`admin-content.js` × 2 og `normalizeModuleTitlePatch` → `buildLocalizedTextMap` i
+  `admin-content-shell.js`). Alle fire er rettet; backend er backstop for agent-API-et.
+- ⚠️ **Eksisterende data er ikke migrert.** Moduler der alle tre språk er identiske ser fortsatt
+  «oversatt» ut. Et opprydningsskript gjenstår — se #892.
+
+**#893 — kurslista følger språkbytte.** Kurstitler løses opp server-side per forespørsel, så en
+cachet `CourseDetail` tilhører språket den ble hentet under. Cachen var nøklet på `courseId` alene,
+og `setLocale` rørte den ikke — lista beholdt forrige språk til deltakeren tilfeldigvis trykket
+«Last kurs». Nå tømmes cachen og åpne kurs hentes på nytt ved språkbytte.
+
+- `courseDetailCache` er flyttet opp til øvrig oppstartstilstand. `setLocale` kjører under boot, og
+  en `let` lenger nede i fila ga en temporal-dead-zone-feil som stoppet hele skriptet.
+- Re-henting går gjennom `renderCourseDetailModules`, som allerede gjør
+  `restoreModuleWorkspaceHomeIfInside` + `reopenInlineAfterRender` rundt sin `innerHTML=""` — så en
+  åpen inline-modul overlever språkbyttet.
+
+Tests: ny unit-suite `module-title-localization` (5 caser: ren streng lagres som streng, ingen
+fabrikert oversettelse over en eksisterende lokalisert tittel, objekt-patch merger fortsatt, blanke
+felt ignoreres, og at et lagret objekt vs. streng er nettopp skillet #894 trenger). Ny e2e-vakt som
+serverer ulik tittel per språk og krever at åpent kurs bytter språk uten «Last kurs».
+tsc 0, unit 909, kontrakter 32, e2e 118.
+
 ## 2.11.2 - 2026-08-11
 
 **Kursporet leses roligere.** To observasjoner fra deltakertesting med et ekte 18-stegs kurs.

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,33 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.11.4 - 2026-08-11
+
+**Opprydningsskript for #892-dataene.** v2.11.3 stoppet ny duplisering, men rader skrevet før den
+ser fortsatt oversatt ut. `npm run maint:collapse-duplicated-titles` kollapser lokaliserte verdier
+der alle språk holder samme streng, tilbake til ren streng — så «ikke oversatt ennå» blir synlig
+igjen på eksisterende innhold, og #894 får noe å måle på.
+
+- **Tørrkjøring som standard.** `--apply` kreves for å skrive. Tørrkjøringen skriver ut id-listene,
+  så du ser nøyaktig hvilke rader som ville endret seg før du gjør noe.
+- **Endringen er visningsnøytral.** `localizeContentText` slår opp `map[locale] ?? map["en-GB"] ??
+  første verdi`, og en ren streng returneres uendret for alle språk. Når alle oppføringer holder
+  samme streng, gir begge kodingene identisk resultat i alle språk — ingen deltaker, forfatter
+  eller eksport kan se forskjell. Kun påstanden «dette har en oversettelse per språk» forsvinner,
+  og den var usann.
+- **Rører bevisst ikke:** ekte oversettelser, delvise oversettelser (to like og én ulik er fortsatt
+  reelt arbeid), enkeltspråk-kart (`{"nb":"…"}` sier *hvilket* språk teksten er på — mer
+  informasjon enn en ren streng), og verdier som allerede er rene strenger.
+- Dekker `Module.title`, `CourseSection.title`, `Course.title` og `Course.description`.
+- Idempotent: en ny kjøring finner ingenting å kollapse.
+
+Tests: `localized-title-cleanup` (10 caser, hovedvekt på hva skriptet **ikke** skal røre, pluss en
+som beviser visningsnøytraliteten ved å sammenligne `localizeContentText` før og etter).
+
+⚠️ **Ikke kjørt mot en ekte database ennå.** Docker var utilgjengelig lokalt, så skriptet er kun
+røykt til Prisma-kallet (modulgraf + spørringsform validert). Kjør tørrkjøringen på stage og les
+id-listene før `--apply`.
+
 ## 2.11.3 - 2026-08-11
 
 **#892 — modultitler skrives ikke lenger identisk til alle språk.** En omdøping skrev forfatterens

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",
@@ -12,6 +12,7 @@
     "maint:scrub-audit-pii": "tsx scripts/maintenance/scrub-audit-pii.ts",
     "maint:backfill-audit-chain": "tsx scripts/maintenance/backfill-audit-chain.ts",
     "maint:verify-audit-chain": "tsx scripts/maintenance/verify-audit-chain.ts",
+    "maint:collapse-duplicated-titles": "tsx scripts/maintenance/collapse-duplicated-titles.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node scripts/runtime/startup.mjs",
     "postgres:setup": "node scripts/postgres/localSetup.mjs setup",

--- a/public/admin-content.js
+++ b/public/admin-content.js
@@ -800,13 +800,8 @@ function normalizeLocalizedTitlePatchValue(value, fieldLabelKey) {
   if (!parsed) {
     return null;
   }
-  if (typeof parsed === "string") {
-    return {
-      "en-GB": parsed,
-      nb: parsed,
-      nn: parsed,
-    };
-  }
+  // #892: en ren streng betyr «forfatteren skrev én tittel på ett språk». Den sendes som streng,
+  // ikke kopiert til alle språk — se updateModuleTitle for hvorfor kopiering var skadelig.
   return parsed;
 }
 
@@ -2284,9 +2279,10 @@ async function handleSaveContentBundle() {
   try {
     const localized = readLocalizedFieldValue(moduleTitleInput, "adminContent.module.name", { required: false });
     if (localized) {
-      titlePatch = typeof localized === "string"
-        ? { "en-GB": localized, nb: localized, nn: localized }
-        : localized;
+      // #892: send strengen som den er. readLocalizedFieldValue gir allerede et lokalisert objekt
+      // når feltet har et sporet original (da merges kun gjeldende språk); en ren streng betyr at
+      // tittelen er uoversatt, og skal lagres slik — ikke kopieres til alle tre språk.
+      titlePatch = localized;
     }
   } catch {
     titlePatch = normalizeLocalizedTitlePatchValue(moduleTitleInput.value, "adminContent.module.name");

--- a/public/participant.html
+++ b/public/participant.html
@@ -166,7 +166,7 @@
       .course-sequence-legend {
         display: flex; flex-wrap: wrap; gap: 14px; margin: 0 0 8px -26px;
         padding-bottom: 8px; border-bottom: 1px solid var(--color-border-soft);
-        font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--color-meta);
+        font-size: 12px; color: var(--color-meta);
       }
       .course-sequence-legend span { display: inline-flex; align-items: center; gap: 6px; }
       .course-sequence-legend i {
@@ -217,9 +217,13 @@
       .course-step--ahead[disabled] { cursor: default; color: var(--color-meta); }
       .course-step--ahead[disabled]:hover { background: transparent; }
 
+      /* Fast bredde: titlene skal starte på samme x uansett om etiketten er «Lesestoff» eller
+         «Test». Variabel bredde ga en flisete venstrekant som fikk lista til å se rotete ut, selv
+         når innholdet var ryddig. Versaler er droppet — 18 rader med STORE BOKSTAVER roper, og
+         etiketten er metadata, ikke en overskrift. */
       .course-step-kind {
-        font-size: 11px; letter-spacing: 0.07em; text-transform: uppercase;
-        color: var(--color-meta); flex-shrink: 0;
+        font-size: 12px; color: var(--color-meta); flex-shrink: 0;
+        width: 5.5rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
       }
       .course-item[data-type="MODULE"] .course-step-kind { color: var(--color-primary); }
 
@@ -233,7 +237,7 @@
       .course-step--now:hover { background: var(--color-primary-tint); }
       .course-step--now:focus-visible { outline: 3px solid var(--color-focus); outline-offset: 2px; }
       .course-step-meta { display: flex; align-items: center; gap: 8px; margin-bottom: 5px; }
-      .course-step-position { font-size: 10px; letter-spacing: 0.07em; text-transform: uppercase; color: var(--color-primary); }
+      .course-step-position { font-size: 12px; color: var(--color-primary); }
       .course-step--now .course-step-title { display: block; font-size: 16px; font-weight: 700; color: var(--color-text); line-height: 1.3; margin-bottom: 8px; }
       .course-step-cta {
         display: inline-flex; align-items: center; width: auto; min-height: 0;

--- a/public/participant.js
+++ b/public/participant.js
@@ -104,6 +104,10 @@ const COMPLETED_MODULE_STATUSES = new Set(["COMPLETED"]);
 
 let currentQuestions = [];
 let currentLocale = resolveInitialLocale(supportedLocales);
+// Declared with the rest of the boot state, not next to the accordion code: setLocale runs during
+// startup and clears this cache (#893), which would hit the temporal dead zone if the `let` sat
+// further down the file.
+let courseDetailCache = {};        // courseId -> CourseDetail (resolved under the fetching locale)
 let latestResult = null;
 // #549: ensures the pass celebration (confetti + banner) fires once per submission, not on every
 // result poll. Reset when the module context changes / a new submission starts.
@@ -304,6 +308,11 @@ function setLocale(locale) {
       })
       .catch(() => {/* silent — stale titles are preferable to an error on locale switch */});
   }
+  // #893: course titles are resolved SERVER-side per request (`localizeContentText` in
+  // routes/courses.ts), so a cached CourseDetail belongs to the locale it was fetched under.
+  // The cache is keyed by courseId alone, so without this the course list kept the previous
+  // language until the participant happened to press "Last kurs" — which they have no reason to.
+  refreshOpenCourseDetailsForLocale();
   setDefaultFieldValues(previousLocale, currentLocale);
   renderSubmissionFields(getSubmissionFields(resolveSelectedModule(loadedModules, selectedModuleId)));
   renderResultSummary(latestResult);
@@ -2949,7 +2958,6 @@ let participantCompletions = {};   // courseId -> completion
 // courses on first load.
 const celebratedCompletedCourses = new Set();
 let courseAccordionInitialized = false;
-let courseDetailCache = {};        // courseId -> CourseDetail
 
 
 document.getElementById("loadCoursesBtn")?.addEventListener("click", async () => {
@@ -2980,6 +2988,27 @@ async function loadParticipantCourses() {
   // of skipping the fetch and leaving the placeholder stuck (#550 follow-up).
   courseDetailCache = {};
   renderParticipantCourseAccordion();
+}
+
+// #893: drop every cached CourseDetail (it was resolved under the old locale) and re-fetch the
+// ones the participant currently has open, so the sequence switches language in place. Courses
+// that are collapsed re-fetch on their next expand, as they already do.
+//
+// The workspace dance matters here: loadCourseDetail → renderCourseDetailModules wipes the
+// container with innerHTML="", so an inline-open module would lose the singleton #moduleWorkspace.
+// renderCourseDetailModules already calls restoreModuleWorkspaceHomeIfInside + reopenInlineAfterRender
+// around that wipe (see doc/FEATURE_SURFACE_MAP.md § 6b), so going through it keeps an open item open.
+function refreshOpenCourseDetailsForLocale() {
+  const container = document.getElementById("courseAccordion");
+  if (!container) return;
+  const openCourseIds = Array.from(container.querySelectorAll(".course-accordion-item.open"))
+    .map((el) => el.dataset.courseId)
+    .filter(Boolean);
+
+  courseDetailCache = {};
+  for (const courseId of openCourseIds) {
+    loadCourseDetail(courseId).catch(() => {/* silent — a failed refresh leaves the old render */});
+  }
 }
 
 function renderParticipantCourseAccordion() {

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -1280,7 +1280,10 @@ function normalizeModuleTitlePatch(title) {
   if (typeof title === "string") {
     const normalized = title.trim();
     if (!normalized) return null;
-    return buildLocalizedTextMap("en-GB", normalized);
+    // #892: en uoversatt tittel sendes som streng. Tidligere fylte buildLocalizedTextMap alle tre
+    // språk med samme tekst, som fikk tittelen til å se oversatt ut og skjulte at den ikke var det.
+    // Utkast som FAKTISK er oversatt kommer hit som objekt (localizeDraftAcrossLocales) og merges.
+    return normalized;
   }
   if (typeof title !== "object") {
     return null;

--- a/scripts/maintenance/collapse-duplicated-titles.ts
+++ b/scripts/maintenance/collapse-duplicated-titles.ts
@@ -1,0 +1,55 @@
+/**
+ * #892 clean-up: collapse localized titles whose locales all hold the same string back into a plain
+ * string, so «not translated yet» becomes detectable again on content written before v2.11.3.
+ *
+ * The change is display-neutral — see src/services/localizedTitleCleanup.ts for why — but it writes
+ * to content tables, so it is a DRY RUN unless you pass --apply.
+ *
+ * Runs against whatever DATABASE_URL is in the environment, so target the intended env explicitly:
+ *   dotenv -e .env.<env> -- tsx scripts/maintenance/collapse-duplicated-titles.ts
+ *   dotenv -e .env.<env> -- tsx scripts/maintenance/collapse-duplicated-titles.ts --apply
+ *
+ * Against Azure, reach the DB the same way as the other maintenance scripts (temporary firewall
+ * rule; see doc/OPERATIONS_RUNBOOK.md). Run the dry run first and read the id lists — they tell you
+ * exactly which rows would change.
+ *
+ * Idempotent: re-running after --apply reports 0 collapsed.
+ */
+import { collapseDuplicatedLocalizedTitles } from "../../src/services/localizedTitleCleanup.js";
+import { prisma } from "../../src/db/prisma.js";
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const result = await collapseDuplicatedLocalizedTitles({ dryRun: !apply });
+
+  for (const [entity, stats] of Object.entries(result.byEntity)) {
+    console.log(
+      JSON.stringify({
+        event: "collapse_duplicated_titles_entity",
+        entity,
+        scanned: stats.scanned,
+        collapsed: stats.collapsed,
+        ids: stats.ids,
+      }),
+    );
+  }
+
+  console.log(
+    JSON.stringify({
+      event: "collapse_duplicated_titles_complete",
+      dryRun: result.dryRun,
+      totalCollapsed: result.totalCollapsed,
+    }),
+  );
+
+  if (result.dryRun && result.totalCollapsed > 0) {
+    console.log("Dry run — re-run with --apply to write these changes.");
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error("collapse_duplicated_titles_failed", error);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/modules/adminContent/adminContentCommands.ts
+++ b/src/modules/adminContent/adminContentCommands.ts
@@ -161,35 +161,41 @@ function normalizeLocalizedTitleSeed(title: string | null | undefined): Localize
   };
 }
 
-function normalizeLocalizedTitlePatch(titlePatch: LocalizedText): LocalizedTextObject {
-  if (typeof titlePatch === "string") {
-    const normalized = titlePatch.trim();
-    if (!normalized) {
-      return {};
-    }
-    return {
-      "en-GB": normalized,
-      nb: normalized,
-      nn: normalized,
-    };
-  }
-
+function normalizeLocalizedTitlePatch(titlePatch: LocalizedTextObject): LocalizedTextObject {
   const normalizedEntries = Object.entries(titlePatch).filter(
     ([, value]) => typeof value === "string" && value.trim().length > 0,
   );
   return Object.fromEntries(normalizedEntries) as LocalizedTextObject;
 }
 
+/**
+ * #892: a plain-string patch means the author typed ONE title in ONE language. It is stored as a
+ * plain string — exactly what `updateSectionTitle` does — and never fanned out into a copy per
+ * locale.
+ *
+ * The old behaviour wrote the same text into `en-GB`, `nb` AND `nn`. Three things went wrong:
+ * every title then looked translated, the participant was served the author's language under
+ * every locale with no signal, and the "this still needs translating" state became undetectable —
+ * a filled `nn` could no longer be distinguished from a deliberate one.
+ *
+ * Stored as a plain string the display is unchanged (`localizeContentText` falls back to it for
+ * every locale), but the data is honest and a translation-status check becomes possible (#894).
+ * A localized OBJECT patch still merges onto the existing map, so translating one language never
+ * disturbs the others.
+ */
 export async function updateModuleTitle(moduleId: string, titlePatch: LocalizedText, actorId: string) {
   const existingModule = await adminContentRepository.findModuleTitle(moduleId);
   if (!existingModule) {
     throw new NotFoundError("Module", "module_not_found", "Module not found.");
   }
 
-  const title = localizedTextCodec.serialize({
-    ...normalizeLocalizedTitleSeed(existingModule.title),
-    ...normalizeLocalizedTitlePatch(titlePatch),
-  });
+  const title =
+    typeof titlePatch === "string"
+      ? localizedTextCodec.serialize(titlePatch)
+      : localizedTextCodec.serialize({
+          ...normalizeLocalizedTitleSeed(existingModule.title),
+          ...normalizeLocalizedTitlePatch(titlePatch),
+        });
   const module = await runInTransaction(async (tx) => {
     const repo = createAdminContentRepository(tx);
     const updated = await repo.updateModuleTitle(moduleId, title);

--- a/src/services/localizedTitleCleanup.ts
+++ b/src/services/localizedTitleCleanup.ts
@@ -1,0 +1,128 @@
+import { prisma } from "../db/prisma.js";
+import { localizedTextCodec } from "../codecs/localizedTextCodec.js";
+
+/**
+ * #892 clean-up: collapse localized-text values whose locales all hold the SAME string back into a
+ * plain string.
+ *
+ * Renaming a module used to fan one title out into `en-GB`, `nb` and `nn`. The rename path is fixed
+ * (v2.11.3), but the rows it already wrote still look translated — which is exactly the signal a
+ * translation-status view needs (#894). This restores the signal on existing content.
+ *
+ * ## Why this is safe
+ *
+ * The transformation is **display-neutral**. `localizeContentText` resolves a locale map as
+ * `map[locale] ?? map["en-GB"] ?? first-value`, and a plain string is returned verbatim for every
+ * locale. When every entry holds the same string S, both encodings render S in every locale — so no
+ * participant, author or export can observe a difference. Only the *claim* «this has a per-locale
+ * translation» goes away, and that claim was false.
+ *
+ * ## What is deliberately left alone
+ *
+ * - **Single-locale maps** (`{"nb":"X"}`). These carry MORE information than a plain string — they
+ *   record which language the text is in. Collapsing them would discard that.
+ * - **Maps with any differing value.** Two locales equal and a third different means someone
+ *   genuinely translated part of it.
+ * - **Values that are already plain strings.** Nothing to do.
+ *
+ * Idempotent: a second run finds nothing to collapse.
+ */
+
+export type EntityKey = "module.title" | "courseSection.title" | "course.title" | "course.description";
+
+export type CleanupEntityResult = {
+  scanned: number;
+  collapsed: number;
+  /** Ids touched (or that WOULD be touched in a dry run), for the operator log. */
+  ids: string[];
+};
+
+export type CleanupResult = {
+  dryRun: boolean;
+  byEntity: Record<EntityKey, CleanupEntityResult>;
+  totalCollapsed: number;
+};
+
+/**
+ * Returns the single shared string when `raw` is a locale map of 2+ entries that all hold the same
+ * value; otherwise null (leave the row untouched).
+ */
+export function collapsibleTitle(raw: string | null | undefined): string | null {
+  const parsed = localizedTextCodec.parse(raw);
+  if (!parsed || typeof parsed !== "object") {
+    return null;
+  }
+
+  const values = Object.values(parsed).filter((v): v is string => typeof v === "string");
+  if (values.length < 2) {
+    return null;
+  }
+
+  const [first, ...rest] = values;
+  const trimmed = first.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return rest.every((v) => v.trim() === trimmed) ? trimmed : null;
+}
+
+type Row = { id: string; value: string | null };
+
+async function collapseRows(
+  rows: Row[],
+  apply: (id: string, value: string) => Promise<unknown>,
+  dryRun: boolean,
+): Promise<CleanupEntityResult> {
+  const ids: string[] = [];
+  for (const row of rows) {
+    const collapsed = collapsibleTitle(row.value);
+    if (collapsed === null) continue;
+    ids.push(row.id);
+    if (!dryRun) {
+      await apply(row.id, collapsed);
+    }
+  }
+  return { scanned: rows.length, collapsed: ids.length, ids };
+}
+
+/**
+ * Scans every localized title/description that the rename paths write to. Dry run by default —
+ * pass `{ dryRun: false }` to write.
+ */
+export async function collapseDuplicatedLocalizedTitles(
+  options: { dryRun?: boolean } = {},
+): Promise<CleanupResult> {
+  const dryRun = options.dryRun !== false;
+
+  const [modules, sections, courses] = await Promise.all([
+    prisma.module.findMany({ select: { id: true, title: true } }),
+    prisma.courseSection.findMany({ select: { id: true, title: true } }),
+    prisma.course.findMany({ select: { id: true, title: true, description: true } }),
+  ]);
+
+  const byEntity: Record<EntityKey, CleanupEntityResult> = {
+    "module.title": await collapseRows(
+      modules.map((m) => ({ id: m.id, value: m.title })),
+      (id, title) => prisma.module.update({ where: { id }, data: { title } }),
+      dryRun,
+    ),
+    "courseSection.title": await collapseRows(
+      sections.map((s) => ({ id: s.id, value: s.title })),
+      (id, title) => prisma.courseSection.update({ where: { id }, data: { title } }),
+      dryRun,
+    ),
+    "course.title": await collapseRows(
+      courses.map((c) => ({ id: c.id, value: c.title })),
+      (id, title) => prisma.course.update({ where: { id }, data: { title } }),
+      dryRun,
+    ),
+    "course.description": await collapseRows(
+      courses.map((c) => ({ id: c.id, value: c.description })),
+      (id, description) => prisma.course.update({ where: { id }, data: { description } }),
+      dryRun,
+    ),
+  };
+
+  const totalCollapsed = Object.values(byEntity).reduce((sum, e) => sum + e.collapsed, 0);
+  return { dryRun, byEntity, totalCollapsed };
+}

--- a/test/e2e/participant-course-sequence.spec.ts
+++ b/test/e2e/participant-course-sequence.spec.ts
@@ -222,6 +222,46 @@ test("an unavailable module is not a dead end, and the current step still opens 
   await expect(page.locator("#sectionReaderBody")).toContainText("Seksjonstekst");
 });
 
+// #893: course titles are resolved server-side per request, so a cached CourseDetail belongs to
+// the locale it was fetched under. The cache is keyed by courseId alone — without an explicit
+// refresh the list kept the previous language until the participant pressed "Last kurs", which
+// they have no reason to do. Found while a tester switched language back and forth.
+test("switching language re-fetches the open course so titles follow the new locale", async ({ page }) => {
+  await mockBase(page);
+
+  // Serve a different title per locale so a stale render is unmistakable.
+  await page.unroute("**/api/courses/c1");
+  await page.route("**/api/courses/c1", (route: Route) => {
+    const locale = route.request().headers()["x-locale"] ?? "nb";
+    const nn = locale === "nn";
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        course: {
+          id: "c1",
+          title: "Kurs",
+          items: [
+            { type: "SECTION", sectionId: "s1", courseItemId: "ci1", title: nn ? "Lesen seksjon" : "Lest seksjon", read: true },
+            { type: "MODULE", moduleId: "m1", courseItemId: "ci2", title: nn ? "Greidd test" : "Bestått test", moduleStatus: "PASSED", available: true },
+            { type: "SECTION", sectionId: "s2", courseItemId: "ci3", title: nn ? "Neste seksjon (nn)" : "Neste seksjon", read: false },
+          ],
+        },
+      }),
+    });
+  });
+
+  await openCourse(page);
+  await expect(page.locator('.course-item[data-key="ci1"] .course-step-title')).toHaveText("Lest seksjon");
+
+  await page.locator("#localeSelect").selectOption("nn");
+
+  // The open course re-fetches and re-renders in the new locale — no "Last kurs" required.
+  await expect(page.locator('.course-item[data-key="ci1"] .course-step-title')).toHaveText("Lesen seksjon");
+  await expect(page.locator('.course-item[data-key="ci2"] .course-step-title')).toHaveText("Greidd test");
+  await expect(page.locator(".course-step--now .course-step-title")).toHaveText("Neste seksjon (nn)");
+});
+
 // Deltakertest 2026-08-11: «i balanse mellom kursinnhold og diskusjon blir diskusjon altfor
 // dominerende». Once the sequence went quiet, the always-expanded discussion board became the
 // heaviest thing on the page. It is a side conversation, not what the participant came for.

--- a/test/m2-admin-content-publication.test.ts
+++ b/test/m2-admin-content-publication.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { app } from "../src/app.js";
 import { localizedTextCodec } from "../src/codecs/localizedTextCodec.js";
+import { localizeContentText } from "../src/i18n/content.js";
 import { prisma } from "../src/db/prisma.js";
 
 const adminHeaders = {
@@ -376,7 +377,15 @@ describe("MVP admin content management and publication", () => {
     await request(app).delete(`/api/admin/content/modules/${moduleId}`).set(adminHeaders);
   });
 
-  it("accepts a plain-string title patch and applies it to all locales", async () => {
+  // #892: this test used to assert that a plain-string patch was copied into en-GB, nb AND nn.
+  // That behaviour was a bug, not a requirement — it made every renamed module look translated,
+  // served participants the author's language under every locale with no signal, and erased the
+  // "still needs translating" state (a filled nn became indistinguishable from a deliberate one).
+  //
+  // The contract now matches updateSectionTitle: a plain string is stored as a plain string.
+  // Display is unchanged, because localizeContentText falls back to it for every locale — which is
+  // asserted below so the change stays provably invisible to participants.
+  it("stores a plain-string title patch as a plain string, without fabricating per-locale copies", async () => {
     const createModuleResponse = await request(app)
       .post("/api/admin/content/modules")
       .set(adminHeaders)
@@ -406,12 +415,53 @@ describe("MVP admin content management and publication", () => {
     });
     const parsedTitle = localizedTextCodec.parse(storedModule?.title ?? null);
 
-    expect(typeof parsedTitle).toBe("object");
-    expect(parsedTitle).toMatchObject({
-      "en-GB": "Unified module title",
-      nb: "Unified module title",
-      nn: "Unified module title",
+    // The stored value carries no locale claim — that is what makes "not translated yet"
+    // detectable again (#894).
+    expect(typeof parsedTitle).toBe("string");
+    expect(parsedTitle).toBe("Unified module title");
+    expect(storedModule?.title.startsWith("{")).toBe(false);
+
+    // …and the participant sees the new title in every locale regardless, so dropping the
+    // fabricated copies changed nothing observable.
+    for (const locale of ["en-GB", "nb", "nn"] as const) {
+      expect(localizeContentText(locale, storedModule?.title ?? "")).toBe("Unified module title");
+    }
+
+    await request(app).delete(`/api/admin/content/modules/${moduleId}`).set(adminHeaders);
+  });
+
+  // The other half of the contract: a localized OBJECT patch still merges, so translating one
+  // language never disturbs the others.
+  it("merges a localized object patch instead of replacing the whole title", async () => {
+    const createModuleResponse = await request(app)
+      .post("/api/admin/content/modules")
+      .set(adminHeaders)
+      .send({
+        title: {
+          "en-GB": `Merge Patch Module ${Date.now()}`,
+          nb: "Fletteoppdatering modul",
+        },
+      });
+
+    expect(createModuleResponse.status).toBe(201);
+    const moduleId = createModuleResponse.body.module.id as string;
+
+    const patchResponse = await request(app)
+      .patch(`/api/admin/content/modules/${moduleId}/title`)
+      .set(adminHeaders)
+      .send({ title: { nn: "Fletteoppdatering modul nynorsk" } });
+
+    expect(patchResponse.status).toBe(200);
+
+    const storedModule = await prisma.module.findUnique({
+      where: { id: moduleId },
+      select: { title: true },
     });
+    const parsedTitle = localizedTextCodec.parse(storedModule?.title ?? null) as Record<string, string>;
+
+    expect(typeof parsedTitle).toBe("object");
+    expect(parsedTitle.nn).toBe("Fletteoppdatering modul nynorsk");
+    expect(parsedTitle.nb).toBe("Fletteoppdatering modul");
 
     await request(app).delete(`/api/admin/content/modules/${moduleId}`).set(adminHeaders);
   });

--- a/test/m2-admin-content-publication.test.ts
+++ b/test/m2-admin-content-publication.test.ts
@@ -431,15 +431,18 @@ describe("MVP admin content management and publication", () => {
   });
 
   // The other half of the contract: a localized OBJECT patch still merges, so translating one
-  // language never disturbs the others.
+  // language never disturbs the others. (Create requires all three locales — localizedTextSchema —
+  // while the patch is partial, so the module starts fully translated and only nn is revised.)
   it("merges a localized object patch instead of replacing the whole title", async () => {
+    const englishTitle = `Merge Patch Module ${Date.now()}`;
     const createModuleResponse = await request(app)
       .post("/api/admin/content/modules")
       .set(adminHeaders)
       .send({
         title: {
-          "en-GB": `Merge Patch Module ${Date.now()}`,
+          "en-GB": englishTitle,
           nb: "Fletteoppdatering modul",
+          nn: "Fletteoppdatering modul (gammel nynorsk)",
         },
       });
 
@@ -461,7 +464,9 @@ describe("MVP admin content management and publication", () => {
 
     expect(typeof parsedTitle).toBe("object");
     expect(parsedTitle.nn).toBe("Fletteoppdatering modul nynorsk");
+    // The untouched locales must survive — that is the whole point of merging.
     expect(parsedTitle.nb).toBe("Fletteoppdatering modul");
+    expect(parsedTitle["en-GB"]).toBe(englishTitle);
 
     await request(app).delete(`/api/admin/content/modules/${moduleId}`).set(adminHeaders);
   });

--- a/test/unit/localized-title-cleanup.test.ts
+++ b/test/unit/localized-title-cleanup.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { collapsibleTitle } from "../../src/services/localizedTitleCleanup.js";
+
+// #892 clean-up. The dangerous direction here is over-collapsing: turning a real partial
+// translation into a plain string would silently destroy an author's work. Most of these cases
+// therefore assert that the script leaves a row ALONE.
+
+describe("collapsibleTitle — what the clean-up may touch", () => {
+  it("collapses a map whose locales all hold the same string", () => {
+    const raw = JSON.stringify({ "en-GB": "Klassisk LLM", nb: "Klassisk LLM", nn: "Klassisk LLM" });
+    expect(collapsibleTitle(raw)).toBe("Klassisk LLM");
+  });
+
+  it("collapses a two-locale duplicate as well", () => {
+    expect(collapsibleTitle(JSON.stringify({ nb: "Kodekjøring", nn: "Kodekjøring" }))).toBe("Kodekjøring");
+  });
+
+  it("ignores differences in surrounding whitespace when comparing", () => {
+    const raw = JSON.stringify({ nb: "Kodekjøring", nn: "  Kodekjøring  " });
+    expect(collapsibleTitle(raw)).toBe("Kodekjøring");
+  });
+});
+
+describe("collapsibleTitle — what it must NOT touch", () => {
+  it("leaves a genuine translation alone", () => {
+    const raw = JSON.stringify({ nb: "Kunnskapskilder", nn: "Kunnskapskjelder" });
+    expect(collapsibleTitle(raw)).toBeNull();
+  });
+
+  it("leaves a partial translation alone — two equal, one different is still real work", () => {
+    const raw = JSON.stringify({ "en-GB": "Knowledge sources", nb: "Kunnskapskilder", nn: "Kunnskapskilder" });
+    expect(collapsibleTitle(raw)).toBeNull();
+  });
+
+  it("leaves a single-locale map alone — it records WHICH language the text is in", () => {
+    // A plain string says "untranslated, language unknown"; {"nb": …} says "untranslated, in nb".
+    // Collapsing would throw that away.
+    expect(collapsibleTitle(JSON.stringify({ nb: "Klassisk LLM" }))).toBeNull();
+  });
+
+  it("leaves an already-plain string alone", () => {
+    expect(collapsibleTitle("Klassisk LLM")).toBeNull();
+  });
+
+  it("leaves empty and malformed values alone", () => {
+    expect(collapsibleTitle(null)).toBeNull();
+    expect(collapsibleTitle(undefined)).toBeNull();
+    expect(collapsibleTitle("")).toBeNull();
+    expect(collapsibleTitle("{not json")).toBeNull();
+    expect(collapsibleTitle(JSON.stringify({ nb: "   ", nn: "   " }))).toBeNull();
+  });
+
+  it("is idempotent — the output of a collapse is never collapsible again", () => {
+    const raw = JSON.stringify({ "en-GB": "Klassisk LLM", nb: "Klassisk LLM", nn: "Klassisk LLM" });
+    const once = collapsibleTitle(raw);
+    expect(once).toBe("Klassisk LLM");
+    expect(collapsibleTitle(once)).toBeNull();
+  });
+});
+
+describe("collapsibleTitle — display neutrality", () => {
+  it("produces a value that renders identically in every locale", async () => {
+    // The safety argument for the whole script: for a duplicated map, the collapsed plain string
+    // resolves to the same text under every locale, so nothing observable changes.
+    const { localizeContentText } = await import("../../src/i18n/content.js");
+    const raw = JSON.stringify({ "en-GB": "Kodekjøring", nb: "Kodekjøring", nn: "Kodekjøring" });
+    const collapsed = collapsibleTitle(raw)!;
+
+    for (const locale of ["en-GB", "nb", "nn"] as const) {
+      expect(localizeContentText(locale, collapsed)).toBe(localizeContentText(locale, raw));
+    }
+  });
+});

--- a/test/unit/module-title-localization.test.ts
+++ b/test/unit/module-title-localization.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #892: renaming a module used to write the author's single title into en-GB, nb AND nn. Every
+// title then looked translated, participants were served the wrong language with no signal, and
+// the "still needs translating" state became undetectable. These tests pin the honest behaviour:
+// a plain string is stored as a plain string; a localized object still merges per locale.
+
+const findModuleTitle = vi.fn();
+const updateModuleTitleRepo = vi.fn();
+const recordAuditEvent = vi.fn();
+
+vi.mock("../../src/modules/adminContent/adminContentRepository.js", () => ({
+  adminContentRepository: {
+    findModuleTitle: (...args: unknown[]) => findModuleTitle(...args),
+  },
+  createAdminContentRepository: () => ({
+    updateModuleTitle: (...args: unknown[]) => updateModuleTitleRepo(...args),
+  }),
+}));
+
+vi.mock("../../src/services/auditService.js", () => ({
+  recordAuditEvent: (...args: unknown[]) => recordAuditEvent(...args),
+}));
+
+vi.mock("../../src/db/transaction.js", () => ({
+  runInTransaction: (fn: (tx: unknown) => unknown) => fn({}),
+}));
+
+async function rename(existingTitle: string | null, patch: unknown) {
+  findModuleTitle.mockResolvedValue({ id: "m1", title: existingTitle });
+  updateModuleTitleRepo.mockImplementation((_id: string, title: string) => ({ id: "m1", title }));
+  const { updateModuleTitle } = await import("../../src/modules/adminContent/adminContentCommands.js");
+  await updateModuleTitle("m1", patch as never, "actor-1");
+  return updateModuleTitleRepo.mock.calls.at(-1)?.[1] as string;
+}
+
+describe("updateModuleTitle — localization honesty (#892)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    findModuleTitle.mockReset();
+    updateModuleTitleRepo.mockReset();
+    recordAuditEvent.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("stores a plain-string rename as a plain string, not one copy per locale", async () => {
+    const stored = await rename("Test, Klassisk LLM", "Klassisk LLM");
+
+    // The regression: {"en-GB":"Klassisk LLM","nb":"Klassisk LLM","nn":"Klassisk LLM"}
+    expect(stored).toBe("Klassisk LLM");
+    expect(stored.startsWith("{")).toBe(false);
+  });
+
+  it("does not fabricate a translation when the previous title was already localized", async () => {
+    const existing = JSON.stringify({ "en-GB": "Classic LLM", nb: "Klassisk LLM", nn: "Klassisk LLM" });
+    const stored = await rename(existing, "Store språkmodeller");
+
+    expect(stored).toBe("Store språkmodeller");
+    // Crucially: nn must NOT silently claim to hold a Norwegian-Nynorsk translation of the new title.
+    expect(stored).not.toContain("nn");
+  });
+
+  it("keeps merging a localized object patch so translating one language leaves the others alone", async () => {
+    const existing = JSON.stringify({ "en-GB": "Classic LLM", nb: "Klassisk LLM" });
+    const stored = await rename(existing, { nn: "Klassisk LLM (nn)" });
+
+    expect(JSON.parse(stored)).toEqual({
+      "en-GB": "Classic LLM",
+      nb: "Klassisk LLM",
+      nn: "Klassisk LLM (nn)",
+    });
+  });
+
+  it("ignores blank entries in an object patch rather than storing empty translations", async () => {
+    const existing = JSON.stringify({ nb: "Klassisk LLM" });
+    const stored = await rename(existing, { nn: "   ", "en-GB": "Classic LLM" });
+
+    const parsed = JSON.parse(stored);
+    expect(parsed["en-GB"]).toBe("Classic LLM");
+    expect(parsed.nn).toBeUndefined();
+  });
+
+  it("a stored plain string is what makes 'needs translation' detectable at all", async () => {
+    // The point of the fix, stated as a test: after a plain rename the value carries no locale
+    // claim, so a future translation-status check (#894) can tell it apart from a real translation.
+    const plain = await rename(null, "Kunnskapskilder");
+    const localized = await rename(null, { nb: "Kunnskapskilder", nn: "Kunnskapskjelder" });
+
+    expect(plain.startsWith("{")).toBe(false);
+    expect(localized.startsWith("{")).toBe(true);
+  });
+});


### PR DESCRIPTION
Tre commits fra deltakertesting av kursporet. Adresserer #892 og #893; #894 er bevisst ikke rørt.

> **Merk:** ingen auto-lukkende nøkkelord er brukt. Per policyen lukkes issues først når fiksen er i **produksjon**, ikke ved merge.

## 2.11.2 — typografi i sporet

Typeetiketten hadde variabel bredde («Lesestoff» mot «Test»), så titlene startet på ulik x. Den flisete venstrekanten fikk lista til å se rotete ut selv når innholdet var ryddig. Etiketten har nå fast bredde, og titlene danner én kolonne. Versalene er droppet — 18 rader med STORE BOKSTAVER roper, og etiketten er metadata, ikke en overskrift.

Teksten var uendret hele veien (`Lesestoff`/`Test`); versalene var ren CSS, så e2e-assertions og skjermlesere er upåvirket.

## 2.11.3 — #892 og #893

**#892 · modultitler skrives ikke lenger identisk til alle språk.** En omdøping skrev forfatterens ene tittel inn i `en-GB`, `nb` **og** `nn`. Hver tittel så dermed oversatt ut, deltakeren fikk forfatterens språk under alle locales uten noe signal, og «mangler oversettelse» ble umulig å oppdage.

En ren streng lagres nå som ren streng — akkurat som `updateSectionTitle` allerede gjorde. Visningen er uendret (`localizeContentText` faller tilbake til den for alle språk), men dataene er ærlige, og det er nettopp det #894 trenger for å kunne måle noe. Et lokalisert objekt merges fortsatt, så å oversette ett språk lar de andre stå.

Dupliseringen lå **fire steder**: én i backend og tre i klienten (`admin-content.js` × 2, `normalizeModuleTitlePatch` → `buildLocalizedTextMap` i `admin-content-shell.js`). Alle rettet; backend står igjen som backstop for agent-API-et.

**#893 · kurslista følger språkbytte.** Kurstitler løses opp server-side per forespørsel, så en cachet `CourseDetail` tilhører språket den ble hentet under. Cachen var nøklet på `courseId` alene og `setLocale` rørte den ikke — lista beholdt forrige språk til deltakeren tilfeldigvis trykket «Last kurs».

`courseDetailCache` er flyttet opp til øvrig oppstartstilstand: `setLocale` kjører under boot, og en `let` lenger nede i fila ga en temporal-dead-zone-feil som stoppet hele skriptet. Fanget ved at samtlige seks sekvens-e2e-er falt samtidig — hadde bare den nye testen falt, ville jeg lett feil sted.

Re-hentingen går gjennom `renderCourseDetailModules`, som allerede gjør `restoreModuleWorkspaceHomeIfInside` + `reopenInlineAfterRender` rundt sin `innerHTML=""`, så en åpen inline-modul overlever språkbyttet.

## 2.11.4 — opprydningsskript

`npm run maint:collapse-duplicated-titles` kollapser lokaliserte verdier der alle språk holder samme streng, tilbake til ren streng. Fiksen over stopper ny duplisering; dette rydder rader skrevet før den.

**Tørrkjøring som standard** — `--apply` kreves for å skrive, og tørrkjøringen skriver ut id-listene.

**Sikkerhetsargumentet er visningsnøytralitet.** `localizeContentText` slår opp `map[locale] ?? map["en-GB"] ?? første verdi`, og en ren streng returneres uendret for alle språk. Holder alle oppføringer samme streng, gir begge kodingene identisk resultat i hvert språk. Kun den usanne påstanden om per-språk-oversettelse forsvinner. En test beviser dette ved å sammenligne `localizeContentText` før og etter.

**Rører bevisst ikke:** ekte oversettelser, delvise oversettelser (to like og én ulik er reelt arbeid), enkeltspråk-kart (`{"nb":"…"}` sier *hvilket* språk teksten er på — mer informasjon enn en ren streng), og verdier som allerede er rene strenger.

## Testing

| Suite | Resultat |
|---|---|
| `tsc --noEmit` | 0 feil |
| Unit | 919 grønne (+15) |
| Kontrakter | 32 grønne |
| Playwright e2e | 118 grønne (+1) |

Nye tester: `module-title-localization` (5 caser), `localized-title-cleanup` (10 caser, hovedvekt på hva skriptet **ikke** skal røre), og en e2e som serverer ulik tittel per språk og krever at et åpent kurs bytter språk uten «Last kurs».

## ⚠️ Ikke verifisert

**Opprydningsskriptet er ikke kjørt mot en ekte database.** Docker var utilgjengelig lokalt, så det er røykt fram til Prisma-kallet — modulgraf og spørringsform er validert mot generert klient, men oppførselen mot ekte rader er ikke sett. Kjør tørrkjøringen på stage og les id-listene før `--apply`.

## Risiko

Klient + backend + et vedlikeholdsskript. Ingen migrasjon, ingen API-endring, ingen infra. Rollback er revert + ny `deploy-app.yml`-kjøring; skriptet er inert til noen kjører det.

**#894** (inline omdøping + oversettelsesstatus) er ikke i denne PR-en. Det er en ombygging av forfatterflaten som fortjener et designvalg først, ikke en feilretting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
