### PR TITLE
Utelat tomme «rammer for kandidaten» ved lagring — v2.11.9

### DIFF
--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,34 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.11.9 - 2026-08-12
+
+**Lagring feilet med 400 på en modul uten «rammer for kandidaten».** Rapportert fra stage etter
+omdøping av en modul:
+
+```
+400 validation_error · path ["candidateTaskConstraints","nb"]
+String must contain at least 1 character(s)
+```
+
+Oversettelsen fyller alltid alle tre språk, også når kilden er tom — resultatet er
+`{"en-GB":"", nb:"", nn:""}`. Lagringen prøvde å utelate feltet med `verdi || undefined`, men et
+objekt er alltid truthy, så det tomme kartet gikk rett gjennom til et skjema som krever minst ett
+tegn per språk. Feltet utelates nå når **alle** språk er tomme. Delvis utfylte kart sendes uendret:
+da er det et ekte problem serveren skal si fra om, ikke noe klienten skal dikte seg ut av (#892).
+
+Feilen er ikke ny — den har ligget der for enhver modul uten rammer, uavhengig av 2.11.7.
+
+**Rubrikk-genereringen fikk «[object Object]» i stedet for scenarioet.** Funnet i samme kodelinje.
+`ensure-rubric` tar ren tekst i ett språk, men klienten sendte `String(språkkart)`. Endepunktet
+gjenbruker en eksisterende rubrikk når den finnes, så utslaget var begrenset til moduler som
+genererte rubrikk for første gang — der ble den generert fra strengen «[object Object]». Bruker nå
+lokale-oppslaget, som var det `locale`-feltet ved siden av allerede forutsatte.
+
+E2e-vakten dekker begge i én test og er verifisert rød uten fiksen.
+
+Tests: tsc 0, e2e 122, dom 5, kontrakter 32. Kun klient.
+
 ## 2.11.8 - 2026-08-12
 
 Tre feil funnet av en gjennomgang av 2.11.5–2.11.7 før prod. To av dem ville rammet produksjon.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.11.8",
+  "version": "2.11.9",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -1263,6 +1263,26 @@ function translateLocalizedText(text) {
   };
 }
 
