### PR TITLE
fix(admin): fasiten hører hjemme i moduleksporten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ doc/pentest/PENTEST-*.md
 
 # Local course-asset storage fallback (dev/test)
 .course-assets-local/
+
+# Cross-model QA gate output (scripts/ai-qa.ps1)
+.ai-qa/

--- a/doc/API_REFERENCE.md
+++ b/doc/API_REFERENCE.md
@@ -180,7 +180,15 @@ The course master toggle is set via the admin course API: `POST`/`PUT /api/admin
 **Certification invariant (#476/#525):** a course completion / certificate is issued only when a
 participant has **passed all modules** in the course **and read all learning sections**. This is
 re-checked both when a module is passed and when a section is marked read.
-| `GET` | `/api/admin/content/modules/:moduleId/export` | ADMINISTRATOR, SUBJECT_MATTER_OWNER |
+| `GET` | `/api/admin/content/modules/:moduleId/export` | ADMINISTRATOR, or an **owner of this module** |
+
+`/modules/:moduleId/export` returns the full editing bundle for the module, **including MCQ
+`correctAnswer` and `rationale`**. Access is owner-or-administrator (`assertModuleOwnership`),
+not merely role-based. Until v2.11.11 the answer key was stripped for non-administrators; that
+redaction was removed because the route is already owner-guarded, the same owner receives the
+same answers from `/export-package`, and the admin UI loads the module through this endpoint —
+so the redaction left the owner editing their own module without its answer key.
+
 | `DELETE` | `/api/admin/content/modules/:moduleId` | ADMINISTRATOR, SUBJECT_MATTER_OWNER |
 | `POST` | `/api/admin/content/generate/module-draft` | ADMINISTRATOR, SUBJECT_MATTER_OWNER |
 | `POST` | `/api/admin/content/generate/mcq` | ADMINISTRATOR, SUBJECT_MATTER_OWNER |

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,23 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.11.11 - 2026-08-14
+
+**Fasiten følger med i moduleksporten igjen.** `GET /modules/:id/export` fjernet `correctAnswer`
+og `rationale` for alle uten ADMINISTRATOR-rolle. Det ble innført som sikkerhetsfiks #392 i
+v1.1.11, men kontrollen viste seg å være virkningsløs:
+
+- Ruta krever allerede at du **eier** modulen (`assertModuleOwnership`), så den som fikk en
+  redigert eksport var forfatteren selv — som leser fasiten i redigeringsflaten uansett.
+- `GET /modules/:id/export-package` gir den samme eieren de samme svarene uredigert. Fasiten
+  var altså allerede tilgjengelig for nøyaktig samme person.
+
+Den eneste reelle effekten var en **ufullstendig sikkerhetskopi**: eksport etterfulgt av import
+ga en modul uten fasit, uten at noe varslet om det.
+
+Omfangskontrollen fra #392 står urørt — en SMO kan fortsatt bare eksportere moduler hen eier,
+og det er fortsatt dekket av test.
+
 ## 2.11.10 - 2026-08-13
 
 **Språkbytte under Direkte redigering ga en blindvei.** Rapportert fra stage: bytt arbeidsflatens

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.11.10",
+  "version": "2.11.11",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/src/routes/adminContent.ts
+++ b/src/routes/adminContent.ts
@@ -376,28 +376,6 @@ adminContentRouter.post("/intent-log", intentLogLimiter, async (request, respons
   response.status(204).end();
 });
 
-type McqSetVersionBundle = Awaited<ReturnType<typeof getModuleContentBundle>>["versions"]["mcqSetVersions"][number];
-
-function redactMcqAnswerKeys(bundle: Awaited<ReturnType<typeof getModuleContentBundle>>) {
-  const stripAnswers = (v: McqSetVersionBundle) => ({
-    ...v,
-    questions: v.questions.map(({ correctAnswer: _c, rationale: _r, ...rest }) => rest),
-  });
-  return {
-    ...bundle,
-    selectedConfiguration: {
-      ...bundle.selectedConfiguration,
-      mcqSetVersion: bundle.selectedConfiguration.mcqSetVersion
-        ? stripAnswers(bundle.selectedConfiguration.mcqSetVersion)
-        : null,
-    },
-    versions: {
-      ...bundle.versions,
-      mcqSetVersions: bundle.versions.mcqSetVersions.map(stripAnswers),
-    },
-  };
-}
-
 adminContentRouter.get("/modules/:moduleId/export", async (request, response) => {
   const actorId = request.context?.userId;
   if (!actorId) {
@@ -406,11 +384,16 @@ adminContentRouter.get("/modules/:moduleId/export", async (request, response) =>
   }
   try {
     await assertModuleOwnership(request.params.moduleId, actorId, request.context?.roles ?? []);
+    // The export carries the MCQ answer key and rationale for everyone who gets this far.
+    //
+    // #392 (v1.1.11) stripped them for non-ADMINISTRATOR callers. That control protected
+    // nothing: assertModuleOwnership above already limits this route to an owner of THIS
+    // module or an admin, the owner authored the answers and reads them in the editor, and
+    // /modules/:id/export-package hands the same owner the same answers untouched. All it
+    // achieved was a lossy backup - export then import silently returned a module with no
+    // answer key. Product decision 2026-08-14: the key belongs in the export.
     const bundle = await getModuleContentBundle(request.params.moduleId);
-    const moduleExport = request.context?.roles?.includes("ADMINISTRATOR")
-      ? bundle
-      : redactMcqAnswerKeys(bundle);
-    response.json({ moduleExport });
+    response.json({ moduleExport: bundle });
   } catch (error) {
     if (error instanceof AppError) {
       response.status(error.httpStatus).json({ error: error.code, message: error.message });

--- a/test/security-p1-392-smo-export-scope.test.ts
+++ b/test/security-p1-392-smo-export-scope.test.ts
@@ -27,7 +27,12 @@ const moduleBody = {
   title: { "en-GB": "Export Scope Test Module", nb: "Eksportomfangsmodul", nn: "Eksportomfangsmodul" },
 };
 
-describe("Security P1 #392: SMO content scope and MCQ answer key protection on export", () => {
+// #392 established two controls on module export. The SCOPE control stands: an SMO may only
+// export a module they own. The answer-key redaction was removed on 2026-08-14 - it hid the
+// key from the very person who wrote it, while /export-package handed the same owner the same
+// key anyway, and its only real effect was a lossy backup (export -> import lost the answers
+// with no warning).
+describe("Security P1 #392: SMO content scope on module export", () => {
   afterAll(async () => {
     await prisma.$disconnect();
   });
@@ -48,7 +53,7 @@ describe("Security P1 #392: SMO content scope and MCQ answer key protection on e
     await request(app).delete(`/api/admin/content/modules/${moduleId}`).set(adminHeaders);
   });
 
-  it("SMO export omits correctAnswer and rationale from MCQ questions; admin export includes them", async () => {
+  it("an owner's export includes correctAnswer and rationale, like an admin's", async () => {
     const createRes = await request(app)
       .post("/api/admin/content/modules")
       .set(smoAHeaders)
@@ -56,7 +61,6 @@ describe("Security P1 #392: SMO content scope and MCQ answer key protection on e
     expect(createRes.status).toBe(201);
     const moduleId = createRes.body.module.id as string;
 
-    // Create an MCQ set version with a question that has correctAnswer and rationale
     const mcqRes = await request(app)
       .post(`/api/admin/content/modules/${moduleId}/mcq-set-versions`)
       .set(smoAHeaders)
@@ -77,7 +81,7 @@ describe("Security P1 #392: SMO content scope and MCQ answer key protection on e
       });
     expect(mcqRes.status).toBe(201);
 
-    // SMO export: correctAnswer and rationale must be absent
+    // The owner gets a complete module back - anything less is a lossy backup.
     const smoExportRes = await request(app)
       .get(`/api/admin/content/modules/${moduleId}/export`)
       .set(smoAHeaders);
@@ -87,24 +91,17 @@ describe("Security P1 #392: SMO content scope and MCQ answer key protection on e
     const smoVersionQuestions = smoExport.versions.mcqSetVersions?.[0]?.questions ?? [];
     expect(smoVersionQuestions.length).toBeGreaterThan(0);
     for (const q of smoVersionQuestions) {
-      expect(q).not.toHaveProperty("correctAnswer");
-      expect(q).not.toHaveProperty("rationale");
-    }
-    if (smoExport.selectedConfiguration?.mcqSetVersion?.questions) {
-      for (const q of smoExport.selectedConfiguration.mcqSetVersion.questions) {
-        expect(q).not.toHaveProperty("correctAnswer");
-        expect(q).not.toHaveProperty("rationale");
-      }
+      expect(q).toHaveProperty("correctAnswer");
+      expect(q).toHaveProperty("rationale");
     }
 
-    // Admin export: correctAnswer and rationale must be present
+    // Admin sees exactly the same shape - the two exports no longer diverge.
     const adminExportRes = await request(app)
       .get(`/api/admin/content/modules/${moduleId}/export`)
       .set(adminHeaders);
     expect(adminExportRes.status).toBe(200);
 
-    const adminExport = adminExportRes.body.moduleExport;
-    const adminVersionQuestions = adminExport.versions.mcqSetVersions?.[0]?.questions ?? [];
+    const adminVersionQuestions = adminExportRes.body.moduleExport.versions.mcqSetVersions?.[0]?.questions ?? [];
     expect(adminVersionQuestions.length).toBeGreaterThan(0);
     for (const q of adminVersionQuestions) {
       expect(q).toHaveProperty("correctAnswer");


### PR DESCRIPTION
**Klar for prod-fast-track** — uavhengig av #896-epicen. Skal merges av deg; jeg rører ikke `main`.

## Hva

`GET /modules/:id/export` fjernet `correctAnswer` og `rationale` for alle uten ADMINISTRATOR-rolle. Redaksjonen kom fra sikkerhetsfiks #392 (v1.1.11) — men den beskyttet ingenting:

- Ruta krever allerede at du **eier** modulen, så den som fikk en redigert eksport var forfatteren selv — som leser fasiten i redigeringsflaten uansett.
- `GET /modules/:id/export-package` gir den samme eieren de samme svarene uredigert.
- Og avgjørende: **admin-UI-et laster modulen gjennom nettopp dette endepunktet** (`admin-content.js:1382`), så redaksjonen etterlot eieren uten fasit i sin egen editor.

Den eneste reelle effekten var en ufullstendig sikkerhetskopi: eksport etterfulgt av import ga en modul uten fasit, uten at noe sa fra.

Produkteierbeslutning 2026-08-14: dette er ikke statshemmeligheter, og fasiten kan uansett regenereres.

## Hva som IKKE endres

**Omfangskontrollen fra #392 står urørt.** SMO-B kan fortsatt ikke eksportere SMO-As modul — det gir 403, og testen dekker det fortsatt. Det som fjernes er bare redaksjonen for den som allerede har passert eierskapssjekken.

## Testing

Integrasjonstestene kjørt mot lokal Postgres: `security-p1-392` (3) og `m2-content-export-import` (8).

Testen for redaksjonen er skrevet om til den nye kontrakten i stedet for å slettes — eierens eksport er komplett, og admin ser nøyaktig samme form.

## Relatert

Løser også åpent punkt 2 i #896: import trenger ingen spesialhåndtering av fasit-løse pakker, siden de ikke lenger oppstår.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
