### PR TITLE
feat(admin): innhold kan si at det ikke er oversatt ennå (#905)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ doc/pentest/PENTEST-*.md
 
 # Cross-model QA gate output (scripts/ai-qa.ps1)
 .ai-qa/
+scripts/ai-qa.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ doc/pentest/PENTEST-*.md
 
 # Local course-asset storage fallback (dev/test)
 .course-assets-local/
+
+# Cross-model QA gate output (scripts/ai-qa.ps1)
+.ai-qa/

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,31 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.11.13 - 2026-08-14
+
+**Innhold kan nå si at det ikke er oversatt ennå (#905).** Oppgavetekst, forventning og rammer
+tok enten en ren streng eller et objekt med **alle tre** språk. Det fantes ingen måte å si «nb er
+oversatt, nn er det ikke».
+
+Konsekvensen var at ærlighetsregelen fra #892 bare kunne håndheves for titler. En klient der
+oversettingen delvis feilet måtte velge mellom 400 (delvis objekt) eller å fylle alle språk med
+kildeteksten — og det siste er det som ble sendt. Resultatet var innhold som *ser* oversatt ut og
+*leser* som feil språk.
+
+To endringer:
+
+- Feltene godtar nå et delvis språkkart, med krav om minst ett utfylt språk. Lagringslaget var
+  allerede forberedt — `LocalizedTextObject` har alltid vært `Partial`.
+- Klienten slutter å blåse en ren streng opp til tre identiske språk før den sender. Den gjorde
+  det av vane, ikke fordi API-et krevde det.
+
+Lesing er uendret: `localizeContentText` faller allerede tilbake mellom språk, som er nettopp
+slik rene strenger alltid har vist seg.
+
+Dette er forutsetningen for publiseringsgaten i #896 S4 — den skal stoppe innhold med
+oversettelseshull, og kunne til nå ikke skille tre ekte oversettelser fra tre kopier av samme
+kildetekst. Samme gjelder oversettelsesstatus i lista (#894) og kriteriene (#902).
+
 ## 2.11.10 - 2026-08-13
 
 **Språkbytte under Direkte redigering ga en blindvei.** Rapportert fra stage: bytt arbeidsflatens

--- a/doc/VERSIONS.md
+++ b/doc/VERSIONS.md
@@ -2,6 +2,22 @@
 
 This document tracks release versions and what each version includes.
 
+## 2.11.14 - 2026-08-15
+
+QA-runde på #905. Å åpne skjemaet var ikke nok — søsterflatene gikk fortsatt i veggen:
+
+- **Eksport og import avviste sin egen datatype.** En delvis oversatt modul kunne lagres, men
+  ikke eksporteres, dupliseres eller importeres — envelopen sender det som er lagret, og import
+  validerte med det strenge skjemaet.
+- **Agent-forfatting avviste enspråklige utkast.** En agent som skriver på ett språk er
+  normaltilfellet, ikke en feil.
+- **Samtaleflyten lagret fortsatt kildeteksten som oversettelse.** Språkkartet fylles med
+  kildeteksten *før* oversettingen, og et språk som feilet ble registrert — men kopien ble
+  aldri fjernet. Det gjorde hele #905 virkningsløs i den flyten folk faktisk bruker. Feilede
+  språk tas nå ut av kartet.
+- **Kriteriegeneratoren fikk `[object Object]`** i stedet for oppgaveteksten, fordi et språkkart
+  ble sendt gjennom `String()`. Kriteriene ble altså generert uten å ha sett oppgaven.
+
 ## 2.11.13 - 2026-08-14
 
 **Innhold kan nå si at det ikke er oversatt ennå (#905).** Oppgavetekst, forventning og rammer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.11.13",
+  "version": "2.11.14",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2-assessment-platform",
-  "version": "2.11.10",
+  "version": "2.11.13",
   "private": true,
   "description": "Internal assessment platform backend bootstrap (M0 foundation).",
   "type": "module",

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -2133,9 +2133,14 @@ async function saveDraftBundleInBackground(options = {}) {
       method: "POST",
       body: JSON.stringify({
         assessmentMode: isFreetextOnly ? "FREETEXT_ONLY" : undefined,
-        taskText: translateLocalizedText(taskText),
-        assessorExpectedContent: translateLocalizedText(assessorExpectedContent),
-        candidateTaskConstraints: omitWhenEveryLocaleBlank(translateLocalizedText(candidateTaskConstraints)),
+        // #905: send the value as it is. translateLocalizedText used to blow a plain string up
+        // into three identical locales here - not because the API demanded it, but out of
+        // habit - which stored the source language under every locale and made an untranslated
+        // field indistinguishable from a translated one. The schema accepts a plain string
+        // ("one language, not translated yet") and now also a partial map.
+        taskText,
+        assessorExpectedContent,
+        candidateTaskConstraints: omitWhenEveryLocaleBlank(candidateTaskConstraints),
         assessmentBlueprint: assessmentBlueprint || undefined,
         rubricVersionId: rubricBody?.rubricVersion?.id,
         promptTemplateVersionId: promptBody?.promptTemplateVersion?.id,

--- a/public/static/admin-content-shell.js
+++ b/public/static/admin-content-shell.js
@@ -1290,6 +1290,19 @@ function omitWhenEveryLocaleBlank(value) {
   return hasText ? value : undefined;
 }
 
+/**
+ * #905: remove one locale from every localized field of a draft-localization result.
+ *
+ * The maps are seeded with the source text for all locales before translation runs, so a locale
+ * that fails has to be taken back out — otherwise the source language is stored as though it
+ * were a translation, and nothing downstream can tell the difference.
+ */
+function dropLocale(localized, locale) {
+  for (const field of ["title", "taskText", "assessorExpectedContent", "candidateTaskConstraints"]) {
+    if (localized[field] && typeof localized[field] === "object") delete localized[field][locale];
+  }
+}
+
 function buildLocalizedTextMap(baseLocale, baseText, translatedEntries = {}) {
   const result = {};
   for (const locale of supportedLocales) {
@@ -1410,14 +1423,22 @@ async function localizeDraftAcrossLocalesWithTitle(title, taskText, assessorExpe
         },
       );
     } catch {
-      // Kildeteksten blir stående, ellers blir utkastet ulagbart — men lokalen registreres som
-      // ikke-oversatt så kalleren kan si fra i stedet for å melde suksess.
+      // #905: DROP the pre-filled source copy for this locale. It used to be left standing
+      // "so the draft stays saveable" — but the API accepts a partial map now, and leaving the
+      // copy is what made a failed translation indistinguishable from a real one. The locale is
+      // recorded as failed so the caller can say so, and the field simply has no value here.
+      dropLocale(localized, targetLocale);
       localized.failedLocales.push(targetLocale);
       continue;
     }
     const draft = result?.draft ?? result;
-    if (!draft?.title) localized.failedLocales.push(targetLocale);
-    localized.title[targetLocale] = draft?.title ?? title;
+    if (!draft?.title) {
+      // A response without a title is not a translation. Same treatment as a thrown error.
+      dropLocale(localized, targetLocale);
+      localized.failedLocales.push(targetLocale);
+      continue;
+    }
+    localized.title[targetLocale] = draft.title;
     localized.taskText[targetLocale] = draft?.taskText ?? taskText;
     localized.assessorExpectedContent[targetLocale] = draft?.assessorExpectedContent ?? assessorExpectedContent;
     localized.candidateTaskConstraints[targetLocale] = draft?.candidateTaskConstraints ?? candidateTaskConstraints ?? "";
@@ -4577,10 +4598,13 @@ function askForMcqGeneration(sourceMaterial, certLevel, locale, generationMode) 
 async function populateSessionDraftCriteriaInBackground() {
   if (!sessionDraft) return;
   if (sessionDraft.criteria) return;
-  const taskText = String(translateLocalizedText(sessionDraft.taskText ?? "") ?? "").trim();
-  const assessorText = String(translateLocalizedText(sessionDraft.assessorExpectedContent ?? "") ?? "").trim();
+  // translateLocalizedText returns a locale MAP, so String() on it produced the literal
+  // "[object Object]" - and the criteria generator was asked to build a rubric for a task it
+  // never saw. localizeValue picks the text for the active locale, which is what was meant.
+  const taskText = localizeValue(sessionDraft.taskText ?? "").trim();
+  const assessorText = localizeValue(sessionDraft.assessorExpectedContent ?? "").trim();
   if (!taskText || !assessorText) return;
-  const constraintsText = String(translateLocalizedText(sessionDraft.candidateTaskConstraints ?? "") ?? "").trim();
+  const constraintsText = localizeValue(sessionDraft.candidateTaskConstraints ?? "").trim();
 
   let blueprintObject = null;
   const bp = sessionDraft.assessmentBlueprint ?? bundle?.selectedConfiguration?.moduleVersion?.assessmentBlueprint;

--- a/src/modules/adminContent/adminContentSchemas.ts
+++ b/src/modules/adminContent/adminContentSchemas.ts
@@ -14,6 +14,27 @@ export const localizedTextPatchObjectSchema = localizedTextObjectSchema.partial(
 );
 export const localizedTextPatchSchema = z.union([z.string().trim().min(1), localizedTextPatchObjectSchema]);
 
+/**
+ * #905: content written in one language and NOT YET translated into the others.
+ *
+ * `localizedTextSchema` accepts either a plain string or an object holding ALL three locales —
+ * there is no way to say "nb is translated, nn is not". That gap made the honesty rule from
+ * #892 unenforceable for anything but titles: a client whose translation partly failed had to
+ * choose between a 400 (partial object) and filling every locale with the source text, which
+ * stores content that looks translated and reads as the wrong language.
+ *
+ * This alias permits a partial map, requiring at least one locale. Reading is unaffected —
+ * `localizeContentText` already falls back across locales, which is how a plain string has
+ * always displayed. A missing locale becomes a fact the data can express, which is what the
+ * publish gate (#896 S4) and the translation-status list (#894) need in order to measure
+ * anything at all.
+ *
+ * Named separately from `localizedTextPatchSchema` even though the shape is identical: a patch
+ * is "change these locales, leave the rest", while this is "this is the whole value, and some
+ * locales are genuinely missing". Same validation, different meaning at the call site.
+ */
+export const localizedTextMaybeUntranslatedSchema = localizedTextPatchSchema;
+
 export function localizedTextIdentity(value: LocalizedText): string {
   if (typeof value === "string") {
     return `plain:${value.trim()}`;
@@ -157,9 +178,11 @@ export const assessmentModeSchema = z.enum(["FREETEXT_PLUS_MCQ", "MCQ_ONLY", "FR
 export const moduleVersionBodySchema = z
   .object({
     assessmentMode: assessmentModeSchema.optional(),
-    taskText: localizedTextSchema.optional(),
-    assessorExpectedContent: localizedTextSchema.optional(),
-    candidateTaskConstraints: localizedTextSchema.optional(),
+    // #905: these are the fields an author writes in one language and has translated
+    // afterwards, so they must be able to arrive partially translated.
+    taskText: localizedTextMaybeUntranslatedSchema.optional(),
+    assessorExpectedContent: localizedTextMaybeUntranslatedSchema.optional(),
+    candidateTaskConstraints: localizedTextMaybeUntranslatedSchema.optional(),
     assessmentBlueprint: z.string().trim().optional(),
     rubricVersionId: z.string().min(1).optional(),
     promptTemplateVersionId: z.string().min(1).optional(),

--- a/src/modules/adminContent/adminContentSchemas.ts
+++ b/src/modules/adminContent/adminContentSchemas.ts
@@ -360,9 +360,12 @@ export const moduleExportPayloadSchema = z.object({
   activeVersion: z.object({
     // #525/#547: MCQ_ONLY exports omit taskText/rubric/promptTemplate (no free-text assessment).
     assessmentMode: assessmentModeSchema.optional(),
-    taskText: localizedTextSchema.nullable().optional(),
-    assessorExpectedContent: localizedTextSchema.nullable().optional(),
-    candidateTaskConstraints: localizedTextSchema.nullable().optional(),
+    // #905: must accept the same partial shape the module-version body now stores, or a
+    // partially translated module can be saved but never exported, duplicated or re-imported
+    // - the envelope emits what is stored, and import would reject its own export.
+    taskText: localizedTextMaybeUntranslatedSchema.nullable().optional(),
+    assessorExpectedContent: localizedTextMaybeUntranslatedSchema.nullable().optional(),
+    candidateTaskConstraints: localizedTextMaybeUntranslatedSchema.nullable().optional(),
     assessmentBlueprint: z.string().nullable().optional(),
     submissionSchema: submissionSchemaBodySchema.nullable().optional(),
     assessmentPolicy: assessmentPolicyBodySchema.nullable().optional(),

--- a/src/modules/adminContent/agentAuthoringSchemas.ts
+++ b/src/modules/adminContent/agentAuthoringSchemas.ts
@@ -12,6 +12,7 @@
 import { z } from "zod";
 import {
   localizedTextSchema,
+  localizedTextMaybeUntranslatedSchema,
   localizedTextPatchSchema,
   certificationLevelInputSchema,
   assessmentModeSchema,
@@ -73,9 +74,12 @@ export const authoringModulePayloadSchema = z
     activeVersion: z
       .object({
         assessmentMode: assessmentModeSchema.optional(),
-        taskText: localizedTextSchema.nullable().optional(),
-        assessorExpectedContent: localizedTextSchema.nullable().optional(),
-        candidateTaskConstraints: localizedTextSchema.nullable().optional(),
+        // #905: an agent authoring in one language is the normal case, not an error - the same
+        // partial shape the module-version body accepts must validate here too, or a valid
+        // single-language draft comes back `valid:false` with an empty plan.
+        taskText: localizedTextMaybeUntranslatedSchema.nullable().optional(),
+        assessorExpectedContent: localizedTextMaybeUntranslatedSchema.nullable().optional(),
+        candidateTaskConstraints: localizedTextMaybeUntranslatedSchema.nullable().optional(),
         assessmentBlueprint: z.string().nullable().optional(),
         submissionSchema: submissionSchemaBodySchema.nullable().optional(),
         assessmentPolicy: assessmentPolicyBodySchema.nullable().optional(),

--- a/test/e2e/admin-content-helpers.ts
+++ b/test/e2e/admin-content-helpers.ts
@@ -258,6 +258,8 @@ export async function mockCommonApis(page: Page, {
     lastMcqLocalizationBody: null as any,
     lastCourseLocalizationBodies: [] as any[],
     lastTitlePatchBody: null as any,
+    // #905: tests need to see exactly which locales a save actually sent.
+    lastModuleVersionBody: null as any,
     lastSourceMaterialExtraction: null as any,
   };
   const extractionJobs = new Map<string, { fileName: string; extractedText: string }>();
@@ -654,6 +656,7 @@ export async function mockCommonApis(page: Page, {
       promptTemplateVersionId?: string;
       mcqSetVersionId?: string;
     };
+    state.lastModuleVersionBody = body;
     const moduleVersion = {
       id: `${moduleId}-version-1`,
       versionNo: 1,

--- a/test/e2e/admin-content-workspaces.spec.ts
+++ b/test/e2e/admin-content-workspaces.spec.ts
@@ -566,6 +566,64 @@ test.describe("admin content browser coverage", () => {
     await expect(page.locator('.locale-picker #profileNavLink[href="/profile"]')).toBeVisible();
   });
 
+  // #905: a locale whose translation failed must be ABSENT from what is saved. Leaving the
+  // source copy behind is what made "not translated yet" invisible to the publish gate (#896 S4)
+  // and to the translation-status list (#894).
+  test("a failed locale is left out of the saved draft, not filled with the source text", async ({ page }) => {
+    const state = await mockCommonApis(page, {
+      modules: [{ id: "module-1", title: "Trade unions", activeVersion: { versionNo: 1 } }],
+      moduleExports: {
+        "module-1": buildMockModuleExport({
+          id: "module-1",
+          title: "Trade unions",
+          moduleVersionId: "module-1-version-1",
+          taskText: localizedText("Norsk scenario"),
+          mcqQuestions: [
+            {
+              stem: localizedText("Question 1"),
+              options: [localizedText("Option A"), localizedText("Option B")],
+              correctAnswer: localizedText("Option B"),
+              rationale: localizedText("Rationale"),
+            },
+          ],
+        }),
+      },
+    });
+
+    // One target locale translates, the other fails outright.
+    let call = 0;
+    await page.route("**/generate/module-draft/localize", async (route: Route) => {
+      call += 1;
+      if (call === 1) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ draft: { title: "Oversatt tittel", taskText: "Oversatt scenario" } }),
+        });
+        return;
+      }
+      await route.fulfill({ status: 500, contentType: "application/json", body: "{}" });
+    });
+
+    await page.goto("/admin-content/module/module-1/conversation");
+    await clickEnabledButton(page, /Edit directly|Rediger direkte/);
+    await page.locator("#previewEditTaskText").fill("Bearbeidet scenario");
+    await page.locator("#previewEditConfirm").click();
+    await clickEnabledButton(page, /Save draft|Lagre utkast/);
+
+    await expect.poll(() => state.lastModuleVersionBody?.taskText).toBeTruthy();
+    const savedTaskText = state.lastModuleVersionBody.taskText;
+
+    // Whatever survived, no locale may hold a copy of the source text - that is the bug.
+    if (typeof savedTaskText === "object") {
+      const values = Object.values(savedTaskText);
+      expect(values.filter((v) => v === "Bearbeidet scenario").length).toBeLessThanOrEqual(1);
+      expect(Object.keys(savedTaskText).length).toBeLessThan(3);
+    } else {
+      expect(savedTaskText).toBe("Bearbeidet scenario");
+    }
+  });
+
   test("direct edit localizes from the active preview locale and save sends a title patch", async ({ page }) => {
     const state = await mockCommonApis(page, {
       modules: [{ id: "module-1", title: "Trade unions", activeVersion: { versionNo: 1 } }],

--- a/test/m2-partial-localization-905.test.ts
+++ b/test/m2-partial-localization-905.test.ts
@@ -1,0 +1,157 @@
+import request from "supertest";
+import { app } from "../src/app.js";
+import { prisma } from "../src/db/prisma.js";
+import { localizedTextCodec } from "../src/codecs/localizedTextCodec.js";
+
+// #905: an author writes in one language and has the rest translated afterwards. Until now the
+// request schema could not express "nb is translated, nn is not" — it accepted a plain string
+// or an object holding all three locales, nothing in between. A client whose translation partly
+// failed therefore had to choose between a 400 and filling every locale with the source text,
+// and the latter is what shipped: content that looks translated and reads as the wrong language.
+//
+// These tests pin the three shapes the field must now accept, and — the point of the exercise —
+// that a missing locale STAYS missing, because the publish gate (#896 S4) and the translation
+// status list (#894) can only measure a hole that is actually there.
+
+const adminHeaders = {
+  "x-user-id": "admin-905",
+  "x-user-email": "admin-905@company.com",
+  "x-user-name": "Localization Admin",
+  "x-user-roles": "ADMINISTRATOR",
+};
+
+async function createModuleWithComponents() {
+  const moduleRes = await request(app)
+    .post("/api/admin/content/modules")
+    .set(adminHeaders)
+    .send({ title: { "en-GB": "Partial locale module", nb: "Delvis modul", nn: "Delvis modul" } });
+  expect(moduleRes.status).toBe(201);
+  const moduleId = moduleRes.body.module.id as string;
+
+  const rubricRes = await request(app)
+    .post(`/api/admin/content/modules/${moduleId}/rubric-versions`)
+    .set(adminHeaders)
+    .send({
+      criteria: { clarity: { label: "Clarity", maxScore: 5, weight: 1, candidateVisible: true } },
+      scalingRule: { max_total: 5 },
+      active: true,
+    });
+  expect(rubricRes.status).toBe(201);
+
+  const promptRes = await request(app)
+    .post(`/api/admin/content/modules/${moduleId}/prompt-template-versions`)
+    .set(adminHeaders)
+    .send({
+      systemPrompt: "You assess practical answers.",
+      userPromptTemplate: "Assess: {{answer}}",
+      active: true,
+    });
+  expect(promptRes.status).toBe(201);
+
+  const mcqRes = await request(app)
+    .post(`/api/admin/content/modules/${moduleId}/mcq-set-versions`)
+    .set(adminHeaders)
+    .send({
+      title: "Set",
+      questions: [
+        {
+          stem: "Which is true?",
+          options: ["This one", "Not this one"],
+          correctAnswer: "This one",
+          rationale: "Because it is.",
+        },
+      ],
+    });
+  expect(mcqRes.status).toBe(201);
+
+  return {
+    moduleId,
+    rubricVersionId: rubricRes.body.rubricVersion.id as string,
+    promptTemplateVersionId: promptRes.body.promptTemplateVersion.id as string,
+    mcqSetVersionId: mcqRes.body.mcqSetVersion.id as string,
+  };
+}
+
+describe("#905 partially translated module-version fields", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("accepts a locale map missing a locale, and does not invent the missing one", async () => {
+    const { moduleId, rubricVersionId, promptTemplateVersionId, mcqSetVersionId } =
+      await createModuleWithComponents();
+
+    // nb written, en-GB translated, nn never got there.
+    const res = await request(app)
+      .post(`/api/admin/content/modules/${moduleId}/module-versions`)
+      .set(adminHeaders)
+      .send({
+        taskText: { nb: "Norsk oppgavetekst", "en-GB": "English task text" },
+        assessorExpectedContent: { nb: "Norsk forventning" },
+        rubricVersionId,
+        promptTemplateVersionId,
+        mcqSetVersionId,
+      });
+    expect(res.status).toBe(201);
+
+    const stored = await prisma.moduleVersion.findUnique({
+      where: { id: res.body.moduleVersion.id as string },
+      select: { taskText: true, assessorExpectedContent: true },
+    });
+    const taskText = localizedTextCodec.parse(stored?.taskText ?? null);
+    const guidance = localizedTextCodec.parse(stored?.assessorExpectedContent ?? null);
+
+    // The hole is the whole point: nn must be absent, not a copy of nb.
+    expect(taskText).toEqual({ nb: "Norsk oppgavetekst", "en-GB": "English task text" });
+    expect(taskText).not.toHaveProperty("nn");
+    expect(guidance).toEqual({ nb: "Norsk forventning" });
+
+    await request(app).delete(`/api/admin/content/modules/${moduleId}`).set(adminHeaders);
+  });
+
+  it("still accepts a plain string as 'written in one language, not translated yet'", async () => {
+    const { moduleId, rubricVersionId, promptTemplateVersionId, mcqSetVersionId } =
+      await createModuleWithComponents();
+
+    const res = await request(app)
+      .post(`/api/admin/content/modules/${moduleId}/module-versions`)
+      .set(adminHeaders)
+      .send({
+        taskText: "Bare norsk, ikke oversatt",
+        assessorExpectedContent: "Bare norsk forventning",
+        rubricVersionId,
+        promptTemplateVersionId,
+        mcqSetVersionId,
+      });
+    expect(res.status).toBe(201);
+
+    const stored = await prisma.moduleVersion.findUnique({
+      where: { id: res.body.moduleVersion.id as string },
+      select: { taskText: true },
+    });
+    // Stored as the string it was - not expanded into three identical locales.
+    expect(stored?.taskText).toBe("Bare norsk, ikke oversatt");
+
+    await request(app).delete(`/api/admin/content/modules/${moduleId}`).set(adminHeaders);
+  });
+
+  it("rejects an empty locale map, which carries no content at all", async () => {
+    const { moduleId, rubricVersionId, promptTemplateVersionId, mcqSetVersionId } =
+      await createModuleWithComponents();
+
+    const res = await request(app)
+      .post(`/api/admin/content/modules/${moduleId}/module-versions`)
+      .set(adminHeaders)
+      .send({
+        taskText: {},
+        assessorExpectedContent: { nb: "Norsk" },
+        rubricVersionId,
+        promptTemplateVersionId,
+        mcqSetVersionId,
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("validation_error");
+
+    await request(app).delete(`/api/admin/content/modules/${moduleId}`).set(adminHeaders);
+  });
+});


### PR DESCRIPTION
Løser #905. Forutsetning for publiseringsgaten i #896 S4.

## Problemet

`taskText`, `assessorExpectedContent` og `candidateTaskConstraints` tok enten en ren streng eller et objekt med **alle tre** språk. Det fantes ingen måte å si «nb er oversatt, nn er det ikke».

Konsekvensen: ærlighetsregelen fra #892 kunne bare håndheves for titler. En klient der oversettingen delvis feilet måtte velge mellom 400 (delvis objekt) eller å fylle alle språk med kildeteksten — og det siste er det som ble sendt. Innhold som *ser* oversatt ut og *leser* som feil språk.

## Endringen

- Skjemaet godtar nå et delvis språkkart, med krav om minst ett utfylt språk
- Klienten slutter å blåse en ren streng opp til tre identiske språk før den sender — den gjorde det av vane, ikke fordi API-et krevde det

Lagringslaget var allerede forberedt: `LocalizedTextObject` har alltid vært `Partial`, og codec-en beholder bare utfylte språk. Lesing er uendret — `localizeContentText` faller allerede tilbake mellom språk.

Eget navn `localizedTextMaybeUntranslatedSchema` i stedet for å gjenbruke patch-varianten: formen er lik, meningen ulik. En patch sier «endre disse språkene», dette sier «dette *er* verdien, og noen språk mangler».

## Testing

Tre nye integrasjonstester, **verifisert i begge retninger** — den delvise varianten gir 400 uten skjemaendringen. Testen sjekker eksplisitt at det manglende språket er *fraværende*, ikke en kopi.

432 integrasjonstester og 123 e2e grønne.

## Hva det låser opp

Publiseringsgaten (#896 S4) kunne til nå ikke skille tre ekte oversettelser fra tre kopier av samme kildetekst. Samme blindhet gjelder #894 (oversettelsesstatus i lista) og #902 (kriterier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)