+/**
+ * Utelat en lokalisert verdi der ALLE språk er tomme, i stedet for å sende den.
+ *
+ * `localizedTextObjectSchema` krever minst ett tegn i hvert av de tre språkene, og et objekt er
+ * alltid truthy — så `verdi || undefined` fanget aldri `{"en-GB":"", nb:"", nn:""}`. Å lagre en
+ * modul uten «rammer for kandidaten» ga derfor:
+ *
+ *   400 validation_error · path ["candidateTaskConstraints","nb"] · String must contain at least 1
+ *
+ * Delvis utfylte kart sendes uendret: da er det et ekte problem serveren skal si fra om, ikke noe
+ * klienten skal dikte seg ut av ved å kopiere ett språk inn i de andre (#892).
+ */
+function omitWhenEveryLocaleBlank(value) {
+  if (value == null) return undefined;
+  if (typeof value === "string") return value.trim() ? value : undefined;
+  if (typeof value !== "object") return undefined;
+  const hasText = Object.values(value).some((text) => typeof text === "string" && text.trim());
+  return hasText ? value : undefined;
+}
+
 function buildLocalizedTextMap(baseLocale, baseText, translatedEntries = {}) {
   const result = {};
   for (const locale of supportedLocales) {
@@ -2068,10 +2088,14 @@ async function saveDraftBundleInBackground(options = {}) {
           blueprintObject = assessmentBlueprint;
         }
       }
+      // ⚠️ translateLocalizedText returnerer et SPRÅKKART, ikke en streng. `String(kart)` gir
+      // "[object Object]" — og dette endepunktet genererer rubrikken fra teksten, så den fikk
+      // servert nettopp den strengen i stedet for scenarioet. Bruk lokale-oppslaget: dette
+      // endepunktet tar ren tekst i ETT språk, og sender allerede `locale` ved siden av.
       const ensureRubricBody = {
-        taskText: String(translateLocalizedText(taskText) ?? "").trim(),
-        assessorExpectedContent: String(translateLocalizedText(assessorExpectedContent) ?? "").trim(),
-        candidateTaskConstraints: String(translateLocalizedText(candidateTaskConstraints) ?? "").trim() || undefined,
+        taskText: String(localizeValueForLocale(taskText, currentLocale) ?? "").trim(),
+        assessorExpectedContent: String(localizeValueForLocale(assessorExpectedContent, currentLocale) ?? "").trim(),
+        candidateTaskConstraints: String(localizeValueForLocale(candidateTaskConstraints, currentLocale) ?? "").trim() || undefined,
         certificationLevel: bundle?.module?.certificationLevel ?? "intermediate",
         locale: currentLocale,
         ...(blueprintObject ? { blueprint: blueprintObject } : {}),
@@ -2104,7 +2128,7 @@ async function saveDraftBundleInBackground(options = {}) {
         assessmentMode: isFreetextOnly ? "FREETEXT_ONLY" : undefined,
         taskText: translateLocalizedText(taskText),
         assessorExpectedContent: translateLocalizedText(assessorExpectedContent),
-        candidateTaskConstraints: translateLocalizedText(candidateTaskConstraints) || undefined,
+        candidateTaskConstraints: omitWhenEveryLocaleBlank(translateLocalizedText(candidateTaskConstraints)),
         assessmentBlueprint: assessmentBlueprint || undefined,
         rubricVersionId: rubricBody?.rubricVersion?.id,
         promptTemplateVersionId: promptBody?.promptTemplateVersion?.id,

--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -1408,4 +1408,70 @@ test.describe("admin content browser coverage", () => {
     );
     expect(courseViolations).toEqual([]);
   });
+
+  // Rapportert fra stage: omdøping av en modul uten «rammer for kandidaten» ga
+  //   400 validation_error · path ["candidateTaskConstraints","nb"]
+  // Oversettelsen fyller alle tre språk med tom streng, og et objekt er alltid truthy — så
+  // `verdi || undefined` slapp {"en-GB":"", nb:"", nn:""} rett gjennom til et skjema som krever
+  // minst ett tegn per språk. Samme test dekker "[object Object]" til rubrikk-generereren.
+  test("saving a module without candidate constraints omits the field instead of sending blanks", async ({ page }) => {
+    await mockCommonApis(page, {
+      modules: [{ id: "module-1", title: "Trade unions", activeVersion: { versionNo: 1 } }],
+      moduleExports: {
+        "module-1": buildMockModuleExport({
+          id: "module-1",
+          title: "Trade unions",
+          moduleVersionId: "module-1-version-1",
+          taskText: { "en-GB": "English scenario", nb: "Norsk scenario", nn: "Nynorsk scenario" },
+          assessorExpectedContent: { "en-GB": "English guidance", nb: "Norsk veiledning", nn: "Nynorsk rettleiing" },
+          mcqQuestions: [
+            {
+              stem: { "en-GB": "Q", nb: "Q", nn: "Q" },
+              options: [
+                { "en-GB": "A", nb: "A", nn: "A" },
+                { "en-GB": "B", nb: "B", nn: "B" },
+              ],
+              correctAnswer: { "en-GB": "B", nb: "B", nn: "B" },
+              rationale: { "en-GB": "R", nb: "R", nn: "R" },
+            },
+          ],
+        }),
+      },
+    });
+
+    let versionBody: any = null;
+    let ensureBody: any = null;
+    await page.route("**/api/admin/content/modules/*/rubric-versions/ensure", async (route: Route) => {
+      ensureBody = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ rubricVersion: { id: "rubric-1", versionNo: 1 } }),
+      });
+    });
+    await page.route("**/api/admin/content/modules/*/module-versions", async (route: Route) => {
+      versionBody = route.request().postDataJSON();
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ moduleVersion: { id: "module-1-version-2", versionNo: 2 } }),
+      });
+    });
+
+    await page.goto("/admin-content/module/module-1/conversation");
+    await clickEnabledButton(page, /Edit directly|Rediger direkte/);
+    await page.locator("#previewEditTitle").fill("Fagforeninger");
+    await page.locator("#previewEditConfirm").click();
+    await clickEnabledButton(page, /Save draft|Lagre utkast/);
+
+    await expect.poll(() => versionBody !== null).toBe(true);
+
+    // The save must not be blocked, and the empty field must simply not be there.
+    await expect(page.getByText(/candidateTaskConstraints/)).toHaveCount(0);
+    expect(versionBody.candidateTaskConstraints).toBeUndefined();
+
+    // The rubric generator is fed the scenario, not a stringified object.
+    expect(ensureBody?.taskText).not.toContain("[object Object]");
+    expect(ensureBody?.taskText).toContain("scenario");
+  });
 });


### PR DESCRIPTION
Rapportert fra stage etter omdøping av en modul:

```
400 validation_error · path ["candidateTaskConstraints","nb"]
String must contain at least 1 character(s)
```

## Årsak

Oversettelsen fyller alltid alle tre språk, også når kilden er tom — resultatet er `{"en-GB":"", nb:"", nn:""}`. Lagringen prøvde å utelate feltet med `verdi || undefined`, men **et objekt er alltid truthy**, så det tomme kartet gikk rett gjennom til et skjema som krever minst ett tegn per språk.

Feltet utelates nå når **alle** språk er tomme. Delvis utfylte kart sendes uendret: da er det et ekte problem serveren skal si fra om, ikke noe klienten skal dikte seg ut av ved å kopiere ett språk inn i de andre (#892).

**Feilen er ikke ny.** Den har ligget der for enhver modul uten «rammer for kandidaten», uavhengig av v2.11.7.

## Bifangst i samme kodelinje

`ensure-rubric` fikk `String(språkkart)` — altså `"[object Object]"` — der den skulle hatt scenarioteksten. Endepunktet genererer rubrikken fra den teksten, men gjenbruker en eksisterende rubrikk når den finnes, så utslaget var begrenset til moduler som genererte rubrikk for **første** gang. De fikk den laget fra strengen `"[object Object]"`.

Bruker nå lokale-oppslaget, som `locale`-feltet ved siden av alltid har forutsatt.

## Test

`tsc` 0 · e2e 122 · dom 5 · kontrakter 32.

Én e2e dekker begge feilene: den fanger `module-versions`- og `ensure-rubric`-kroppene og krever at feltet er fraværende og at rubrikk-teksten er scenarioet. **Verifisert rød uten fiksen** — begge påstandene faller.

## Rollback

Ren revert. Kun klient, ingen API-, schema- eller modellendring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
